### PR TITLE
Index selection

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -60,43 +60,44 @@ import org.apache.spark.sql.types._
  */
 
 private[oap] trait IndexType {
-  final val INDEX_METRICS_KEY_ORDER = 0
-  final val INDEX_METRICS_KEY_GROUP = 1
-  final val INDEX_METRICS_KEY_ITERABLE = 2
-  final val INDEX_METRICS_KEY_EXISTENCE = 4
-  final val INDEX_METRICS_TOTAL_NUMBER = 8
 
-  // A metrics BitSet
-  //    0 1 2 3 4 5 6 7
-  //    X X X X X X X X
-  //    | | | | Reserved
-  //    | | | |
-  //    | | | |
-  //    | | | |
-  //    | | | +> Quick check key's existence.
-  //    | | +> Key value is iterable in index.
-  //    | +> Key is organized in group.
-  //    +> Key is stored in order.
-  def metrics: BitSet = BitSet.fromBitMask(Array(0))
+  // Bit is set if index is sorted index. hash-based index unset this.
+  // Once this bit is on, indexOrder should be called to check direction.
+  final val INDEX_METRICS_KEY_ORDER_BIT_MASK = 0
 
-  // if index is sorted index. hash-based index unset this.
-  // metrics.set(INDEX_METRICS_KEY_ORDER)
-
-  // if index is scanned in group.
-  // a special case is index is built in group, but scan is not.
-  // metrics.set(INDEX_METRICS_KEY_GROUP)
+  // Bit is set if index is scanned in group.
+  // One special case is index is built in group, but scan is out of order
+  // like below bitmap to let the items can be scanned in row sequence.
+  // RowId: | 0 1 2 3 4 |
+  //        +-----------+
+  // Key-1  | x       x |
+  // Key-2  |     x     |
+  //        +-----------+
+  // The scan row id sequence can be 0 2 4 instead of 0 4 2.
+  final val INDEX_METRICS_KEY_GROUP_BIT_MASK = 1
 
   // if key value is needed.
   // sometimes a range based index may not store all keys in index.
   // TODO: index scan does not return key, enable in future.
-  // metrics.set(INDEX_METRICS_KEY_ITERABLE)
+  final val INDEX_METRICS_KEY_ITERABLE_BIT_MASK = 2
 
   // if support fast existence check.
-  // metrics.set(INDEX_METRICS_KEY_EXISTENCE)
+  final val INDEX_METRICS_KEY_EXISTENCE_BIT_MASK = 4
+
+  // A metrics BitSet
+  //    0 1 2 3 4 5 6 7
+  //    X X X X RESERVED
+  //    | | | |
+  //    | | | +> INDEX_METRICS_KEY_EXISTENCE_BIT_MASK.
+  //    | | +> INDEX_METRICS_KEY_ITERABLE_BIT_MASK.
+  //    | +> INDEX_METRICS_KEY_GROUP_BIT_MASK.
+  //    +> INDEX_METRICS_KEY_ORDER_BIT_MASK.
+  def metrics: BitSet = BitSet.fromBitMask(Array(0))
 
   // Get index sort direction if INDEX_METRICS_KEY_ORDER is true.
   def indexOrder: Seq[SortDirection] = Seq.empty
 
+  // Check if this index matches the required index metrics.
   def satisfy(requirements: Option[IndexType]): Boolean = requirements match {
     case Some(r) => metrics.equals(r.metrics)
     case _ => true // No requirements.
@@ -123,7 +124,7 @@ private[oap] case class BTreeIndex(entries: Seq[BTreeIndexEntry] = Nil) extends 
   }
 
   override def metrics: BitSet =
-    BitSet.fromBitMask(Array(INDEX_METRICS_KEY_ORDER | INDEX_METRICS_KEY_GROUP))
+    BitSet.fromBitMask(Array(INDEX_METRICS_KEY_ORDER_BIT_MASK | INDEX_METRICS_KEY_GROUP_BIT_MASK))
 }
 
 private[oap] case class BitMapIndex(entries: Seq[Int] = Nil) extends IndexType {
@@ -187,8 +188,7 @@ private[oap] class IndexMeta(
 
   override def toString: String = name + ": " + indexType
 
-  private def writeBitSet(
-      value: BitSet, totalSizeToWrite: Int, out: FSDataOutputStream): Unit = {
+  private def writeBitSet(value: BitSet, totalSizeToWrite: Int, out: FSDataOutputStream): Unit = {
     val sizeBefore = out.size
     value.toBitMask.foreach(out.writeLong)
     val sizeWritten = out.size - sizeBefore

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -93,7 +93,7 @@ private[oap] trait IndexType {
   def metrics: BitSet = BitSet.fromBitMask(Array(0))
 
   // Get index sort direction if INDEX_METRICS_KEY_ORDER is true.
-  def indexOrder: Seq[SortDirection] = Seq.empty
+  def indexOrder: Seq[SortDirection] = Nil
 
   // Check if this index matches the required index metrics.
   def satisfy(requirements: Option[IndexType]): Boolean = requirements match {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -288,13 +288,13 @@ private[sql] class OapFileFormat extends FileFormat
     if (expressions.nonEmpty && sparkSession.conf.get(SQLConf.OAP_ENABLE_OINDEX)) {
       meta match {
         case Some(m) if requiredTypes.isEmpty =>
-          expressions.map(m.isSupportedByIndex(_, None)).reduce(_ && _)
+          expressions.forall(m.isSupportedByIndex(_, None))
         case Some(m) if requiredTypes.length == expressions.length =>
-          expressions.zip(requiredTypes).map{ x =>
+          expressions.zip(requiredTypes).forall{ x =>
             val expression = x._1
             val requirement = Some(x._2)
             m.isSupportedByIndex(expression, requirement)
-          }.reduce(_ && _)
+          }
         case _ => false
       }
     } else false

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.datasources.oap
 
 import java.net.URI
 
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
@@ -31,7 +30,7 @@ import org.apache.parquet.hadoop.util.SerializationUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeSet, Expression, JoinedRow}
+import org.apache.spark.sql.catalyst.expressions.{Expression, JoinedRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.{GenerateOrdering, GenerateUnsafeProjection}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.oap.filecache.DataFileHandleCacheManager
@@ -275,43 +274,30 @@ private[sql] class OapFileFormat extends FileFormat
     }
   }
 
-  private def indexHashSetList = {
-    assert(meta.isDefined)
-    val hashSetList = new mutable.ListBuffer[mutable.HashSet[String]]()
-    val bTreeIndexAttrSet = new mutable.HashSet[String]()
-    val bitmapIndexAttrSet = new mutable.HashSet[String]()
-    var idx = 0
-    val m = meta.get
-    while(idx < m.indexMetas.length) {
-      m.indexMetas(idx).indexType match {
-        case BTreeIndex(entries) =>
-          bTreeIndexAttrSet.add(m.schema(entries.head.ordinal).name)
-        case BitMapIndex(entries) =>
-          entries.map(ordinal => m.schema(ordinal).name).foreach(bitmapIndexAttrSet.add)
-        case _ => // we don't support other types of index
+  /**
+   * Check if index satisfies strategies' requirements.
+   *
+   * @param expressions: Index expressions.
+   * @param requiredTypes: Required index metrics by optimization strategies.
+   * @return
+   */
+  def hasAvailableIndex(
+      expressions: Seq[Expression],
+      requiredTypes: Seq[IndexType] = Nil
+  ): Boolean = {
+    if (expressions.nonEmpty && sparkSession.conf.get(SQLConf.OAP_ENABLE_OINDEX)) {
+      meta match {
+        case Some(m) if requiredTypes.isEmpty =>
+          expressions.map(m.isSupportedByIndex(_, None)).reduce(_ && _)
+        case Some(m) if requiredTypes.length == expressions.length =>
+          expressions.zip(requiredTypes).map{ x =>
+            val expression = x._1
+            val requirement = Some(x._2)
+            m.isSupportedByIndex(expression, requirement)
+          }.reduce(_ && _)
+        case _ => false
       }
-      idx += 1
-    }
-    hashSetList.append(bTreeIndexAttrSet)
-    hashSetList.append(bitmapIndexAttrSet)
-    hashSetList
-  }
-
-  def hasAvailableIndex(expressions: Seq[Expression]): Boolean = {
-    meta match {
-      case Some(m) if sparkSession.conf.get(SQLConf.OAP_ENABLE_OINDEX) =>
-        expressions.exists(m.isSupportedByIndex(_, indexHashSetList))
-      case _ => false
-    }
-  }
-
-  def hasAvailableIndex(attributes: AttributeSet): Boolean = {
-    meta match {
-      case Some(m) if sparkSession.conf.get(SQLConf.OAP_ENABLE_OINDEX) =>
-        attributes.map{attr =>
-          indexHashSetList.map(_.contains(attr.name)).reduce(_ || _)}.reduce(_ && _)
-      case _ => false
-    }
+    } else false
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -195,78 +195,55 @@ private[oap] class OapDataReader(
     logDebug("Initializing OapDataReader...")
     // TODO how to save the additional FS operation to get the Split size
     val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf)
-
     val start = System.currentTimeMillis()
+
     filterScanner match {
       case Some(fs) if fs.existRelatedIndexFile(path, conf) =>
         val indexPath = IndexUtils.indexFileFromDataFile(path, fs.meta.name, fs.meta.time)
-
         val initFinished = System.currentTimeMillis()
-        val statsAnalyseResult = tryToReadStatistics(indexPath, conf)
-        val statsAnalyseFinished = System.currentTimeMillis()
 
-        val indexFileSize = indexPath.getFileSystem(conf).getContentSummary(indexPath).getLength
-        val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
-        val isTesting = conf.getBoolean(SQLConf.OAP_IS_TESTING.key,
-                              SQLConf.OAP_IS_TESTING.defaultValue.get)
         val enableOIndex = conf.getBoolean(SQLConf.OAP_ENABLE_OINDEX.key,
           SQLConf.OAP_ENABLE_OINDEX.defaultValue.get)
-        val isAscending = options.getOrElse(
-          OapFileFormat.OAP_QUERY_ORDER_OPTION_KEY, "false").toBoolean
-        val limit = options.getOrElse(OapFileFormat.OAP_QUERY_LIMIT_OPTION_KEY, "0").toInt
 
-        if (options.contains(OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY)) {
-          fs.setScanNumLimit(
-            options(OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY).toInt
-          )
-        }
+        val useIndex = enableOIndex && canUseIndex(indexPath, conf)
+        val indexPolicyCheckFinished = System.currentTimeMillis()
 
-        val forceIndexScan: Boolean = limit > 0 ||
-          options.contains(OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY) ||
-          options.contains(OapFileFormat.OAP_INDEX_GROUP_BY_OPTION_KEY)
+        // Below is for OAP developers to easily analyze and compare performance without removing
+        // the index after it's created.
+        val iter = if (!useIndex) {
+          logWarning("OAP index is skipped. Set below flags to force enable index,\n" +
+            "sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true) or \n" +
+            "sqlContext.conf.setConfString(SQLConf.OAP_EXECUTOR_INDEX_SELECTION.key, false)")
+          fileScanner.iterator(conf, requiredIds)
+        } else {
+          val isAscending = options.getOrElse(
+            OapFileFormat.OAP_QUERY_ORDER_OPTION_KEY, "false").toBoolean
+          val limit = options.getOrElse(OapFileFormat.OAP_QUERY_LIMIT_OPTION_KEY, "0").toInt
 
-        // Once index is disabled, there is no way to do index optimized query.
-        // OapStrategy should aware of this and create a non-fast query plan.
-        assert((!enableOIndex && forceIndexScan) == false)
-
-        val iter =
-          // Below is for OAP developers to easily analyze and compare performance without removing
-          // the index after it's created.
-          if (!enableOIndex) {
-            logWarning("OAP index is disabled. Using below approach to enable index,\n" +
-              "sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true)")
-            fileScanner.iterator(conf, requiredIds)
-          } else if (!forceIndexScan && indexFileSize > dataFileSize * 0.7 && !isTesting) {
-            logWarning(s"Index File size $indexFileSize B is too large comparing " +
-                        s"to Data File Size $dataFileSize. Using Data File Scan instead.")
-            fileScanner.iterator(conf, requiredIds)
-          } else {
-            statsAnalyseResult match {
-              case StaticsAnalysisResult.FULL_SCAN if !forceIndexScan =>
-                fileScanner.iterator(conf, requiredIds)
-              case StaticsAnalysisResult.USE_INDEX =>
-                fs.initialize(path, conf)
-                // total Row count can be get from the filter scanner
-                val rowIDs = {
-                  if (limit > 0) {
-                    if (isAscending) fs.toArray.take(limit)
-                    else fs.toArray.reverse.take(limit)
-                  }
-                  else fs.toArray
-                }
-
-                OapIndexInfo.partitionOapIndex.put(path.toString(), true)
-                logInfo("Partition File " + path.toString() + " will use OAP index.\n")
-                fileScanner.iterator(conf, requiredIds, rowIDs)
-              case StaticsAnalysisResult.SKIP_INDEX =>
-                Iterator.empty
-            }
+          if (options.contains(OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY)) {
+            fs.setScanNumLimit(
+              options(OapFileFormat.OAP_INDEX_SCAN_NUM_OPTION_KEY).toInt
+            )
           }
+
+          fs.initialize(path, conf)
+          // total Row count can be get from the filter scanner
+          val rowIDs = {
+            if (limit > 0) {
+              if (isAscending) fs.toArray.take(limit)
+              else fs.toArray.reverse.take(limit)
+            }
+            else fs.toArray
+          }
+          OapIndexInfo.partitionOapIndex.put(path.toString(), true)
+          logInfo("Partition File " + path.toString() + " will use OAP index.\n")
+          fileScanner.iterator(conf, requiredIds, rowIDs)
+        }
 
         val iteratorFinished = System.currentTimeMillis()
         logDebug("Load Index: " + (initFinished - start) + "ms")
-        logDebug("Load Stats: " + (statsAnalyseFinished - initFinished) + "ms")
-        logDebug("Construct Iterator: " + (iteratorFinished - statsAnalyseFinished) + "ms")
+        logDebug("Load Stats: " + (indexPolicyCheckFinished - initFinished) + "ms")
+        logDebug("Construct Iterator: " + (iteratorFinished - indexPolicyCheckFinished) + "ms")
         iter
       case _ =>
         logDebug("No index file exist for data file: " + path)
@@ -276,6 +253,37 @@ private[oap] class OapDataReader(
         logDebug("Construct Iterator: " + (iteratorFinished - start) + "ms")
 
         iter
+    }
+  }
+
+  /**
+   * Executor chooses to use index or not according to policies.
+   *  1. OAP_EXECUTOR_INDEX_SELECTION is enabled.
+   *  2. Statistics info recommends index scan.
+   *  3. Considering about file I/O, index file size should be less
+   *     than data file.
+   *  4. TODO: add more.
+   *
+   * @param indexPath: index file path.
+   * @param conf: configurations
+   * @return Boolean to indicate if executor chooses to use index.
+   */
+  private def canUseIndex(indexPath: Path, conf: Configuration): Boolean = {
+    if (conf.getBoolean(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key,
+        SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.defaultValue.get)) {
+      // Index selection is enabled, executor chooses index according to policy.
+      // Get statistics info.
+      val statsAnalyseResult = tryToReadStatistics(indexPath, conf)
+
+      // Get file size info
+      val indexFileSize = indexPath.getFileSystem(conf).getContentSummary(indexPath).getLength
+      val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
+
+      statsAnalyseResult == StaticsAnalysisResult.USE_INDEX &&
+        indexFileSize <= dataFileSize * 0.7
+    } else {
+      // Index selection is disabled, executor always uses index.
+      true
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -272,15 +272,18 @@ private[oap] class OapDataReader(
     if (conf.getBoolean(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key,
         SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.defaultValue.get)) {
       // Index selection is enabled, executor chooses index according to policy.
-      // Get statistics info.
-      val statsAnalyseResult = tryToReadStatistics(indexPath, conf)
 
-      // Get file size info
+      // Policy 1: index file size < data file size.
       val indexFileSize = indexPath.getFileSystem(conf).getContentSummary(indexPath).getLength
       val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
+      indexFileSize <= dataFileSize * 0.7
 
-      statsAnalyseResult == StaticsAnalysisResult.USE_INDEX &&
-        indexFileSize <= dataFileSize * 0.7
+      // Policy 2: statistics tells the scan cost
+      // TODO: Get statistics info after statistics is enabled.
+      // val statsAnalyseResult = tryToReadStatistics(indexPath, conf)
+      // statsAnalyseResult == StaticsAnalysisResult.USE_INDEX
+
+      // More Policies
     } else {
       // Index selection is disabled, executor always uses index.
       true

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -276,7 +276,9 @@ private[oap] class OapDataReader(
       // Policy 1: index file size < data file size.
       val indexFileSize = indexPath.getFileSystem(conf).getContentSummary(indexPath).getLength
       val dataFileSize = path.getFileSystem(conf).getContentSummary(path).getLength
-      indexFileSize <= dataFileSize * 0.7
+      val ratio = conf.getDouble(SQLConf.OAP_INDEX_FILE_SIZE_MAX_RATIO.key,
+        SQLConf.OAP_INDEX_FILE_SIZE_MAX_RATIO.defaultValue.get)
+      indexFileSize <= dataFileSize * ratio
 
       // Policy 2: statistics tells the scan cost
       // TODO: Get statistics info after statistics is enabled.

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -715,19 +715,19 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val OAP_IS_TESTING =
-    SQLConfigBuilder("spark.sql.oap.testing")
-      .internal()
-      .doc("To indicate if the test is ongoing")
-      .booleanConf
-      .createWithDefault(false)
-
   val OAP_ENABLE_OINDEX =
     SQLConfigBuilder("spark.sql.oap.oindex.enabled")
       .internal()
       .doc("To indicate to enable/disable oindex for developers even if the index file is there")
       .booleanConf
       .createWithDefault(true)
+
+  val OAP_ENABLE_EXECUTOR_INDEX_SELECTION =
+    SQLConfigBuilder("spark.sql.oap.oindex.cbo.enabled")
+      .internal()
+      .doc("To indicate if enable/disable index cbo which helps to choose a fast query path")
+      .booleanConf
+      .createWithDefault(false)
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -723,11 +723,18 @@ object SQLConf {
       .createWithDefault(true)
 
   val OAP_ENABLE_EXECUTOR_INDEX_SELECTION =
-    SQLConfigBuilder("spark.sql.oap.oindex.cbo.enabled")
+    SQLConfigBuilder("spark.sql.oap.oindex.eis.enabled")
       .internal()
       .doc("To indicate if enable/disable index cbo which helps to choose a fast query path")
       .booleanConf
       .createWithDefault(false)
+
+  val OAP_INDEX_FILE_SIZE_MAX_RATIO =
+    SQLConfigBuilder("spark.sql.oap.oindex.size.ratio")
+      .internal()
+      .doc("To indicate if enable/disable index cbo which helps to choose a fast query path")
+      .doubleConf
+      .createWithDefault(0.7)
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -36,7 +36,6 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
   private var currentPath: String = _
 
   override def beforeEach(): Unit = {
-    sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, false)
     val path = Utils.createTempDir().getAbsolutePath
     currentPath = path

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapCheckIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapCheckIndexSuite.scala
@@ -35,7 +35,6 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
   sparkConf.set("spark.memory.offHeap.size", "100m")
 
   override def beforeEach(): Unit = {
-    sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, false)
     val path1 = Utils.createTempDir().getAbsolutePath
     val path2 = Utils.createTempDir().getAbsolutePath

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -33,7 +33,6 @@ class OapDDLSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
   sparkConf.set("spark.memory.offHeap.size", "100m")
 
   override def beforeEach(): Unit = {
-    sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, false)
     val path1 = Utils.createTempDir().getAbsolutePath
     val path2 = Utils.createTempDir().getAbsolutePath

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -32,7 +32,6 @@ class OapIndexQuerySuite extends QueryTest with SharedSQLContext with BeforeAndA
   sparkConf.set("spark.memory.offHeap.size", "100m")
 
   override def beforeEach(): Unit = {
-    sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     val path1 = Utils.createTempDir().getAbsolutePath
 
     sql(s"""CREATE TEMPORARY VIEW oap_test_1 (a INT, b STRING)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -211,29 +211,4 @@ class OapPlannerSuite
 
     sql("drop oindex index1 on oap_fix_length_schema_table")
   }
-
-  test("index selection") {
-    spark.conf.set(OapFileFormat.ROW_GROUP_SIZE, 50)
-    val data = (1 to 300).map{ i =>
-      (i % 101, i % 37)
-    }
-    val dataRDD = spark.sparkContext.parallelize(data, 10)
-
-    dataRDD.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_fix_length_schema_table select * from t")
-    sql("create oindex index1 on oap_fix_length_schema_table (a)")
-    sql("create oindex index2 on oap_fix_length_schema_table (b)")
-    sql("create oindex index3 on oap_fix_length_schema_table (a, b)")
-
-    val sqlString =
-      "SELECT * " +
-        "FROM oap_fix_length_schema_table " +
-        "where a = 5 and b > 20 "
-
-    sql(sqlString).collect.map(println(_))
-
-
-    sql("drop oindex index1 on oap_fix_length_schema_table")
-  }
-
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -19,15 +19,11 @@ package org.apache.spark.sql.execution.datasources.oap
 
 import java.io.File
 
+import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfter
 
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
-
 import org.apache.spark.scheduler.SparkListenerOapIndexInfoUpdate
-import org.apache.spark.SparkConf
 import org.apache.spark.sql._
-import org.apache.spark.sql.execution.datasources.oap.{DataSourceMeta, OapFileFormat}
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, ScannerBuilder}
 import org.apache.spark.sql.execution.datasources.oap.io.{OapIndexInfo, OapIndexInfoStatus}
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataReader
@@ -48,7 +44,6 @@ class OapSuite extends QueryTest with SharedSQLContext with BeforeAndAfter {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     path = Utils.createTempDir()
     path.delete()
     parquetPath = Utils.createTempDir()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexSuite.scala
@@ -35,7 +35,6 @@ class BitMapIndexSuite extends QueryTest with SharedSQLContext with BeforeAndAft
   sparkConf.set("spark.memory.offHeap.size", "100m")
 
   override def beforeEach(): Unit = {
-    sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     val path = Utils.createTempDir().getAbsolutePath
     sql(s"""CREATE TEMPORARY VIEW oap_test (a INT, b STRING)
             | USING oap

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
@@ -41,7 +41,6 @@ class IndexSelectionSuite extends SharedSQLContext with BeforeAndAfterEach{
   sparkConf.set("spark.memory.offHeap.size", "100m")
 
   override def beforeEach(): Unit = {
-    sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     sqlContext.conf.setConf(SQLConf.OAP_ENABLE_TRIE_OVER_BTREE, false)
     val data = (1 to 300).map(i => (i, i + 100, i + 200, i + 300, s"this is row $i"))
     val df = sparkContext.parallelize(data, 3).toDF("a", "b", "c", "d", "e")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/FileSkipSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/FileSkipSuite.scala
@@ -28,7 +28,6 @@ class FileSkipSuite extends QueryTest with SharedSQLContext with BeforeAndAfterE
   import testImplicits._
 
   override def beforeEach(): Unit = {
-    sqlContext.conf.setConf(SQLConf.OAP_IS_TESTING, true)
     val path1 = Utils.createTempDir().getAbsolutePath
 
     sql(s"""CREATE TEMPORARY VIEW oap_test_1 (a INT, b STRING)

--- a/src/test/scala/org/apache/spark/sql/hive/execution/OapQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/OapQuerySuite.scala
@@ -37,7 +37,6 @@ class OapQuerySuite extends HiveComparisonTest with BeforeAndAfter  {
 
   override def beforeAll() {
     super.beforeAll()
-    sparkContext.conf.set(SQLConf.OAP_IS_TESTING.key, SQLConf.OAP_IS_TESTING.defaultValueString)
     TestHive.setCacheTables(true)
     // Timezone is fixed to America/Los_Angeles for those timezone sensitive tests (timestamp_*)
     TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add a flag to tell if executor can choose index, and
   related code to parse the flag.
2. Add index metrics and refine the logic that metadata
   matches the index requirement. This matching happens
   when oapStrategies figure out an optimized plan, now if
   oap strategies ask for 2 indexes, they should give the
   index metrics respectively and check if all index exists
   in metadata.
3. PushDownFilter to index is not changed, as so far it is
   still responsible for the multi-column index selection.
   This part will be refactored in future.

Signed-off-by: Wang, Yue A <yue.a.wang@intel.com>

## How was this patch tested?
mvn test passed.