### PR TITLE
Make Statistics Parameter configurable

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexWriter.scala
@@ -120,7 +120,7 @@ private[oap] class BTreeIndexWriter(
 
     def writeTask(): Seq[IndexBuildResult] = {
       val statisticsManager = new StatisticsManager
-      statisticsManager.initialize(BTreeIndexType, keySchema)
+      statisticsManager.initialize(BTreeIndexType, keySchema, configuration)
       // key -> RowIDs list
       val hashMap = new java.util.HashMap[InternalRow, java.util.ArrayList[Long]]()
       var cnt = 0L

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexWriter.scala
@@ -103,7 +103,7 @@ private[oap] class BitMapIndexWriter(
 
     def writeTask(): Seq[IndexBuildResult] = {
       val statisticsManager = new StatisticsManager
-      statisticsManager.initialize(BitMapIndexType, keySchema)
+      statisticsManager.initialize(BitMapIndexType, keySchema, configuration)
       // Current impl just for fast proving the effect of BitMap Index,
       // we can do the optimize below:
       // 1. each bitset in hashmap value has same length, we can save the

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -224,7 +224,7 @@ private[oap] class OapDataReader(
 
       val statisticsManager = new StatisticsManager
       statisticsManager.read(stsArray, filterScanner.get.getSchema)
-      statisticsManager.analyse(filterScanner.get.intervalArray)
+      statisticsManager.analyse(filterScanner.get.intervalArray, conf)
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.oap.io
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataOutputStream, Path}
-import org.apache.parquet.format.{CompressionCodec, Encoding}
+import org.apache.parquet.format.CompressionCodec
 import org.apache.parquet.io.api.Binary
 
 import org.apache.spark.internal.Logging
@@ -163,7 +163,6 @@ private[oap] class OapDataReader(
     val start = System.currentTimeMillis()
     filterScanner match {
       case Some(fs) if fs.existRelatedIndexFile(path, conf) =>
-        fs.initialize(path, conf)
         val indexPath = IndexUtils.indexFileFromDataFile(path, fs.meta.name, fs.meta.time)
 
         val initFinished = System.currentTimeMillis()
@@ -174,6 +173,7 @@ private[oap] class OapDataReader(
           case StaticsAnalysisResult.FULL_SCAN =>
             fileScanner.iterator(conf, requiredIds)
           case StaticsAnalysisResult.USE_INDEX =>
+            fs.initialize(path, conf)
             // total Row count can be get from the filter scanner
             val rowIDs = fs.toArray.sorted
             fileScanner.iterator(conf, requiredIds, rowIDs)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -113,6 +113,7 @@ private[oap] class BloomFilterStatistics extends Statistics {
         ).filter(interval => ordering.compare(interval.start, interval.end) == 0
           && interval.startInclude && interval.endInclude).map(_.start).toArray
       } else null
+    val values = equalValues.map(value => convertor(value).getBytes)
     val skipFlag = if (equalValues != null && equalValues.length > 0) {
       !equalValues.map(value => bfIndex
         .checkExist(convertor(value).getBytes))

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -578,9 +578,16 @@ object SQLConf {
         "\"SAMPLE\" for SampleBasedStatistics, " +
         "\"PARTBYVALUE\" for PartedByValueStatistics. " +
         "If you want to add more than one type, just use comma " +
-        "to separate, eg. \"MINMAX, SAMPLE, PARTBYVALUE\"")
+        "to separate, eg. \"MINMAX, SAMPLE, PARTBYVALUE, BLOOM\"")
       .stringConf
-      .createWithDefault("MINMAX, SAMPLE, PARTBYVALUE")
+      .createWithDefault("MINMAX, SAMPLE, PARTBYVALUE, BLOOM")
+
+  val SPINACH_STATISTICS_PART_NUM =
+    SQLConfigBuilder("spark.sql.spinach.Statistics.partNum")
+      .internal()
+      .doc("PartedByValueStatistics gives statistics with the value interval, default 5")
+      .intConf
+      .createWithDefault(5)
 
   val OAP_STATISTICS_SAMPLE_RATE =
     SQLConfigBuilder("spark.sql.oap.Statistics.sampleRate")
@@ -593,9 +600,9 @@ object SQLConf {
     SQLConfigBuilder("spark.sql.oap.Bloomfilter.maxBits")
       .internal()
       .doc("Define the max bit count parameter used in bloom " +
-        "filter, default 1073741824")
+        "filter, default 33554432")
       .intConf
-      .createWithDefault(1073741824)
+      .createWithDefault(1 << 25)
 
   val OAP_BLOOMFILTER_NUMHASHFUNC =
     SQLConfigBuilder("spark.sql.oap.Bloomfilter.numHashFunc")

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -602,7 +602,7 @@ object SQLConf {
       .doc("Define the max bit count parameter used in bloom " +
         "filter, default 33554432")
       .intConf
-      .createWithDefault(1 << 25)
+      .createWithDefault(1 << 20)
 
   val OAP_BLOOMFILTER_NUMHASHFUNC =
     SQLConfigBuilder("spark.sql.oap.Bloomfilter.numHashFunc")

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -582,8 +582,8 @@ object SQLConf {
       .stringConf
       .createWithDefault("MINMAX, SAMPLE, PARTBYVALUE, BLOOM")
 
-  val SPINACH_STATISTICS_PART_NUM =
-    SQLConfigBuilder("spark.sql.spinach.Statistics.partNum")
+  val OAP_STATISTICS_PART_NUM =
+    SQLConfigBuilder("spark.sql.oap.Statistics.partNum")
       .internal()
       .doc("PartedByValueStatistics gives statistics with the value interval, default 5")
       .intConf


### PR DESCRIPTION


## What changes were proposed in this pull request?

1. Use sparkSession.sessionState.newHaddopConf in CreateIndex. Because
   sparkSession.sparkContext.hadoopConfiguration doesn't have full configs
2. Setup Statistics parameters during initialization
3. Put indexScanner.initialization after tryToReadStatistics


## How was this patch tested?

Unit Tests

