### PR TITLE
Avoid NPE if bestIndexer is null when debug is on.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexContext.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexContext.scala
@@ -137,7 +137,9 @@ private[oap] class IndexContext(meta: DataSourceMeta) extends Logging {
       lastIdx = availableIndexes.head._1
       bestIndexer = availableIndexes.head._2
     }
-    logDebug("\t" + bestIndexer.toString + "; lastIdx: " + lastIdx)
+    if (bestIndexer != null) {
+      logInfo("\t" + bestIndexer.toString + "; lastIdx: " + lastIdx)
+    }
     (lastIdx, bestIndexer)
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexContext.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexContext.scala
@@ -138,7 +138,9 @@ private[oap] class IndexContext(meta: DataSourceMeta) extends Logging {
       bestIndexer = availableIndexes.head._2
     }
     if (bestIndexer != null) {
-      logInfo("\t" + bestIndexer.toString + "; lastIdx: " + lastIdx)
+      logDebug("\t" + bestIndexer.toString + "; lastIdx: " + lastIdx)
+    } else {
+      logDebug("\t" + "No best indexer is found.")
     }
     (lastIdx, bestIndexer)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
add if statement to check that the bestIndexer is not null.
Use logInfo instead of logDebug to avoid scalastyle exception.

## How was this patch tested?
Use mvn test and all the tests passed.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

