### PR TITLE
Using extended event and listener to report index infor from executors to driver

### DIFF
--- a/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -127,4 +127,9 @@ public class SparkFirehoseListener implements SparkListenerInterface {
     public void onCustomInfoUpdate(SparkListenerCustomInfoUpdate customInfoUpdate) {
         onEvent(customInfoUpdate);
     }
+
+    @Override
+    public void onOapIndexInfoUpdate(SparkListenerOapIndexInfoUpdate oapIndexInfoUpdate) {
+        onEvent(oapIndexInfoUpdate);
+    }
 }

--- a/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -150,10 +150,16 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
 
       // Right now there are two extended user events. First is for fiber cache infor update.
       // Second is for oap index infor update.
-      sc.listenerBus.post(SparkListenerCustomInfoUpdate(blockManagerId.host, executorId,
-        customizedInfo.head))
-      sc.listenerBus.post(SparkListenerOapIndexInfoUpdate(blockManagerId.host, executorId,
-        customizedInfo.last))
+      // The cusInfo is serialized string for fiber and oap index status.
+      customizedInfo.foreach { cusInfo =>
+        if (cusInfo.contains("fiberFilePath")) {
+          sc.listenerBus.post(SparkListenerCustomInfoUpdate(blockManagerId.host, executorId,
+            cusInfo))
+        } else if (cusInfo.contains("useOapIndex")) {
+          sc.listenerBus.post(SparkListenerOapIndexInfoUpdate(blockManagerId.host, executorId,
+            cusInfo))
+        }
+      }
   }
 
   /**

--- a/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -148,7 +148,7 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
         context.reply(HeartbeatResponse(reregisterBlockManager = true))
       }
 
-      // Right now there are two user events. First is for fiber cache infor update.
+      // Right now there are two extended user events. First is for fiber cache infor update.
       // Second is for oap index infor update.
       sc.listenerBus.post(SparkListenerCustomInfoUpdate(blockManagerId.host, executorId,
         customizedInfo.head))

--- a/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -134,10 +134,9 @@ private[spark] class Executor(
    */
   private var heartbeatFailures = 0
 
-  // TODO: make it configurable
   private val customInfoClassNameSeq = Seq(
-  "org.apache.spark.sql.execution.datasources.oap.filecache.OapFiberCacheHeartBeatMessager",
-  "org.apache.spark.sql.execution.datasources.oap.io.OapIndexHeartBeatMessager")
+    "org.apache.spark.sql.execution.datasources.oap.filecache.OapFiberCacheHeartBeatMessager",
+    "org.apache.spark.sql.execution.datasources.oap.io.OapIndexHeartBeatMessager")
   private val customManagerSeq: Seq[CustomManager] = customInfoClassNameSeq.map(cIC =>
     Utils.classForName(cIC).newInstance().asInstanceOf[CustomManager])
 

