### PR TITLE
Add the compression type for the oap data file name if it's compresed.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -373,12 +373,12 @@ private[oap] class OapOutputWriter(
   private val writer: OapDataWriter = {
     val isCompressed: Boolean = FileOutputFormat.getCompressOutput(context)
     val conf: Configuration = context.getConfiguration()
-    val compressionFileFormat: String = ""
     val compressionType: String =
       conf.get(OapFileFormat.COMPRESSION, OapFileFormat.DEFAULT_COMPRESSION).toString()
-    if (!compressionType.isEmpty() && !compressionType.matches("UNCOMPRESSED")) {
-      compressionFileFormat.concat("." + compressionType.toLowerCase())
-    }
+    val compressionFileFormat: String =
+      if (!compressionType.isEmpty() && !compressionType.matches("UNCOMPRESSED")) {
+        "." + compressionType.toLowerCase()
+      } else ""
     val file: Path = new Path(path, getFileName(compressionFileFormat +
                                                 OapFileFormat.OAP_DATA_EXTENSION))
     val fs: FileSystem = file.getFileSystem(conf)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -372,11 +372,19 @@ private[oap] class OapOutputWriter(
   }
   private val writer: OapDataWriter = {
     val isCompressed: Boolean = FileOutputFormat.getCompressOutput(context)
-    val file: Path = new Path(path, getFileName(OapFileFormat.OAP_DATA_EXTENSION))
-    val fs: FileSystem = file.getFileSystem(context.getConfiguration)
+    val conf: Configuration = context.getConfiguration()
+    var compressionFormat: String = ""
+    compressionFormat =
+      conf.get(OapFileFormat.COMPRESSION, OapFileFormat.DEFAULT_COMPRESSION).toString()
+    if (!compressionFormat.isEmpty() && !compressionFormat.matches("UNCOMPRESSED")) {
+      compressionFormat = "." + compressionFormat.toLowerCase()
+    }
+    val file: Path = new Path(path, getFileName(compressionFormat +
+                                                OapFileFormat.OAP_DATA_EXTENSION))
+    val fs: FileSystem = file.getFileSystem(conf)
     val fileOut: FSDataOutputStream = fs.create(file, false)
 
-    new OapDataWriter(isCompressed, fileOut, dataSchema, context.getConfiguration)
+    new OapDataWriter(isCompressed, fileOut, dataSchema, conf)
   }
 
   override def write(row: Row): Unit = throw new NotImplementedError("write(row: Row)")

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -378,6 +378,8 @@ private[oap] class OapOutputWriter(
       conf.get(OapFileFormat.COMPRESSION, OapFileFormat.DEFAULT_COMPRESSION).toString()
     if (!compressionFormat.isEmpty() && !compressionFormat.matches("UNCOMPRESSED")) {
       compressionFormat = "." + compressionFormat.toLowerCase()
+    } else {
+      compressionFormat = ""
     }
     val file: Path = new Path(path, getFileName(compressionFormat +
                                                 OapFileFormat.OAP_DATA_EXTENSION))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -371,18 +371,18 @@ private[oap] class OapOutputWriter(
     partitionString = ps
   }
   private val writer: OapDataWriter = {
-    val isCompressed: Boolean = FileOutputFormat.getCompressOutput(context)
-    val conf: Configuration = context.getConfiguration()
-    val compressionType: String =
+    val isCompressed = FileOutputFormat.getCompressOutput(context)
+    val conf = context.getConfiguration()
+    val compressionType =
       conf.get(OapFileFormat.COMPRESSION, OapFileFormat.DEFAULT_COMPRESSION).trim()
-    val compressionFileFormat: String =
+    val compressionFileFormat =
       if (!compressionType.isEmpty() && !compressionType.matches("UNCOMPRESSED")) {
         "." + compressionType.toLowerCase()
       } else ""
-    val file: Path = new Path(path, getFileName(compressionFileFormat +
-                                                OapFileFormat.OAP_DATA_EXTENSION))
-    val fs: FileSystem = file.getFileSystem(conf)
-    val fileOut: FSDataOutputStream = fs.create(file, false)
+    val file =
+      new Path(path, getFileName(compressionFileFormat + OapFileFormat.OAP_DATA_EXTENSION))
+    val fs = file.getFileSystem(conf)
+    val fileOut = fs.create(file, false)
 
     new OapDataWriter(isCompressed, fileOut, dataSchema, conf)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -373,15 +373,13 @@ private[oap] class OapOutputWriter(
   private val writer: OapDataWriter = {
     val isCompressed: Boolean = FileOutputFormat.getCompressOutput(context)
     val conf: Configuration = context.getConfiguration()
-    var compressionFormat: String = ""
-    compressionFormat =
+    val compressionFileFormat: String = ""
+    val compressionType: String =
       conf.get(OapFileFormat.COMPRESSION, OapFileFormat.DEFAULT_COMPRESSION).toString()
-    if (!compressionFormat.isEmpty() && !compressionFormat.matches("UNCOMPRESSED")) {
-      compressionFormat = "." + compressionFormat.toLowerCase()
-    } else {
-      compressionFormat = ""
+    if (!compressionType.isEmpty() && !compressionType.matches("UNCOMPRESSED")) {
+      compressionFileFormat.concat("." + compressionType.toLowerCase())
     }
-    val file: Path = new Path(path, getFileName(compressionFormat +
+    val file: Path = new Path(path, getFileName(compressionFileFormat +
                                                 OapFileFormat.OAP_DATA_EXTENSION))
     val fs: FileSystem = file.getFileSystem(conf)
     val fileOut: FSDataOutputStream = fs.create(file, false)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -374,7 +374,7 @@ private[oap] class OapOutputWriter(
     val isCompressed: Boolean = FileOutputFormat.getCompressOutput(context)
     val conf: Configuration = context.getConfiguration()
     val compressionType: String =
-      conf.get(OapFileFormat.COMPRESSION, OapFileFormat.DEFAULT_COMPRESSION).toString()
+      conf.get(OapFileFormat.COMPRESSION, OapFileFormat.DEFAULT_COMPRESSION).trim()
     val compressionFileFormat: String =
       if (!compressionType.isEmpty() && !compressionType.matches("UNCOMPRESSED")) {
         "." + compressionType.toLowerCase()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -77,6 +77,54 @@ class OapSuite extends QueryTest with SharedSQLContext with BeforeAndAfter {
     }
   }
 
+  test("Add the corresponding compression type for the OAP data file name if any") {
+    val defaultCompressionType =
+      sqlContext.conf.getConfString(SQLConf.OAP_COMPRESSION.key).toLowerCase()
+    val fileNameIterator = path.listFiles()
+    for (fileName <- fileNameIterator) {
+      if (fileName.toString().endsWith(OapFileFormat.OAP_DATA_EXTENSION)) {
+          assert(fileName.toString().contains(defaultCompressionType) == true)
+      }
+    }
+
+    sqlContext.conf.setConfString(SQLConf.OAP_COMPRESSION.key, "SNAPPY")
+    val snappyDf = sqlContext.read.format("oap").load(path.getAbsolutePath)
+    snappyDf.write.format("oap").mode(SaveMode.Overwrite).save(path.getAbsolutePath)
+    val snappyCompressionType =
+      sqlContext.conf.getConfString(SQLConf.OAP_COMPRESSION.key).toLowerCase()
+    val snappyFileNameIterator = path.listFiles()
+    for (fileName <- snappyFileNameIterator) {
+      if (fileName.toString().endsWith(OapFileFormat.OAP_DATA_EXTENSION)) {
+          assert(fileName.toString().contains(snappyCompressionType) == true)
+      }
+    }
+
+    sqlContext.conf.setConfString(SQLConf.OAP_COMPRESSION.key, "LZO")
+    val lzoDf = sqlContext.read.format("oap").load(path.getAbsolutePath)
+    lzoDf.write.format("oap").mode(SaveMode.Overwrite).save(path.getAbsolutePath)
+    val lzoCompressionType =
+      sqlContext.conf.getConfString(SQLConf.OAP_COMPRESSION.key).toLowerCase()
+    val lzoFileNameIterator = path.listFiles()
+    for (fileName <- lzoFileNameIterator) {
+      if (fileName.toString().endsWith(OapFileFormat.OAP_DATA_EXTENSION)) {
+          assert(fileName.toString().contains(lzoCompressionType) == true)
+      }
+    }
+
+    // If the OAP data file is uncompressed, keep the original file name.
+    sqlContext.conf.setConfString(SQLConf.OAP_COMPRESSION.key, "UNCOMPRESSED")
+    val uncompressDf = sqlContext.read.format("oap").load(path.getAbsolutePath)
+    uncompressDf.write.format("oap").mode(SaveMode.Overwrite).save(path.getAbsolutePath)
+    val uncompressCompressionType =
+      sqlContext.conf.getConfString(SQLConf.OAP_COMPRESSION.key).toLowerCase()
+    val uncompressFileNameIterator = path.listFiles()
+    for (fileName <- uncompressFileNameIterator) {
+      if (fileName.toString().endsWith(OapFileFormat.OAP_DATA_EXTENSION)) {
+          assert(fileName.toString().contains(uncompressCompressionType) == false)
+      }
+    }
+  }
+
   /** Verifies data and schema. */
   private def verifyFrame(df: DataFrame): Unit = {
     // schema

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -78,7 +78,7 @@ class OapSuite extends QueryTest with SharedSQLContext with BeforeAndAfter {
   }
 
   test("Add the corresponding compression type for the OAP data file name if any") {
-    Seq("GZIP", "SNAPPY", "LZO", "UNCOMPRESSED").exists (codec => {
+    Seq("GZIP", "SNAPPY", "LZO", "UNCOMPRESSED").foreach (codec => {
       sqlContext.conf.setConfString(SQLConf.OAP_COMPRESSION.key, codec)
       val df = sqlContext.read.format("oap").load(path.getAbsolutePath)
       df.write.format("oap").mode(SaveMode.Overwrite).save(path.getAbsolutePath)
@@ -95,7 +95,6 @@ class OapSuite extends QueryTest with SharedSQLContext with BeforeAndAfter {
           }
         }
       }
-      true
     })
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
If the oap data file name is compressed, just add the compression type to the data file name.
If it's uncompressed, keep the original file name.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
1. mvn test.
2. manually change the compression type at runtime and verified that the file name is added with the corresponding compression type after the data is saved.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

