### PR TITLE
Add 'CheckIndex' DDL to check data files without indices

### DIFF
--- a/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -155,6 +155,7 @@ statement
     | DROP SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
         partitionSpec?                                                 #oapDropIndex
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
+    | CHECK SINDEX ON tableIdentifier                                  #oapCheckIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
     ;
 
@@ -714,7 +715,7 @@ nonReserved
     | DESCRIBE | DROP | EXISTS | FALSE | FOR | GROUP | IN | INSERT | INTO | IS |LIKE
     | NULL | ORDER | OUTER | TABLE | TRUE | WITH | RLIKE
     | AND | CASE | CAST | DISTINCT | DIV | ELSE | END | FUNCTION | INTERVAL | MACRO | OR | STRATIFY | THEN
-    | UNBOUNDED | WHEN
+    | UNBOUNDED | WHEN | CHECK
     | DATABASE | SELECT | FROM | WHERE | HAVING | TO | TABLE | WITH | NOT | CURRENT_DATE | CURRENT_TIMESTAMP
     ;
 
@@ -804,6 +805,7 @@ USE: 'USE';
 PARTITIONS: 'PARTITIONS';
 FUNCTIONS: 'FUNCTIONS';
 DROP: 'DROP';
+CHECK: 'CHECK';
 UNION: 'UNION';
 EXCEPT: 'EXCEPT';
 SETMINUS: 'MINUS';

--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1459,4 +1459,10 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     val tableName = visitTableIdentifier(ctx.tableIdentifier)
     OapShowIndex(tableName, tableName.identifier)
   }
+
+  override def visitOapCheckIndex(ctx: OapCheckIndexContext): LogicalPlan =
+    withOrigin(ctx) {
+      val tableIdentifier = visitTableIdentifier(ctx.tableIdentifier)
+      OapCheckIndex(tableIdentifier, tableIdentifier.identifier)
+    }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -71,18 +71,48 @@ private[oap] case class BTreeIndex(entries: Seq[BTreeIndexEntry] = Nil) extends 
   def appendEntry(entry: BTreeIndexEntry): BTreeIndex = BTreeIndex(entries :+ entry)
 
   override def toString: String = "COLUMN(" + entries.mkString(", ") + ") BTREE"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: BTreeIndex =>
+        that.entries.length == entries.length &&
+          that.entries.indices.forall(i => that.entries(i).ordinal == entries(i).ordinal)
+      case _ => false
+    }
+
+  override def hashCode(): Int = super.hashCode()
 }
 
 private[oap] case class BitMapIndex(entries: Seq[Int] = Nil) extends IndexType {
   def appendEntry(entry: Int): BitMapIndex = BitMapIndex(entries :+ entry)
 
   override def toString: String = "COLUMN(" + entries.mkString(", ") + ") BITMAP"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: BitMapIndex =>
+        that.entries.length == entries.length &&
+          that.entries.indices.forall(i => that.entries(i) == entries(i))
+      case _ => false
+    }
+
+  override def hashCode(): Int = super.hashCode()
 }
 
 private[oap] case class HashIndex(entries: Seq[Int] = Nil) extends IndexType {
   def appendEntry(entry: Int): HashIndex = HashIndex(entries :+ entry)
 
   override def toString: String = "COLUMN(" + entries.mkString(", ") + ") BITMAP"
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: HashIndex =>
+        that.entries.length == entries.length &&
+          that.entries.indices.forall(i => that.entries(i) == entries(i))
+      case _ => false
+    }
+
+  override def hashCode(): Int = super.hashCode()
 }
 
 private[oap] class FileMeta {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add DDL to check index:  `check oindex on table`
List data files which have no index files in each partition directory;
Check index of the same name between different partition directories

## How was this patch tested?
unit tests