--- a/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -134,13 +134,12 @@ private[spark] class Executor(
    */
   private var heartbeatFailures = 0
 
-  // get the singleton instance that user configured
-//  private val customInfoClassName = conf.getOption("spark.executor.customInfoClass")
-  // todo: make it configurable
-  private val customInfoClassName = Some(
-  "org.apache.spark.sql.execution.datasources.oap.filecache.OapHeartBeatMessager")
-  private val customManager: Option[CustomManager] = customInfoClassName
-    .map(cIC => Utils.classForName(cIC).newInstance().asInstanceOf[CustomManager])
+  // TODO: make it configurable
+  private val customInfoClassNameSeq = Seq(
+  "org.apache.spark.sql.execution.datasources.oap.filecache.OapFiberCacheHeartBeatMessager",
+  "org.apache.spark.sql.execution.datasources.oap.io.OapIndexHeartBeatMessager")
+  private val customManagerSeq: Seq[CustomManager] = customInfoClassNameSeq.map(cIC =>
+    Utils.classForName(cIC).newInstance().asInstanceOf[CustomManager])
 
   startDriverHeartbeater()
 
@@ -527,7 +526,7 @@ private[spark] class Executor(
       executorId,
       accumUpdates.toArray,
       env.blockManager.blockManagerId,
-      customManager.map(_.status(conf)))
+      customManagerSeq.map(_.status(conf)))
 
     try {
       val response = heartbeatReceiverRef.askWithRetry[HeartbeatResponse](

--- a/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -144,6 +144,15 @@ case class SparkListenerCustomInfoUpdate(
     customizedInfo: String) extends SparkListenerEvent
 
 /**
+ * Interface for creating OAP index information listeners which are used to
+ * report to OAP users.
+ */
+@DeveloperApi
+case class SparkListenerOapIndexInfoUpdate(
+    hostName: String,
+    executorId: String,
+    oapIndexInfo: String) extends SparkListenerEvent
+/**
  * Interface for creating history listeners defined in other modules like SQL, which are used to
  * rebuild the history UI.
  */
@@ -258,6 +267,11 @@ private[spark] trait SparkListenerInterface {
    * Called when the driver receives some user customized info.
    */
   def onCustomInfoUpdate(customInfoUpdate: SparkListenerCustomInfoUpdate) { }
+
+  /**
+   * Called when the driver receives oap index info.
+   */
+  def onOapIndexInfoUpdate(oapIndexInfoUpdate: SparkListenerOapIndexInfoUpdate) { }
 }
 
 

--- a/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -68,6 +68,9 @@ private[spark] trait SparkListenerBus
       case customInfoUpdateEvent: SparkListenerCustomInfoUpdate =>
         listener.onCustomInfoUpdate(customInfoUpdateEvent) // deal with info update event
 
+      case oapIndexInfoUpdateEvent: SparkListenerOapIndexInfoUpdate =>
+        listener.onOapIndexInfoUpdate(oapIndexInfoUpdateEvent) // oap index info update event
+
       case _ => listener.onOtherEvent(event)
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -273,7 +273,7 @@ private[sql] class OapFileFormat extends FileFormat
               _.statistics), filter, m.schema))) {
             Iterator.empty
           } else {
-            OapDataReader.partitionOAPIndex.put(file.filePath, false)
+            OapIndexInfo.partitionOapIndex.put(file.filePath, false)
             val iter = new OapDataReader(
               new Path(new URI(file.filePath)), m, filterScanner, requiredIds)
               .initialize(conf, options)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -271,6 +271,7 @@ private[sql] class OapFileFormat extends FileFormat
               _.statistics), filter, m.schema))) {
             Iterator.empty
           } else {
+            OapDataReader.partitionOAPIndex.put(file.filePath, false)
             val iter = new OapDataReader(
               new Path(new URI(file.filePath)), m, filterScanner, requiredIds)
               .initialize(conf, options)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -38,7 +38,7 @@ import org.apache.spark.util.io.ChunkedByteBuffer
 
 
 // TODO need to register within the SparkContext
-class OapHeartBeatMessager extends CustomManager with Logging {
+class OapFiberCacheHeartBeatMessager extends CustomManager with Logging {
   override def status(conf: SparkConf): String = {
     FiberCacheManager.status
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -18,14 +18,14 @@
 package org.apache.spark.sql.execution.datasources.oap.io
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.executor.custom.CustomManager
 import org.apache.hadoop.fs.{FSDataOutputStream, Path}
 import org.apache.parquet.format.CompressionCodec
 import org.apache.parquet.io.api.Binary
 
+import org.apache.spark.executor.custom.CustomManager
 import org.apache.spark.internal.Logging
-import org.apache.spark.scheduler.SparkListenerOapIndexInfoUpdate
 import org.apache.spark.SparkConf
+import org.apache.spark.scheduler.SparkListenerOapIndexInfoUpdate
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap.{DataSourceMeta, OapFileFormat}
 import org.apache.spark.sql.execution.datasources.oap.filecache.DataFiberBuilder
@@ -35,7 +35,6 @@ import org.apache.spark.sql.execution.datasources.oap.utils.OapIndexInfoStatusSe
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
-
 import org.apache.spark.util.TimeStampedHashMap
 
 class OapIndexHeartBeatMessager extends CustomManager with Logging {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -159,14 +159,11 @@ private[oap] class OapDataWriter(
   }
 }
 
-object OapDataReader extends Logging {
-  var useIndex: Boolean = false
+private[oap] object OapDataReader extends Logging {
+  var useIndex: String = "false"
   var partitionData: String = null
   def status: String = {
-    val indexStatusRawData: String =
-      if (useIndex && partitionData != null) {
-        " partition data will use OAP index.\n"
-      } else " partition data will not use OAP index.\n"
+    val indexStatusRawData: String = s" Partition File $partitionData use OAP index $useIndex"
     indexStatusRawData
   }
   def update(indexInfo: SparkListenerOapIndexInfoUpdate): Unit = {
@@ -188,7 +185,7 @@ private[oap] class OapDataReader(
     val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf)
 
     val start = System.currentTimeMillis()
-    OapDataReader.useIndex = false
+    OapDataReader.useIndex = "false"
     OapDataReader.partitionData = path.toString()
     filterScanner match {
       case Some(fs) if fs.existRelatedIndexFile(path, conf) =>
@@ -236,7 +233,8 @@ private[oap] class OapDataReader(
                   else fs.toArray
                 }
 
-                OapDataReader.useIndex = true
+                OapDataReader.useIndex = "true"
+                logInfo("Partition File " + path.toString() + " will use OAP index.\n")
                 fileScanner.iterator(conf, requiredIds, rowIDs)
               case StaticsAnalysisResult.SKIP_INDEX =>
                 Iterator.empty

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -40,7 +40,7 @@ import org.apache.spark.util.TimeStampedHashMap
 
 class OapIndexHeartBeatMessager extends CustomManager with Logging {
   override def status(conf: SparkConf): String = {
-    OapDataReader.status
+    OapIndexInfo.status
   }
 }
 
@@ -164,12 +164,12 @@ private[oap] class OapDataWriter(
 
 private[oap] case class OapIndexInfoStatus(path: String, useIndex: Boolean)
 
-private[oap] object OapDataReader extends Logging {
-  val partitionOAPIndex = new TimeStampedHashMap[String, Boolean](updateTimeStampOnGet = true)
+private[oap] object OapIndexInfo extends Logging {
+  val partitionOapIndex = new TimeStampedHashMap[String, Boolean](updateTimeStampOnGet = true)
   def status: String = {
-    val indexInfoStatusSeq = partitionOAPIndex.map(kv => OapIndexInfoStatus(kv._1, kv._2)).toSeq
+    val indexInfoStatusSeq = partitionOapIndex.map(kv => OapIndexInfoStatus(kv._1, kv._2)).toSeq
     val threshTime = System.currentTimeMillis()
-    partitionOAPIndex.clearOldValues(threshTime)
+    partitionOapIndex.clearOldValues(threshTime)
     logDebug("current partition files: \n" +
       indexInfoStatusSeq.map{case indexInfoStatus: OapIndexInfoStatus =>
         "partition file: " + indexInfoStatus.path +
@@ -251,7 +251,7 @@ private[oap] class OapDataReader(
                   else fs.toArray
                 }
 
-                OapDataReader.partitionOAPIndex.put(path.toString(), true)
+                OapIndexInfo.partitionOapIndex.put(path.toString(), true)
                 logInfo("Partition File " + path.toString() + " will use OAP index.\n")
                 fileScanner.iterator(conf, requiredIds, rowIDs)
               case StaticsAnalysisResult.SKIP_INDEX =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/listener/OapIndexInfoListener.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/listener/OapIndexInfoListener.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.sql.execution.datasources.oap.listener
 
 import org.apache.spark.scheduler.{SparkListener, SparkListenerOapIndexInfoUpdate}
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataReader
+import org.apache.spark.sql.execution.datasources.oap.io.OapIndexInfo
 
 class OapIndexInfoListener extends SparkListener {
   override def onOapIndexInfoUpdate(indexInfo: SparkListenerOapIndexInfoUpdate): Unit = {
-    OapDataReader.update(indexInfo)
+    OapIndexInfo.update(indexInfo)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/listener/OapIndexInfoListener.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/listener/OapIndexInfoListener.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.listener
+
+import org.apache.spark.scheduler.{SparkListener, SparkListenerOapIndexInfoUpdate}
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataReader
+
+class OapIndexInfoListener extends SparkListener {
+  override def onOapIndexInfoUpdate(indexInfo: SparkListenerOapIndexInfoUpdate): Unit = {
+    OapDataReader.update(indexInfo)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDe.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDe.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.utils
+
+import org.apache.spark.sql.execution.datasources.oap.io.OapIndexInfoStatus
+
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+
+/**
+ * This is user defined Json protocol for SerDe, here the format of Json output should like
+ * following:
+ *   {"oapIndexInfoStatusRawDataArray" :
+ *     ["partitionFilePath" : ""
+ *      {"useOapIndexJValue" :
+ *        ["true/false" : Boolean]
+       }]
+       [] ... []}
+ */
+
+private[oap] object OapIndexInfoStatusSerDe extends SerDe[String, Seq[OapIndexInfoStatus]] {
+  import org.json4s.jackson.JsonMethods._
+
+  override def serialize(indexStatusRawDataArray: Seq[OapIndexInfoStatus]): String = {
+    val statusJArray = JArray(indexStatusRawDataArray.map(indexStatusRawDataToJson).toList)
+    compact(render("oapIndexInfoStatusRawDataArray" -> statusJArray))
+  }
+
+  override def deserialize(json: String): Seq[OapIndexInfoStatus] = {
+    (parse(json) \
+      "oapIndexInfoStatusRawDataArray").extract[List[JValue]].map(indexStatusRawDataFromJson)
+  }
+
+  private implicit val format = DefaultFormats
+
+  private[oap] def indexStatusRawDataFromJson(json: JValue): OapIndexInfoStatus = {
+    val path = (json \ "partitionFilePath").extract[String]
+    val useIndex = (json \ "useOapIndexJValue").extract[Boolean]
+    OapIndexInfoStatus(path, useIndex)
+  }
+
+  private[oap] def indexStatusRawDataToJson(statusRawData: OapIndexInfoStatus): JValue = {
+    ("partitionFilePath" -> statusRawData.path)~
+      ("useOapIndexJValue" -> statusRawData.useIndex)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDe.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDe.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.sql.execution.datasources.oap.utils
 
-import org.apache.spark.sql.execution.datasources.oap.io.OapIndexInfoStatus
-
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 
+import org.apache.spark.sql.execution.datasources.oap.io.OapIndexInfoStatus
 
 /**
  * This is user defined Json protocol for SerDe, here the format of Json outputs are like
@@ -32,7 +31,6 @@ import org.json4s.JsonDSL._
  *      "useOapIndex" : "true/false"}
  *     {} ... {}]}
  */
-
 private[oap] object OapIndexInfoStatusSerDe extends SerDe[String, Seq[OapIndexInfoStatus]] {
   import org.json4s.jackson.JsonMethods._
 
@@ -42,8 +40,8 @@ private[oap] object OapIndexInfoStatusSerDe extends SerDe[String, Seq[OapIndexIn
   }
 
   override def deserialize(json: String): Seq[OapIndexInfoStatus] = {
-    (parse(json) \
-      "oapIndexInfoStatusRawDataArray").extract[List[JValue]].map(indexStatusRawDataFromJson)
+    (parse(json) \ "oapIndexInfoStatusRawDataArray").extract[List[JValue]].map(
+      indexStatusRawDataFromJson)
   }
 
   private implicit val format = DefaultFormats

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDe.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDe.scala
@@ -25,14 +25,12 @@ import org.json4s.JsonDSL._
 
 
 /**
- * This is user defined Json protocol for SerDe, here the format of Json output should like
+ * This is user defined Json protocol for SerDe, here the format of Json outputs are like
  * following:
  *   {"oapIndexInfoStatusRawDataArray" :
  *     ["partitionFilePath" : ""
- *      {"useOapIndexJValue" :
- *        ["true/false" : Boolean]
-       }]
-       [] ... []}
+ *      "useOapIndex" : "true/false"]
+ *     [] ... []}
  */
 
 private[oap] object OapIndexInfoStatusSerDe extends SerDe[String, Seq[OapIndexInfoStatus]] {
@@ -52,12 +50,12 @@ private[oap] object OapIndexInfoStatusSerDe extends SerDe[String, Seq[OapIndexIn
 
   private[oap] def indexStatusRawDataFromJson(json: JValue): OapIndexInfoStatus = {
     val path = (json \ "partitionFilePath").extract[String]
-    val useIndex = (json \ "useOapIndexJValue").extract[Boolean]
+    val useIndex = (json \ "useOapIndex").extract[Boolean]
     OapIndexInfoStatus(path, useIndex)
   }
 
   private[oap] def indexStatusRawDataToJson(statusRawData: OapIndexInfoStatus): JValue = {
     ("partitionFilePath" -> statusRawData.path)~
-      ("useOapIndexJValue" -> statusRawData.useIndex)
+      ("useOapIndex" -> statusRawData.useIndex)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDe.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDe.scala
@@ -28,9 +28,9 @@ import org.json4s.JsonDSL._
  * This is user defined Json protocol for SerDe, here the format of Json outputs are like
  * following:
  *   {"oapIndexInfoStatusRawDataArray" :
- *     ["partitionFilePath" : ""
- *      "useOapIndex" : "true/false"]
- *     [] ... []}
+ *     [{"partitionFilePath" : ""
+ *      "useOapIndex" : "true/false"}
+ *     {} ... {}]}
  */
 
 private[oap] object OapIndexInfoStatusSerDe extends SerDe[String, Seq[OapIndexInfoStatus]] {

--- a/src/main/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
@@ -22,8 +22,7 @@ import java.io.PrintStream
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{OapSession, SQLContext}
-import org.apache.spark.sql.execution.datasources.oap.listener.FiberInfoListener
-import org.apache.spark.sql.execution.datasources.oap.listener.OapIndexInfoListener
+import org.apache.spark.sql.execution.datasources.oap.listener.{FiberInfoListener, OapIndexInfoListener}
 import org.apache.spark.sql.hive.{HiveUtils, OapSessionState}
 import org.apache.spark.util.Utils
 

--- a/src/main/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
@@ -23,6 +23,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{OapSession, SQLContext}
 import org.apache.spark.sql.execution.datasources.oap.listener.FiberInfoListener
+import org.apache.spark.sql.execution.datasources.oap.listener.OapIndexInfoListener
 import org.apache.spark.sql.hive.{HiveUtils, OapSessionState}
 import org.apache.spark.util.Utils
 
@@ -65,6 +66,8 @@ private[hive] object OapEnv extends Logging {
 
     logDebug("register FiberInfoListener")
     sparkContext.addSparkListener(new FiberInfoListener)
+    logDebug("register OapIndexInfoListener")
+    sparkContext.addSparkListener(new OapIndexInfoListener)
 
     SparkSQLEnv.sparkContext = sparkContext
     SparkSQLEnv.sqlContext = sqlContext

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDeSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDeSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.utils
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.execution.datasources.oap.io.OapIndexInfoStatus
+
+import org.json4s.jackson.JsonMethods._
+
+class OapIndexInfoStatusSerDeSuite extends SparkFunSuite {
+  private def assertStringEquals(json1: String, json2: String) {
+    val formatJsonString = (json: String) => json.replaceAll("[\\s|]", "")
+    assert(formatJsonString(json1) === formatJsonString(json2),
+      s"input ${formatJsonString(json1)} got ${formatJsonString(json2)}")
+  }
+
+  test("test oap index info status raw data") {
+    val path = "partitionFile"
+    val useIndex = true
+    val indexInfoStatusRawData = OapIndexInfoStatus(path, useIndex)
+    val newIndexInfoStatusRawData =
+      OapIndexInfoStatusSerDe.indexStatusRawDataFromJson(
+        OapIndexInfoStatusSerDe.indexStatusRawDataToJson(indexInfoStatusRawData))
+    assertStatusRawDataEquals(indexInfoStatusRawData, newIndexInfoStatusRawData)
+  }
+
+  test("test oap index infor status ser and deser") {
+    val path1 = "partitionFile1"
+    val useIndex1 = true
+    val path2 = "partitionFile2"
+    val useIndex2 = false
+    val rawData1 = OapIndexInfoStatus(path1, useIndex1)
+    val rawData2 = OapIndexInfoStatus(path2, useIndex2)
+    val indexInfoStatusSeq = Seq(rawData1, rawData2)
+    val indexInfoStatusSerializeStr = OapIndexInfoStatusSerDe.serialize(indexInfoStatusSeq)
+    assertStringEquals(indexInfoStatusSerializeStr,
+      OapIndexInfoStatusSerDeTestStrs.indexInfoStatusRawDataSeqString)
+    val indexInfoDeserializeSeq = OapIndexInfoStatusSerDe.deserialize(indexInfoStatusSerializeStr)
+    assert(indexInfoStatusSeq.length === indexInfoDeserializeSeq.length)
+    var i = 0
+    while (i < indexInfoDeserializeSeq.length) {
+      assertStatusRawDataEquals(indexInfoDeserializeSeq(i), indexInfoDeserializeSeq(i))
+      i += 1
+    }
+  }
+
+  private def assertStatusRawDataEquals(data1: OapIndexInfoStatus, data2: OapIndexInfoStatus) = {
+    assert(data1.path === data2.path)
+    assert(data1.useIndex === data2.useIndex)
+  }
+}
+
+private[oap] object OapIndexInfoStatusSerDeTestStrs {
+  val indexInfoStatusRawDataSeqString =
+    s"""
+       |{
+       |  "oapIndexInfoStatusRawDataArray" : [
+       |    {
+       |      "partitionFilePath" : "partitionFile1",
+       |      "useOapIndex" : true
+       |    },
+       |    {
+       |      "partitionFilePath" : "partitionFile2",
+       |      "useOapIndex" : false
+       |    }
+       |  ]
+       |}
+     """
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDeSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapIndexInfoStatusSerDeSuite.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.oap.utils
 
+import org.json4s.jackson.JsonMethods._
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.datasources.oap.io.OapIndexInfoStatus
-
-import org.json4s.jackson.JsonMethods._
 
 class OapIndexInfoStatusSerDeSuite extends SparkFunSuite {
   private def assertStringEquals(json1: String, json2: String) {


### PR DESCRIPTION
Add SparkListenerOapIndexInfoUpdate event and OapIndexInfoListener listener
to report OAP index information to OAP users from executors to driver

The OAP index information will include which partition data will be using
OAP index or not.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

This is the the first version. I will update to add the partition data file information in the second version.

I just want to share earlier to get the comments or suggestions first. Thanks.



## How was this patch tested?
mvn test
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

