### PR TITLE
fix FileMeta's data file name of Parquet

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputWriter.scala
@@ -85,7 +85,8 @@ private[index] class OapIndexOutputWriter(
       recordWriter.close(context)
       recordWriter = null
       results = results :+
-          IndexBuildResult(inputFileName, rowCount, "", new Path(inputFileName).getParent.toString)
+        IndexBuildResult(new Path(inputFileName).getName,
+          rowCount, "", new Path(inputFileName).getParent.toString)
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputWriter.scala
@@ -84,9 +84,8 @@ private[index] class OapIndexOutputWriter(
     if (recordWriter != null) {
       recordWriter.close(context)
       recordWriter = null
-      results = results :+
-        IndexBuildResult(new Path(inputFileName).getName,
-          rowCount, "", new Path(inputFileName).getParent.toString)
+      results = results :+ IndexBuildResult(
+        new Path(inputFileName).getName, rowCount, "", new Path(inputFileName).getParent.toString)
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.internal.SQLConf
@@ -242,6 +241,31 @@ class DataSourceMetaSuite extends SharedSQLContext with BeforeAndAfter {
     assert(fileHeader2.recordCount === 100)
     assert(fileHeader2.dataFileCount === 3)
     assert(fileHeader2.indexCount === 2)
+  }
+
+  test("FileMeta's data file name test for parquet") {
+    val df = sparkContext.parallelize(1 to 100, 3)
+      .map(i => (i, i + 100, s"this is row $i"))
+      .toDF("a", "b", "c")
+    df.write.format("parquet").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
+    val oapDf = sqlContext.read.format("parquet").load(tmpDir.getAbsolutePath)
+    oapDf.createOrReplaceTempView("t")
+
+    val path = new Path(
+      new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
+
+    val fs = path.getFileSystem(new Configuration())
+    assert(!fs.exists(path))
+
+    sql("create oindex index1 on t (a)") // this will create index files along with meta file
+    assert(fs.exists(path))
+
+    val oapMeta = DataSourceMeta.initialize(path, sparkContext.hadoopConfiguration)
+    val fileMetas = oapMeta.fileMetas
+    assert(fileMetas.length === 3)
+    assert(fileMetas.map(_.recordCount).sum === 100)
+    assert(fileMetas(0).dataFileName.endsWith(".parquet"))
+    assert(fileMetas(0).dataFileName.startsWith("part"))
   }
 
   test("Oap meta for partitioned table") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
to make `DataFileName` field in meta file of Parquet file format only store data file's name, excluding path.

## How was this patch tested?
unit test