### PR TITLE
Ensure catalystRequestedSchema is correct to read data

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapReadSupportImpl.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapReadSupportImpl.scala
@@ -52,13 +52,14 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportHelp
  */
 class OapReadSupportImpl extends ReadSupport[UnsafeRow] with Logging {
 
+  private val readSupportHelper = new ParquetReadSupportHelper
 
   /**
    * Called on executor side before [[prepareForRead()]] and instantiating actual Parquet record
    * readers.  Responsible for figuring out Parquet requested schema used for column pruning.
    */
   override def init(context: InitContext): ReadContext = {
-    ParquetReadSupportHelper.init(context)
+    readSupportHelper.init(context)
   }
 
   /**
@@ -71,7 +72,7 @@ class OapReadSupportImpl extends ReadSupport[UnsafeRow] with Logging {
                                keyValueMetaData: JMap[String, String],
                                fileSchema: MessageType,
                                readContext: ReadContext): RecordMaterializer[UnsafeRow] = {
-    ParquetReadSupportHelper.prepareForRead(conf, keyValueMetaData, fileSchema, readContext)
+    readSupportHelper.prepareForRead(conf, keyValueMetaData, fileSchema, readContext)
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupportHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupportHelper.scala
@@ -27,7 +27,7 @@ import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 
-object ParquetReadSupportHelper {
+class ParquetReadSupportHelper {
 
   val readSupport = new ParquetReadSupport
 
@@ -39,6 +39,10 @@ object ParquetReadSupportHelper {
                       fileSchema: MessageType,
                       readContext: ReadContext): RecordMaterializer[UnsafeRow]
   = readSupport.prepareForRead(conf, keyValueMetaData, fileSchema, readContext)
+
+}
+
+object ParquetReadSupportHelper {
 
   val SPARK_ROW_REQUESTED_SCHEMA = ParquetReadSupport.SPARK_ROW_REQUESTED_SCHEMA
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -628,4 +628,17 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
       "b='10' or (b = '20' and a in (10,20,30))"),
       Row(10, "10") :: Row(20, "20") :: Nil)
   }
+
+  test("test parquet inner join") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i / 10, s"$i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
+    sql("create oindex index1 on parquet_test (a)")
+
+    checkAnswer(sql("select t2.a, sum(t2.b) " +
+      "from (select a from parquet_test where a = 3 ) t1 " +
+      "inner join parquet_test t2 on t1.a = t2.a " +
+      "group by t2.a"),
+      Row(3, 3450.0) :: Nil)
+  }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

1、add a new class named ParquetReadSupportHelper
2、move init & prepareForRead method from object  ParquetReadSupportHelper to class ParquetReadSupportHelper
3、Create an independent ParquetReadSupportHelper instance for each OapReadSupportImpl instance

All of the changes are ensure OapReadSupportImpl to hold an independent catalystRequestedSchema definition in ParquetReadSupport &  make sure ParquetReader holds the right parquetRequestedSchema & catalystRequestedSchema .

The key code that causes the error is ParquetReadSupport.init, in this func parquetRequestedSchema construct from catalystRequestedSchema and  before this commits there are maybe  three scenarios as below:
1、catalystRequestedSchema & parquetRequestedSchema all right
2、parquetRequestedSchema create by right catalystRequestedSchema , but catalystRequestedSchema error replace
3、parquetRequestedSchema create by error catalystRequestedSchema ,but they are same

There may be other scenarios，but scenarios 3 can be verified by  ParquetReadSupport.prepareRead method, if the schema can be accepted by target parquet file, there is read wrong data scene but no errors.

## How was this patch tested?
Integration testing & Stressing Test: 
1、table join it self
2、all subquery  can use index