### PR TITLE
Refactor oap strategy

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/OAPStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/OAPStrategies.scala
@@ -18,15 +18,17 @@
 package org.apache.spark.sql.execution
 
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{SparkSession, Strategy, execution}
-import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier, expressions}
+import org.apache.spark.sql.{execution, SparkSession, Strategy}
+import org.apache.spark.sql.catalyst.{expressions, InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, PhysicalOperation}
-import org.apache.spark.sql.catalyst.plans.{LeftSemi, logical}
+import org.apache.spark.sql.catalyst.plans.{logical, LeftSemi}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.DataSourceScanExec.{INPUT_PATHS, PUSHED_FILTERS}
 import org.apache.spark.sql.execution.datasources._

--- a/src/main/scala/org/apache/spark/sql/execution/OAPStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/OAPStrategies.scala
@@ -61,14 +61,12 @@ trait OAPStrategies extends Logging {
       case logical.ReturnAnswer(rootPlan) => rootPlan match {
         case logical.Limit(IntegerLiteral(limit), logical.Sort(order, true, child)) =>
           val childPlan = calcChildPlan(child, limit, order)
-          TakeOrderedAndProjectExec(limit, order, child.output,
-                                    childPlan) :: Nil
+          TakeOrderedAndProjectExec(limit, order, child.output, childPlan) :: Nil
         case logical.Limit(
             IntegerLiteral(limit),
             logical.Project(projectList, logical.Sort(order, true, child))) =>
           val childPlan = calcChildPlan(child, limit, order)
-          execution.TakeOrderedAndProjectExec(limit, order,
-                                              projectList, childPlan) :: Nil
+          TakeOrderedAndProjectExec(limit, order, projectList, childPlan) :: Nil
         case _ =>
           Nil
       }
@@ -385,7 +383,7 @@ case class OrderLimitOapFileScanExec(
     val orderByString = Utils.truncatedString(sortOrder, "[", ",", "]")
     val outputString = Utils.truncatedString(output, "[", ",", "]")
 
-    s"PushDownSortToOAPFileScanExec(limit=$limit, orderBy=$orderByString, output=$outputString)"
+    s"OrderLimitOapFileScanExec(limit=$limit, orderBy=$orderByString, output=$outputString)"
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/OAPStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/OAPStrategies.scala
@@ -23,19 +23,19 @@ import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{execution, SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.{expressions, InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
-import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, PhysicalOperation}
+import org.apache.spark.sql.catalyst.plans.{logical, LeftSemi}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution
 import org.apache.spark.sql.execution.DataSourceScanExec.{INPUT_PATHS, PUSHED_FILTERS}
-import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.{CaseInsensitiveMap, _}
 import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
-import org.apache.spark.sql.Strategy
+import org.apache.spark.sql.execution.joins.BuildRight
 import org.apache.spark.util.Utils
 
-trait OAPStrategies {
+trait OAPStrategies extends Logging {
 
   /**
    * Plans special cases of orderby+limit operators.
@@ -61,12 +61,14 @@ trait OAPStrategies {
       case logical.ReturnAnswer(rootPlan) => rootPlan match {
         case logical.Limit(IntegerLiteral(limit), logical.Sort(order, true, child)) =>
           val childPlan = calcChildPlan(child, limit, order)
-          execution.TakeOrderedAndProjectExec(limit, order, child.output, childPlan) :: Nil
+          TakeOrderedAndProjectExec(limit, order, child.output,
+                                    childPlan) :: Nil
         case logical.Limit(
             IntegerLiteral(limit),
             logical.Project(projectList, logical.Sort(order, true, child))) =>
           val childPlan = calcChildPlan(child, limit, order)
-          execution.TakeOrderedAndProjectExec(limit, order, projectList, childPlan) :: Nil
+          execution.TakeOrderedAndProjectExec(limit, order,
+                                              projectList, childPlan) :: Nil
         case _ =>
           Nil
       }
@@ -84,175 +86,228 @@ trait OAPStrategies {
             (file.fileFormat.isInstanceOf[OapFileFormat] &&
               file.fileFormat.initialize(file.sparkSession, file.options, file.location)
               .asInstanceOf[OapFileFormat].hasAvailableIndex(orderAttributes))) {
-          PushDownSortToOAPFileScanExec(limit, order, projectList,
-            TakeOrderedOAPFileScan(projectList, filters, relation, file, table, limit, order.head))
+          val OapOption = file.options +
+            (OapFileFormat.OAP_QUERY_LIMIT_OPTION_KEY -> limit.toString) +
+            (OapFileFormat.OAP_QUERY_ORDER_OPTION_KEY -> order.head.isAscending.toString)
+          OrderLimitOapFileScanExec(
+            limit, order, projectList,
+            GenerateOapFileScanPlan(
+              projectList, filters, relation, file, table, OapOption))
         }
         else PlanLater(child)
       case _ => PlanLater(child)
     }
-
-
-    /**
-     * Pretty much like FileSourceStrategy.apply() as the only difference is the sort
-     * and limit config were pushed down to FileScanRDD's reader function.
-     * TODO: remove OAP irrelevant code.
-     */
-    def TakeOrderedOAPFileScan(
-                                projects: Seq[NamedExpression], filters: Seq[Expression],
-                                l: LogicalPlan, files : HadoopFsRelation,
-                                table: Option[TableIdentifier],
-                                limit : Int, order : SortOrder): SparkPlan = {
-        // Filters on this relation fall into four categories based
-        // on where we can use them to avoid
-        // reading unneeded data:
-        //  - partition keys only - used to prune directories to read
-        //  - bucket keys only - optionally used to prune files to read
-        //  - keys stored in the data only - optionally used to skip groups of data in files
-        //  - filters that need to be evaluated again after the scan
-        val filterSet = ExpressionSet(filters)
-
-        // The attribute name of predicate could be different than the one in schema in case of
-        // case insensitive, we should change them to match the one in schema, so we donot need to
-        // worry about case sensitivity anymore.
-        val normalizedFilters = filters.map { e =>
-          e transform {
-            case a: AttributeReference =>
-              a.withName(l.output.find(_.semanticEquals(a)).get.name)
-          }
-        }
-
-        val partitionColumns =
-          l.resolve(files.partitionSchema, files.sparkSession.sessionState.analyzer.resolver)
-        val partitionSet = AttributeSet(partitionColumns)
-        val partitionKeyFilters =
-          ExpressionSet(normalizedFilters.filter(_.references.subsetOf(partitionSet)))
-        logInfo(s"Pruning directories with: ${partitionKeyFilters.mkString(",")}")
-
-        val dataColumns =
-          l.resolve(files.dataSchema, files.sparkSession.sessionState.analyzer.resolver)
-
-        // Partition keys are not available in the statistics of the files.
-        val dataFilters = normalizedFilters.filter(_.references.intersect(partitionSet).isEmpty)
-
-        // Predicates with both partition keys and attributes need to be evaluated after the scan.
-        val afterScanFilters = filterSet -- partitionKeyFilters
-        logInfo(s"Post-Scan Filters: ${afterScanFilters.mkString(",")}")
-
-        val selectedPartitions = files.location.listFiles(partitionKeyFilters.toSeq)
-
-        val filterAttributes = AttributeSet(afterScanFilters)
-        val requiredExpressions: Seq[NamedExpression] = filterAttributes.toSeq ++ projects
-        val requiredAttributes = AttributeSet(requiredExpressions)
-
-        val readDataColumns =
-          dataColumns
-            .filter(requiredAttributes.contains)
-            .filterNot(partitionColumns.contains)
-        val prunedDataSchema = readDataColumns.toStructType
-        logInfo(s"Pruned Data Schema: ${prunedDataSchema.simpleString(5)}")
-
-        val pushedDownFilters = dataFilters.flatMap(DataSourceStrategy.translateFilter)
-        logInfo(s"Pushed Filters: ${pushedDownFilters.mkString(",")}")
-
-        val readFile = files.fileFormat.asInstanceOf[OapFileFormat].buildReaderWithPartitionValues(
-          sparkSession = files.sparkSession,
-          dataSchema = files.dataSchema,
-          partitionSchema = files.partitionSchema,
-          requiredSchema = prunedDataSchema,
-          filters = pushedDownFilters,
-          order.isAscending,
-          limit,
-          options = files.options,
-          hadoopConf = files.sparkSession.sessionState.newHadoopConfWithOptions(files.options))
-        logInfo(s"Pushed Order By $order, Limit $limit.")
-
-        val plannedPartitions = {
-          val defaultMaxSplitBytes = files.sparkSession.sessionState.conf.filesMaxPartitionBytes
-          val openCostInBytes = files.sparkSession.sessionState.conf.filesOpenCostInBytes
-          val defaultParallelism = files.sparkSession.sparkContext.defaultParallelism
-          val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
-          val bytesPerCore = totalBytes / defaultParallelism
-          val maxSplitBytes = Math.min(defaultMaxSplitBytes,
-            Math.max(openCostInBytes, bytesPerCore))
-          logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
-            s"open cost is considered as scanning $openCostInBytes bytes.")
-
-          val splitFiles = selectedPartitions.flatMap { partition =>
-            partition.files.flatMap { file =>
-              assert(!files.fileFormat.isSplitable(files.sparkSession, files.options, file.getPath))
-              val blockLocations = OAPFileUtils.getBlockLocations(file)
-              val hosts = OAPFileUtils.getBlockHosts(blockLocations, 0, file.getLen)
-              Seq(PartitionedFile(
-                partition.values, file.getPath.toUri.toString, 0, file.getLen, hosts))
-            }
-          }.toArray.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
-
-          val partitions = new ArrayBuffer[FilePartition]
-          val currentFiles = new ArrayBuffer[PartitionedFile]
-          var currentSize = 0L
-
-          /** Add the given file to the current partition. */
-          def addFile(file: PartitionedFile): Unit = {
-            currentSize += file.length + openCostInBytes
-            currentFiles.append(file)
-          }
-
-          /** Close the current partition and move to the next. */
-          def closePartition(): Unit = {
-            if (currentFiles.nonEmpty) {
-              val newPartition =
-                FilePartition(
-                  partitions.size,
-                  currentFiles.toArray.toSeq) // Copy to a new Array.
-              partitions.append(newPartition)
-            }
-            currentFiles.clear()
-            currentSize = 0
-          }
-
-          // Assign files to partitions using "First Fit Decreasing" (FFD)
-          // TODO: consider adding a slop factor here?
-          splitFiles.foreach { file =>
-            if (currentSize + file.length > maxSplitBytes) {
-              closePartition()
-            }
-            addFile(file)
-          }
-          closePartition()
-          partitions
-        }
-
-        // These metadata values make scan plans uniquely identifiable for equality checking.
-        val meta = Map(
-          "PartitionFilters" -> partitionKeyFilters.mkString("[", ", ", "]"),
-          "Format" -> files.fileFormat.toString,
-          "ReadSchema" -> prunedDataSchema.simpleString,
-          PUSHED_FILTERS -> pushedDownFilters.mkString("[", ", ", "]"),
-          INPUT_PATHS -> files.location.paths.mkString(", "))
-
-        val scan =
-          DataSourceScanExec.create(
-            readDataColumns ++ partitionColumns,
-            new FileScanRDD(
-              files.sparkSession,
-              readFile,
-              plannedPartitions),
-            files,
-            meta,
-            table)
-
-        val afterScanFilter = afterScanFilters.toSeq.reduceOption(expressions.And)
-        val withFilter = afterScanFilter.map(execution.FilterExec(_, scan)).getOrElse(scan)
-        val withProjections = if (projects == withFilter.output) {
-          withFilter
-        } else {
-          execution.ProjectExec(projects, withFilter)
-        }
-
-        withProjections
-    }
-    // TODO: Add more OAP specific strategies
   }
+
+  // TODO: Add more OAP specific strategies
+  /**
+   * OAPSemiJoinStrategy optimizes SemiJoin.
+   * SemiJoin can take assumption that each value in right
+   * table is distinct, so we can take advantage of OAP index
+   * that we tell index scan to return only 1 item from each
+   * index entry.
+   *
+   * Limitation:
+   * 1. Query & Filter column must have index.
+   * TODO: choose any index if no filter.
+   *
+   */
+  object OAPSemiJoinStrategy extends Strategy with Logging {
+    private def canBroadcast(plan: LogicalPlan): Boolean = {
+      val conf = SparkSession.getActiveSession.get.sessionState.conf
+      plan.statistics.isBroadcastable ||
+        plan.statistics.sizeInBytes <= conf.autoBroadcastJoinThreshold
+    }
+
+    def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+      case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
+        if joinType == LeftSemi && canBroadcast(right) =>
+        Seq(joins.BroadcastHashJoinExec(
+          leftKeys, rightKeys, joinType, BuildRight, condition, planLater(left),
+          calcChildPlan(right, rightKeys.map{SortOrder(_, Ascending)})))
+      case _ => Nil
+    }
+
+    def calcChildPlan(child : LogicalPlan, order : Seq[SortOrder])
+    : SparkPlan = child match {
+      case PhysicalOperation(
+      projectList, filters, relation@LogicalRelation(file: HadoopFsRelation, _, table)) =>
+        val filterAttributes = AttributeSet(ExpressionSet(filters))
+        val orderAttributes = AttributeSet(ExpressionSet(order.map(_.child)))
+        if ((orderAttributes.size == 1 &&
+          (filterAttributes.isEmpty || filterAttributes == orderAttributes)) &&
+          (file.fileFormat.isInstanceOf[OapFileFormat] &&
+            file.fileFormat.initialize(file.sparkSession, file.options, file.location)
+              .asInstanceOf[OapFileFormat].hasAvailableIndex(orderAttributes))) {
+          val OapOption = new CaseInsensitiveMap(file.options +
+            (OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY -> "1"))
+          DistinctOapFileScanExec(
+            scanNumber = 1,
+            projectList,
+            GenerateOapFileScanPlan(projectList, filters, relation, file, table, OapOption))
+        }
+        else PlanLater(child)
+      case _ => PlanLater(child)
+    }
+  }
+
+  /**
+   * Pretty much like FileSourceStrategy.apply() as the only difference is the sort
+   * and limit config were pushed down to FileScanRDD's reader function.
+   * TODO: remove OAP irrelevant code.
+   */
+  def GenerateOapFileScanPlan(
+                               projects: Seq[NamedExpression], filters: Seq[Expression],
+                               l: LogicalPlan, files : HadoopFsRelation,
+                               table: Option[TableIdentifier],
+                               OapOption: Map[String, String]): SparkPlan = {
+    // Filters on this relation fall into four categories based
+    // on where we can use them to avoid
+    // reading unneeded data:
+    //  - partition keys only - used to prune directories to read
+    //  - bucket keys only - optionally used to prune files to read
+    //  - keys stored in the data only - optionally used to skip groups of data in files
+    //  - filters that need to be evaluated again after the scan
+    val filterSet = ExpressionSet(filters)
+
+    // The attribute name of predicate could be different than the one in schema in case of
+    // case insensitive, we should change them to match the one in schema, so we donot need to
+    // worry about case sensitivity anymore.
+    val normalizedFilters = filters.map { e =>
+      e transform {
+        case a: AttributeReference =>
+          a.withName(l.output.find(_.semanticEquals(a)).get.name)
+      }
+    }
+
+    val partitionColumns =
+      l.resolve(files.partitionSchema, files.sparkSession.sessionState.analyzer.resolver)
+    val partitionSet = AttributeSet(partitionColumns)
+    val partitionKeyFilters =
+      ExpressionSet(normalizedFilters.filter(_.references.subsetOf(partitionSet)))
+    logInfo(s"Pruning directories with: ${partitionKeyFilters.mkString(",")}")
+
+    val dataColumns =
+      l.resolve(files.dataSchema, files.sparkSession.sessionState.analyzer.resolver)
+
+    // Partition keys are not available in the statistics of the files.
+    val dataFilters = normalizedFilters.filter(_.references.intersect(partitionSet).isEmpty)
+
+    // Predicates with both partition keys and attributes need to be evaluated after the scan.
+    val afterScanFilters = filterSet -- partitionKeyFilters
+    logInfo(s"Post-Scan Filters: ${afterScanFilters.mkString(",")}")
+
+    val selectedPartitions = files.location.listFiles(partitionKeyFilters.toSeq)
+
+    val filterAttributes = AttributeSet(afterScanFilters)
+    val requiredExpressions: Seq[NamedExpression] = filterAttributes.toSeq ++ projects
+    val requiredAttributes = AttributeSet(requiredExpressions)
+
+    val readDataColumns =
+      dataColumns
+        .filter(requiredAttributes.contains)
+        .filterNot(partitionColumns.contains)
+    val prunedDataSchema = readDataColumns.toStructType
+    logInfo(s"Pruned Data Schema: ${prunedDataSchema.simpleString(5)}")
+
+    val pushedDownFilters = dataFilters.flatMap(DataSourceStrategy.translateFilter)
+    logInfo(s"Pushed Filters: ${pushedDownFilters.mkString(",")}")
+
+    val readFile = files.fileFormat.asInstanceOf[OapFileFormat].buildReaderWithPartitionValues(
+      sparkSession = files.sparkSession,
+      dataSchema = files.dataSchema,
+      partitionSchema = files.partitionSchema,
+      requiredSchema = prunedDataSchema,
+      filters = pushedDownFilters,
+      options = OapOption,
+      hadoopConf = files.sparkSession.sessionState.newHadoopConfWithOptions(files.options))
+
+    val plannedPartitions = {
+      val defaultMaxSplitBytes = files.sparkSession.sessionState.conf.filesMaxPartitionBytes
+      val openCostInBytes = files.sparkSession.sessionState.conf.filesOpenCostInBytes
+      val defaultParallelism = files.sparkSession.sparkContext.defaultParallelism
+      val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
+      val bytesPerCore = totalBytes / defaultParallelism
+      val maxSplitBytes = Math.min(defaultMaxSplitBytes,
+        Math.max(openCostInBytes, bytesPerCore))
+      logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+        s"open cost is considered as scanning $openCostInBytes bytes.")
+
+      val splitFiles = selectedPartitions.flatMap { partition =>
+        partition.files.flatMap { file =>
+          assert(!files.fileFormat.isSplitable(files.sparkSession, files.options, file.getPath))
+          val blockLocations = OAPFileUtils.getBlockLocations(file)
+          val hosts = OAPFileUtils.getBlockHosts(blockLocations, 0, file.getLen)
+          Seq(PartitionedFile(
+            partition.values, file.getPath.toUri.toString, 0, file.getLen, hosts))
+        }
+      }.toArray.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+
+      val partitions = new ArrayBuffer[FilePartition]
+      val currentFiles = new ArrayBuffer[PartitionedFile]
+      var currentSize = 0L
+
+      /** Add the given file to the current partition. */
+      def addFile(file: PartitionedFile): Unit = {
+        currentSize += file.length + openCostInBytes
+        currentFiles.append(file)
+      }
+
+      /** Close the current partition and move to the next. */
+      def closePartition(): Unit = {
+        if (currentFiles.nonEmpty) {
+          val newPartition =
+            FilePartition(
+              partitions.size,
+              currentFiles.toArray.toSeq) // Copy to a new Array.
+          partitions.append(newPartition)
+        }
+        currentFiles.clear()
+        currentSize = 0
+      }
+
+      // Assign files to partitions using "First Fit Decreasing" (FFD)
+      // TODO: consider adding a slop factor here?
+      splitFiles.foreach { file =>
+        if (currentSize + file.length > maxSplitBytes) {
+          closePartition()
+        }
+        addFile(file)
+      }
+      closePartition()
+      partitions
+    }
+
+    // These metadata values make scan plans uniquely identifiable for equality checking.
+    val meta = Map(
+      "PartitionFilters" -> partitionKeyFilters.mkString("[", ", ", "]"),
+      "Format" -> files.fileFormat.toString,
+      "ReadSchema" -> prunedDataSchema.simpleString,
+      PUSHED_FILTERS -> pushedDownFilters.mkString("[", ", ", "]"),
+      INPUT_PATHS -> files.location.paths.mkString(", "))
+
+    val scan =
+      DataSourceScanExec.create(
+        readDataColumns ++ partitionColumns,
+        new FileScanRDD(
+          files.sparkSession,
+          readFile,
+          plannedPartitions),
+        files,
+        meta,
+        table)
+
+    val afterScanFilter = afterScanFilters.toSeq.reduceOption(expressions.And)
+    val withFilter = afterScanFilter.map(execution.FilterExec(_, scan)).getOrElse(scan)
+    val withProjections = if (projects == withFilter.output) {
+      withFilter
+    } else {
+      execution.ProjectExec(projects, withFilter)
+    }
+
+    withProjections
+  }
+
 
   /**
    * A Util class to handle file block (hadoop/hdfs file) related information.
@@ -260,7 +315,7 @@ trait OAPStrategies {
   object OAPFileUtils {
 
     private[OAPStrategies] def getBlockLocations(file: FileStatus)
-                                : Array[BlockLocation] = file match {
+    : Array[BlockLocation] = file match {
       case f: LocatedFileStatus => f.getBlockLocations
       case f => Array.empty[BlockLocation]
     }
@@ -303,22 +358,28 @@ trait OAPStrategies {
 }
 
 /**
- * A simple wrapper Exec to mark push down execution, which
- * can be easily viewed by sql explain.
+ * A simple wrapper SparkPlan exec base class to mark OAP related execution,
+ * which can be easily viewed by sql explain.
  */
-case class PushDownSortToOAPFileScanExec(
-                                          limit: Int,
-                                          sortOrder: Seq[SortOrder],
-                                          projectList: Seq[NamedExpression],
-                                          child: SparkPlan) extends UnaryExecNode {
-
+abstract class OapFileScanExec extends UnaryExecNode {
   /**
    * Here we can not tell its order because rows in each partition may not in order
    * because they could come from different files, which is because spark combines
    * files reading sometimes (depends on various conditions) for better performance.
    * Refer to fileScanRDD for the file reading combination.
    */
-  override def outputOrdering: Seq[SortOrder] = Nil
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+
+  override protected def doExecute(): RDD[InternalRow] = child.execute()
+
+  override def output: Seq[Attribute] = child.output
+}
+
+case class OrderLimitOapFileScanExec(
+                                      limit: Int,
+                                      sortOrder: Seq[SortOrder],
+                                      projectList: Seq[NamedExpression],
+                                      child: SparkPlan) extends OapFileScanExec {
 
   override def simpleString: String = {
     val orderByString = Utils.truncatedString(sortOrder, "[", ",", "]")
@@ -326,8 +387,16 @@ case class PushDownSortToOAPFileScanExec(
 
     s"PushDownSortToOAPFileScanExec(limit=$limit, orderBy=$orderByString, output=$outputString)"
   }
+}
 
-  override protected def doExecute(): RDD[InternalRow] = child.execute()
+case class DistinctOapFileScanExec(
+                                    scanNumber: Int,
+                                    projectList: Seq[NamedExpression],
+                                    child: SparkPlan) extends OapFileScanExec {
 
-  override def output: Seq[Attribute] = child.output
+  override def simpleString: String = {
+    val outputString = Utils.truncatedString(output, "[", ",", "]")
+
+    s"DistinctOapFileScanExec(output=$outputString, scan [$scanNumber] row of each index)"
+  }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/OAPStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/OAPStrategies.scala
@@ -86,9 +86,9 @@ trait OAPStrategies extends Logging {
             (file.fileFormat.isInstanceOf[OapFileFormat] &&
               file.fileFormat.initialize(file.sparkSession, file.options, file.location)
               .asInstanceOf[OapFileFormat].hasAvailableIndex(orderAttributes))) {
-          val OapOption = file.options +
+          val OapOption = new CaseInsensitiveMap(file.options +
             (OapFileFormat.OAP_QUERY_LIMIT_OPTION_KEY -> limit.toString) +
-            (OapFileFormat.OAP_QUERY_ORDER_OPTION_KEY -> order.head.isAscending.toString)
+            (OapFileFormat.OAP_QUERY_ORDER_OPTION_KEY -> order.head.isAscending.toString))
           OrderLimitOapFileScanExec(
             limit, order, projectList,
             GenerateOapFileScanPlan(

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -49,10 +49,10 @@ private[sql] class OapFileFormat extends FileFormat
   with Serializable {
 
   override def initialize(
-    sparkSession: SparkSession,
-    options: Map[String, String],
-    fileCatalog: FileCatalog,
-    readFiles: Option[Seq[FileStatus]] = None): FileFormat = {
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      fileCatalog: FileCatalog,
+      readFiles: Option[Seq[FileStatus]] = None): FileFormat = {
     super.initialize(sparkSession, options, fileCatalog)
 
     val hadoopConf = sparkSession.sparkContext.hadoopConfiguration
@@ -85,9 +85,9 @@ private[sql] class OapFileFormat extends FileFormat
   var meta: Option[DataSourceMeta] = _
 
   override def prepareWrite(
-    sparkSession: SparkSession,
-    job: Job, options: Map[String, String],
-    dataSchema: StructType): OutputWriterFactory = {
+      sparkSession: SparkSession,
+      job: Job, options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory = {
     val conf = job.getConfiguration
 
     // TODO: Should we have our own config util instead of SqlConf?
@@ -117,32 +117,32 @@ private[sql] class OapFileFormat extends FileFormat
   }
 
   override def isSplitable(
-                            sparkSession: SparkSession,
-                            options: Map[String, String],
-                            path: Path): Boolean = false
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      path: Path): Boolean = false
 
   override def buildReader(
-                            sparkSession: SparkSession,
-                            dataSchema: StructType,
-                            partitionSchema: StructType,
-                            requiredSchema: StructType,
-                            filters: Seq[Filter],
-                            options: Map[String, String],
-                            hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
     buildReaderWithPartitionValues(
       sparkSession, dataSchema, partitionSchema, requiredSchema, filters, options, hadoopConf)
   }
 
 
   override def buildReaderWithPartitionValues(
-                                               sparkSession: SparkSession,
-                                               dataSchema: StructType,
-                                               partitionSchema: StructType,
-                                               requiredSchema: StructType,
-                                               filters: Seq[Filter],
-                                               options: Map[String, String],
-                                               hadoopConf: Configuration
-                                             ): (PartitionedFile) => Iterator[InternalRow] = {
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration
+  ): (PartitionedFile) => Iterator[InternalRow] = {
     // TODO we need to pass the extra data source meta information via the func parameter
     meta match {
       case Some(m) =>
@@ -418,9 +418,9 @@ private[oap] case class OapWriteResult(
     fileName: String, rowsWritten: Int, partitionString: String)
 
 private[oap] class OapOutputWriter(
-                                            path: String,
-                                            dataSchema: StructType,
-                                            context: TaskAttemptContext) extends OutputWriter {
+    path: String,
+    dataSchema: StructType,
+    context: TaskAttemptContext) extends OutputWriter {
   private var rowCount = 0
   private var partitionString: String = ""
   override def setPartitionString(ps: String): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -142,7 +142,7 @@ private[sql] class OapFileFormat extends FileFormat
       filters: Seq[Filter],
       options: Map[String, String],
       hadoopConf: Configuration
-  ): (PartitionedFile) => Iterator[InternalRow] = {
+  ): PartitionedFile => Iterator[InternalRow] = {
     // TODO we need to pass the extra data source meta information via the func parameter
     meta match {
       case Some(m) =>
@@ -492,7 +492,7 @@ private[sql] object OapFileFormat {
   /**
    * Oap Optimization Options.
    */
-  val OAP_QUERY_ORDER_OPTION_KEY = "OapOrderQuery"
-  val OAP_QUERY_LIMIT_OPTION_KEY = "OapLimitQuery"
-  val OAP_INDEX_SCAN_NUM_OPTION_KEY = "OapLimitIndexScan"
+  val OAP_QUERY_ORDER_OPTION_KEY = "oap.scan.file.order"
+  val OAP_QUERY_LIMIT_OPTION_KEY = "oap.scan.file.limit"
+  val OAP_INDEX_SCAN_NUM_OPTION_KEY = "oap.scan.index.limit"
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -80,7 +80,7 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
           // find the first key in the left-most leaf node
           var tmpNode = root
           while (!tmpNode.isLeaf) tmpNode = tmpNode.childAt(0)
-          currentKeyArray(i) = new CurrentKey(tmpNode, 0, 0)
+          currentKeyArray(i) = new CurrentKey(tmpNode, 0, 0, getLimitScanNum())
         } else {
           // find the first identical key or the first key right greater than the specified one
           if (keySchema.size > interval.start.numFields) { // exists Dummy_Key
@@ -174,7 +174,7 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
     if (node.isLeaf) {
       // here currentKey is equal to candidate or the last key on the left side
       // which is less than the candidate
-      val currentKey = new CurrentKey(node, m, 0)
+      val currentKey = new CurrentKey(node, m, 0, getLimitScanNum())
 
       if (notFind && findFirst) {
         // if not found and the goal is to find the start key, then let's move forward a key

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -122,8 +122,14 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     })
 
     if (bitMapArray.nonEmpty) {
-      internalBitSet = bitMapArray.reduceLeft(_ | _)
-      internalItr = internalBitSet.iterator
+      if (limitScanEnabled()) {
+        // Get N items from each index.
+        internalItr = bitMapArray.flatMap(
+            bitSet => bitSet.iterator.take(getLimitScanNum())).iterator
+      } else {
+        internalBitSet = bitMapArray.reduceLeft(_ | _)
+        internalItr = internalBitSet.iterator
+      }
       empty = false
     } else {
       empty = true

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -124,8 +124,8 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     if (bitMapArray.nonEmpty) {
       if (limitScanEnabled()) {
         // Get N items from each index.
-        internalItr = bitMapArray.flatMap(
-            bitSet => bitSet.iterator.take(getLimitScanNum())).iterator
+        internalItr = bitMapArray.flatMap(bitSet =>
+          bitSet.iterator.take(getLimitScanNum())).iterator
       } else {
         internalBitSet = bitMapArray.reduceLeft(_ | _)
         internalItr = internalBitSet.iterator

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -46,6 +46,19 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
   var intervalArray: ArrayBuffer[RangeInterval] = _
   protected var keySchema: StructType = _
 
+  /**
+   * Scan N items from each index entry.
+   */
+  private var limitScan : Int = 0
+
+  def setScanNumLimit(scanNum : Int) : Unit = {
+    limitScan = scanNum
+  }
+
+  def getLimitScanNum() : Int = limitScan
+
+  def limitScanEnabled() : Boolean = limitScan > 0
+
   def meta: IndexMeta = idxMeta
   def getSchema: StructType = keySchema
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -157,8 +157,7 @@ private[oap] class OapDataReader(
   requiredIds: Array[Int]) extends Logging {
 
   def initialize(conf: Configuration,
-                 ascending: Boolean = true,
-                 limit: Int = 0): Iterator[InternalRow] = {
+                 options: Map[String, String] = Map.empty): Iterator[InternalRow] = {
     logDebug("Initializing OapDataReader...")
     // TODO how to save the additional FS operation to get the Split size
     val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf)
@@ -176,21 +175,35 @@ private[oap] class OapDataReader(
         val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
         val isTesting = conf.getBoolean(SQLConf.OAP_IS_TESTING.key,
                               SQLConf.OAP_IS_TESTING.defaultValue.get)
+
+        val isAscending = options.getOrElse(
+          OapFileFormat.OAP_QUERY_ORDER_OPTION_KEY, "false").toBoolean
+        val limit = options.getOrElse(OapFileFormat.OAP_QUERY_LIMIT_OPTION_KEY, "0").toInt
+
+        if (options.contains(OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY)) {
+          fs.setScanNumLimit(
+            options.get(OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY).get.toInt
+          )
+        }
+
+        val isFastIndexQuery : Boolean =
+          limit > 0 || options.contains(OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY)
+
         val iter =
-          if (limit <= 0 && indexFileSize > dataFileSize * 0.7 && !isTesting) {
+          if (!isFastIndexQuery && indexFileSize > dataFileSize * 0.7 && !isTesting) {
             logWarning(s"Index File size $indexFileSize B is too large comparing " +
                         s"to Data File Size $dataFileSize. Using Data File Scan instead.")
             fileScanner.iterator(conf, requiredIds)
           } else {
             statsAnalyseResult match {
-              case StaticsAnalysisResult.FULL_SCAN if (limit <= 0) =>
+              case StaticsAnalysisResult.FULL_SCAN if !isFastIndexQuery =>
                 fileScanner.iterator(conf, requiredIds)
               case StaticsAnalysisResult.USE_INDEX =>
                 fs.initialize(path, conf)
                 // total Row count can be get from the filter scanner
                 val rowIDs = {
                   if (limit > 0) {
-                    if (ascending) fs.toArray.take(limit)
+                    if (isAscending) fs.toArray.take(limit)
                     else fs.toArray.reverse.take(limit)
                   }
                   else fs.toArray

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -60,9 +60,7 @@ class OapIndexQuerySuite extends QueryTest with SharedSQLContext with BeforeAndA
   }
 
   test("index row boundary") {
-    val groupSize = spark.sparkContext.hadoopConfiguration
-      .get(OapFileFormat.ROW_GROUP_SIZE,
-        OapFileFormat.DEFAULT_ROW_GROUP_SIZE).toInt
+    val groupSize = 1024 // use a small row group to check boundary.
 
     val testRowId = groupSize - 1
     val data: Seq[(Int, String)] = (0 until groupSize * 3)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -72,7 +72,7 @@ class OapPlannerSuite
     // check strategy is applied.
     checkKeywordsExist(
       sql("explain SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7"),
-      "PushDownSortToOAPFileScanExec")
+      "OrderLimitOapFileScanExec")
 
     // ASC
     checkAnswer(

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.execution.OAPStrategies
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
-import org.apache.spark.SparkConf
 
 case class Source(name: String, age: Int, addr: String, phone: String, height: Int)
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -69,8 +69,10 @@ class OapPlannerSuite
     sql("create oindex index1 on oap_sort_opt_table (a)")
     sql("create oindex index2 on oap_sort_opt_table (b)")
 
-    sql("explain SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7")
-      .collect().map(println(_))
+    // check strategy is applied.
+    checkKeywordsExist(
+      sql("explain SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7"),
+      "PushDownSortToOAPFileScanExec")
 
     // ASC
     checkAnswer(
@@ -128,13 +130,13 @@ class OapPlannerSuite
     sql("create oindex index1 on oap_distinct_opt_table (a)")
 
     spark.experimental.extraStrategies = SortPushDownStrategy :: OAPSemiJoinStrategy :: Nil
-//    checkKeywordsExist(
-//      sql("explain SELECT * " +
-//      "FROM oap_sort_opt_table t1 " +
-//      "WHERE EXISTS " +
-//      "(SELECT 1 FROM oap_distinct_opt_table t2 " +
-//      "WHERE t1.a = t2.a AND t2.a >= 1 AND t1.a < 5) " +
-//      "ORDER BY a"), "DistinctOapFileScanExec")
+    checkKeywordsExist(
+      sql("explain SELECT * " +
+      "FROM oap_sort_opt_table t1 " +
+      "WHERE EXISTS " +
+      "(SELECT 1 FROM oap_distinct_opt_table t2 " +
+      "WHERE t1.a = t2.a AND t2.a >= 1 AND t1.a < 5) " +
+      "ORDER BY a"), "DistinctOapFileScanExec")
 
     checkAnswer(
       sql("SELECT * " +

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.execution.datasources.oap
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.OAPStrategies
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
+import org.apache.spark.SparkConf
 
 case class Source(name: String, age: Int, addr: String, phone: String, height: Int)
 
@@ -35,20 +35,26 @@ class OapPlannerSuite
   with OAPStrategies
 {
   import testImplicits._
-
   sparkConf.set("spark.memory.offHeap.size", "100m")
 
   override def beforeEach(): Unit = {
     sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     val path1 = Utils.createTempDir().getAbsolutePath
+    val path2 = Utils.createTempDir().getAbsolutePath
 
     sql(s"""CREATE TEMPORARY VIEW oap_sort_opt_table (a INT, b STRING)
            | USING oap
            | OPTIONS (path '$path1')""".stripMargin)
+
+    sql(s"""CREATE TEMPORARY VIEW oap_distinct_opt_table (a INT, b STRING)
+           | USING oap
+           | OPTIONS (path '$path2')""".stripMargin)
+
   }
 
   override def afterEach(): Unit = {
     sqlContext.dropTempTable("oap_sort_opt_table")
+    sqlContext.dropTempTable("oap_distinct_opt_table")
   }
 
   test("SortPushDown Test") {
@@ -62,6 +68,9 @@ class OapPlannerSuite
     sql("insert overwrite table oap_sort_opt_table select * from t")
     sql("create oindex index1 on oap_sort_opt_table (a)")
     sql("create oindex index2 on oap_sort_opt_table (b)")
+
+    sql("explain SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7")
+      .collect().map(println(_))
 
     // ASC
     checkAnswer(
@@ -99,5 +108,45 @@ class OapPlannerSuite
 
     sql("drop oindex index1 on oap_sort_opt_table")
     sql("drop oindex index2 on oap_sort_opt_table")
+  }
+
+  test("Distinct index scan if SemiJoin Test") {
+    spark.sqlContext.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "false")
+    spark.conf.set(OapFileFormat.ROW_GROUP_SIZE, 50)
+    val data = (1 to 300).map{ i => (i, s"this is test $i")}
+    val dataRDD = spark.sparkContext.parallelize(data, 10)
+
+    dataRDD.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_sort_opt_table select * from t")
+    sql("create oindex index1 on oap_sort_opt_table (a)")
+
+    val data1 = (1 to 300).map{ i => (i % 10, s"this is test $i")}
+    val dataRDD1 = spark.sparkContext.parallelize(data1, 5)
+
+    dataRDD1.toDF("key", "value").createOrReplaceTempView("t1")
+    sql("insert overwrite table oap_distinct_opt_table select * from t1")
+    sql("create oindex index1 on oap_distinct_opt_table (a)")
+
+    spark.experimental.extraStrategies = SortPushDownStrategy :: OAPSemiJoinStrategy :: Nil
+//    checkKeywordsExist(
+//      sql("explain SELECT * " +
+//      "FROM oap_sort_opt_table t1 " +
+//      "WHERE EXISTS " +
+//      "(SELECT 1 FROM oap_distinct_opt_table t2 " +
+//      "WHERE t1.a = t2.a AND t2.a >= 1 AND t1.a < 5) " +
+//      "ORDER BY a"), "DistinctOapFileScanExec")
+
+    checkAnswer(
+      sql("SELECT * " +
+      "FROM oap_sort_opt_table t1 " +
+      "WHERE EXISTS " +
+      "(SELECT 1 FROM oap_distinct_opt_table t2 " +
+      "WHERE t1.a = t2.a AND t2.a >= 1 AND t1.a < 5) " +
+      "ORDER BY a"),
+      Seq(
+        Row(1, "this is test 1"),
+        Row(2, "this is test 2"),
+        Row(3, "this is test 3"),
+        Row(4, "this is test 4")))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor oap strategies:

1. Refine OAP fileformat interface, get rid of independent param and use a Map to hold all flags. 
2. Give each OAP strategy a self-owned wrapper execution class which holds all related information and can be viewed from webUI. Using wrapper class avoids trivial changes inside SPARK.
3. Add a SemiJoin optimization which is only applied when BroadcastHashJoin is selected. The optimization is take advantage of the distinct feature of SemiJoin, i.e. ask index scan to give only 1 item out. Also add related test case.

## How was this patch tested?

MVN test pass