### PR TITLE
fix parquet index building

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -260,7 +260,7 @@ private[sql] class ParquetFileFormat
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {
-    true
+    !sparkSession.conf.get(SQLConf.SPINACH_PARQUET_ENABLED)
   }
 
   override private[sql] def buildReaderWithPartitionValues(

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/indexPlans.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.spinach._
 import org.apache.spark.sql.execution.datasources.spinach.utils.SpinachUtils
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 
@@ -54,6 +55,10 @@ case class CreateIndex(
         (fileCatalog, s, SpinachFileFormat.SPINACH_DATA_FILE_CLASSNAME, id)
       case LogicalRelation(
       HadoopFsRelation(_, fileCatalog, _, s, _, _: ParquetFileFormat, _), _, id) =>
+        if (!sparkSession.conf.get(SQLConf.SPINACH_PARQUET_ENABLED)) {
+          throw new SpinachException(s"turn on ${
+            SQLConf.SPINACH_PARQUET_ENABLED.key} to allow index building on parquet files")
+        }
         (fileCatalog, s, SpinachFileFormat.PARQUET_DATA_FILE_CLASSNAME, id)
       case other =>
         throw new SpinachException(s"We don't support index building for ${other.simpleString}")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Not allow parquet to split one file into multiple tasks to eliminate no lease error when building index, if we are using OAP for parquet data.


## How was this patch tested?

add a test case.
Fixes #243 
