### PR TITLE
Finish "drop index" function instantly when dropping nonexistent index

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -242,12 +242,13 @@ case class DropIndex(
             val oldMeta = m.get
             val existsIndexes = oldMeta.indexMetas
             val existsData = oldMeta.fileMetas
-            if (!existsIndexes.exists(_.name == indexName)) {
+            if (existsIndexes.forall(_.name != indexName)) {
               if (!allowNotExists) {
                 throw new AnalysisException(
                   s"""Index $indexName does not exist on ${identifier.getOrElse(parent)}""")
               } else {
                 logWarning(s"drop non-exists index $indexName")
+                return Nil
               }
             }
             if (existsData != null) existsData.foreach(metaBuilder.addFileMeta)


### PR DESCRIPTION
## What changes were proposed in this pull request?
finish "drop index" function instantly when dropping nonexistent index using
`drop oindex if exists indexName on table`

A refinement that could prevent from unnecessary meta copy.
## How was this patch tested?
unit test