### PR TITLE
Fix index query boundary miss issue.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -146,7 +146,7 @@ private[oap] case class OapDataFile(path: String, schema: StructType) extends Da
     var lastGroupId = -1
     rowIds.indices.iterator.map { idx =>
       val rowId = rowIds(idx)
-      val groupId = ((rowId + 1) / meta.rowCountInEachGroup).toInt
+      val groupId = (rowId / meta.rowCountInEachGroup).toInt
       val rowIdxInGroup = (rowId % meta.rowCountInEachGroup).toInt
 
       if (lastGroupId != groupId) {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -21,7 +21,9 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
 
@@ -33,7 +35,7 @@ class OapDDLIndexQuerySuite extends QueryTest with SharedSQLContext with BeforeA
     val path1 = Utils.createTempDir().getAbsolutePath
 
     sql(s"""CREATE TEMPORARY VIEW oap_test_1 (a INT, b STRING)
-           | USING parquet
+           | USING oap
            | OPTIONS (path '$path1')""".stripMargin)
   }
 
@@ -55,5 +57,23 @@ class OapDDLIndexQuerySuite extends QueryTest with SharedSQLContext with BeforeA
       assert(dfWithoutIdx.count == dfwithIdx.count)
       assert(dfWithoutIdx.count == dfOriginal.count)
   }
+
+  test("index row boundary") {
+    spark.sqlContext.conf.setConfString(SQLConf.OAP_STATISTICS_TYPES.key, "")
+
+    val testRowId = spark.sparkContext.hadoopConfiguration
+                     .get(OapFileFormat.ROW_GROUP_SIZE,
+                          OapFileFormat.DEFAULT_ROW_GROUP_SIZE).toInt - 1
+    val data: Seq[(Int, String)] = (0 until 4096).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test_1 select * from t")
+    sql("create sindex index1 on oap_test_1 (a)")
+
+    checkAnswer(sql(s"SELECT * FROM oap_test_1 WHERE a = $testRowId"),
+      Row(testRowId, s"this is test $testRowId") :: Nil)
+
+    sql("drop sindex index1 on oap_test_1")
+  }
+
 }
 


### PR DESCRIPTION
boundary query missed because of incorrect row index.

Signed-off-by: Wang, Yue A <yue.a.wang@intel.com>


## How was this patch tested?
mvn test pass