### PR TITLE
Fix SampleBasedStatistics bug.

### DIFF
--- a/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/statistics/SampleBasedStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/statistics/SampleBasedStatisticsSuite.scala
@@ -124,7 +124,7 @@ class SampleBasedStatisticsSuite extends StatisticsTest{
     assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
 
     generateInterval(IndexScanner.DUMMY_KEY_START, rowGen(0),
-      startInclude = true, endInclude = true)
+      startInclude = true, endInclude = false)
     assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
 
     generateInterval(IndexScanner.DUMMY_KEY_START, rowGen(300),
@@ -140,7 +140,7 @@ class SampleBasedStatisticsSuite extends StatisticsTest{
     assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
 
     generateInterval(rowGen(300), IndexScanner.DUMMY_KEY_END,
-      startInclude = true, endInclude = true)
+      startInclude = false, endInclude = true)
     assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(301), IndexScanner.DUMMY_KEY_END,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `SampleBaseStatisticsSuite` bug #249 .

This happens with low possibility, for the sample based property.

`StatisticsManager` does not has this problem for its `analyze` function.

## How was this patch tested?

unit test.

