### PR TITLE
Add one configuration for developers to easily ignore index

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -275,8 +275,8 @@ private[sql] class OapFileFormat extends FileFormat
 
         hadoopConf.setDouble(SQLConf.OAP_FULL_SCAN_THRESHOLD.key,
           sparkSession.conf.get(SQLConf.OAP_FULL_SCAN_THRESHOLD))
-        hadoopConf.setBoolean(SQLConf.OAP_USE_INDEX.key,
-          sparkSession.conf.get(SQLConf.OAP_USE_INDEX))
+        hadoopConf.setBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key,
+          sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS))
         val broadcastedHadoopConf =
           sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
@@ -332,20 +332,24 @@ private[sql] class OapFileFormat extends FileFormat
   }
 
   def hasAvailableIndex(expressions: Seq[Expression]): Boolean = {
-    meta match {
-      case Some(m) =>
-        expressions.exists(m.isSupportedByIndex(_, indexHashSetList))
-      case None => false
-    }
+    if (sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS)) {
+      meta match {
+        case Some(m) =>
+          expressions.exists(m.isSupportedByIndex(_, indexHashSetList))
+        case None => false
+      }
+    } else false
   }
 
   def hasAvailableIndex(attributes: AttributeSet): Boolean = {
-    meta match {
-      case Some(m) =>
-        attributes.map{attr =>
-          indexHashSetList.map(_.contains(attr.name)).reduce(_ || _)}.reduce(_ && _)
-      case None => false
-    }
+    if (sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS)) {
+      meta match {
+        case Some(m) =>
+          attributes.map{attr =>
+            indexHashSetList.map(_.contains(attr.name)).reduce(_ || _)}.reduce(_ && _)
+        case None => false
+      }
+    } else false
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -334,8 +334,7 @@ private[sql] class OapFileFormat extends FileFormat
   def hasAvailableIndex(expressions: Seq[Expression]): Boolean = {
     (meta, sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS)) match {
       case (Some(m), true) => expressions.exists(m.isSupportedByIndex(_, indexHashSetList))
-      case (None, true) => false
-      case (None, false) => false
+      case (None, _) => false
       case (_, false) => false
     }
   }
@@ -345,8 +344,7 @@ private[sql] class OapFileFormat extends FileFormat
       case (Some(m), true) =>
           attributes.map{attr =>
             indexHashSetList.map(_.contains(attr.name)).reduce(_ || _)}.reduce(_ && _)
-      case (None, true) => false
-      case (None, false) => false
+      case (None, _) => false
       case (_, false) => false
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -275,6 +275,8 @@ private[sql] class OapFileFormat extends FileFormat
 
         hadoopConf.setDouble(SQLConf.OAP_FULL_SCAN_THRESHOLD.key,
           sparkSession.conf.get(SQLConf.OAP_FULL_SCAN_THRESHOLD))
