### PR TITLE
fix index for or(like,like) bug

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/IndexScanner.scala
@@ -127,7 +127,7 @@ private[spinach] object ScannerBuilder extends Logging {
       case LessThan(attribute, ic(key)) =>
         val ranger = new RangeInterval(IndexScanner.DUMMY_KEY_START, key, true, false)
         mutable.HashMap(attribute -> ArrayBuffer(ranger))
-      case _ => null
+      case _ => mutable.HashMap.empty
     }
   }
 


### PR DESCRIPTION
when exec sql like "SELECT * FROM spinach_test WHERE a >= 180 and a < 200 AND (b like '%22%' or b like '%21%')" will throw NPE :
java.lang.NullPointerException
	at org.apache.spark.sql.execution.datasources.spinach.index.ScannerBuilder$.combineIntervalMaps(IndexScanner.scala:84)
	at org.apache.spark.sql.execution.datasources.spinach.index.ScannerBuilder$.optimizeFilterBound(IndexScanner.scala:114)
	at org.apache.spark.sql.execution.datasources.spinach.index.ScannerBuilder$$anonfun$1.apply(IndexScanner.scala:151)
	at org.apache.spark.sql.execution.datasources.spinach.index.ScannerBuilder$$anonfun$1.apply(IndexScanner.scala:151)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:186)
	at org.apache.spark.sql.execution.datasources.spinach.index.ScannerBuilder$.build(IndexScanner.scala:151)
	at org.apache.spark.sql.execution.datasources.spinach.SpinachFileFormat.buildReader(SpinachFileFormat.scala:173)
	at org.apache.spark.sql.execution.datasources.spinach.SpinachFileFormat.buildReaderWithPartitionValues(SpinachFileFormat.scala:118)
	at org.apache.spark.sql.execution.datasources.FileSourceStrategy$.apply(FileSourceStrategy.scala:153)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner$$anonfun$1.apply(QueryPlanner.scala:60)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner$$anonfun$1.apply(QueryPlanner.scala:60)
	at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner.plan(QueryPlanner.scala:61)
	at org.apache.spark.sql.execution.SparkPlanner.plan(SparkPlanner.scala:47)
	at org.apache.spark.sql.execution.SparkPlanner$$anonfun$plan$1$$anonfun$apply$1.applyOrElse(SparkPlanner.scala:51)
	at org.apache.spark.sql.execution.SparkPlanner$$anonfun$plan$1$$anonfun$apply$1.applyOrElse(SparkPlanner.scala:48)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:301)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:301)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:69)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformUp(TreeNode.scala:300)
	at org.apache.spark.sql.execution.SparkPlanner$$anonfun$plan$1.apply(SparkPlanner.scala:48)
	at org.apache.spark.sql.execution.SparkPlanner$$anonfun$plan$1.apply(SparkPlanner.scala:48)
	at scala.collection.Iterator$$anon$11.next(Iterator.scala:409)
	at org.apache.spark.sql.execution.QueryExecution.sparkPlan$lzycompute(QueryExecution.scala:78)
	at org.apache.spark.sql.execution.QueryExecution.sparkPlan(QueryExecution.scala:76)
	at org.apache.spark.sql.execution.QueryExecution.executedPlan$lzycompute(QueryExecution.scala:83)
	at org.apache.spark.sql.execution.QueryExecution.executedPlan(QueryExecution.scala:83)
	at org.apache.spark.sql.QueryTest.assertEmptyMissingInput(QueryTest.scala:356)
	at org.apache.spark.sql.QueryTest.checkAnswer(QueryTest.scala:173)
	at org.apache.spark.sql.QueryTest.checkAnswer(QueryTest.scala:186)
	at org.apache.spark.sql.execution.datasources.spinach.index.BitMapIndexSuite$$anonfun$5.apply$mcV$sp(BitMapIndexSuite.scala:128)
	at org.apache.spark.sql.execution.datasources.spinach.index.BitMapIndexSuite$$anonfun$5.apply(BitMapIndexSuite.scala:120)
	at org.apache.spark.sql.execution.datasources.spinach.index.BitMapIndexSuite$$anonfun$5.apply(BitMapIndexSuite.scala:120)
	at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:166)
	at org.apache.spark.SparkFunSuite.withFixture(SparkFunSuite.scala:57)
	at org.scalatest.FunSuiteLike$class.invokeWithFixture$1(FunSuiteLike.scala:163)
	at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)
	at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
	at org.scalatest.FunSuiteLike$class.runTest(FunSuiteLike.scala:175)
	at org.apache.spark.sql.execution.datasources.spinach.index.BitMapIndexSuite.org$scalatest$BeforeAndAfterEach$$super$runTest(BitMapIndexSuite.scala:30)

fix it。