### PR TITLE
Move the common writeHead to IndexUtils

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileWriter.scala
@@ -44,15 +44,9 @@ private case class BTreeIndexFileWriter(
 
   private var rowIdListSize = 0
   private var footerSize = 0
-  private def writeVersion(version: Int): Unit = {
-    writer.write("OAPIDX".getBytes("UTF-8"))
-    assert(version <= 65535)
-    val data = Array((version >> 8).toByte, (version & 0xFF).toByte)
-    writer.write(data)
-  }
 
   def start(): Unit = {
-    writeVersion(IndexFile.INDEX_VERSION)
+    IndexUtils.writeHead(writer, IndexFile.INDEX_VERSION)
   }
 
   def writeNode(buf: Array[Byte]): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources.oap.index
 
-import java.io.{ByteArrayInputStream, ObjectInputStream}
 import java.nio.ByteBuffer
 
 import scala.collection.mutable
@@ -27,7 +26,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap
 import org.roaringbitmap.buffer.MutableRoaringBitmap
-import sun.nio.ch.DirectBuffer
 
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.catalyst.InternalRow
@@ -70,7 +68,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   private var bmEntryListCache: CacheResult = _
   private var bmEntryListBuffer: Array[Byte] = _
 
-  @transient private var bmRowIdIterator: Iterator[Integer] = Iterator[Integer]()
+  @transient private var bmRowIdIterator: Iterator[Integer] = _
   private var empty: Boolean = _
 
   override def hasNext: Boolean = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.oap.index
 
-import java.io.{ByteArrayOutputStream, DataOutputStream, ObjectOutputStream, OutputStream}
+import java.io.{ByteArrayOutputStream, DataOutputStream, OutputStream}
 
 import scala.collection.mutable
 import scala.collection.immutable
@@ -158,22 +158,12 @@ private[oap] class BitmapIndexRecordWriter(
   private def flushToFile(): Unit = {
     val statisticsManager = new StatisticsManager
     statisticsManager.initialize(BitMapIndexType, keySchema, configuration)
-    writeHead(writer, IndexFile.INDEX_VERSION)
+    IndexUtils.writeHead(writer, IndexFile.INDEX_VERSION)
     writeUniqueKeyList()
     writeBmEntryList()
     writeBmOffsetList()
     // The index end is also the starting position of stats file.
     statisticsManager.write(writer)
     writeBmFooter()
-  }
-
- // TODO: below are common for both BTree and Bitmap indexes. It can be abstracted into IndexWriter.
-  private def writeHead(writer: OutputStream, version: Int): Unit = {
-    val headerContent = "OAPIDX"
-    writer.write(headerContent.getBytes("UTF-8"))
-    assert(version <= 65535)
-    val versionData = Array((version >> 8).toByte, (version & 0xFF).toByte)
-    writer.write(versionData)
-    assert((headerContent.length + versionData.size) == IndexFile.indexFileHeaderLength)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.parquet.bytes.LittleEndianDataOutputStream
 
 import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
@@ -33,7 +34,17 @@ import org.apache.spark.unsafe.types.UTF8String
  * Utils for Index read/write
  */
 private[oap] object IndexUtils {
-  // TODO remove this and corresponding test
+
+  def writeHead(writer: OutputStream, version: Int): Int = {
+    val headerContent = "OAPIDX"
+    writer.write(headerContent.getBytes("UTF-8"))
+    assert(version <= 65535)
+    val versionData = Array((version >> 8).toByte, (version & 0xFF).toByte)
+    writer.write(versionData)
+    assert((headerContent.length + versionData.size) == IndexFile.indexFileHeaderLength)
+    IndexFile.indexFileHeaderLength
+  }
+
   def writeInt(out: OutputStream, v: Int): Unit = {
     out.write((v >>>  0) & 0xFF)
     out.write((v >>>  8) & 0xFF)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/PermutermIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/PermutermIndexRecordWriter.scala
@@ -67,7 +67,7 @@ private[index] class PermutermIndexRecordWriter(
     var i = 0
     var fileOffset = 0
     val offsetMap = new java.util.HashMap[UTF8String, Int]()
-    fileOffset += writeHead(writer, IndexFile.INDEX_VERSION)
+    fileOffset += IndexUtils.writeHead(writer, IndexFile.INDEX_VERSION)
     // write data segment.
     while (i < partitionUniqueSize) {
       offsetMap.put(uniqueKeys(i), fileOffset)
@@ -116,14 +116,6 @@ private[index] class PermutermIndexRecordWriter(
     var length = 0
     trieNode.children.foreach(length += writeTrie(writer, _, treeMap))
     length + writer.writeNode(trieNode, treeMap)
-  }
-
-  private def writeHead(writer: OutputStream, version: Int): Int = {
-    writer.write("OAPIDX".getBytes("UTF-8"))
-    assert(version <= 65535)
-    val data = Array((version >> 8).toByte, (version & 0xFF).toByte)
-    writer.write(data)
-    IndexFile.indexFileHeaderLength
   }
 }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
@@ -22,8 +22,9 @@ import java.io.{ByteArrayOutputStream, DataOutputStream}
 import org.apache.hadoop.fs.Path
 import org.junit.Assert._
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 import org.apache.spark.unsafe.Platform
 
 class IndexUtilsSuite extends SparkFunSuite with Logging {
@@ -82,5 +83,16 @@ class IndexUtilsSuite extends SparkFunSuite with Logging {
         new Path("/path/to/"),
         new Path("/path/to/_temp/2/"),
         ".t1.ABC.index1.index").toString)
+  }
+
+  test("writeHead to write common and consistent index version to all the index file headers") {
+    val buf = new ByteArrayOutputStream(8)
+    val out = new DataOutputStream(buf)
+    IndexUtils.writeHead(out, IndexFile.INDEX_VERSION)
+    val bytes = buf.toByteArray
+    assert(Platform.getByte(bytes, Platform.BYTE_ARRAY_OFFSET + 6) ==
+      (IndexFile.INDEX_VERSION >> 8).toByte)
+    assert(Platform.getByte(bytes, Platform.BYTE_ARRAY_OFFSET + 7) ==
+      (IndexFile.INDEX_VERSION & 0xFF).toByte)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

writeHead is used by all index writers, so move to IndexUtils.


## How was this patch tested?

mvn clean test package