+        hadoopConf.setBoolean(SQLConf.OAP_USE_INDEX.key,
+          sparkSession.conf.get(SQLConf.OAP_USE_INDEX))
         val broadcastedHadoopConf =
           sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -332,24 +332,21 @@ private[sql] class OapFileFormat extends FileFormat
   }
 
   def hasAvailableIndex(expressions: Seq[Expression]): Boolean = {
-    if (sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS)) {
-      meta match {
-        case Some(m) =>
-          expressions.exists(m.isSupportedByIndex(_, indexHashSetList))
-        case None => false
-      }
-    } else false
+    (meta, sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS)) match {
+      case (Some(m), true) => expressions.exists(m.isSupportedByIndex(_, indexHashSetList)
+      case (None, false) => false
+      case (_, false) => false
+    }
   }
 
   def hasAvailableIndex(attributes: AttributeSet): Boolean = {
-    if (sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS)) {
-      meta match {
-        case Some(m) =>
+    (meta, sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS)) match {
+      case (Some(m), true) =>
           attributes.map{attr =>
             indexHashSetList.map(_.contains(attr.name)).reduce(_ || _)}.reduce(_ && _)
-        case None => false
-      }
-    } else false
+      case (None, false) => false
+      case (_, false) => false
+    }
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -333,7 +333,8 @@ private[sql] class OapFileFormat extends FileFormat
 
   def hasAvailableIndex(expressions: Seq[Expression]): Boolean = {
     (meta, sparkSession.conf.get(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS)) match {
-      case (Some(m), true) => expressions.exists(m.isSupportedByIndex(_, indexHashSetList)
+      case (Some(m), true) => expressions.exists(m.isSupportedByIndex(_, indexHashSetList))
+      case (None, true) => false
       case (None, false) => false
       case (_, false) => false
     }
@@ -344,6 +345,7 @@ private[sql] class OapFileFormat extends FileFormat
       case (Some(m), true) =>
           attributes.map{attr =>
             indexHashSetList.map(_.contains(attr.name)).reduce(_ || _)}.reduce(_ && _)
+      case (None, true) => false
       case (None, false) => false
       case (_, false) => false
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -176,13 +176,14 @@ private[oap] class OapDataReader(
         val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
         val isTesting = conf.getBoolean(SQLConf.OAP_IS_TESTING.key,
                               SQLConf.OAP_IS_TESTING.defaultValue.get)
-        val use_index_for_developers = conf.getBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key,
+        val useIndexForDev = conf.getBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key,
                               SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.defaultValue.get)
         val iter =
           // Below is for OAP developers to easily analyze and compare performance without removing
           // the index after it's created.
-          if (!use_index_for_developers) {
-            logWarning("Index won't be used")
+          if (!useIndexForDev) {
+            logWarning("OAP index is disabled. Using below approach to enable index,
+              sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true)")
             fileScanner.iterator(conf, requiredIds)
           } else if (limit <= 0 && indexFileSize > dataFileSize * 0.7 && !isTesting) {
             logWarning(s"Index File size $indexFileSize B is too large comparing " +

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -182,8 +182,8 @@ private[oap] class OapDataReader(
           // Below is for OAP developers to easily analyze and compare performance without removing
           // the index after it's created.
           if (!useIndexForDev) {
-            logWarning("OAP index is disabled. Using below approach to enable index,
-              sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true)")
+            logWarning("OAP index is disabled. Using below approach to enable index," +
+              "sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true)")
             fileScanner.iterator(conf, requiredIds)
           } else if (limit <= 0 && indexFileSize > dataFileSize * 0.7 && !isTesting) {
             logWarning(s"Index File size $indexFileSize B is too large comparing " +

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -176,8 +176,15 @@ private[oap] class OapDataReader(
         val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
         val isTesting = conf.getBoolean(SQLConf.OAP_IS_TESTING.key,
                               SQLConf.OAP_IS_TESTING.defaultValue.get)
+        val use_index = conf.getBoolean(SQLConf.OAP_USE_INDEX.key,
+                              SQLConf.OAP_USE_INDEX.defaultValue.get)
         val iter =
-          if (indexFileSize > dataFileSize * 0.7 && !isTesting) {
+          // Below is for OAP developers to easily analyze and compare performance without removing
+          // the index after it's created.
+          if (!use_index) {
+            logWarning("Index won't be used")
+            fileScanner.iterator(conf, requiredIds)
+          } else if (indexFileSize > dataFileSize * 0.7 && !isTesting) {
             logWarning(s"Index File size $indexFileSize B is too large comparing " +
                         s"to Data File Size $dataFileSize. Using Data File Scan instead.")
             fileScanner.iterator(conf, requiredIds)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -175,8 +175,8 @@ private[oap] class OapDataReader(
         val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
         val isTesting = conf.getBoolean(SQLConf.OAP_IS_TESTING.key,
                               SQLConf.OAP_IS_TESTING.defaultValue.get)
-        val useIndexForDev = conf.getBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key,
-                               SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.defaultValue.get)
+        val enableOIndex = conf.getBoolean(SQLConf.OAP_ENABLE_OINDEX.key,
+          SQLConf.OAP_ENABLE_OINDEX.defaultValue.get)
         val isAscending = options.getOrElse(
           OapFileFormat.OAP_QUERY_ORDER_OPTION_KEY, "false").toBoolean
         val limit = options.getOrElse(OapFileFormat.OAP_QUERY_LIMIT_OPTION_KEY, "0").toInt
@@ -193,7 +193,7 @@ private[oap] class OapDataReader(
         val iter =
           // Below is for OAP developers to easily analyze and compare performance without removing
           // the index after it's created.
-          if (!useIndexForDev) {
+          if (!enableOIndex) {
             logWarning("OAP index is disabled. Using below approach to enable index,\n" +
               "sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true)")
             fileScanner.iterator(conf, requiredIds)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -176,12 +176,12 @@ private[oap] class OapDataReader(
         val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
         val isTesting = conf.getBoolean(SQLConf.OAP_IS_TESTING.key,
                               SQLConf.OAP_IS_TESTING.defaultValue.get)
-        val use_index = conf.getBoolean(SQLConf.OAP_USE_INDEX.key,
-                              SQLConf.OAP_USE_INDEX.defaultValue.get)
+        val use_index_for_developers = conf.getBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key,
+                              SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.defaultValue.get)
         val iter =
           // Below is for OAP developers to easily analyze and compare performance without removing
           // the index after it's created.
-          if (!use_index) {
+          if (!use_index_for_developers) {
             logWarning("Index won't be used")
             fileScanner.iterator(conf, requiredIds)
           } else if (limit <= 0 && indexFileSize > dataFileSize * 0.7 && !isTesting) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -177,12 +177,12 @@ private[oap] class OapDataReader(
         val isTesting = conf.getBoolean(SQLConf.OAP_IS_TESTING.key,
                               SQLConf.OAP_IS_TESTING.defaultValue.get)
         val useIndexForDev = conf.getBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key,
-                              SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.defaultValue.get)
+                               SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.defaultValue.get)
         val iter =
           // Below is for OAP developers to easily analyze and compare performance without removing
           // the index after it's created.
           if (!useIndexForDev) {
-            logWarning("OAP index is disabled. Using below approach to enable index," +
+            logWarning("OAP index is disabled. Using below approach to enable index,\n" +
               "sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true)")
             fileScanner.iterator(conf, requiredIds)
           } else if (limit <= 0 && indexFileSize > dataFileSize * 0.7 && !isTesting) {

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -648,10 +648,10 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val OAP_USE_INDEX_FOR_DEVELOPERS =
-    SQLConfigBuilder("spark.sql.oap.use.index")
+  val OAP_ENABLE_OINDEX =
+    SQLConfigBuilder("spark.sql.oap.oindex.enabled")
       .internal()
-      .doc("To indicate to use index or not even if the index file is there")
+      .doc("To indicate to enable/disable oindex for developers even if the index file is there")
       .booleanConf
       .createWithDefault(true)
 

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -648,7 +648,7 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val OAP_USE_INDEX =
+  val OAP_USE_INDEX_FOR_DEVELOPERS =
     SQLConfigBuilder("spark.sql.oap.use.index")
       .internal()
       .doc("To indicate to use index or not even if the index file is there")

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -648,6 +648,12 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_USE_INDEX =
+    SQLConfigBuilder("spark.sql.oap.use.index")
+      .internal()
+      .doc("To indicate to use index or not even if the index file is there")
+      .booleanConf
+      .createWithDefault(true)
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -21,9 +21,15 @@ import java.io.File
 
 import org.scalatest.BeforeAndAfter
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
+import org.apache.spark.sql.execution.datasources.oap.{DataSourceMeta, OapFileFormat}
+import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, ScannerBuilder}
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataReader
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources._
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 import org.apache.spark.util.Utils
@@ -98,6 +104,48 @@ class OapSuite extends QueryTest with SharedSQLContext with BeforeAndAfter {
         }
       }
     })
+  }
+
+  test("Enable/disable using OAP index after the index is created already") {
+    val dir = Utils.createTempDir()
+    dir.delete()
+    val data = sparkContext.parallelize(1 to 100, 1)
+      .map(i => (i, s"this is row $i"))
+    data.toDF("a", "b").write.format("oap").mode(SaveMode.Overwrite).save(dir.getAbsolutePath)
+    val files = dir.listFiles
+    var oapDataFile: File = null
+    var oapMetaFile: File = null
+    files.foreach { fileName =>
+      if (fileName.toString().endsWith(OapFileFormat.OAP_DATA_EXTENSION)) oapDataFile = fileName
+      if (fileName.toString().endsWith(OapFileFormat.OAP_META_FILE)) oapMetaFile = fileName
+    }
+    val df = sqlContext.read.format("oap").load(dir.getAbsolutePath)
+    df.createOrReplaceTempView("oap_table")
+    sql("create oindex oap_idx on oap_table (a)")
+    val conf = spark.sparkContext.hadoopConfiguration
+    val filePath = new Path(oapDataFile.toString)
+    val metaPath = new Path(oapMetaFile.toString)
+    val dataSourceMeta = DataSourceMeta.initialize(metaPath, conf)
+    val requiredIds = Array(0, 1)
+    // No index scanner is used.
+    val readerNoIndex = new OapDataReader(filePath, dataSourceMeta, None, requiredIds)
+    val itNoIndex = readerNoIndex.initialize(conf)
+    assert (itNoIndex.size == 100)
+    val ic = new IndexContext(dataSourceMeta)
+    val filters: Array[Filter] = Array(
+      And(GreaterThan("a", 9), LessThan("a", 14)))
+    ScannerBuilder.build(filters, ic)
+    var filterScanner = ic.getScanner
+    val readerIndex = new OapDataReader(filePath, dataSourceMeta, filterScanner, requiredIds)
+    val itIndex = readerIndex.initialize(conf)
+    assert (itIndex.size == 4)
+    conf.setBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, false)
+    val itSetIgnoreIndex = readerIndex.initialize(conf)
+    assert (itSetIgnoreIndex.size == 100)
+    conf.setBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true)
+    val itSetUseIndex = readerIndex.initialize(conf)
+    assert (itSetUseIndex.size == 4)
+    dir.delete()
   }
 
   /** Verifies data and schema. */

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -23,6 +23,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.datasources.oap.{DataSourceMeta, OapFileFormat}
@@ -130,7 +131,7 @@ class OapSuite extends QueryTest with SharedSQLContext with BeforeAndAfter {
     // No index scanner is used.
     val readerNoIndex = new OapDataReader(filePath, dataSourceMeta, None, requiredIds)
     val itNoIndex = readerNoIndex.initialize(conf)
-    assert (itNoIndex.size == 100)
+    assert(itNoIndex.size == 100)
     val ic = new IndexContext(dataSourceMeta)
     val filters: Array[Filter] = Array(
       And(GreaterThan("a", 9), LessThan("a", 14)))
@@ -138,13 +139,13 @@ class OapSuite extends QueryTest with SharedSQLContext with BeforeAndAfter {
     var filterScanner = ic.getScanner
     val readerIndex = new OapDataReader(filePath, dataSourceMeta, filterScanner, requiredIds)
     val itIndex = readerIndex.initialize(conf)
-    assert (itIndex.size == 4)
-    conf.setBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, false)
+    assert(itIndex.size == 4)
+    conf.setBoolean(SQLConf.OAP_ENABLE_OINDEX.key, false)
     val itSetIgnoreIndex = readerIndex.initialize(conf)
-    assert (itSetIgnoreIndex.size == 100)
-    conf.setBoolean(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true)
+    assert(itSetIgnoreIndex.size == 100)
+    conf.setBoolean(SQLConf.OAP_ENABLE_OINDEX.key, true)
     val itSetUseIndex = readerIndex.initialize(conf)
-    assert (itSetUseIndex.size == 4)
+    assert(itSetUseIndex.size == 4)
     dir.delete()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This option is for OAP developers to easily analyze the OAP
performance w/ and w/o index even if the index is created already.

Usage:
sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX.key, value)

The value is true by default. This means that the index will be
used by default. Otherwise, the index won't be used.

## How was this patch tested?
mvn test
