### PR TITLE
The patch about stagePreRun(maybe a simple begin of stream shuffle)

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -184,7 +184,9 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
     if (statuses == null) {
       return true
     }
-    size != statuses.length
+    val length = statuses.length
+    logInfo(s"lyjmark: [isMapOutputsMissing]shuffleId($shuffleId) status!=null, size($size) status.length($length)")
+    size != length
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -157,10 +157,42 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
   }
 
   /**
-   * Return statistics about all of the outputs for a given shuffle.
-   */
-  def getStatistics(dep: ShuffleDependency[_, _, _]): MapOutputStatistics = {
-    val statuses = getStatuses(dep.shuffleId)
+    * This function used while "spark.sql.baidu.stagePreRun=true".
+    * When 'isMissing' inconsistent with the return of MapOutputStatus, mainly 2 scenarios:
+    *   1. isMissing = true but MapOutputStatus is completed: This will cause the BlockFetcher hang.
+    *   2. isMissing = false but MapOutputStatus not completed: This will cause data loss!
+    * So here we should get the isMissing flag and MapOutputStatus atomicly.
+    * @return Tuple of shuffleId missing flag and sequence same with getMapSizesByExecutorId.
+    */
+  def preRunGetMapSizesByExecutorId(shuffleId: Int, startPartition: Int, endPartition: Int)
+  : (Boolean, Seq[(BlockManagerId, Seq[(BlockId, Long)])]) = {
+    logDebug(s"[pre-run] Fetching outputs for shuffle $shuffleId," +
+      s"partitions $startPartition-$endPartition")
+    val statuses = getStatuses(shuffleId, openPreRun = true)
+    // Synchronize on the returned array because, on the driver, it gets mutated in place
+    statuses.synchronized {
+      val status = MapOutputTracker.convertMapStatuses(shuffleId,
+        startPartition, endPartition, statuses, openPreRun = true)
+      val isMissing = isMapOutputsMissing(shuffleId)
+      return (isMissing, status)
+    }
+  }
+
+  private def isMapOutputsMissing(shuffleId: Int): Boolean = {
+    val statuses = mapStatuses.get(shuffleId).orNull
+    val size = mapStatusesSize.getOrElse(shuffleId, 0)
+    if (statuses == null) {
+      return true
+    }
+    size != statuses.length
+  }
+
+  /**
+    * Return statistics about all of the outputs for a given shuffle.
+    */
+  def getStatistics(dep: ShuffleDependency[_, _, _],
+                    openPreRun: Boolean = false): MapOutputStatistics = {
+    val statuses = getStatuses(dep.shuffleId, openPreRun = openPreRun)
     // Synchronize on the returned array because, on the driver, it gets mutated in place
     statuses.synchronized {
       val totalSizes = new Array[Long](dep.partitioner.numPartitions)
@@ -176,13 +208,13 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
   /**
    * Get or fetch the array of MapStatuses for a given shuffle ID. NOTE: clients MUST synchronize
    * on this array when reading it, because on the driver, we may be changing it in place.
-   *
+   * lyjmark: add a default param openPreRun here
    * (It would be nice to remove this restriction in the future.)
    */
-  private def getStatuses(shuffleId: Int): Array[MapStatus] = {
+  private def getStatuses(shuffleId: Int, openPreRun: Boolean = false): Array[MapStatus] = {
     val statuses = mapStatuses.get(shuffleId).orNull
-    if (statuses == null) {
-      logInfo("Don't have map outputs for shuffle " + shuffleId + ", fetching them")
+    if (statuses == null || (openPreRun && isMapOutputsMissing(shuffleId))) {
+      logInfo("Don't have(or missing) map outputs for shuffle " + shuffleId + ", fetching them")
       val startTime = System.currentTimeMillis
       var fetchedStatuses: Array[MapStatus] = null
       fetching.synchronized {
@@ -198,9 +230,12 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
         // Either while we waited the fetch happened successfully, or
         // someone fetched it in between the get and the fetching.synchronized.
         fetchedStatuses = mapStatuses.get(shuffleId).orNull
-        if (fetchedStatuses == null) {
+        if (fetchedStatuses == null || (openPreRun && isMapOutputsMissing(shuffleId))) {
           // We have to do the fetch, get others to wait for us.
           fetching += shuffleId
+          if (openPreRun) {
+            fetchedStatuses = null
+          }
         }
       }
 
@@ -213,6 +248,9 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
           fetchedStatuses = MapOutputTracker.deserializeMapStatuses(fetchedBytes)
           logInfo("Got the output locations")
           mapStatuses.put(shuffleId, fetchedStatuses)
+          if (openPreRun) {
+            mapStatusesSize.put(shuffleId, fetchedStatuses.count(_ != null))
+          }
         } finally {
           fetching.synchronized {
             fetching -= shuffleId
@@ -309,18 +347,28 @@ private[spark] class MapOutputTrackerMaster(conf: SparkConf)
     }
   }
 
-  def registerMapOutput(shuffleId: Int, mapId: Int, status: MapStatus) {
+  def registerMapOutput(shuffleId: Int, mapId: Int, status: MapStatus,
+                        openPreRun: Boolean = false) {
     val array = mapStatuses(shuffleId)
     array.synchronized {
       array(mapId) = status
     }
+    // lyjmark: for performance consideration, here add a swich
+    if (openPreRun) {
+      cachedSerializedStatuses.remove(shuffleId)
+    }
   }
 
   /** Register multiple map output information for the given shuffle */
-  def registerMapOutputs(shuffleId: Int, statuses: Array[MapStatus], changeEpoch: Boolean = false) {
+  def registerMapOutputs(shuffleId: Int, statuses: Array[MapStatus],
+                         changeEpoch: Boolean = false, openPreRun: Boolean = false) {
     mapStatuses.put(shuffleId, Array[MapStatus]() ++ statuses)
     if (changeEpoch) {
       incrementEpoch()
+    }
+    // lyjmark: for performance consideration, here add a swich
+    if (openPreRun) {
+      cachedSerializedStatuses.remove(shuffleId)
     }
   }
 
@@ -532,14 +580,17 @@ private[spark] object MapOutputTracker extends Logging {
       shuffleId: Int,
       startPartition: Int,
       endPartition: Int,
-      statuses: Array[MapStatus]): Seq[(BlockManagerId, Seq[(BlockId, Long)])] = {
+      statuses: Array[MapStatus],
+      openPreRun: Boolean = false): Seq[(BlockManagerId, Seq[(BlockId, Long)])] = {
     assert (statuses != null)
     val splitsByAddress = new HashMap[BlockManagerId, ArrayBuffer[(BlockId, Long)]]
     for ((status, mapId) <- statuses.zipWithIndex) {
       if (status == null) {
-        val errorMessage = s"Missing an output location for shuffle $shuffleId"
-        logError(errorMessage)
-        throw new MetadataFetchFailedException(shuffleId, startPartition, errorMessage)
+        if (!openPreRun) {
+          val errorMessage = s"Missing an output location for shuffle $shuffleId"
+          logError(errorMessage)
+          throw new MetadataFetchFailedException(shuffleId, startPartition, errorMessage)
+        }
       } else {
         for (part <- startPartition until endPartition) {
           splitsByAddress.getOrElseUpdate(status.location, ArrayBuffer()) +=

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -184,6 +184,8 @@ class DAGScheduler(
   private[scheduler] val eventProcessLoop = new DAGSchedulerEventProcessLoop(this)
   taskScheduler.setDAGScheduler(this)
 
+  private val openPreRun = sc.getConf.getBoolean("spark.sql.baidu.stagePreRun", false)
+
   /**
    * Called by the TaskSetManager to report task's starting.
    */
@@ -902,7 +904,8 @@ class DAGScheduler(
 
     // If the whole stage has already finished, tell the listener and remove it
     if (finalStage.isAvailable) {
-      markMapStageJobAsFinished(job, mapOutputTracker.getStatistics(dependency))
+      markMapStageJobAsFinished(job,
+        mapOutputTracker.getStatistics(dependency, openPreRun = openPreRun))
     }
 
     submitWaitingStages()
@@ -923,7 +926,11 @@ class DAGScheduler(
           for (parent <- missing) {
             submitStage(parent)
           }
-          waitingStages += stage
+          if (openPreRun && isStagePreRunnable(stage)) {
+            submitMissingTasks(stage, jobId.get)
+          } else {
+            waitingStages += stage
+          }
         }
       }
     } else {
@@ -1154,6 +1161,11 @@ class DAGScheduler(
                   // If the whole job has finished, remove it
                   if (job.numFinished == job.numPartitions) {
                     markStageAsFinished(resultStage)
+                    // When pre-run opened, while final job finished, it's independent running
+                    // stages may not finish.
+                    if(openPreRun) {
+                      cancelJobIndependentRunningStages(job, "job has finished")
+                    }
                     cleanupStateForJobAndIndependentStages(job)
                     listenerBus.post(
                       SparkListenerJobEnd(job.jobId, clock.getTimeMillis(), JobSucceeded))
@@ -1201,7 +1213,7 @@ class DAGScheduler(
               mapOutputTracker.registerMapOutputs(
                 shuffleStage.shuffleDep.shuffleId,
                 shuffleStage.outputLocInMapOutputTrackerFormat(),
-                changeEpoch = true)
+                changeEpoch = true, openPreRun = openPreRun)
 
               clearCacheLocs()
 
@@ -1215,7 +1227,8 @@ class DAGScheduler(
               } else {
                 // Mark any map-stage jobs waiting on this stage as finished
                 if (shuffleStage.mapStageJobs.nonEmpty) {
-                  val stats = mapOutputTracker.getStatistics(shuffleStage.shuffleDep)
+                  val stats = mapOutputTracker.getStatistics(shuffleStage.shuffleDep,
+                    openPreRun = openPreRun)
                   for (job <- shuffleStage.mapStageJobs) {
                     markMapStageJobAsFinished(job, stats)
                   }
@@ -1223,6 +1236,13 @@ class DAGScheduler(
               }
 
               // Note: newly runnable stages will be submitted below when we submit waiting stages
+            } else {
+              if (openPreRun) {
+                mapOutputTracker.registerMapOutput(
+                  shuffleStage.shuffleDep.shuffleId,
+                  smt.partitionId, status,
+                  openPreRun = openPreRun)
+              }
             }
         }
 
@@ -1327,7 +1347,7 @@ class DAGScheduler(
           mapOutputTracker.registerMapOutputs(
             shuffleId,
             stage.outputLocInMapOutputTrackerFormat(),
-            changeEpoch = true)
+            changeEpoch = true, openPreRun = openPreRun)
         }
         if (shuffleToMapStage.isEmpty) {
           mapOutputTracker.incrementEpoch()
@@ -1470,6 +1490,47 @@ class DAGScheduler(
       job.listener.jobFailed(error)
       cleanupStateForJobAndIndependentStages(job)
       listenerBus.post(SparkListenerJobEnd(job.jobId, clock.getTimeMillis(), JobFailed(error)))
+    }
+  }
+
+  /** While pre-run opened, we should handle the running parent running stage,
+    * mainly logic of this func same with failJobAndIndependentStages
+    */
+  private def cancelJobIndependentRunningStages(
+       job: ActiveJob,
+       cancelReason: String): Unit = {
+    val shouldInterruptThread =
+      if (job.properties == null) false
+      else job.properties.getProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false").toBoolean
+
+    // Cancel all independent, running stages.
+    val stages = jobIdToStageIds(job.jobId)
+    if (stages.isEmpty) {
+      logError("No stages registered for job " + job.jobId)
+    }
+    stages.foreach { stageId =>
+      val jobsForStage: Option[HashSet[Int]] = stageIdToStage.get(stageId).map(_.jobIds)
+      if (jobsForStage.isEmpty || !jobsForStage.get.contains(job.jobId)) {
+        logError(
+          "Job %d not registered for stage %d even though that stage was registered for the job"
+            .format(job.jobId, stageId))
+      } else if (jobsForStage.get.size == 1) {
+        if (!stageIdToStage.contains(stageId)) {
+          logError(s"Missing Stage for stage with id $stageId")
+        } else {
+          // This is the only job that uses this stage, so fail the stage if it is running.
+          val stage = stageIdToStage(stageId)
+          if (runningStages.contains(stage)) {
+            try { // cancelTasks will fail if a SchedulerBackend does not implement killTask
+              taskScheduler.cancelTasks(stageId, shouldInterruptThread)
+              markStageAsFinished(stage, Some(cancelReason))
+            } catch {
+              case e: UnsupportedOperationException =>
+                logInfo(s"Could not cancel tasks for stage $stageId", e)
+            }
+          }
+        }
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/PreRunShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PreRunShuffleBlockFetcherIterator.scala
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.io.InputStream
+import java.util.concurrent.LinkedBlockingQueue
+
+import scala.collection.mutable.{ArrayBuffer, HashSet, Queue}
+import scala.util.control.NonFatal
+import org.apache.spark._
+import org.apache.spark.network.buffer.ManagedBuffer
+import org.apache.spark.network.shuffle.{BlockFetchingListener, ShuffleClient}
+import org.apache.spark.shuffle.FetchFailedException
+import org.apache.spark.util.Utils
+
+import scala.collection.mutable
+
+/**
+ * An iterator that fetches multiple blocks. For local blocks, it fetches from the local block
+ * manager. For remote blocks, it fetches them using the provided BlockTransferService.
+ *
+ * This creates an iterator of (BlockID, InputStream) tuples so the caller can handle blocks
+ * in a pipelined fashion as they are received.
+ *
+ * The implementation throttles the remote fetches to they don't exceed maxBytesInFlight to avoid
+ * using too much memory.
+ *
+ * @param context [[TaskContext]], used for metrics update
+ * @param shuffleClient [[ShuffleClient]] for fetching remote blocks
+ * @param blockManager [[BlockManager]] for reading local blocks
+ * @param blocksByAddress list of blocks to fetch grouped by the [[BlockManagerId]].
+ *                        For each block we also require the size (in bytes as a long field) in
+ *                        order to throttle the memory usage.
+ * @param maxBytesInFlight max size (in bytes) of remote blocks to fetch at any given point.
+ */
+private[spark]
+final class PreRunShuffleBlockFetcherIterator(
+    context: TaskContext,
+    shuffleClient: ShuffleClient,
+    blockManager: BlockManager,
+    getBlocksHandler: () => (Boolean, Seq[(BlockManagerId, Seq[(BlockId, Long)])]),
+    shuffleId: Int,
+    maxBytesInFlight: Long)
+  extends Iterator[(BlockId, InputStream)] with Logging {
+
+  import ShuffleBlockFetcherIterator._
+
+  /**
+   * Total number of blocks to fetch. This can be smaller than the total number of blocks
+   * in [[blocksByAddress]] because we filter out zero-sized blocks in [[initialize]].
+   *
+   * This should equal localBlocks.size + remoteBlocks.size.
+   */
+  private[this] var numBlocksToFetch = 0
+
+  /**
+   * The number of blocks proccessed by the caller. The iterator is exhausted when
+   * [[numBlocksProcessed]] == [[numBlocksToFetch]].
+   */
+  private[this] var numBlocksProcessed = 0
+
+  private[this] val startTime = System.currentTimeMillis
+
+  /** Local blocks to fetch, excluding zero-sized blocks. */
+  private[this] val localBlocks = new ArrayBuffer[BlockId]()
+  private[this] val localFetchedBlocks = new HashSet[BlockId]()
+
+  /** Remote blocks to fetch, excluding zero-sized blocks. */
+  private[this] val remoteBlocks = new HashSet[BlockId]()
+
+  /**
+   * A queue to hold our results. This turns the asynchronous model provided by
+   * [[org.apache.spark.network.BlockTransferService]] into a synchronous model (iterator).
+   */
+  private[this] val results = new LinkedBlockingQueue[FetchResult]
+
+  /**
+   * Current [[FetchResult]] being processed. We track this so we can release the current buffer
+   * in case of a runtime exception when processing the current buffer.
+   */
+  @volatile private[this] var currentResult: FetchResult = null
+
+  /**
+   * Queue of fetch requests to issue; we'll pull requests off this gradually to make sure that
+   * the number of bytes in flight is limited to maxBytesInFlight.
+   */
+  private[this] val fetchRequests = new Queue[FetchRequest]
+
+  /** Current bytes in flight from our requests */
+  private[this] var bytesInFlight = 0L
+
+  private[this] val shuffleMetrics = context.taskMetrics().createShuffleReadMetricsForDependency()
+
+  /**
+   * Whether the iterator is still active. If isZombie is true, the callback interface will no
+   * longer place fetched blocks into [[results]].
+   */
+  @volatile private[this] var isZombie = false
+
+  initialize()
+
+  // Decrements the buffer reference count.
+  // The currentResult is set to null to prevent releasing the buffer again on cleanup()
+  private[storage] def releaseCurrentResultBuffer(): Unit = {
+    // Release the current buffer if necessary
+    currentResult match {
+      case SuccessFetchResult(_, _, _, buf) => buf.release()
+      case _ =>
+    }
+    currentResult = null
+  }
+
+  /**
+   * Mark the iterator as zombie, and release all buffers that haven't been deserialized yet.
+   */
+  private[this] def cleanup() {
+    isZombie = true
+    releaseCurrentResultBuffer()
+    // Release buffers in the results queue
+    val iter = results.iterator()
+    while (iter.hasNext) {
+      val result = iter.next()
+      result match {
+        case SuccessFetchResult(_, _, _, buf) => buf.release()
+        case _ =>
+      }
+    }
+  }
+
+  private[this] def sendRequest(req: FetchRequest) {
+    logDebug("Sending request for %d blocks (%s) from %s".format(
+      req.blocks.size, Utils.bytesToString(req.size), req.address.hostPort))
+    bytesInFlight += req.size
+
+    // so we can look up the size of each blockID
+    val sizeMap = req.blocks.map { case (blockId, size) => (blockId.toString, size) }.toMap
+    val blockIds = req.blocks.map(_._1.toString)
+
+    val address = req.address
+    shuffleClient.fetchBlocks(address.host, address.port, address.executorId, blockIds.toArray,
+      new BlockFetchingListener {
+        override def onBlockFetchSuccess(blockId: String, buf: ManagedBuffer): Unit = {
+          // Only add the buffer to results queue if the iterator is not zombie,
+          // i.e. cleanup() has not been called yet.
+          if (!isZombie) {
+            // Increment the ref count because we need to pass this to a different thread.
+            // This needs to be released after use.
+            buf.retain()
+            results.put(new SuccessFetchResult(BlockId(blockId), address, sizeMap(blockId), buf))
+            shuffleMetrics.incRemoteBytesRead(buf.size)
+            shuffleMetrics.incRemoteBlocksFetched(1)
+          }
+          logTrace("Got remote block " + blockId + " after " + Utils.getUsedTimeMs(startTime))
+        }
+
+        override def onBlockFetchFailure(blockId: String, e: Throwable): Unit = {
+          logError(s"Failed to get block(s) from ${req.address.host}:${req.address.port}", e)
+          results.put(new FailureFetchResult(BlockId(blockId), address, e))
+        }
+      }
+    )
+  }
+
+  private[this] def splitLocalRemoteBlocks(): (ArrayBuffer[FetchRequest], Boolean) = {
+    // Make remote requests at most maxBytesInFlight / 5 in length; the reason to keep them
+    // smaller than maxBytesInFlight is to allow multiple, parallel fetches from up to 5
+    // nodes, rather than blocking on reading output from one node.
+    val targetRequestSize = math.max(maxBytesInFlight / 5, 1L)
+    logDebug("maxBytesInFlight: " + maxBytesInFlight + ", targetRequestSize: " + targetRequestSize)
+
+    // Split local and remote blocks. Remote blocks are further split into FetchRequests of size
+    // at most maxBytesInFlight in order to limit the amount of data in flight.
+    val remoteRequests = new ArrayBuffer[FetchRequest]
+
+    val (outputMissing, status) = getBlocksHandler()
+    var needFetchedBlocks = false
+
+    // Tracks total number of blocks (including zero sized blocks)
+    var totalBlocks = 0
+    localBlocks.clear()
+    for ((address, blockInfos) <- status) {
+      totalBlocks += blockInfos.size
+      if (address.executorId == blockManager.blockManagerId.executorId) {
+        // Filter out zero-sized blocks
+        localBlocks ++= blockInfos.filter(bl => bl._2 != 0 &&
+          !localFetchedBlocks.contains(bl._1)).map(_._1)
+        if (localBlocks.nonEmpty) {
+          needFetchedBlocks = true
+        }
+        numBlocksToFetch += localBlocks.size
+        localFetchedBlocks ++= localBlocks
+      } else {
+        val iterator = blockInfos.iterator
+        var curRequestSize = 0L
+        var curBlocks = new ArrayBuffer[(BlockId, Long)]
+        while (iterator.hasNext) {
+          val (blockId, size) = iterator.next()
+          // Skip empty blocks
+          if (size > 0) {
+            if (!remoteBlocks.contains(blockId)) {
+              curBlocks += ((blockId, size))
+              remoteBlocks += blockId
+              numBlocksToFetch += 1
+              curRequestSize += size
+              needFetchedBlocks = true
+            }
+          } else if (size < 0) {
+            throw new BlockException(blockId, "Negative block size " + size)
+          }
+          if (curRequestSize >= targetRequestSize) {
+            // Add this FetchRequest
+            remoteRequests += new FetchRequest(address, curBlocks)
+            curBlocks = new ArrayBuffer[(BlockId, Long)]
+            logDebug(s"Creating fetch request of $curRequestSize at $address")
+            curRequestSize = 0
+          }
+        }
+        // Add in the final request
+        if (curBlocks.nonEmpty) {
+          remoteRequests += new FetchRequest(address, curBlocks)
+        }
+      }
+    }
+    fetchLocalBlocks()
+    logInfo(s"Getting $numBlocksToFetch non-empty blocks out of $totalBlocks blocks")
+    
+    val hasNext = (outputMissing, needFetchedBlocks) match {
+      case (_, true) => true
+      case (true, false) => true
+      case (false, false) => false
+    }
+
+    (remoteRequests, hasNext)
+  }
+
+  /**
+   * Fetch the local blocks while we are fetching remote blocks. This is ok because
+   * [[ManagedBuffer]]'s memory is allocated lazily when we create the input stream, so all we
+   * track in-memory are the ManagedBuffer references themselves.
+   */
+  private[this] def fetchLocalBlocks() {
+    val iter = localBlocks.iterator
+    while (iter.hasNext) {
+      val blockId = iter.next()
+      try {
+        val buf = blockManager.getBlockData(blockId)
+        shuffleMetrics.incLocalBlocksFetched(1)
+        shuffleMetrics.incLocalBytesRead(buf.size)
+        buf.retain()
+        results.put(new SuccessFetchResult(blockId, blockManager.blockManagerId, 0, buf))
+      } catch {
+        case e: Exception =>
+          // If we see an exception, stop immediately.
+          logError(s"Error occurred while fetching local blocks", e)
+          results.put(new FailureFetchResult(blockId, blockManager.blockManagerId, e))
+          return
+      }
+    }
+  }
+
+  private[this] def initialize(): Unit = {
+    // Add a task completion callback (called in both success case and failure case) to cleanup.
+    context.addTaskCompletionListener(_ => cleanup())
+
+    // Split local and remote blocks.
+    val remoteRequests = splitLocalRemoteBlocks()._1
+    // Add the remote requests into our queue in a random order
+    fetchRequests ++= Utils.randomize(remoteRequests)
+
+    // Send out initial requests for blocks, up to our maxBytesInFlight
+    fetchUpToMaxBytes()
+
+    val numFetches = remoteRequests.size - fetchRequests.size
+    logInfo("Started " + numFetches + " remote fetches in" + Utils.getUsedTimeMs(startTime))
+
+    // Get Local Blocks
+    // fetchLocalBlocks()
+    // logDebug("Got local blocks in " + Utils.getUsedTimeMs(startTime))
+  }
+
+  override def hasNext: Boolean = {
+    if (numBlocksProcessed < numBlocksToFetch) {
+      return true
+    }
+
+    val (remoteRequests, hasNext) = splitLocalRemoteBlocks()
+    fetchRequests ++= Utils.randomize(remoteRequests)
+    fetchUpToMaxBytes()
+
+    hasNext
+  }
+
+  /**
+   * Fetches the next (BlockId, InputStream). If a task fails, the ManagedBuffers
+   * underlying each InputStream will be freed by the cleanup() method registered with the
+   * TaskCompletionListener. However, callers should close() these InputStreams
+   * as soon as they are no longer needed, in order to release memory as early as possible.
+   *
+   * Throws a FetchFailedException if the next block could not be fetched.
+   */
+  override def next(): (BlockId, InputStream) = {
+    numBlocksProcessed += 1
+    val startFetchWait = System.currentTimeMillis()
+    currentResult = results.take()
+    val result = currentResult
+    val stopFetchWait = System.currentTimeMillis()
+    shuffleMetrics.incFetchWaitTime(stopFetchWait - startFetchWait)
+
+    result match {
+      case SuccessFetchResult(_, _, size, _) => bytesInFlight -= size
+      case _ =>
+    }
+    // Send fetch requests up to maxBytesInFlight
+    fetchUpToMaxBytes()
+
+    result match {
+      case FailureFetchResult(blockId, address, e) =>
+        throwFetchFailedException(blockId, address, e)
+
+      case SuccessFetchResult(blockId, address, _, buf) =>
+        try {
+          (result.blockId, new BufferReleasingInputStream(buf.createInputStream(), this))
+        } catch {
+          case NonFatal(t) =>
+            throwFetchFailedException(blockId, address, t)
+        }
+    }
+  }
+
+  private def fetchUpToMaxBytes(): Unit = {
+    // Send fetch requests up to maxBytesInFlight
+    while (fetchRequests.nonEmpty &&
+      (bytesInFlight == 0 || bytesInFlight + fetchRequests.front.size <= maxBytesInFlight)) {
+      sendRequest(fetchRequests.dequeue())
+    }
+  }
+
+  private def throwFetchFailedException(blockId: BlockId, address: BlockManagerId, e: Throwable) = {
+    blockId match {
+      case ShuffleBlockId(shufId, mapId, reduceId) =>
+        throw new FetchFailedException(address, shufId.toInt, mapId.toInt, reduceId, e)
+      case _ =>
+        throw new SparkException(
+          "Failed to get block " + blockId + ", which is not a shuffle block", e)
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hi chenghao & daoyuan, as today I mentioned, there's a simple realization in Baidu of limit optimization by preRun the limit stage. Also some refetching logic, please have a look when you have time. Thanks :)
We mainly do these things below:
    1. Add new func `preRunGetMapSizesByExecutorId` in `MapOutputTracker` for the scenario of preRun=open, atomize `getStatus` and `outputMissing` operations
    2. Set `isOutputMissing` private
    3. Add new Class PreRunShuffleBlockFetcherIterator
    4. Add config `spark.sql.baidu.stagePreRun`
          1) reader check the stagePreRun config to make a decision of using which shuffleBlockIterator
          2) mapOutputTracker support the preRun config and default value
    5. Add the comments of new added config

## How was this patch tested?

It currently running in baidu internal and it can accelerate some limit scenario.
And this patch has a bug here when the upstream is down, it will still refetch, I will fix it by adding a max retry time.

