### PR TITLE
Fix bugs in Index Statistics for Multi-Column case 

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -45,6 +45,8 @@ private[oap] class PartByValueStatistics extends Statistics {
 
   private lazy val maxPartNum: Int = StatisticsManager.partNumber
   @transient private lazy val ordering = GenerateOrdering.create(schema)
+  @transient private lazy val partialOrdering =
+    GenerateOrdering.create(StructType(schema.dropRight(1)))
 
   protected case class PartedByValueMeta(idx: Int, row: InternalRow,
                                          curMaxId: Int, accumulatorCnt: Int)
@@ -112,39 +114,55 @@ private[oap] class PartByValueStatistics extends Statistics {
   //                       |_______|_______|_______|_______|_______|
   // interval id:        0     1       2       3       4       5      6
   // value array:(-inf, r0) [r0,r1) [r1,r2) [r2,r3) [r3,r4) [r4,r5]  (r5, +inf)
-  protected def getIntervalIdx(row: Key, include: Boolean): Int = {
-    var i = 0
-    while (i < metas.length && (include && ordering.gteq(row, metas(i).row)
-      || !include && ordering.gt(row, metas(i).row))) i += 1
-    if (include && ordering.compare(metas.last.row, row) == 0) metas.last.idx // for row == r5
-    else i
+  private def getIntervalIdx(row: Key, include: Boolean, isStart: Boolean): Int = {
+    // Only two cases are accepted, or something is wrong.
+    // 1. meta.row = [1, "aaa"], row = [1, "bbb"] => row.numFields == schema.length
+    // 2. meta.row = [1, "aaa"], row = [1, DUMMY_KEY_START] => row.numFields == schema.length - 1
+    assert(row.numFields == schema.length || row.numFields == schema.length - 1,
+      s"Can't compare row with current schema. row: $row, schema: $schema")
+
+    metas.zipWithIndex.indexWhere {
+      case (meta, index) =>
+        if (row.numFields == schema.length) {
+          if (include && index < metas.length - 1) ordering.compare(row, meta.row) < 0
+          else ordering.compare(row, meta.row) <= 0
+        } else {
+          if (isStart) partialOrdering.compare(row, meta.row) <= 0
+          else partialOrdering.compare(row, meta.row) < 0
+        }
+    }
+  }
+
+  protected def getIntervalIdxForStart(start: Key, include: Boolean): Int = {
+    getIntervalIdx(start, include, isStart = true)
+  }
+
+  protected def getIntervalIdxForEnd(end: Key, include: Boolean): Int = {
+    getIntervalIdx(end, include, isStart = false)
   }
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double = {
     val wholeCount = metas.last.accumulatorCnt
-    val partNum = metas.length - 1
 
     val start = intervalArray.head
     val end = intervalArray.last
-    val left = if (start.start == IndexScanner.DUMMY_KEY_START) 0
-      else getIntervalIdx(start.start, start.startInclude)
-    val right = if (end.end == IndexScanner.DUMMY_KEY_END) metas.length + 1
-      else getIntervalIdx(end.end, end.endInclude)
 
-    if (left == partNum + 1 || right == 0) {
+    val left = getIntervalIdxForStart(start.start, start.startInclude)
+    val right = getIntervalIdxForEnd(end.end, end.endInclude)
+
+    if (left == -1 || right == 0) {
       // interval.min > partition.max || interval.max < partition.min
       StaticsAnalysisResult.SKIP_INDEX
     } else {
       var cover: Double =
-        if (right <= partNum) metas(right).accumulatorCnt else metas.last.accumulatorCnt
-      if (start.start != IndexScanner.DUMMY_KEY_START && left > 0 &&
-        ordering.lteq(start.start, metas(left).row)) {
+        if (right != -1) metas(right).accumulatorCnt else metas.last.accumulatorCnt
+
+      if (left > 0) {
         cover -= metas(left - 1).accumulatorCnt
         cover += 0.5 * (metas(left).accumulatorCnt - metas(left - 1).accumulatorCnt)
       }
 
-      if (end.end != IndexScanner.DUMMY_KEY_END && right <= partNum &&
-        ordering.gteq(end.end, metas(right - 1).row)) {
+      if (right != -1) {
         cover -= 0.5 * (metas(right).accumulatorCnt - metas(right - 1).accumulatorCnt)
       }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -82,8 +82,9 @@ private[oap] class SampleBasedStatistics extends Statistics {
       StaticsAnalysisResult.USE_INDEX
     } else {
       var hitCnt = 0
+      val partialOrder = GenerateOrdering.create(StructType(schema.dropRight(1)))
       for (row <- sampleArray) {
-        if (Statistics.rowInIntervalArray(row, intervalArray, ordering)) hitCnt += 1
+        if (Statistics.rowInIntervalArray(row, intervalArray, ordering, partialOrder)) hitCnt += 1
       }
       hitCnt * 1.0 / sampleArray.length
     }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -135,6 +135,27 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
     sql("drop oindex index1 on oap_test")
   }
 
+  test("filtering multi index") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
+    sql("create oindex index1 on oap_test (a, b)")
+
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b < 'this is test 3'"),
+      Row(150, "this is test 150") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b >= 'this is test 1'"),
+      Row(150, "this is test 150") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b = 'this is test 150'"),
+      Row(150, "this is test 150") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 299 and b < 'this is test 9'"),
+      Row(300, "this is test 300") :: Nil)
+
+    sql("drop oindex index1 on oap_test")
+  }
+
   test("filtering parquet") {
     val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution.datasources.oap.statistics
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexScanner, IndexUtils}
 import org.apache.spark.unsafe.Platform
 
@@ -133,6 +135,8 @@ class PartByValueStatisticsSuite extends StatisticsTest{
 
   test("test analyze function") {
     val keys = (1 to 300).map(i => rowGen(i)).toArray // keys needs to be sorted
+    val dummyStart = new JoinedRow(InternalRow(1), IndexScanner.DUMMY_KEY_START)
+    val dummyEnd = new JoinedRow(InternalRow(300), IndexScanner.DUMMY_KEY_END)
 
     val partByCalueWrite = new TestPartByValue
     partByCalueWrite.initialize(schema)
@@ -144,7 +148,7 @@ class PartByValueStatisticsSuite extends StatisticsTest{
     partByValueRead.initialize(schema)
     partByValueRead.read(bytes, 0)
 
-    generateInterval(IndexScanner.DUMMY_KEY_START, IndexScanner.DUMMY_KEY_END, true, true)
+    generateInterval(dummyStart, dummyEnd, true, true)
     assert(partByValueRead.analyse(intervalArray) == 1.0)
 
     generateInterval(rowGen(1), rowGen(301), true, true)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsSuite.scala
@@ -83,70 +83,70 @@ class StatisticsSuite extends StatisticsTest with BeforeAndAfterAll {
 
   test("rowInSingleInterval: normal test") {
     assert(Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(row1, row3, true, true), ordering), "2.0 is in [1.0, 3.0]")
+      RangeInterval(row1, row3, true, true), ordering, ordering), "2.0 is in [1.0, 3.0]")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row3),
-      RangeInterval(row1, row2, true, true), ordering), "3.0 is not in [1.0, 2.0]")
+      RangeInterval(row1, row2, true, true), ordering, ordering), "3.0 is not in [1.0, 2.0]")
     assert(Statistics.rowInSingleInterval(internalRow2unsafeRow(row1),
-      RangeInterval(IndexScanner.DUMMY_KEY_START, row2, false, true), ordering),
+      RangeInterval(IndexScanner.DUMMY_KEY_START, row2, false, true), partialOrdering, ordering),
       "1.0 is in (-inf, 2.0]")
     assert(Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(IndexScanner.DUMMY_KEY_START, row2, false, true), ordering),
+      RangeInterval(IndexScanner.DUMMY_KEY_START, row2, false, true), partialOrdering, ordering),
       "2.0 is in (-inf, 2.0]")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(IndexScanner.DUMMY_KEY_START, row2, false, false), ordering),
