### PR TITLE
Add getPartitionsRefreshed method to get partitions on the disk

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
@@ -93,5 +93,19 @@ object OapUtils extends Logging {
     value.map(v => InternalRow(CatalystTypeConverters.convertToCatalyst(v)))
   }
   def keyFromAny(value: Any): Key = InternalRow(CatalystTypeConverters.convertToCatalyst(value))
-}
 
+  /**
+    * Refresh any cached file listings of @param fileIndex,
+    * and return partitions if data is partitioned, or a single partition if data is unpartitioned.
+    * indicate all valid files grouped into partition(s) on the disk
+    * @param fileIndex [[FileIndex]] of a relation
+    * @param partitionSpec the specification of the partitions
+    * @return all valid files grouped into partition(s) on the disk
+    */
+  def getPartitionsRefreshed(fileIndex: FileIndex,
+                             partitionSpec: Option[TablePartitionSpec] = None)
+  : Seq[PartitionDirectory] = {
+    fileIndex.refresh()
+    getPartitions(fileIndex, partitionSpec)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
@@ -102,9 +102,9 @@ object OapUtils extends Logging {
    * @param partitionSpec the specification of the partitions
    * @return all valid files grouped into partition(s) on the disk
    */
-  def getPartitionsRefreshed(fileIndex: FileIndex,
-                             partitionSpec: Option[TablePartitionSpec] = None)
-  : Seq[PartitionDirectory] = {
+  def getPartitionsRefreshed(
+      fileIndex: FileIndex,
+      partitionSpec: Option[TablePartitionSpec] = None): Seq[PartitionDirectory] = {
     fileIndex.refresh()
     getPartitions(fileIndex, partitionSpec)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
@@ -95,13 +95,13 @@ object OapUtils extends Logging {
   def keyFromAny(value: Any): Key = InternalRow(CatalystTypeConverters.convertToCatalyst(value))
 
   /**
-    * Refresh any cached file listings of @param fileIndex,
-    * and return partitions if data is partitioned, or a single partition if data is unpartitioned.
-    * indicate all valid files grouped into partition(s) on the disk
-    * @param fileIndex [[FileIndex]] of a relation
-    * @param partitionSpec the specification of the partitions
-    * @return all valid files grouped into partition(s) on the disk
-    */
+   * Refresh any cached file listings of @param fileIndex,
+   * and return partitions if data is partitioned, or a single partition if data is unpartitioned.
+   * indicate all valid files grouped into partition(s) on the disk
+   * @param fileIndex [[FileIndex]] of a relation
+   * @param partitionSpec the specification of the partitions
+   * @return all valid files grouped into partition(s) on the disk
+   */
   def getPartitionsRefreshed(fileIndex: FileIndex,
                              partitionSpec: Option[TablePartitionSpec] = None)
   : Seq[PartitionDirectory] = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
If we do some queries on a table, then file listings will be cached in FileIndex of the relation.
The method, `OapUtils.getPartitions`, is used to get all valid files grouped into partition(s) of the relation.
Cache and disk will be inconsistent once some data files of this relation are moved or deleted.

Therefore, add a method, `OapUtils.getPartitionsRefreshed`, to refresh cached file listings of FileIndex, then get partitions.
## How was this patch tested?
unit tests

