### PR TITLE
fix bug for hasAvailableIndex judging conditions.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -114,13 +114,13 @@ object FileSourceStrategy extends Strategy with Logging {
           } else {
             logInfo("hasAvailableIndex = false, will retain ParquetFileFormat.")
             _fsRelation.fileFormat.initialize(_fsRelation.sparkSession, _fsRelation.options,
-              selectedPartitions.flatMap(p => p.files).toSeq)
+              selectedPartitions.flatMap(p => p.files))
             _fsRelation
           }
 
         case _: FileFormat =>
           _fsRelation.fileFormat.initialize(_fsRelation.sparkSession, _fsRelation.options,
-            selectedPartitions.flatMap(p => p.files).toSeq)
+            selectedPartitions.flatMap(p => p.files))
           _fsRelation
       }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -394,8 +394,6 @@ private[oap] case class DataSourceMeta(
         checkInMetaSet(attrRef)
       case In(attrRef: AttributeReference, _) =>
         checkInMetaSet(attrRef)
-      case IsNotNull(attrRef: AttributeReference) =>
-        checkInMetaSet(attrRef)
       case _ => false
     }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -394,6 +394,8 @@ private[oap] case class DataSourceMeta(
         checkInMetaSet(attrRef)
       case In(attrRef: AttributeReference, _) =>
         checkInMetaSet(attrRef)
+      case IsNotNull(attrRef: AttributeReference) =>
+        checkInMetaSet(attrRef)
       case _ => false
     }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -288,9 +288,9 @@ private[sql] class OapFileFormat extends FileFormat
     if (expressions.nonEmpty && sparkSession.conf.get(SQLConf.OAP_ENABLE_OINDEX)) {
       meta match {
         case Some(m) if requiredTypes.isEmpty =>
-          expressions.forall(m.isSupportedByIndex(_, None))
+          expressions.exists(m.isSupportedByIndex(_, None))
         case Some(m) if requiredTypes.length == expressions.length =>
-          expressions.zip(requiredTypes).forall{ x =>
+          expressions.zip(requiredTypes).exists{ x =>
             val expression = x._1
             val requirement = Some(x._2)
             m.isSupportedByIndex(expression, requirement)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -197,6 +197,9 @@ class FilterSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEac
 
     checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
       Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+
+    checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND b = 'this is test 2'"),
+      Row(2, "this is test 2") :: Nil)
   }
 
   test("filtering parquet2") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1、OapFileFormat.hasAvailableIndex : forall -> exists,  n colums use to query, one column can use index is enough
2、Remove redundant collection conversion by intellij...
## How was this patch tested?
1、FilterSuite."filtering parquet", the third sql should use  index a. 
2、We need white box testing to verify that sql case use expected index