+      RangeInterval(IndexScanner.DUMMY_KEY_START, row2, false, false), partialOrdering, ordering),
       "2.0 is not in (-inf, 2.0)")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row3),
-      RangeInterval(IndexScanner.DUMMY_KEY_START, row2, false, true), ordering),
+      RangeInterval(IndexScanner.DUMMY_KEY_START, row2, false, true), partialOrdering, ordering),
       "3.0 is not in (-inf, 2.0]")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row1),
-      RangeInterval(row2, IndexScanner.DUMMY_KEY_END, true, false), ordering),
+      RangeInterval(row2, IndexScanner.DUMMY_KEY_END, true, false), ordering, partialOrdering),
       "1.0 is in [2, +inf)")
     assert(Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(row2, IndexScanner.DUMMY_KEY_END, true, false), ordering),
+      RangeInterval(row2, IndexScanner.DUMMY_KEY_END, true, false), ordering, partialOrdering),
       "2.0 is in [2, +inf)")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(row2, IndexScanner.DUMMY_KEY_END, false, false), ordering),
+      RangeInterval(row2, IndexScanner.DUMMY_KEY_END, false, false), ordering, partialOrdering),
       "2.0 is not in (2, +inf)")
     assert(Statistics.rowInSingleInterval(internalRow2unsafeRow(row3),
-      RangeInterval(row2, IndexScanner.DUMMY_KEY_END, true, false), ordering),
+      RangeInterval(row2, IndexScanner.DUMMY_KEY_END, true, false), ordering, partialOrdering),
       "3.0 is in [2, +inf)")
     assert(Statistics.rowInSingleInterval(internalRow2unsafeRow(row3),
       RangeInterval(IndexScanner.DUMMY_KEY_START, IndexScanner.DUMMY_KEY_END, false, false),
-      ordering), "3.0 is in (-inf, +inf)")
+      partialOrdering, partialOrdering), "3.0 is in (-inf, +inf)")
   }
 
   test("rowInSingleInterval: bound test") {
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row1),
-      RangeInterval(row1, row1, false, false), ordering), "1.0 is not in (1.0, 1.0)")
+      RangeInterval(row1, row1, false, false), ordering, ordering), "1.0 is not in (1.0, 1.0)")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row1),
-      RangeInterval(row1, row1, false, true), ordering), "1.0 is not in (1.0, 1.0]")
+      RangeInterval(row1, row1, false, true), ordering, ordering), "1.0 is not in (1.0, 1.0]")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row1),
-      RangeInterval(row1, row1, true, false), ordering), "1.0 is not in [1.0, 1.0)")
+      RangeInterval(row1, row1, true, false), ordering, ordering), "1.0 is not in [1.0, 1.0)")
     assert(Statistics.rowInSingleInterval(internalRow2unsafeRow(row1),
-      RangeInterval(row1, row1, true, true), ordering), "1.0 is in [1.0, 1.0]")
+      RangeInterval(row1, row1, true, true), ordering, ordering), "1.0 is in [1.0, 1.0]")
   }
 
   test("rowInSingleInterval: wrong interval test") {
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(row3, row2, false, false), ordering), "2.0 is not in (3.0, 2.0)")
+      RangeInterval(row3, row2, false, false), ordering, ordering), "2.0 is not in (3.0, 2.0)")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(row3, row2, false, true), ordering), "2.0 is not in (3.0, 2.0]")
+      RangeInterval(row3, row2, false, true), ordering, ordering), "2.0 is not in (3.0, 2.0]")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(row3, row2, true, false), ordering), "2.0 is not in [3.0, 2.0)")
+      RangeInterval(row3, row2, true, false), ordering, ordering), "2.0 is not in [3.0, 2.0)")
     assert(!Statistics.rowInSingleInterval(internalRow2unsafeRow(row2),
-      RangeInterval(row3, row2, true, true), ordering), "2.0 is not in [3.0, 2.0]")
+      RangeInterval(row3, row2, true, true), ordering, ordering), "2.0 is not in [3.0, 2.0]")
   }
 
   test("rowInIntervalArray") {
     assert(!Statistics.rowInIntervalArray(internalRow2unsafeRow(row1),
-      null, ordering), "intervalArray is null")
+      null, ordering, ordering), "intervalArray is null")
     assert(Statistics.rowInIntervalArray(internalRow2unsafeRow(InternalRow(1.5)),
       ArrayBuffer(RangeInterval(row1, row2, false, false),
-        RangeInterval(row2, row3, false, false)), ordering),
+        RangeInterval(row2, row3, false, false)), ordering, partialOrdering),
       "1.5 is in (1,2) union (2,3)")
     assert(!Statistics.rowInIntervalArray(internalRow2unsafeRow(InternalRow(-1.0)),
       ArrayBuffer(RangeInterval(row1, row2, false, false),
-        RangeInterval(row2, row3, false, false)), ordering),
+        RangeInterval(row2, row3, false, false)), ordering, partialOrdering),
       "-1.0 is not in (1,2) union (2,3)")
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsTest.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsTest.scala
@@ -52,6 +52,8 @@ abstract class StatisticsTest extends SparkFunSuite with BeforeAndAfterEach {
 
   @transient lazy protected val converter: UnsafeProjection = UnsafeProjection.create(schema)
   @transient lazy protected val ordering: BaseOrdering = GenerateOrdering.create(schema)
+  @transient lazy protected val partialOrdering: BaseOrdering =
+    GenerateOrdering.create(StructType(schema.dropRight(1)))
   protected var out: TestIndexOutputWriter = _
 
   protected var intervalArray: ArrayBuffer[RangeInterval] = new ArrayBuffer[RangeInterval]()


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Multi-Column case, an interval has more than one columns and the last one
maybe DUMMY_KEY. For example interval.start = (1, 100, "a", DUMMY_KEY_START)
But, interval.start != DUMMY_KEY_START, and compare it may still encounter
ArrayIndexOutOfBoundException. This PR fixes this problem

Based on PR #257 

## How was this patch tested?

Unit Test

