### PR TITLE
use code gen to convert unsaferow

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BTreeIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BTreeIndexWriter.scala
@@ -161,10 +161,6 @@ private[spinach] class BTreeIndexWriter(
       // sort keys
       java.util.Arrays.sort(uniqueKeys, comparator)
       // build index file
-//      val indexFile = IndexUtils.indexFileFromDataFile(d, indexName)
-//      val fs = indexFile.getFileSystem(configuration)
-      // we are overwriting index files
-//      val fileOut = fs.create(indexFile, true)
       var i = 0
       var fileOffset = 0L
       val offsetMap = new java.util.HashMap[InternalRow, Long]()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BTreeIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BTreeIndexWriter.scala
@@ -130,7 +130,7 @@ private[spinach] class BTreeIndexWriter(
           taskReturn = taskReturn ++: writeIndexFromRows(taskContext, iterator)
           writeNewFile = true
         } else {
-          val v = InternalRow.fromSeq(iterator.next().copy().toSeq(keySchema))
+          val v = genericProjector(iterator.next()).copy()
           statisticsManager.addSpinachKey(v)
           if (!hashMap.containsKey(v)) {
             val list = new java.util.ArrayList[Long]()
@@ -259,6 +259,7 @@ private[spinach] class BTreeIndexWriter(
   }
 
   @transient private lazy val projector = UnsafeProjection.create(keySchema)
+  @transient private lazy val genericProjector = FromUnsafeProjection(keySchema)
 
   /**
    * write file correspond to [[UnsafeIndexNode]]

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BitMapIndexWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/spinach/index/BitMapIndexWriter.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.execution.datasources.spinach.index
 
 import java.io.{ByteArrayOutputStream, ObjectOutputStream}
 
-import org.apache.spark.sql.catalyst.expressions.FromUnsafeProjection
-
 import scala.collection.mutable
 
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -29,6 +27,7 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.rdd.InputFileNameHolder
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.FromUnsafeProjection
 import org.apache.spark.sql.execution.datasources.WriteResult
 import org.apache.spark.sql.execution.datasources.spinach.statistics._
 import org.apache.spark.sql.types.StructType


### PR DESCRIPTION
## What changes were proposed in this pull request?

When read data during building index, we will convert it back to generic row to save space. This patch will use `GenerateSafeProjection` for this convertion.


## How was this patch tested?

Existed tests.

