### PR TITLE
bugFix for fiber info status()

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
@@ -107,7 +107,7 @@ object FiberCacheManager extends AbstractFiberCacheManger {
 
 
     val filePathSet = new mutable.HashSet[String]()
-    val statusRawData = dataFiberConfPairs.map {
+    val statusRawData = dataFiberConfPairs.collect {
       case (dataFiber @ DataFiber(dataFile : SpinachDataFile, _, _), conf)
         if !filePathSet.contains(dataFile.path) =>
         val fileMeta =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use "collect" instead of "map" to accept PartialFunction in status() method in order to get data fiber cached info in Executor.

## How was this patch tested?
Existed unit tests.