### PR TITLE
remove unnecessary logic

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -80,16 +80,6 @@ private[sql] object FileSourceStrategy extends Strategy with Logging {
         }
       }
 
-      def fileExists(r: HadoopFsRelation): Boolean = {
-        val paths = r.location.paths
-        // no paths specify
-        if (paths.length < 1) return false
-        val path = paths.head
-        val fs = path.getFileSystem(r.sparkSession.sparkContext.hadoopConfiguration)
-        val meta = new Path(path, OapFileFormat.OAP_META_FILE)
-        fs.exists(meta)
-      }
-
       val partitionColumns =
         l.resolve(_files.partitionSchema, _files.sparkSession.sessionState.analyzer.resolver)
       val partitionSet = AttributeSet(partitionColumns)
@@ -106,7 +96,7 @@ private[sql] object FileSourceStrategy extends Strategy with Logging {
         // if config true turn to OapFileFormat
         // else turn to ParquetFileFormat
         case a: ParquetFileFormat
-          if fileExists(_files) && _files.sparkSession.conf.get(SQLConf.OAP_PARQUET_ENABLED) =>
+          if _files.sparkSession.conf.get(SQLConf.OAP_PARQUET_ENABLED) =>
           val oapFileFormat = new OapFileFormat
           oapFileFormat
             .initialize(_files.sparkSession,


### PR DESCRIPTION
I think this fileExists operation is duplicate, unnecessary, and at the same time brings some problems.
For example, we have the following partition data:
	/shitu/day=20170710/part-0.parquet
	/shitu/day=20170711/part-0.parquet
Then we do "create sindex" operations in day=20170711, and get the following results:
        /shitu/day=20170710/part-0.parquet
	/shitu/day=20170711/part-0.parquet
	/shitu/day=20170711/part-0.userid.index
	/shitu/day=20170711/.spinach.meta
Then we do the following query: select * from shitu where day=20170711  and userid = 1
Because the order of the catalog list is /shitu/day=20170710,/shitu/day=20170711
So in the original logic, we'll see if /shitu/day=20170710/.spinach.meta exists, and although we've create sindex on /shitu/day=20170711 partition , it never triggers spinach read.
