### PR TITLE
fix bug when creating dup named index

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -107,6 +107,7 @@ case class CreateIndex(
               s"""Index $indexName exists on ${identifier.getOrElse(parent)}""")
           } else {
             logWarning(s"Dup index name $indexName")
+            return Nil
           }
         }
         if (existsData != null) existsData.foreach(metaBuilder.addFileMeta)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed a bug when creating duplicated named index.
`create oindex idxa on table(column)`
`create oindex if not exists idxa on table(column)`

to prevent from creating duplicated named index.

## How was this patch tested?
OapDDLSuite
