### PR TITLE
Fix nit of index check logic in DataSourceMeta

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -295,36 +295,39 @@ private[oap] case class DataSourceMeta(
      val bTreeSet: mutable.HashSet[String] = hashSetList(0)
      val bitmapSet: mutable.HashSet[String] = hashSetList(1)
      var attr: String = null
+
+     def checkInMetaSet(attrRef: AttributeReference): Boolean = {
+       if (attr ==  null || attr == attrRef.name) {
+         attr = attrRef.name
+         bTreeSet.contains(attr) || bitmapSet.contains(attr)
+       } else false
+     }
+
      def checkAttribute(filter: Expression): Boolean = filter match {
        case Or(left, right) =>
          checkAttribute(left) && checkAttribute(right)
        case And(left, right) =>
          checkAttribute(left) && checkAttribute(right)
        case EqualTo(attrRef: AttributeReference, _) =>
-         if (attr ==  null || attr == attrRef.name) {
-           attr = attrRef.name
-           bTreeSet.contains(attr) || bitmapSet.contains(attr)
-         } else false
+         checkInMetaSet(attrRef)
+       case EqualTo(_, attrRef: AttributeReference) =>
+         checkInMetaSet(attrRef)
        case LessThan(attrRef: AttributeReference, _) =>
-         if (attr ==  null || attr == attrRef.name) {
-           attr = attrRef.name
-           bTreeSet.contains(attr) || bitmapSet.contains(attr)
-         } else false
+         checkInMetaSet(attrRef)
+       case LessThan(_, attrRef: AttributeReference) =>
+         checkInMetaSet(attrRef)
        case LessThanOrEqual(attrRef: AttributeReference, _) =>
-         if (attr ==  null || attr == attrRef.name) {
-           attr = attrRef.name
-           bTreeSet.contains(attr) || bitmapSet.contains(attr)
-         } else false
+         checkInMetaSet(attrRef)
+       case LessThanOrEqual(_, attrRef: AttributeReference) =>
+         checkInMetaSet(attrRef)
        case GreaterThan(attrRef: AttributeReference, _) =>
-         if (attr ==  null || attr == attrRef.name) {
-           attr = attrRef.name
-           bTreeSet.contains(attr) || bitmapSet.contains(attr)
-         } else false
+         checkInMetaSet(attrRef)
+       case GreaterThan(_, attrRef: AttributeReference) =>
+         checkInMetaSet(attrRef)
        case GreaterThanOrEqual(attrRef: AttributeReference, _) =>
-         if (attr ==  null || attr == attrRef.name) {
-           attr = attrRef.name
-           bTreeSet.contains(attr) || bitmapSet.contains(attr)
-         } else false
+         checkInMetaSet(attrRef)
+       case GreaterThanOrEqual(_, attrRef: AttributeReference) =>
+         checkInMetaSet(attrRef)
        case _ => false
      }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -375,11 +375,13 @@ class DataSourceMetaSuite extends SharedSQLContext with BeforeAndAfter {
     val isNotNull = Seq(IsNotNull(AttributeReference("b", IntegerType)()))
     val eq = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)))
     val eq2 = Seq(EqualTo(AttributeReference("b", IntegerType)(), Literal(1)))
+    val eq3 = Seq(EqualTo(Literal(1), AttributeReference("a", IntegerType)()))
     val lt = Seq(LessThan(AttributeReference("a", IntegerType)(), Literal(1)))
     val gt = Seq(GreaterThan(AttributeReference("a", IntegerType)(), Literal(1)))
     val gt2 = Seq(GreaterThan(AttributeReference("c", StringType)(), Literal("A Row")))
     val lte = Seq(LessThanOrEqual(AttributeReference("a", IntegerType)(), Literal(1)))
     val gte = Seq(GreaterThanOrEqual(AttributeReference("a", IntegerType)(), Literal(1)))
+    val gte1 = Seq(GreaterThanOrEqual(Literal(1), AttributeReference("a", IntegerType)()))
     val or1 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
       EqualTo(AttributeReference("a", IntegerType)(), Literal(1))) )
     val or2 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
@@ -458,11 +460,13 @@ class DataSourceMetaSuite extends SharedSQLContext with BeforeAndAfter {
 
     assert(! isNotNull.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(eq.exists(meta.isSupportedByIndex(_, hashSetList)))
+    assert(eq3.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(lt.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(gt.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(gt2.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(lte.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(gte.exists(meta.isSupportedByIndex(_, hashSetList)))
+    assert(gte1.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(! eq2.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(or1.exists(meta.isSupportedByIndex(_, hashSetList)))
     assert(or2.exists(meta.isSupportedByIndex(_, hashSetList)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Find a nit in `isSupportedByIndex` logic, the AttributeReference may appear in both side of BinaryComparison. Example in `TypeCoercion.scala`


## How was this patch tested?
Add tests in origin DataSourceMetaSuite.

