### PR TITLE
[bug] should use actual index type to invoke proper index writer

### DIFF
--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -37,6 +37,7 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
 
   override def beforeEach(): Unit = {
     sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, false)
     val path = Utils.createTempDir().getAbsolutePath
     currentPath = path
     sql(s"""CREATE TEMPORARY VIEW oap_test (a INT, b STRING)
@@ -70,6 +71,7 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
     sqlContext.dropTempTable("parquet_test_date")
     sql("DROP TABLE IF EXISTS t_refresh")
     sql("DROP TABLE IF EXISTS t_refresh_parquet")
+    sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, true)
   }
 
   test("empty table") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since we may create permuterm index when user specifying btree index, we should use actual index type to invoke proper index writer


## How was this patch tested?

unit tests.

