### PR TITLE
optimize oap config

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Parquet Support - Enable OAP support for parquet files
 * Usage: `sqlContext.conf.setConfString(SQLConf.OAP_PARQUET_ENABLED.key, "false")`
 
 Fiber Cache Size - Total Memory size to cache Fiber. Unit: KB
-* Default: 307200
+* Default: `spark.executor.memory * 0.3`
 * Usage: `sqlContext.conf.setConfString(SQLConf.OAP_FIBERCACHE_SIZE.key, s"{100 * 1024 * 1024}")`
 
 Full Scan Threshold - If the analysis result is above this threshold, it will go through the whole data file instead of read index data.
@@ -73,12 +73,12 @@ Full Scan Threshold - If the analysis result is above this threshold, it will go
 * Usage: `sqlContext.conf.setConfString(SQLConf.OAP_FULL_SCAN_THRESHOLD.key, "0.8")`
 
 Row Group Size - Row count for each row group
-* Default: 1024
+* Default: 1048576
 * Usage1: `sqlContext.conf.setConfString(SQLConf.OAP_ROW_GROUP_SIZE.key, "1025")`
 * Usage2: `CREATE TABLE t USING oap OPTIONS ('rowgroup' '1024')`
 
 Compression Codec - Choose compression type for OAP data files.
-* Default: UNCOMPRESSED
+* Default: GZIP
 * Values: UNCOMPRESSED, SNAPPY, GZIP, LZO
 * Usage1: `sqlContext.conf.setConfString(SQLConf.OAP_COMPRESSION.key, "SNAPPY")`
 * Usage2: `CREATE TABLE t USING oap OPTIONS ('compression' 'SNAPPY')`

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -383,9 +383,9 @@ private[sql] object OapFileFormat {
   val PARQUET_DATA_FILE_CLASSNAME = classOf[ParquetDataFile].getCanonicalName
 
   val COMPRESSION = "oap.compression"
-  val DEFAULT_COMPRESSION = "UNCOMPRESSED"
+  val DEFAULT_COMPRESSION = SQLConf.OAP_COMPRESSION.defaultValueString
   val ROW_GROUP_SIZE = "oap.rowgroup.size"
-  val DEFAULT_ROW_GROUP_SIZE = "1024"
+  val DEFAULT_ROW_GROUP_SIZE = SQLConf.OAP_ROW_GROUP_SIZE.defaultValueString
 
   def serializeDataSourceMeta(conf: Configuration, meta: Option[DataSourceMeta]): Unit = {
     SerializationUtil.writeObjectToConfAsBase64(OAP_DATA_SOURCE_META, meta, conf)

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -630,16 +630,16 @@ object SQLConf {
     .doc("Sets the compression codec use when writing Parquet files. Acceptable values include: " +
       "uncompressed, snappy, gzip, lzo.")
     .stringConf
-    .transform(_.toLowerCase())
-    .checkValues(Set("uncompressed", "snappy", "gzip", "lzo"))
-    .createWithDefault("uncompressed")
+    .transform(_.toUpperCase())
+    .checkValues(Set("UNCOMPRESSED", "SNAPPY", "GZIP", "LZO"))
+    .createWithDefault("GZIP")
 
   val OAP_ROW_GROUP_SIZE =
     SQLConfigBuilder("spark.sql.oap.rowgroup.size")
       .internal()
       .doc("Define the row number for each row group")
       .intConf
-      .createWithDefault(1024)
+      .createWithDefault(1024 * 1024)
 
 
   object Deprecated {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
@@ -90,6 +90,9 @@ class FiberSuite extends SparkFunSuite with Logging with BeforeAndAfterAll {
   }
 
   test("test data file meta") {
+    val previousRowGroupSize = conf.get(OapFileFormat.ROW_GROUP_SIZE)
+    // change default row group size
+    conf.set(OapFileFormat.ROW_GROUP_SIZE, "1024")
     val schema = new StructType()
       .add("a", IntegerType)
       .add("b", StringType)
@@ -105,6 +108,8 @@ class FiberSuite extends SparkFunSuite with Logging with BeforeAndAfterAll {
       assert(meta.rowCountInLastGroup === rowCountInLastGroups(i))
       assert(meta.rowGroupsMeta.length === rowGroupCounts(i))
     }
+    if (previousRowGroupSize == null) conf.unset(OapFileFormat.ROW_GROUP_SIZE)
+    else conf.set(OapFileFormat.ROW_GROUP_SIZE, previousRowGroupSize)
   }
 
   test("test oap row group configuration") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set default row group size to 1048576
Set default compression codec to GZIP
Set default fiber cache size to 0.3 * EXECUTOR_MEMORY


## How was this patch tested?

Unit test
