### PR TITLE
add close method for spn dataFile to close dataFile manually

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/filecache/FiberCacheManager.scala
@@ -166,6 +166,21 @@ private[spinach] object DataFileHandleCacheManager extends Logging {
   def apply[T <: DataFileHandle](fiberCache: DataFile, conf: Configuration): T = {
     cache.get(ConfigurationCache(fiberCache, conf)).asInstanceOf[T]
   }
+
+  /**
+   * close finStream and evict dataFile -> DataFileHandler manually
+   * @param dataFile: the dataFile whose finStream will be closed and
+   *                dataFileHandler will be evict out of memory
+   */
+  def evictDataFileHandler(dataFile: DataFile): Unit = {
+    val entry = ConfigurationCache(dataFile, new Configuration())
+    if(cache.asMap().asScala.contains(entry)) {
+      val fsDataInputStream = cache.asMap().asScala(entry).fin
+      if(fsDataInputStream != null) fsDataInputStream.close()
+
+      cache.invalidate(entry)
+    }
+  }
 }
 
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/io/SpinachDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/io/SpinachDataFile.scala
@@ -139,7 +139,7 @@ private[spinach] case class SpinachDataFile(path: String, schema: StructType) ex
     new Iterator[InternalRow]() {
       override def hasNext: Boolean = {
         val hasNextRow = iter.hasNext
-        if (!hasNextRow) closeFile()
+        if (!hasNextRow) close()
         hasNextRow
       }
 
@@ -185,7 +185,7 @@ private[spinach] case class SpinachDataFile(path: String, schema: StructType) ex
     new Iterator[InternalRow]() {
       override def hasNext: Boolean = {
         val hasNextRow = iter.hasNext
-        if (!hasNextRow) closeFile()
+        if (!hasNextRow) close()
         hasNextRow
       }
 
@@ -204,7 +204,7 @@ private[spinach] case class SpinachDataFile(path: String, schema: StructType) ex
   /**
    * close this SpinachDataFile and evict the corresponding data file handler out of memory
    */
-  def closeFile(): Unit = {
+  def close(): Unit = {
     // close fileHandler's finStream and evict file handler out of memory
     DataFileHandleCacheManager.evictDataFileHandler(this)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
For issue #246 

- [ 1] 
add close method for spn dataFile to close FSDataInputStream manually, meanwhile evict spinachDataFileHandler if it is cached in memory.

- [ 2]
modify SpinachDataFile's iterator to close data file after the last internalRow is returned. 

## How was this patch tested?
Unit test