### PR TITLE
Rewriting partition Fetching for checking Index integrity

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -642,9 +642,6 @@ case class OapCheckIndex(
         throw new OapException(s"We don't support index checking for ${other.simpleString}")
     }
 
-    // ignore empty partition directory
-//    val partitionDirs =
-//      OapUtils.getPartitionsRefreshed(fileCatalog, partitionSpec).filter(_.files.nonEmpty)
     val rootPaths = fileCatalog.rootPaths
     val fs = if (rootPaths.nonEmpty) {
       rootPaths.head.getFileSystem(sparkSession.sparkContext.hadoopConfiguration)
@@ -657,10 +654,9 @@ case class OapCheckIndex(
     } else {
       val partitionDirs =
         OapUtils.getPartitionPaths(rootPaths, fs, fileCatalog.partitionSchema, partitionSpec)
-      val (partitionWithMeta, partitionWithNoMeta) = checkOapMetaFile(fs, partitionDirs)
-      analyzeIndexBetweenPartitions(sparkSession, fs, partitionWithMeta)
-      processPartitionsWithNoMeta(partitionWithNoMeta) ++
-        partitionWithMeta.flatMap(checkEachPartition(sparkSession, fs, dataSchema, _))
+
+      analyzeIndexBetweenPartitions(sparkSession, fs, partitionDirs)
+      partitionDirs.flatMap(checkEachPartition(sparkSession, fs, dataSchema, _))
     }
 
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -516,15 +516,17 @@ case class OapCheckIndex(
   override val output: Seq[Attribute] =
     AttributeReference("Analysis Result", StringType, nullable = false)() :: Nil
 
+  @Deprecated
   private def checkOapMetaFile(
       fs: FileSystem,
-      partitionDirs: Seq[PartitionDirectory]): (Seq[Path], Seq[Path]) = {
+      partitionDirs: Seq[Path]): (Seq[Path], Seq[Path]) = {
     require(null ne fs, "file system should not be null!")
 
-    partitionDirs.map(_.files.head.getPath.getParent)
-      .partition(partitionDir => fs.exists(new Path(partitionDir, OapFileFormat.OAP_META_FILE)))
+    partitionDirs.partition(partitionDir =>
+      fs.exists(new Path(partitionDir, OapFileFormat.OAP_META_FILE)))
   }
 
+  @Deprecated
   private def processPartitionsWithNoMeta(partitionDirs: Seq[Path]): Seq[Row] = {
     partitionDirs.map(partitionPath =>
       Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
@@ -641,18 +643,20 @@ case class OapCheckIndex(
     }
 
     // ignore empty partition directory
-    val partitionDirs =
-      OapUtils.getPartitionsRefreshed(fileCatalog, partitionSpec).filter(_.files.nonEmpty)
-    val fs = if (partitionDirs.nonEmpty) {
-      partitionDirs.head.files.head.getPath
-        .getFileSystem(sparkSession.sparkContext.hadoopConfiguration)
+//    val partitionDirs =
+//      OapUtils.getPartitionsRefreshed(fileCatalog, partitionSpec).filter(_.files.nonEmpty)
+    val rootPaths = fileCatalog.rootPaths
+    val fs = if (rootPaths.nonEmpty) {
+      rootPaths.head.getFileSystem(sparkSession.sparkContext.hadoopConfiguration)
     } else {
       null
     }
 
-    if (partitionDirs.isEmpty || (null eq fs)) {
+    if (rootPaths.isEmpty || (null eq fs)) {
       Seq.empty
     } else {
+      val partitionDirs =
+        OapUtils.getPartitionPaths(rootPaths, fs, fileCatalog.partitionSchema, partitionSpec)
       val (partitionWithMeta, partitionWithNoMeta) = checkOapMetaFile(fs, partitionDirs)
       analyzeIndexBetweenPartitions(sparkSession, fs, partitionWithMeta)
       processPartitionsWithNoMeta(partitionWithNoMeta) ++

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
@@ -82,14 +82,14 @@ object OapUtils extends Logging {
   }
 
   /**
-   * Get partition directory path(s),
+   * Get partition directory path(s) which has oap meta,
    * return directories' paths if data is partitioned, or a single path if data is unpartitioned.
    * @param rootPaths the root paths of [[FileIndex]] of the relation
    * @param fs File system
    * @param partitionSchema partitioned column(s) schema of the relation
    * @param partitionSpec Schema of the partitioning columns,
    *                      or the empty schema if the table is not partitioned
-   * @return all valid path(s) of directories pertain to the table
+   * @return all valid path(s) of directories containing meta pertain to the table
    */
   def getPartitionPaths(
       rootPaths: Seq[Path],

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapCheckIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapCheckIndexSuite.scala
@@ -61,7 +61,7 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
     checkAnswer(sql("check oindex on oap_test_2"), Nil)
   }
 
-  test("check existent meta file") {
+  ignore("check existent meta file") {
     val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
     val df = data.toDF("key", "value")
     val path = Utils.createTempDir().toString
@@ -71,7 +71,7 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
     checkAnswer(sql("check oindex on t"), Nil)
   }
 
-  test("check nonexistent meta file") {
+  ignore("check nonexistent meta file") {
     val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
     val df = data.toDF("key", "value")
     val path = Utils.createTempDir().toString
@@ -84,7 +84,7 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
       Row(s"Meta file not found in partition: $path"))
   }
 
-  test("check meta file: Partially missing") {
+  ignore("check meta file: Partially missing") {
     val data: Seq[(Int, Int)] = (1 to 10).map { i => (i, i) }
     data.toDF("key", "value").createOrReplaceTempView("t")
 
@@ -119,6 +119,7 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
     sql("insert overwrite table oap_test_1 select * from t")
     sql("insert overwrite table oap_test_2 select * from t")
 
+    checkAnswer(sql("check oindex on oap_test_1"), Nil)
     checkAnswer(sql("check oindex on oap_test_2"), Nil)
 
     sql("create oindex index1 on oap_test_1 (a)")
@@ -128,7 +129,7 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
   }
 
   test("check index on table: Missing data file") {
-    val data = sparkContext.parallelize(1 to 300, 3).map { i => (i, s"this is test $i") }
+    val data = sparkContext.parallelize(1 to 300, 1).map { i => (i, s"this is test $i") }
     val df = data.toDF("key", "value")
     val path = Utils.createTempDir().toString
     df.write.format("oap").mode(SaveMode.Overwrite).save(path)
@@ -143,14 +144,9 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
     val dataFileName = metaOpt.get.fileMetas.head.dataFileName
     Utils.deleteRecursively(new File(path, dataFileName))
 
-    val checkResult =
-      if (metaOpt.get.fileMetas.length > 1) {
-        Seq(Row(s"Data file: $path/$dataFileName not found!"))
-      } else {
-        Nil
-      }
     // Check again
-    checkAnswer(sql("check oindex on t"), checkResult)
+    checkAnswer(sql("check oindex on t"),
+      Seq(Row(s"Data file: $path/$dataFileName not found!")))
   }
 
   test("check index on table: Missing index file") {
@@ -204,13 +200,15 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
         |partition (b=2, c='c2')
         |SELECT key from t where value == 4
       """.stripMargin)
+
+    checkAnswer(sql("check oindex on oap_partition_table"), Nil)
     sql("create oindex idx1 on oap_partition_table(a)")
 
     checkAnswer(sql("check oindex on oap_partition_table"), Nil)
   }
 
   test("check index on partitioned table: Missing data file") {
-    val data = sparkContext.parallelize(1 to 300, 4).map { i => (i, i) }
+    val data = sparkContext.parallelize(1 to 300).map { i => (i, i) }
     data.toDF("key", "value").createOrReplaceTempView("t")
 
     sql(
@@ -224,8 +222,9 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
       """
         |INSERT INTO TABLE oap_partition_table
         |partition (b=2, c='c2')
-        |SELECT key from t where value >= 104
+        |SELECT key from t where value = 104
       """.stripMargin)
+
     sql("create oindex idx1 on oap_partition_table(a)")
 
     checkAnswer(sql("check oindex on oap_partition_table"), Nil)
@@ -235,22 +234,16 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
     val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
     assert(metaOpt.nonEmpty)
     assert(metaOpt.get.fileMetas.nonEmpty)
-
     val dataFileName = metaOpt.get.fileMetas.head.dataFileName
     Utils.deleteRecursively(new File(new Path(partitionPath, dataFileName).toUri.getPath))
 
-    val checkResult: Seq[Row] =
-      if (metaOpt.get.fileMetas.length > 1) {
-        Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!"))
-      } else {
-        Nil
-      }
     // Check again
-    checkAnswer(sql("check oindex on oap_partition_table"), checkResult)
+    checkAnswer(sql("check oindex on oap_partition_table"),
+      Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!")))
   }
 
   test("check index on partitioned table: Missing index file") {
-    val data = sparkContext.parallelize(1 to 300, 4).map { i => (i, i) }
+    val data = sparkContext.parallelize(1 to 300).map { i => (i, i) }
     data.toDF("key", "value").createOrReplaceTempView("t")
 
     sql(
@@ -313,13 +306,12 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
         |SELECT key from t where value == 104
       """.stripMargin)
 
+    checkAnswer(sql("check oindex on oap_partition_table"), Nil)
+
     // Create a B+ tree index on Column("a")
     sql("create oindex idx1 on oap_partition_table(a) partition(b=1, c='c1')")
 
-    val partitionPath =
-      new Path(spark.sqlContext.conf.warehousePath, "oap_partition_table/b=2/c=c2")
-    checkAnswer(sql("check oindex on oap_partition_table"),
-      Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
+    checkAnswer(sql("check oindex on oap_partition_table"), Nil)
 
     sql("create oindex idx1 on oap_partition_table(a) using bitmap partition(b=2, c='c2')")
 
@@ -331,7 +323,7 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
 
   }
 
-  test("check index on partitioned table for a specified partition: Missing meta file") {
+  ignore("check index on partitioned table for a specified partition: Missing meta file") {
     val data: Seq[(Int, Int)] = (1 to 10).map { i => (i, i) }
     data.toDF("key", "value").createOrReplaceTempView("t")
 
@@ -349,11 +341,11 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
         |SELECT key from t where value == 4
       """.stripMargin)
 
-    val partitionPath =
-      new Path(spark.sqlContext.conf.warehousePath + "/oap_partition_table/b=2/c=c2")
-    checkAnswer(
-      sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
-      Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
+//    val partitionPath =
+//      new Path(spark.sqlContext.conf.warehousePath + "/oap_partition_table/b=2/c=c2")
+//    checkAnswer(
+//      sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
+//      Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
 
     sql("create oindex idx1 on oap_partition_table(a) partition(b=2, c='c2')")
 
@@ -389,23 +381,17 @@ class OapCheckIndexSuite extends QueryTest with SharedSQLContext with BeforeAndA
     val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
     assert(metaOpt.nonEmpty)
     assert(metaOpt.get.fileMetas.nonEmpty)
-
     val dataFileName = metaOpt.get.fileMetas.head.dataFileName
     Utils.deleteRecursively(new File(new Path(partitionPath, dataFileName).toUri.getPath))
 
-    val checkResult: Seq[Row] =
-      if (metaOpt.get.fileMetas.length > 1) {
-        Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!"))
-      } else {
-        Nil
-      }
     // Check again
     checkAnswer(sql("check oindex on oap_partition_table partition(b=1, c='c1')"), Nil)
-    checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"), checkResult)
+    checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
+      Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!")))
   }
 
   test("check index on partitioned table for a specified partition: Missing index file") {
-    val data = sparkContext.parallelize(1 to 300, 4).map { i => (i, i) }
+    val data = sparkContext.parallelize(1 to 300).map { i => (i, i) }
     data.toDF("key", "value").createOrReplaceTempView("t")
 
     sql(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Rewrote partition fetching method (adding `getPartitionPaths`) to get all partitions
that have an oap meta file.
For `check oindex on table` command:
Since it is used for checking index integrity of specified table, the target partition
directories are those have an oap meta file.
So `getPartitionPaths` method get table's all directory paths that have an oap meta file.
We feed the returned list of path(s) to `checkXXX` method for checking integrity.

- Discard some methods that are unnecessary to use, including `checkOapMetaFile`, since
the target path(s) are certainly have a meta file.

## How was this patch tested?
OapCheckIndexSuite
