### PR TITLE
Fix bugs in Index Statistics for Multi-Column case

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -76,25 +76,26 @@ private[oap] class MinMaxStatistics extends Statistics {
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double = {
     val start = intervalArray.head
     val end = intervalArray.last
-    var result = false
 
-    if (start.start != IndexScanner.DUMMY_KEY_START) {
-      // > or >= start
-      if (start.startInclude) {
-        result |= ordering.gt(start.start, max)
-      } else {
-        result |= ordering.gteq(start.start, max)
-      }
-    }
-    if (end.end != IndexScanner.DUMMY_KEY_END) {
-      // < or <= end
-      if (end.endInclude) {
-        result |= ordering.lt(end.end, min)
-      } else {
-        result |= ordering.lteq(end.end, min)
-      }
-    }
+    val startOutOfBound =
+      if (start.start.numFields > 0) {
+        val startSchema = StructType(schema.slice(0, start.start.numFields))
+        val startOrdering = GenerateOrdering.create(startSchema)
+        if (start.start.numFields == schema.length && !start.startInclude) {
+          startOrdering.gteq(start.start, max)
+        } else startOrdering.gt(start.start, max)
+      } else false
 
-    if (result) StaticsAnalysisResult.SKIP_INDEX else StaticsAnalysisResult.USE_INDEX
+    val endOutOfBound =
+      if (end.end.numFields > 0) {
+        val endSchema = StructType(schema.slice(0, end.end.numFields))
+        val endOrdering = GenerateOrdering.create(endSchema)
+        if (end.end.numFields == schema.length && !end.endInclude) {
+          endOrdering.lteq(end.end, min)
+        } else endOrdering.lt(end.end, min)
+      } else false
+
+    if (startOutOfBound || endOutOfBound) StaticsAnalysisResult.SKIP_INDEX
+    else StaticsAnalysisResult.USE_INDEX
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
 import org.apache.spark.sql.execution.datasources.oap.index._
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.Platform
 
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -113,29 +113,29 @@ object Statistics {
     4 + value.getSizeInBytes
   }
 
-  // logic is complex, needs to be refactored :(
   def rowInSingleInterval(row: InternalRow, interval: RangeInterval,
                           order: BaseOrdering): Boolean = {
-    if (interval.start == IndexScanner.DUMMY_KEY_START) {
-      if (interval.end == IndexScanner.DUMMY_KEY_END) true
-      else {
-        if (order.lt(row, interval.end)) true
-        else if (order.equiv(row, interval.end) && interval.endInclude) true
-        else false
-      }
-    } else {
-      if (order.lt(row, interval.start)) false
-      else if (order.equiv(row, interval.start)) {
-        if (interval.startInclude) {
-          if (interval.end != IndexScanner.DUMMY_KEY_END &&
-            order.equiv(interval.start, interval.end) && !interval.endInclude) {false}
-          else true
-        } else false
-      }
-      else if (interval.end != IndexScanner.DUMMY_KEY_END && (order.gt(row, interval.end) ||
-        (order.equiv(row, interval.end) && !interval.endInclude))) {false}
-      else true
+
+    val withinStart = try {
+      if (interval.startInclude) order.compare(row, interval.start) >= 0
+      else order.compare(row, interval.start) > 0
+    } catch {
+      // When this happen, here is the case:
+      // row = 1, start = DUMMY_KEY_START OR
+      // row = (1, 200, 4, "a"), start = (1, 200, 4, DUMMY_KEY_START)
+      // This means, the last field is DUMMY_KEY_START and others are same
+      // So, row is within start
+      case _: ArrayIndexOutOfBoundsException => true
     }
+
+    val withInEnd = try {
+      if (interval.endInclude) order.compare(row, interval.end) <= 0
+      else order.compare(row, interval.end) < 0
+    } catch {
+      case _: ArrayIndexOutOfBoundsException => true
+    }
+
+    withinStart && withInEnd
   }
   def rowInIntervalArray(row: InternalRow, intervalArray: ArrayBuffer[RangeInterval],
                          order: BaseOrdering): Boolean = {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -138,22 +138,22 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
   test("filtering multi index") {
     val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table spinach_test select * from t")
-    sql("create sindex index1 on spinach_test (a, b)")
+    sql("insert overwrite table oap_test select * from t")
+    sql("create sindex index1 on oap_test (a, b)")
 
-    checkAnswer(sql("SELECT * FROM spinach_test WHERE a = 150 and b < 'this is test 3'"),
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b < 'this is test 3'"),
       Row(150, "this is test 150") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM spinach_test WHERE a = 150 and b >= 'this is test 1'"),
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b >= 'this is test 1'"),
       Row(150, "this is test 150") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM spinach_test WHERE a = 150 and b = 'this is test 150'"),
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b = 'this is test 150'"),
       Row(150, "this is test 150") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM spinach_test WHERE a > 299 and b < 'this is test 9'"),
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 299 and b < 'this is test 9'"),
       Row(300, "this is test 300") :: Nil)
 
-    sql("drop sindex index1 on spinach_test")
+    sql("drop sindex index1 on oap_test")
   }
 
   test("filtering parquet") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -136,7 +136,6 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
   }
 
   test("filtering multi index") {
-    sqlContext.conf.setConf(SQLConf.SPINACH_STATISTICS_TYPES, "PARTBYVALUE")
     val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table spinach_test select * from t")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -135,6 +135,28 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
     sql("drop oindex index1 on oap_test")
   }
 
+  test("filtering multi index") {
+    sqlContext.conf.setConf(SQLConf.SPINACH_STATISTICS_TYPES, "PARTBYVALUE")
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table spinach_test select * from t")
+    sql("create sindex index1 on spinach_test (a, b)")
+
+    checkAnswer(sql("SELECT * FROM spinach_test WHERE a = 150 and b < 'this is test 3'"),
+      Row(150, "this is test 150") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM spinach_test WHERE a = 150 and b >= 'this is test 1'"),
+      Row(150, "this is test 150") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM spinach_test WHERE a = 150 and b = 'this is test 150'"),
+      Row(150, "this is test 150") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM spinach_test WHERE a > 299 and b < 'this is test 9'"),
+      Row(300, "this is test 300") :: Nil)
+
+    sql("drop sindex index1 on spinach_test")
+  }
+
   test("filtering parquet") {
     val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")


### PR DESCRIPTION


## What changes were proposed in this pull request?

In Multi-Column case, an interval has more than one columns and the last one
maybe DUMMY_KEY. For example interval.start = (1, 100, "a", DUMMY_KEY_START)
But, interval.start != DUMMY_KEY_START, and compare it may still encounter
ArrayIndexOutOfBoundException. This PR fixes this problem


## How was this patch tested?

Unit tests and added case
