### PR TITLE
Use InternalRow instead of UnsafeRow to save Memory

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BPlusTreeScanner.scala
@@ -73,7 +73,6 @@ private[spinach] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner
             // find the last identical key or the last key less than the specified one on the left
             this.intervalArray(i).end = moveTo(root, interval.end, false, order).currentKey
           }
-
         }
         // to deal with the LeftOpen condition
         while (!interval.startInclude &&
@@ -99,7 +98,6 @@ private[spinach] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner
       ordering.compare(
         currentKeyArray(i).currentKey, intervalArray(i).end) >= 0
     }
-
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BTreeIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BTreeIndexWriter.scala
@@ -128,7 +128,7 @@ private[spinach] class BTreeIndexWriter(
           taskReturn = taskReturn ++: writeIndexFromRows(taskContext, iterator)
           writeNewFile = true
         } else {
-          val v = InternalRow.fromSeq(iterator.next().toSeq(keySchema))
+          val v = InternalRow.fromSeq(iterator.next().copy().toSeq(keySchema))
           statisticsManager.addSpinachKey(v)
           if (!hashMap.containsKey(v)) {
             val list = new java.util.ArrayList[Long]()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BTreeIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BTreeIndexWriter.scala
@@ -128,7 +128,7 @@ private[spinach] class BTreeIndexWriter(
           taskReturn = taskReturn ++: writeIndexFromRows(taskContext, iterator)
           writeNewFile = true
         } else {
-          val v = iterator.next().copy()
+          val v = InternalRow.fromSeq(iterator.next().toSeq(keySchema))
           statisticsManager.addSpinachKey(v)
           if (!hashMap.containsKey(v)) {
             val list = new java.util.ArrayList[Long]()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BitMapIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BitMapIndexWriter.scala
@@ -116,7 +116,7 @@ private[spinach] class BitMapIndexWriter(
           taskReturn = taskReturn ++: writeIndexFromRows(taskContext, iterator)
           writeNewFile = true
         } else {
-          val v = iterator.next().copy()
+          val v = InternalRow.fromSeq(iterator.next().toSeq(keySchema))
           statisticsManager.addSpinachKey(v)
           if (!tmpMap.contains(v)) {
             val list = new mutable.ListBuffer[Int]()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BitMapIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BitMapIndexWriter.scala
@@ -116,7 +116,7 @@ private[spinach] class BitMapIndexWriter(
           taskReturn = taskReturn ++: writeIndexFromRows(taskContext, iterator)
           writeNewFile = true
         } else {
-          val v = InternalRow.fromSeq(iterator.next().toSeq(keySchema))
+          val v = InternalRow.fromSeq(iterator.next().copy().toSeq(keySchema))
           statisticsManager.addSpinachKey(v)
           if (!tmpMap.contains(v)) {
             val list = new mutable.ListBuffer[Int]()


### PR DESCRIPTION
## What changes were proposed in this pull request?

For index key, the field size usually is small, so InternalRow is better.

## How was this patch tested?

Unit test
