### PR TITLE
[TRIE] add trie index type in DataSourceMeta

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -79,6 +79,12 @@ private[oap] case class BitMapIndex(entries: Seq[Int] = Nil) extends IndexType {
   override def toString: String = "COLUMN(" + entries.mkString(", ") + ") BITMAP"
 }
 
+private[oap] case class TrieIndex(entries: Seq[Int] = Nil) extends IndexType {
+  def appendEntry(entry: Int): TrieIndex = TrieIndex(entries :+ entry)
+
+  override def toString: String = "COLUMN(" + entries.mkString(", ") + ") TRIE"
+}
+
 private[oap] case class HashIndex(entries: Seq[Int] = Nil) extends IndexType {
   def appendEntry(entry: Int): HashIndex = HashIndex(entries :+ entry)
 
@@ -180,6 +186,10 @@ private[oap] class IndexMeta(
         out.writeByte(HASH_INDEX_TYPE)
         entries.foreach(keyBits += _)
         writeBitSet(keyBits, INDEX_META_KEY_LENGTH, out)
+      case TrieIndex(entries) =>
+        out.writeByte(TRIE_INDEX_TYPE)
+        entries.foreach(keyBits += _)
+        writeBitSet(keyBits, INDEX_META_KEY_LENGTH, out)
     }
   }
 
@@ -211,6 +221,7 @@ private[oap] class IndexMeta(
         flag match {
           case BITMAP_INDEX_TYPE => BitMapIndex(keyBits.toSeq)
           case HASH_INDEX_TYPE => HashIndex(keyBits.toSeq)
+          case TRIE_INDEX_TYPE => TrieIndex(keyBits.toSeq)
         }
     }
   }
