### PR TITLE
Minor refactor in FiberCacheManger to support cache eviction

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
@@ -88,9 +88,9 @@ private[spinach] trait AbstractFiberCacheManger extends Logging {
           // Use KB as Unit due to large weight will cause Guava overflow
           val weight = math.ceil(value.fiberData.size() / 1024.0)
           if (weight > Int.MaxValue / 2) { // make sure totalWeight + fiberSize less than Int.Max
-            logWarning(s"Caching a fiber with 1TB size! Please make sure your memory is enough.")
+            throw new SpinachException(s"Fiber with more than 1TB size is not allowed.")
           }
-          math.min(weight, Int.MaxValue).toInt
+          weight.toInt
         }
       })
       .maximumWeight(weight)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
@@ -86,7 +86,7 @@ private[spinach] trait AbstractFiberCacheManger extends Logging {
       .weigher(new Weigher[ENTRY, FiberCache] {
         override def weigh(key: ENTRY, value: FiberCache): Int = {
           // Use KB as Unit due to large weight will cause Guava overflow
-          val weight = value.fiberData.size() / 1024
+          val weight = math.ceil(value.fiberData.size() / 1024.0)
           if (weight > Int.MaxValue / 2) { // make sure totalWeight + fiberSize less than Int.Max
             logWarning(s"Caching a fiber with 1TB size! Please make sure your memory is enough.")
           }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
@@ -19,10 +19,11 @@ package org.apache.spark.sql.execution.datasources.spinach.filecache
 
 import java.util.concurrent.TimeUnit
 
-import com.google.common.cache._
-import org.apache.hadoop.conf.Configuration
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
+import com.google.common.cache._
+import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.SparkConf
 import org.apache.spark.executor.custom.CustomManager
@@ -84,7 +85,7 @@ private[spinach] trait AbstractFiberCacheManger extends Logging {
       .maximumWeight(weight)
       .removalListener(new RemovalListener[ENTRY, FiberCache] {
         override def onRemoval(n: RemovalNotification[ENTRY, FiberCache]): Unit = {
-          logDebug("Loading Fiber Cache" + (n.getKey.key match {
+          logDebug("Removing Fiber Cache" + (n.getKey.key match {
             case DataFiber(file, group, fiber) => s"(Data: ${file.path}, $group, $fiber)"
             case IndexFiber(file) => s"(Index: ${file.file.toString})"
           }))

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -604,6 +604,20 @@ object SQLConf {
       .intConf
       .createWithDefault(3)
 
+  val SPINACH_FIBERCACHE_SIZE =
+    SQLConfigBuilder("spark.sql.spinach.fiberCache.size")
+      .internal()
+      .doc("Define the size of fiber cache in KB, default 300 * 1024 KB")
+      .longConf
+      .createWithDefault(307200)
+
+  val SPINACH_FIBERCACHE_STATS =
+    SQLConfigBuilder("spark.sql.spinach.fiberCache.stats")
+      .internal()
+      .doc("Whether enable cach stats record, default false")
+      .booleanConf
+      .createWithDefault(false)
+
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManagerSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.spinach.filecache
+
+import com.google.common.cache.CacheStats
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.SparkFunSuite
+
+class FiberCacheManagerSuite extends SparkFunSuite {
+
+  test("Default Size") {
+    // Default cache memory is set to 300MB
+    val configuration = new Configuration()
+    configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
+
+    TestFiberCacheManger.reset(configuration)
+    (0 until 150).foreach { i =>
+      TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
+    }
+    assert(TestFiberCacheManger.getStat.evictionCount() > 0)
+    assert(TestFiberCacheManger.getStat.evictionCount() < 20)
+  }
+
+  test("1GB Size") {
+    val configuration = new Configuration()
+    configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
+    configuration.setLong(SQLConf.SPINACH_FIBERCACHE_SIZE.key, 1024 * 1024)
+
+    TestFiberCacheManger.reset(configuration)
+    (0 until 512).foreach{ i =>
+      TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
+    }
+    assert(TestFiberCacheManger.getStat.evictionCount() > 0)
+    assert(TestFiberCacheManger.getStat.evictionCount() < 40)
+  }
+
+  test("8GB Size, Guava overflow issue if weigher use Byte as Unit (#239)") {
+    val configuration = new Configuration()
+    configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
+    configuration.setLong(SQLConf.SPINACH_FIBERCACHE_SIZE.key, 8 * 1024 * 1024)
+
+    TestFiberCacheManger.reset(configuration)
+    (0 until 4 * 1024).foreach{ i =>
+      TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
+    }
+    assert(TestFiberCacheManger.getStat.evictionCount() > 0)
+    assert(TestFiberCacheManger.getStat.evictionCount() < 100)
+  }
+
+  test("1TB Size, Enough size for most scenario") {
+    val configuration = new Configuration()
+    configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
+    configuration.setLong(SQLConf.SPINACH_FIBERCACHE_SIZE.key, 1024 * 1024 * 1024)
+
+    TestFiberCacheManger.reset(configuration)
+    (0 until 512 * 1024).foreach{ i =>
+      TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
+    }
+    assert(TestFiberCacheManger.getStat.evictionCount() > 0)
+    assert(TestFiberCacheManger.getStat.evictionCount() < 1000)
+  }
+}
+
+case class TestFiber(id: Int) extends Fiber
+
+object TestFiberCacheManger extends AbstractFiberCacheManger {
+
+  // 2 MB test fiber data
+  private val testFiberData = MemoryManager.allocate(2 * 1024 * 1024)
+
+  override def fiber2Data(fiber: Fiber, conf: Configuration): FiberCache = {
+    fiber match {
+      case TestFiber(_) => testFiberData
+    }
+  }
+
+  override def freeFiberData(fiberCache: FiberCache): Unit = {}
+
+  def getStat: CacheStats = cache.stats()
+
+  def reset(configuration: Configuration): Unit = cache = null
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManagerSuite.scala
@@ -30,7 +30,7 @@ class FiberCacheManagerSuite extends SparkFunSuite {
     val configuration = new Configuration()
     configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
 
-    TestFiberCacheManger.reset(configuration)
+    TestFiberCacheManger.reset()
     (0 until 150).foreach { i =>
       TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
     }
@@ -43,7 +43,7 @@ class FiberCacheManagerSuite extends SparkFunSuite {
     configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
     configuration.setLong(SQLConf.SPINACH_FIBERCACHE_SIZE.key, 1024 * 1024)
 
-    TestFiberCacheManger.reset(configuration)
+    TestFiberCacheManger.reset()
     (0 until 512).foreach{ i =>
       TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
     }
@@ -56,7 +56,7 @@ class FiberCacheManagerSuite extends SparkFunSuite {
     configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
     configuration.setLong(SQLConf.SPINACH_FIBERCACHE_SIZE.key, 8 * 1024 * 1024)
 
-    TestFiberCacheManger.reset(configuration)
+    TestFiberCacheManger.reset()
     (0 until 4 * 1024).foreach{ i =>
       TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
     }
@@ -69,12 +69,24 @@ class FiberCacheManagerSuite extends SparkFunSuite {
     configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
     configuration.setLong(SQLConf.SPINACH_FIBERCACHE_SIZE.key, 1024 * 1024 * 1024)
 
-    TestFiberCacheManger.reset(configuration)
+    TestFiberCacheManger.reset()
     (0 until 512 * 1024).foreach{ i =>
       TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
     }
     assert(TestFiberCacheManger.getStat.evictionCount() > 0)
     assert(TestFiberCacheManger.getStat.evictionCount() < 1000)
+  }
+
+  test("4TB Size, Exceed the maximum memory limit") { // Weight 4G = 2M * 2 * 1024
+    val configuration = new Configuration()
+    configuration.setBoolean(SQLConf.SPINACH_FIBERCACHE_STATS.key, true)
+    configuration.setLong(SQLConf.SPINACH_FIBERCACHE_SIZE.key, 4 * 1024 * 1024 * 1024L)
+
+    TestFiberCacheManger.reset()
+    (0 until 2 * 1024 * 1024 + 1).foreach { i =>
+      TestFiberCacheManger(TestFiber(i), configuration): DataFiberCache
+    }
+    assert(TestFiberCacheManger.getStat.evictionCount() > 0)
   }
 }
 
@@ -95,5 +107,5 @@ object TestFiberCacheManger extends AbstractFiberCacheManger {
 
   def getStat: CacheStats = cache.stats()
 
-  def reset(configuration: Configuration): Unit = cache = null
+  def reset(): Unit = cache = null
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Use configuration to assign a proper cache size
2. Use KB instead of B as Unit in `weigher` due to Guava known issue

## How was this patch tested?

Unit Test

Fixes #239 

