### PR TITLE
Shade all parquet dependencies to avoid lib conflict in Spark.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,8 +304,7 @@
             <includes>
               <include>org.spark-project.spark:unused</include>
               <include>com.google.guava:guava</include>
-              <include>org.apache.parquet:parquet-column</include>
-              <include>org.apache.parquet:parquet-hadoop</include>
+              <include>org.apache.parquet:*</include>
             </includes>
           </artifactSet>
           <relocations>


### PR DESCRIPTION
Signed-off-by: Wang, Yue A <yue.a.wang@intel.com>

## What changes were proposed in this pull request?

Shade all parquet dependencies to avoid lib conflict in Spark.

## How was this patch tested?
mvn test pass

