### PR TITLE
fix npe when DataFileHandleCacheManager.cache trigger removelister 

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -24,8 +24,8 @@ import scala.collection.mutable
 
 import com.google.common.cache._
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.{SparkConf, SparkEnv}
 
+import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.executor.custom.CustomManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.OapException

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -24,8 +24,8 @@ import scala.collection.mutable
 
 import com.google.common.cache._
 import org.apache.hadoop.conf.Configuration
-
 import org.apache.spark.{SparkConf, SparkEnv}
+
 import org.apache.spark.executor.custom.CustomManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.OapException
@@ -35,7 +35,7 @@ import org.apache.spark.storage.{BlockId, FiberBlockId, StorageLevel}
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.TimeStampedHashMap
 import org.apache.spark.util.collection.BitSet
-import org.apache.spark.util.io.{ChunkedByteBuffer, ChunkedByteBufferOutputStream}
+import org.apache.spark.util.io.ChunkedByteBuffer
 
 
 // TODO need to register within the SparkContext
@@ -198,7 +198,7 @@ private[oap] object DataFileHandleCacheManager extends Logging {
         override def onRemoval(n: RemovalNotification[ENTRY, DataFileHandle])
         : Unit = {
           logDebug(s"Evicting Data File Handle ${n.getKey.path}")
-          n.getValue.fin.close()
+          n.getValue.close
         }
       })
       .build[ENTRY, DataFileHandle](new CacheLoader[ENTRY, DataFileHandle]() {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -69,4 +69,10 @@ private[oap] object DataFile {
 abstract class DataFileHandle {
   def fin: FSDataInputStream
   def len: Long
+
+  def close: Unit = {
+    if (fin != null) {
+      fin.close
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When DataFileHandleCacheManager.cache trigger removelister and DataFileHandle is ParquetDataFileHandle will throw  NullPointerException like this stack because of ParquetDataFileHandle not hold fin , so ParquetDataFileHandle.fin is always null.

`17/11/07 22:29:39 WARN guava.cache.LocalCache [Executor task launch worker-1180]: Exception thrown by removal listener
java.lang.NullPointerException
        at org.apache.spark.sql.execution.datasources.spinach.DataFileHandleCacheManager$$anon$4.onRemoval(FiberCacheManager.scala:111)
        at org.spark_project.guava.cache.LocalCache.processPendingNotifications(LocalCache.java:2016)
        at org.spark_project.guava.cache.LocalCache$Segment.runUnlockedCleanup(LocalCache.java:3521)
        at org.spark_project.guava.cache.LocalCache$Segment.postWriteCleanup(LocalCache.java:3497)
        at org.spark_project.guava.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2333)
        at org.spark_project.guava.cache.LocalCache$Segment.get(LocalCache.java:2257)
        at org.spark_project.guava.cache.LocalCache.get(LocalCache.java:4000)
        at org.spark_project.guava.cache.LocalCache.getOrLoad(LocalCache.java:4004)
        at org.spark_project.guava.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4874)
        at org.apache.spark.sql.execution.datasources.spinach.DataFileHandleCacheManager$.apply(FiberCacheManager.scala:123)
        at org.apache.spark.sql.execution.datasources.spinach.ParquetDataFile.recordReaderBuilder(ParquetDataFile.scala:72)
        at org.apache.spark.sql.execution.datasources.spinach.ParquetDataFile.iterator(ParquetDataFile.scala:51)
        at org.apache.spark.sql.execution.datasources.spinach.SpinachDataReader.initialize(SpinachDataReaderWriter.scala:119)
        at org.apache.spark.sql.execution.datasources.spinach.SpinachFileFormat$$anonfun$buildReader$4.apply(SpinachFileFormat.scala:166)
        at org.apache.spark.sql.execution.datasources.spinach.SpinachFileFormat$$anonfun$buildReader$4.apply(SpinachFileFormat.scala:161)
        at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:116)
        at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:91)
        at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.processNext(Unknown Source)
        at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
        at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$8$$anon$1.hasNext(WholeStageCodegenExec.scala:370)
        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
        at org.apache.spark.shuffle.sort.UnsafeShuffleWriter.write(UnsafeShuffleWriter.java:161)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:79)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:47)
        at org.apache.spark.scheduler.Task.run(Task.scala:86)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:274)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)`
