### PR TITLE
Revert "Modify Index To Use Dictionary Encoding (#209)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ spinach.rowgroup.szie
 * Default: 1024
 * Usage: `System.setProperty("spinach.rowgroup.size", "1024")`
 
-spinach.encoding.dictionaryEnabled
-* To enable/disable dictionary encoding
-* Default: False
-* Usage: `System.setProperty("spinach.encoding.dictionaryEnabled", "true")`
-
 spinach.compression.codec
 * Choose compression type
 * Default: GZIP

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BPlusTreeScanner.scala
@@ -38,24 +38,23 @@ private[spinach] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner
 
   def initialize(dataPath: Path, conf: Configuration): IndexScanner = {
     assert(keySchema ne null)
-    encodeIntervalAndSchema(dataPath, conf)
     // val root = BTreeIndexCacheManager(dataPath, context, keySchema, meta)
     val path = IndexUtils.indexFileFromDataFile(dataPath, meta.name)
     logDebug("Loading Index File: " + path)
     logDebug("\tFile Szie: " + path.getFileSystem(conf).getFileStatus(path).getLen)
     val indexScanner = IndexFiber(IndexFile(path))
     val indexData: IndexFiberCacheData = FiberCacheManager(indexScanner, conf)
-    val root = meta.open(indexData, encodedKeySchema)
+    val root = meta.open(indexData, keySchema)
 
     _init(root)
   }
 
   def _init(root : IndexNode): IndexScanner = {
     assert(intervalArray ne null, "intervalArray is null!")
-    this.ordering = GenerateOrdering.create(encodedKeySchema)
-    currentKeyArray = new Array[CurrentKey](encodedIntervalArray.length)
+    this.ordering = GenerateOrdering.create(keySchema)
+    currentKeyArray = new Array[CurrentKey](intervalArray.length)
     currentKeyIdx = 0 // reset to initialized value for this thread
-    encodedIntervalArray.zipWithIndex.foreach {
+    intervalArray.zipWithIndex.foreach {
       case(interval: RangeInterval, i: Int) =>
         var order: Ordering[Key] = null
         if (interval.start == IndexScanner.DUMMY_KEY_START) {
@@ -65,14 +64,14 @@ private[spinach] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner
           currentKeyArray(i) = new CurrentKey(tmpNode, 0, 0)
         } else {
           // find the first identical key or the first key right greater than the specified one
-          if (encodedKeySchema.size > interval.start.numFields) { // exists Dummy_Key
-            order = GenerateOrdering.create(StructType(encodedKeySchema.dropRight(1)))
+          if (keySchema.size > interval.start.numFields) { // exists Dummy_Key
+            order = GenerateOrdering.create(StructType(keySchema.dropRight(1)))
           } else order = this.ordering
           currentKeyArray(i) = moveTo(root, interval.start, true, order)
-          if (encodedKeySchema.size > interval.end.numFields) { // exists Dummy_Key
-            order = GenerateOrdering.create(StructType(encodedKeySchema.dropRight(1)))
+          if (keySchema.size > interval.end.numFields) { // exists Dummy_Key
+            order = GenerateOrdering.create(StructType(keySchema.dropRight(1)))
             // find the last identical key or the last key less than the specified one on the left
-            this.encodedIntervalArray(i).end = moveTo(root, interval.end, false, order).currentKey
+            this.intervalArray(i).end = moveTo(root, interval.end, false, order).currentKey
           }
 
         }
@@ -89,16 +88,16 @@ private[spinach] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner
 
   // i: the interval index
   def intervalShouldStop(i: Int): Boolean = { // detect if we need to stop scanning
-    if (encodedIntervalArray(i).end == IndexScanner.DUMMY_KEY_END) { // Left-Only search
+    if (intervalArray(i).end == IndexScanner.DUMMY_KEY_END) { // Left-Only search
       return false
     }
-    if (encodedIntervalArray(i).endInclude) { // RightClose
+    if (intervalArray(i).endInclude) { // RightClose
       ordering.compare(
-        currentKeyArray(i).currentKey, encodedIntervalArray(i).end) > 0
+        currentKeyArray(i).currentKey, intervalArray(i).end) > 0
     }
     else { // RightOpen
       ordering.compare(
-        currentKeyArray(i).currentKey, encodedIntervalArray(i).end) >= 0
+        currentKeyArray(i).currentKey, intervalArray(i).end) >= 0
     }
 
   }
@@ -175,7 +174,7 @@ private[spinach] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner
 
 
   override def hasNext: Boolean = {
-    if (encodedIntervalArray.isEmpty) return false
+    if (intervalArray.isEmpty) return false
     for(i <- currentKeyIdx until currentKeyArray.length) {
       if (!currentKeyArray(i).isEnd && !intervalShouldStop(i)) {
         return true

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BitMapScanner.scala
@@ -45,7 +45,6 @@ private[spinach] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScann
 
   override def initialize(dataPath: Path, conf: Configuration): IndexScanner = {
     assert(keySchema ne null)
-    encodeIntervalAndSchema(dataPath, conf)
     val path = IndexUtils.indexFileFromDataFile(dataPath, meta.name)
     val indexScanner = IndexFiber(IndexFile(path))
     val indexData: IndexFiberCacheData = FiberCacheManager(indexScanner, conf)
@@ -65,11 +64,11 @@ private[spinach] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScann
     val inputStream = new ByteArrayInputStream(byteArray)
     val in = new ObjectInputStream(inputStream)
     val hashMap = in.readObject().asInstanceOf[mutable.HashMap[InternalRow, BitSet]]
-    this.ordering = GenerateOrdering.create(encodedKeySchema)
+    this.ordering = GenerateOrdering.create(keySchema)
 
     // get sorted key list and generate final bitset
     val sortedKeyList = hashMap.keySet.toList.sorted(this.ordering)
-    val bitMapArray = encodedIntervalArray.flatMap(range => {
+    val bitMapArray = intervalArray.flatMap(range => {
       val startIdx = if (range.start == IndexScanner.DUMMY_KEY_START) {
         // diff from which startIdx not found, so here startIdx = -2
         -2

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/IndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/IndexWriter.scala
@@ -27,8 +27,6 @@ private[index] abstract class IndexWriter (
     relation: WriteIndexRelation,
     job: Job,
     isAppend: Boolean) extends BaseWriterContainer(relation.toWriteRelation, job, isAppend) {
-  protected val dataFileSchema = relation.dataSchema
-  protected val readerClassName = relation.readerClassName
   // TODO figure out right way to deal with bucket
   protected def newIndexOutputWriter(bucketId: Option[Int] = None): IndexOutputWriter = {
     try {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/WriteIndexRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/WriteIndexRelation.scala
@@ -27,8 +27,6 @@ import org.apache.spark.sql.types.StructType
 case class WriteIndexRelation(
     sparkSession: SparkSession,
     keySchema: StructType,
-    dataSchema: StructType,
-    readerClassName: String,
     prepareJobForWrite: Job => IndexOutputWriterFactory) {
   def toWriteRelation: WriteRelation = WriteRelation(
     sparkSession, keySchema, null, prepareJobForWrite, None)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/indexPlans.scala
@@ -128,8 +128,6 @@ case class CreateIndex(
         WriteIndexRelation(
           sparkSession,
           keySchema,
-          s,
-          readerClassName,
           indexFileFormat.prepareWrite(sparkSession, _, null, keySchema))
 
       val writerContainer = {
@@ -330,8 +328,6 @@ case class RefreshIndex(
           WriteIndexRelation(
             sparkSession,
             keySchema,
-            s,
-            readerClassName,
             indexFileFormat.prepareWrite(sparkSession, _, null, keySchema))
 
         val writerContainer = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/io/DataFile.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.spinach.io
 
-import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Success, Try}
 
 import org.apache.hadoop.conf.Configuration
@@ -25,14 +24,11 @@ import org.apache.hadoop.fs.FSDataInputStream
 import org.apache.parquet.column.Dictionary
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.SpinachException
-import org.apache.spark.sql.execution.datasources.spinach.Key
 import org.apache.spark.sql.execution.datasources.spinach.filecache.DataFiberCache
-import org.apache.spark.sql.execution.datasources.spinach.index.RangeInterval
-import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
+
 
 abstract class DataFile {
   def path: String
@@ -59,104 +55,6 @@ private[spinach] object DataFile {
       case None => throw new SpinachException(
         s"Cannot find constructor of signature like:" +
           s" (String, StructType) for class $dataFileClassName")
-    }
-  }
-
-  def encodeKey(dictionaries: Array[Dictionary], schema: StructType, key: Key): Key = {
-    val values = schema.zipWithIndex.map {
-      case (field, ordinal) =>
-        val dict = dictionaries(ordinal)
-        if (dict != null) {
-          (0 until dictionaries(ordinal).getMaxId).find { i =>
-            field.dataType match {
-              case StringType =>
-                UTF8String.fromBytes(dict.decodeToBinary(i).getBytes)
-                  .equals(key.getUTF8String(ordinal))
-              case IntegerType =>
-                dict.decodeToInt(i) == key.getInt(ordinal)
-              case dataType => sys.error(s"not support data type: $dataType")
-            }
-          } match {
-            case Some(value) => value
-            case None => -1
-          }
-        } else {
-          key.get(ordinal, field.dataType)
-        }
-    }
-    InternalRow.fromSeq(values)
-  }
-
-  def encodeSchema(dictionaries: Array[Dictionary], schema: StructType): StructType = {
-    val fields = schema.zipWithIndex.map{
-      case (field, ordinal) =>
-        if (dictionaries(ordinal) == null) field
-        else StructField(field.name, IntegerType, field.nullable)
-    }
-    StructType(fields)
-  }
-
-  def rangeToEncodedValues(dictionary: Dictionary, field: StructField, start: Key, end: Key,
-                           startInclude: Boolean, endInclude: Boolean): Seq[Int] = {
-
-    val ordering = GenerateOrdering.create(StructType(field :: Nil))
-
-    (0 until dictionary.getMaxId).filter{ id =>
-      val value = InternalRow(
-        field.dataType match {
-          case StringType => UTF8String.fromBytes(dictionary.decodeToBinary(id).getBytes)
-          case IntegerType => dictionary.decodeToInt(id)
-          case other => sys.error(s"not support data type: $other")
-        })
-
-      (ordering.compare(value, start) > 0 && ordering.compare(value, end) < 0) ||
-        (startInclude && ordering.compare(value, start) == 0) ||
-        (endInclude && ordering.compare(value, end) == 0)
-    }
-  }
-
-  def encodeInterval(dictionaries: Array[Dictionary],
-                     schema: StructType,
-                     intervalArray: ArrayBuffer[RangeInterval]): ArrayBuffer[RangeInterval] = {
-
-    if (intervalArray.isEmpty) return intervalArray
-
-    val prefixValues = schema.dropRight(1).zipWithIndex.map {
-      case (field, ordinal) =>
-        if (dictionaries(ordinal) != null) {
-          rangeToEncodedValues(
-            dictionaries(ordinal), field,
-            InternalRow(intervalArray.head.start.get(ordinal, field.dataType)),
-            InternalRow(intervalArray.head.end.get(ordinal, field.dataType)),
-            intervalArray.head.startInclude, intervalArray.head.endInclude)
-            .headOption match {
-            case Some(value) => value
-            case None => -1
-          }
-        } else {
-          intervalArray.head.start.get(ordinal, field.dataType)
-        }
-    }
-
-    val index = schema.length - 1
-    val dataType = schema.last.dataType
-    if (dictionaries.last != null) {
-      intervalArray.flatMap { interval =>
-        rangeToEncodedValues(
-          dictionaries.last, schema.last,
-          InternalRow(interval.start.get(index, dataType)),
-          InternalRow(interval.end.get(index, dataType)),
-          interval.startInclude, interval.endInclude).map { r =>
-          val key = InternalRow.fromSeq(prefixValues :+ r)
-          RangeInterval(key, key, includeStart = true, includeEnd = true)
-        }
-      }
-    } else {
-      intervalArray.map { interval =>
-        val start = InternalRow.fromSeq(prefixValues :+ interval.start.get(index, dataType))
-        val end = InternalRow.fromSeq(prefixValues :+ interval.end.get(index, dataType))
-        RangeInterval(start, end, interval.startInclude, interval.endInclude)
-      }
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/io/ParquetDataFile.scala
@@ -107,9 +107,7 @@ private[spinach] case class ParquetDataFile(path: String, schema: StructType) ex
     new ParquetDataFileHandle().read(conf, new Path(StringUtils.unEscapeString(path)))
   }
 
-  override def getDictionary(fiberId: Int, conf: Configuration): Dictionary = {
-    null
-  }
+  override def getDictionary(fiberId: Int, conf: Configuration): Dictionary = null
 }
 
 private[spinach] object  ParquetDataFile {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/io/SpinachDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/io/SpinachDataReaderWriter.scala
@@ -186,7 +186,7 @@ private[spinach] class SpinachDataReader(
   private def tryToReadStatistics(indexPath: Path, conf: Configuration): Double = {
     if (!filterScanner.get.canBeOptimizedByStatistics) {
       StaticsAnalysisResult.USE_INDEX
-    } else if (filterScanner.get.encodedIntervalArray.isEmpty) {
+    } else if (filterScanner.get.intervalArray.length == 0) {
       StaticsAnalysisResult.SKIP_INDEX
     } else {
       val fs = indexPath.getFileSystem(conf)
@@ -205,8 +205,8 @@ private[spinach] class SpinachDataReader(
       fin.close()
 
       val statisticsManager = new StatisticsManager
-      statisticsManager.read(stsArray, filterScanner.get.getEncodedSchema)
-      statisticsManager.analyse(filterScanner.get.encodedIntervalArray)
+      statisticsManager.read(stsArray, filterScanner.get.getSchema)
+      statisticsManager.analyse(filterScanner.get.intervalArray)
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/FilterSuite.scala
@@ -20,13 +20,11 @@ package org.apache.spark.sql.execution.datasources.spinach
 import java.sql.Date
 
 import org.scalatest.BeforeAndAfterEach
-import scala.util.Random
 
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
-
 
 
 class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
@@ -110,39 +108,6 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
     checkAnswer(sql("SELECT * FROM spinach_test WHERE a > 1 AND a <= 3"),
       Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
     sql("drop sindex index1 on spinach_test")
-  }
-
-  test("filtering with dictionary encoding enabled") {
-    System.setProperty("spinach.encoding.dictionaryEnabled", "true")
-    val data = (1 to 300).map { i => (i, s"this is test $i") }.toArray
-    // Shuffle this array
-    val rnd = new Random(0)
-    data.indices.reverse.foreach{i =>
-      val index = rnd.nextInt(i + 1)
-      val temp = data(i)
-      data(i) = data(index)
-      data(index) = temp
-    }
-
-    val df = data.toSeq.toDF("a", "b")
-    df.createOrReplaceTempView("t")
-    sql("insert overwrite table spinach_test select * from t")
-
-    sql("create sindex index1 on spinach_test (a, b) using btree")
-    checkAnswer(
-      sql("SELECT * FROM spinach_test" +
-        " WHERE a = 293 AND b >= 'this is test 291' AND b < 'this is test 299'"),
-      df.filter("a = 293 AND b >= 'this is test 291' AND b < 'this is test 299'"))
-    sql("drop sindex index1 on spinach_test")
-
-    sql("create sindex index3 on spinach_test (a, b) using bitmap")
-    checkAnswer(
-      sql("SELECT * FROM spinach_test" +
-        " WHERE a = 293 AND b >= 'this is test 291' AND b < 'this is test 299'"),
-      df.filter("a = 293 AND b >= 'this is test 291' AND b < 'this is test 299'"))
-    sql("drop sindex index3 on spinach_test")
-
-    System.clearProperty("spinach.encoding.dictionaryEnabled")
   }
 
   test("filtering parquet") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/index/BPlusTreeMultiColumnSearchSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/index/BPlusTreeMultiColumnSearchSuite.scala
@@ -101,9 +101,6 @@ class BPlusTreeMultiColumnSearchSuite extends SparkFunSuite
     assert(unHandledFilters.sameElements(expectedUnHandleredFilter))
     ic.getScanner match {
       case Some(scanner: BPlusTreeScanner) =>
-        // this is only for test
-        scanner.encodedIntervalArray = scanner.intervalArray
-        scanner.setEncodedSchema(scanner.getSchema)
         assert(scanner._init(
           BPlusTreeMultiColumnSearchSuite.indexMeta.open(null, null)).toSet === expectedIds, "")
       case None => throw new Exception(s"expect scanner, but got None")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/index/BPlusTreeSingleColumnSearchSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/index/BPlusTreeSingleColumnSearchSuite.scala
@@ -286,9 +286,6 @@ class BPlusTreeSingleColumnSearchSuite extends SparkFunSuite
     assert(unHandledFilters.sameElements(expectedUnHandleredFilter))
     ic.getScanner match {
       case Some(scanner: BPlusTreeScanner) =>
-        // this is only for test
-        scanner.encodedIntervalArray = scanner.intervalArray
-        scanner.setEncodedSchema(scanner.getSchema)
         assert(scanner._init(
           BPlusTreeSingleColumnSearchSuite.indexMeta.open(null, null)).toSet === expectedIds, "")
       case None => throw new Exception(s"expect scanner, but got None")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This reverts commit a141d3a3c8363fcca1d929b50556e1004d6bd577.

Why I revert this commit:
1. To utilize dictionary encoding in Index, current Index implementation need
   to be modified in both writer and scanner. But there is no plan yet. So, this
   commit can't bring any benefit while adding some extra latency.

2. In current code structure, IndexScanner has to read Data File first to decide
   if dictionary encoding is needed. This act against the purpose of index.

3. Data Writer used a 'fallback' strategy to decide if a column can use dictionary
   encoding. This will cause one column has two or more encoding types. It's hard
   for Index to handle this senario.

So,  revert this commit until it can bring some benefit.

## How was this patch tested?

Unit test
