### PR TITLE
Fix Parquet backward scan issue.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -212,11 +212,15 @@ private[oap] class OapDataReader(
           }
           fs.initialize(path, conf)
           // total Row count can be get from the filter scanner
-          if (limit > 0) {
+          val rowIds = if (limit > 0) {
             if (isAscending) fs.toArray.take(limit)
             else fs.toArray.reverse.take(limit)
           }
           else fs.toArray
+
+          // Parquet reader does not support backward scan, so rowIds must be sorted.
+          if (meta.dataReaderClassName contains("ParquetDataFile")) rowIds.sorted
+          else rowIds
         }
         val start = System.currentTimeMillis()
         val iter = fileScanner.iterator(conf, requiredIds, getRowIds(options))

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -18,12 +18,10 @@
 package org.apache.spark.sql.execution.datasources.oap
 
 import org.scalatest.BeforeAndAfterEach
-import org.apache.spark.SparkConf
+
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
-
 
 class OapIndexQuerySuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
   import testImplicits._

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.datasources.oap
 
 import org.scalatest.BeforeAndAfterEach
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.internal.SQLConf
@@ -33,14 +32,21 @@ class OapIndexQuerySuite extends QueryTest with SharedSQLContext with BeforeAndA
 
   override def beforeEach(): Unit = {
     val path1 = Utils.createTempDir().getAbsolutePath
+    val path2 = Utils.createTempDir().getAbsolutePath
 
     sql(s"""CREATE TEMPORARY VIEW oap_test_1 (a INT, b STRING)
            | USING oap
            | OPTIONS (path '$path1')""".stripMargin)
+
+    sql(s"""CREATE TEMPORARY VIEW oap_parquet_test_1 (a INT, b STRING)
+           | USING parquet
+           | OPTIONS (path '$path2')""".stripMargin)
+
   }
 
   override def afterEach(): Unit = {
     sqlContext.dropTempTable("oap_test_1")
+    sqlContext.dropTempTable("oap_parquet_test_1")
   }
 
   test("index integrity") {
@@ -72,5 +78,38 @@ class OapIndexQuerySuite extends QueryTest with SharedSQLContext with BeforeAndA
       Row(testRowId, s"this is test $testRowId") :: Nil)
 
     sql("drop oindex index1 on oap_test_1")
+  }
+
+  test("check sequence reading if parquet format") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i =>
+      if (i == 10) (1, s"this is test $i")
+      else (i, s"this is test $i")
+    }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+
+    sql("insert overwrite table oap_parquet_test_1 select * from t")
+    sql("create oindex index1 on oap_parquet_test_1 (a)")
+
+    // While a in (0, 3), rowIds = (1, 10, 2)
+    // sort to ensure the sequence reading on parquet. so results are (1, 2, 10)
+    val parquetRslt = sql("select * from oap_parquet_test_1 where a > 0 and a < 3").collect
+    assert(parquetRslt.corresponds(
+      Row(1, "this is test 1") ::
+      Row(2, "this is test 2") ::
+      Row(1, "this is test 10") :: Nil) {_ == _})
+
+    sql("insert overwrite table oap_test_1 select * from t")
+    sql("create oindex index1 on oap_test_1 (a)")
+
+    // Sort is unnecessary for oap format, so rowIds should be (1, 10, 2)
+    val oapResult = sql("select * from oap_test_1 where a > 0 and a < 3").collect
+    assert(oapResult.corresponds(
+      Row(1, "this is test 1") ::
+      Row(1, "this is test 10") ::
+      Row(2, "this is test 2") :: Nil) {_ == _})
+
+    sql("drop oindex index1 on oap_parquet_test_1")
+    sql("drop oindex index1 on oap_test_1")
+
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Sort row ids before parquet reader starts scan.
2. Add unit test to make sure there is no escape.

## How was this patch tested?

unit test