@@ -220,6 +231,7 @@ private[oap] object IndexMeta {
   final val BTREE_INDEX_TYPE = 0
   final val BITMAP_INDEX_TYPE = 1
   final val HASH_INDEX_TYPE = 2
+  final val TRIE_INDEX_TYPE = 3
 
   def apply() : IndexMeta = new IndexMeta()
   def apply(name: String, time: String, indexType: IndexType): IndexMeta = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -79,10 +79,8 @@ private[oap] case class BitMapIndex(entries: Seq[Int] = Nil) extends IndexType {
   override def toString: String = "COLUMN(" + entries.mkString(", ") + ") BITMAP"
 }
 
-private[oap] case class TrieIndex(entries: Seq[Int] = Nil) extends IndexType {
-  def appendEntry(entry: Int): TrieIndex = TrieIndex(entries :+ entry)
-
-  override def toString: String = "COLUMN(" + entries.mkString(", ") + ") TRIE"
+private[oap] case class TrieIndex(entry: Int) extends IndexType {
+  override def toString: String = s"COLUMN($entry) TRIE"
 }
 
 private[oap] case class HashIndex(entries: Seq[Int] = Nil) extends IndexType {
@@ -186,9 +184,9 @@ private[oap] class IndexMeta(
         out.writeByte(HASH_INDEX_TYPE)
         entries.foreach(keyBits += _)
         writeBitSet(keyBits, INDEX_META_KEY_LENGTH, out)
-      case TrieIndex(entries) =>
+      case TrieIndex(entry) =>
         out.writeByte(TRIE_INDEX_TYPE)
-        entries.foreach(keyBits += _)
+        keyBits += entry
         writeBitSet(keyBits, INDEX_META_KEY_LENGTH, out)
     }
   }
@@ -221,7 +219,7 @@ private[oap] class IndexMeta(
         flag match {
           case BITMAP_INDEX_TYPE => BitMapIndex(keyBits.toSeq)
           case HASH_INDEX_TYPE => HashIndex(keyBits.toSeq)
-          case TRIE_INDEX_TYPE => TrieIndex(keyBits.toSeq)
+          case TRIE_INDEX_TYPE => TrieIndex(keyBits.firstKey)
         }
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputFormat.scala
@@ -61,7 +61,8 @@ private[index] class OapIndexOutputFormat extends FileOutputFormat[Void, Interna
       new BitmapIndexRecordWriter(configuration, writer, schema)
     } else if (indexType == "PERMUTERM") {
       val writer = file.getFileSystem(configuration).create(file, true)
-      new PermutermIndexRecordWriter(configuration, writer, schema)
+      // use BTree temporary
+      new BTreeIndexRecordWriter(configuration, writer, schema)
     } else {
       throw new OapException("Unknown Index Type: " + indexType)
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputFormat.scala
@@ -26,8 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.types.StructType
 
-private[index] class OapIndexOutputFormat()
-    extends FileOutputFormat[Void, InternalRow] {
+private[index] class OapIndexOutputFormat extends FileOutputFormat[Void, InternalRow] {
 
   override def getRecordWriter(
       taskAttemptContext: TaskAttemptContext): RecordWriter[Void, InternalRow] = {
@@ -60,6 +59,9 @@ private[index] class OapIndexOutputFormat()
     } else if (indexType == "BITMAP") {
       val writer = file.getFileSystem(configuration).create(file, true)
       new BitmapIndexRecordWriter(configuration, writer, schema)
+    } else if (indexType == "PERMUTERM") {
+      val writer = file.getFileSystem(configuration).create(file, true)
+      new PermutermIndexRecordWriter(configuration, writer, schema)
     } else {
       throw new OapException("Unknown Index Type: " + indexType)
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -110,7 +110,8 @@ case class CreateIndex(
           indexType == BTreeIndexType && indexColumns.length == 1) {
           val entry = schema.map(_.name).toIndexedSeq.indexOf(indexColumns(0).columnName)
           if (schema(entry).dataType == StringType) {
-            logInfo(s"Building a TRIE index for the column, to turn off this, disable ${}")
+            logInfo("Building a TRIE index for the column, to turn off this, " +
+              s"please disable ${SQLConf.OAP_ENABLE_TRIE_OVER_BTREE.key}")
             PermutermIndexType
           } else BTreeIndexType
         } else indexType

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -105,7 +105,16 @@ case class CreateIndex(
         metaBuilder.withNewSchema(schema)
       }
 
-      indexType match {
+      val innerIndexType =
+        if (sparkSession.conf.get(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE) &&
+          indexType == BTreeIndexType && indexColumns.length == 1) {
+          val entry = schema.map(_.name).toIndexedSeq.indexOf(indexColumns(0).columnName)
+          if (schema(entry).dataType == StringType) {
+            logInfo(s"Building a TRIE index for the column, to turn off this, disable ${}")
+            PermutermIndexType
+          } else BTreeIndexType
+        } else indexType
+      innerIndexType match {
         case BTreeIndexType =>
           val entries = indexColumns.map(c => {
             val dir = if (c.isAscending) Ascending else Descending
@@ -116,6 +125,10 @@ case class CreateIndex(
           val entries = indexColumns.map(col =>
             schema.map(_.name).toIndexedSeq.indexOf(col.columnName))
           metaBuilder.addIndexMeta(new IndexMeta(indexName, time, BitMapIndex(entries)))
+        case PermutermIndexType =>
+          val entries = indexColumns.map(col =>
+            schema.map(_.name).toIndexedSeq.indexOf(col.columnName))
+          metaBuilder.addIndexMeta(new IndexMeta(indexName, time, TrieIndex(entries)))
         case _ =>
           sys.error(s"Not supported index type $indexType")
       }
@@ -335,13 +348,16 @@ case class RefreshIndex(
     })
 
     val buildrst = indices.map(i => {
-      var indexType : AnyIndexType = BTreeIndexType
+      var indexType: AnyIndexType = BTreeIndexType
 
       val indexColumns = i.indexType match {
         case BTreeIndex(entries) =>
           entries.map(e => IndexColumn(schema(e.ordinal).name, e.dir == Ascending))
         case BitMapIndex(entries) =>
           indexType = BitMapIndexType
+          entries.map(e => IndexColumn(schema(e).name))
+        case TrieIndex(entries) =>
+          indexType = PermutermIndexType
           entries.map(e => IndexColumn(schema(e).name))
         case it => sys.error(s"Not implemented index type $it")
       }
@@ -473,6 +489,9 @@ case class OapShowIndex(table: TableIdentifier, relationName: String)
       case BitMapIndex(entries) =>
         entries.zipWithIndex.map(ei =>
           Row(relationName, i.name, ei._2, schema(ei._1).name, "A", "BITMAP"))
+      case TrieIndex(entries) =>
+        entries.zipWithIndex.map(ei =>
+          Row(relationName, i.name, ei._2, schema(ei._1).name, "A", "TRIE"))
       case t => sys.error(s"not support index type $t for index ${i.name}")
     })
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -128,9 +128,8 @@ case class CreateIndex(
             schema.map(_.name).toIndexedSeq.indexOf(col.columnName))
           metaBuilder.addIndexMeta(new IndexMeta(indexName, time, BitMapIndex(entries)))
         case PermutermIndexType =>
-          val entries = indexColumns.map(col =>
-            schema.map(_.name).toIndexedSeq.indexOf(col.columnName))
-          metaBuilder.addIndexMeta(new IndexMeta(indexName, time, TrieIndex(entries)))
+          val entry = schema.map(_.name).toIndexedSeq.indexOf(indexColumns(0).columnName)
+          metaBuilder.addIndexMeta(new IndexMeta(indexName, time, TrieIndex(entry)))
         case _ =>
           sys.error(s"Not supported index type $indexType")
       }
@@ -358,9 +357,9 @@ case class RefreshIndex(
         case BitMapIndex(entries) =>
           indexType = BitMapIndexType
           entries.map(e => IndexColumn(schema(e).name))
-        case TrieIndex(entries) =>
+        case TrieIndex(entry) =>
           indexType = PermutermIndexType
-          entries.map(e => IndexColumn(schema(e).name))
+          Seq(IndexColumn(schema(entry).name))
         case it => sys.error(s"Not implemented index type $it")
       }
 
@@ -491,9 +490,8 @@ case class OapShowIndex(table: TableIdentifier, relationName: String)
       case BitMapIndex(entries) =>
         entries.zipWithIndex.map(ei =>
           Row(relationName, i.name, ei._2, schema(ei._1).name, "A", "BITMAP"))
-      case TrieIndex(entries) =>
-        entries.zipWithIndex.map(ei =>
-          Row(relationName, i.name, ei._2, schema(ei._1).name, "A", "TRIE"))
+      case TrieIndex(entry) =>
+        Seq(Row(relationName, i.name, 0, schema(entry).name, "A", "TRIE"))
       case t => sys.error(s"not support index type $t for index ${i.name}")
     })
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -108,8 +108,9 @@ case class CreateIndex(
       val innerIndexType =
         if (sparkSession.conf.get(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE) &&
           indexType == BTreeIndexType && indexColumns.length == 1) {
-          val entry = schema.map(_.name).toIndexedSeq.indexOf(indexColumns(0).columnName)
-          if (schema(entry).dataType == StringType) {
+          // if indexColumn only has size 1 and is of StringType, we can build trie to support
+          // better search.
+          if (schema(indexColumns(0).columnName).dataType.sameType(StringType)) {
             logInfo("Building a TRIE index for the column, to turn off this, " +
               s"please disable ${SQLConf.OAP_ENABLE_TRIE_OVER_BTREE.key}")
             PermutermIndexType

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexTypes.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexTypes.scala
@@ -29,3 +29,7 @@ case object BTreeIndexType extends AnyIndexType {
 case object BitMapIndexType extends AnyIndexType {
   override def toString: String = "BITMAP"
 }
+
+case object PermutermIndexType extends AnyIndexType {
+  override def toString: String = "PERMUTERM"
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -194,7 +194,8 @@ object StatisticsManager {
   val statisticsTypeMap: scala.collection.mutable.Map[AnyIndexType, Array[StatisticsType]] =
     scala.collection.mutable.Map(
       BTreeIndexType -> Array.empty,
-      BitMapIndexType -> Array.empty)
+      BitMapIndexType -> Array.empty,
+      PermutermIndexType -> Array.empty)
 
   /**
    * Using a static object to store parameter is not a good idea, some reasons:

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -707,6 +707,14 @@ object SQLConf {
       .intConf
       .createWithDefault(1024 * 1024)
 
+  val OAP_ENABLE_TRIE_OVER_BTREE =
+    SQLConfigBuilder("spark.sql.oap.oindex.trie.enabled")
+      .internal()
+      .doc("To indicate to enable/disable using trie for single-column string type column " +
+        "to build index using trie when the index type is btree")
+      .booleanConf
+      .createWithDefault(true)
+
   val OAP_IS_TESTING =
     SQLConfigBuilder("spark.sql.oap.testing")
       .internal()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -344,6 +344,7 @@ class DataSourceMetaSuite extends SharedSQLContext with BeforeAndAfter {
   }
 
   test("test hasAvailableIndex from Meta") {
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, false)
     val df = sparkContext.parallelize(1 to 100, 3)
       .map(i => (i, i + 100, s"this is row $i"))
       .toDF("a", "b", "c")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -47,6 +47,7 @@ class DataSourceMetaSuite extends SharedSQLContext with BeforeAndAfter {
   }
 
   override def afterAll(): Unit = {
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, true)
     try {
       Utils.deleteRecursively(tmpDir)
     } finally {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -34,6 +34,7 @@ class OapDDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
 
   override def beforeEach(): Unit = {
     sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, false)
     val path1 = Utils.createTempDir().getAbsolutePath
     val path2 = Utils.createTempDir().getAbsolutePath
 
@@ -92,6 +93,32 @@ class OapDDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
         Row("oap_test_2", "index6", 0, "a", "A", "BITMAP") ::
         Row("oap_test_2", "index1", 0, "a", "D", "BTREE") ::
         Row("oap_test_2", "index1", 1, "b", "D", "BTREE") :: Nil)
+  }
+
+  test("check create index with trie") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    checkAnswer(sql("show oindex from oap_test_1"), Nil)
+    sql("insert overwrite table oap_test_1 select * from t")
+    sql("insert overwrite table oap_test_2 select * from t")
+    sql("create oindex index1 on oap_test_1 (b) using btree")
+    sql("create oindex index2 on oap_test_1 (b desc) ")
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, true)
+    sql("create oindex index3 on oap_test_2 (b desc) using btree")
+    sql("create oindex index4 on oap_test_2 (b desc)")
+    sql("create oindex index5 on oap_test_2 (a desc)")
+    sql("create oindex index1 on oap_test_2 (b desc, a desc)")
+
+    checkAnswer(sql("show oindex from oap_test_1"),
+      Row("oap_test_1", "index1", 0, "b", "A", "BTREE") ::
+        Row("oap_test_1", "index2", 0, "b", "D", "BTREE") :: Nil)
+
+    checkAnswer(sql("show oindex in oap_test_2"),
+      Row("oap_test_2", "index1", 0, "b", "D", "BTREE") ::
+        Row("oap_test_2", "index1", 1, "a", "D", "BTREE") ::
+        Row("oap_test_2", "index3", 0, "b", "A", "TRIE") ::
+        Row("oap_test_2", "index4", 0, "b", "A", "TRIE") ::
+        Row("oap_test_2", "index5", 0, "a", "D", "BTREE") :: Nil)
   }
 
   test("create and drop index with partition specify") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -53,6 +53,7 @@ class OapDDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
     sqlContext.dropTempTable("oap_test_1")
     sqlContext.dropTempTable("oap_test_2")
     sqlContext.sql("drop table oap_partition_table")
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, true)
   }
 
   test("write index for table read in from DS api") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
@@ -42,6 +42,7 @@ class IndexSelectionSuite extends SharedSQLContext with BeforeAndAfterEach{
 
   override def beforeEach(): Unit = {
     sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, false)
     val data = (1 to 300).map(i => (i, i + 100, i + 200, i + 300, s"this is row $i"))
     val df = sparkContext.parallelize(data, 3).toDF("a", "b", "c", "d", "e")
     df.write.format("oap").mode(SaveMode.Overwrite).save(tempDir.getAbsolutePath)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
@@ -52,6 +52,7 @@ class IndexSelectionSuite extends SharedSQLContext with BeforeAndAfterEach{
 
   override def afterEach(): Unit = {
     sqlContext.dropTempTable("oap_test")
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, true)
   }
 
   override def beforeAll(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

add trie index type in DataSourceMeta. add a config value of "spark.sql.oap.oindex.trie.enabled" to create permuterm index


## How was this patch tested?

unit tests.

