### PR TITLE
register FiberInfoListener in SpinachEnv

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/thriftserver/SpinachEnv.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/thriftserver/SpinachEnv.scala
@@ -22,6 +22,7 @@ import java.io.PrintStream
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SpinachSession, SQLContext}
+import org.apache.spark.sql.execution.datasources.spinach.listener.FiberInfoListener
 import org.apache.spark.sql.hive.{HiveUtils, SpinachSessionState}
 import org.apache.spark.util.Utils
 
@@ -61,6 +62,10 @@ private[hive] object SpinachEnv extends Logging {
       sessionState.metadataHive.setError(new PrintStream(System.err, true, "UTF-8"))
       sparkSession.conf.set("spark.sql.hive.version", HiveUtils.hiveExecutionVersion)
     }
+
+    logDebug("register FiberInfoListener")
+    sparkContext.addSparkListener(new FiberInfoListener)
+
     SparkSQLEnv.sparkContext = sparkContext
     SparkSQLEnv.sqlContext = sqlContext
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Register customized listener, FiberInfoListener, in SpinachEnv for spark sql shell.
Alternatively, FiberInfoListener could also be set in spark-defaults.conf/spark.extraListeners by users.

## How was this patch tested?
Existed unit tests.