### PR TITLE
Evict indexFiberCacheData out of cache when dropping index

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable
 import collection.JavaConverters._
 import com.google.common.cache._
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
 import org.apache.spark.executor.custom.CustomManager
@@ -87,6 +88,15 @@ private[spinach] sealed trait AbstractFiberCacheManger extends Logging {
  * Fiber Cache Manager
  */
 object FiberCacheManager extends AbstractFiberCacheManger {
+  def removeIndexFiberCacheData(idxPath: Path): Unit =
+    cache.asMap().keySet().asScala.foreach{
+      case entry @ ConfigurationCache(key: IndexFiber, _)
+        if key.file.file.toUri.compareTo(idxPath.toUri) == 0 =>
+        cache.invalidate(entry)
+      case _ =>
+    }
+
+
   override def fiber2Data(fiber: Fiber, conf: Configuration): FiberCache = fiber match {
     case DataFiber(file, columnIndex, rowGroupId) =>
       file.getFiberData(rowGroupId, columnIndex, conf)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
@@ -92,13 +92,9 @@ object FiberCacheManager extends AbstractFiberCacheManger {
    * @param fiber:the fiber whose corresponding memory block(off -heap) that needs to be evicted
    */
   def evictFiberCacheData(fiber: Fiber): Unit = fiber match {
-    case IndexFiber(IndexFile(idxPath)) =>
-      cache.asMap().keySet().asScala.foreach{
-        case entry @ ConfigurationCache(key: IndexFiber, _)
-          if key.file.file.toUri.compareTo(idxPath.toUri) == 0 =>
-          cache.invalidate(entry)
-        case _ =>
-      }
+    case idxFiber: IndexFiber =>
+      val entry = ConfigurationCache[Fiber](idxFiber, new Configuration())
+      if(cache.asMap().asScala.contains(entry)) cache.invalidate(entry)
     case _ => // todo: consider whether we indeed need to evict DataFiberCachedData manually
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/indexPlans.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.spinach._
-import org.apache.spark.sql.execution.datasources.spinach.filecache.FiberCacheManager
+import org.apache.spark.sql.execution.datasources.spinach.filecache.{FiberCacheManager, IndexFiber}
+import org.apache.spark.sql.execution.datasources.spinach.io.IndexFile
 import org.apache.spark.sql.execution.datasources.spinach.utils.SpinachUtils
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
@@ -231,7 +232,7 @@ case class DropIndex(
             }.toSeq
             filePaths.filter(_.toString.endsWith(
               "." + indexName + SpinachFileFormat.SPINACH_INDEX_EXTENSION)).foreach{idxPath =>
-              FiberCacheManager.removeIndexFiberCacheData(idxPath)
+              FiberCacheManager.evictFiberCacheData(IndexFiber(IndexFile(idxPath)))
               fs.delete(idxPath, true)}
           }
         })

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/FilterSuite.scala
@@ -112,6 +112,30 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
     sql("drop sindex index1 on spinach_test")
   }
 
+  test("test Index CachedData eviction") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").registerTempTable("t")
+    sql("insert overwrite table spinach_test select * from t")
+    sql("create sindex index1 on spinach_test (a)")
+
+    checkAnswer(sql("SELECT * FROM spinach_test WHERE a = 1"),
+      Row(1, "this is test 1") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM spinach_test WHERE a > 1 AND a <= 3"),
+      Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+    sql("drop sindex index1 on spinach_test")
+
+    sql("create sindex index1 on spinach_test (b)")
+
+    checkAnswer(sql("SELECT * FROM spinach_test WHERE b = 'this is test 1'"),
+      Row(1, "this is test 1") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM spinach_test WHERE b = 'this is test 34'"),
+      Row(34, "this is test 34") :: Nil)
+
+    sql("drop sindex index1 on spinach_test")
+  }
+
   test("filtering with dictionary encoding enabled") {
     System.setProperty("spinach.encoding.dictionaryEnabled", "true")
     val data = (1 to 300).map { i => (i, s"this is test $i") }.toArray


### PR DESCRIPTION
## What changes were proposed in this pull request?
Resolved issue #198  :
Add removeIndexFiberCacheData method in FiberCacheManager, evict the corresponding indexCacheData(Memory block) during dropping index.

## How was this patch tested?
Existed unit tests.