### PR TITLE
use readFully instead of read for HDFS file read

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -104,7 +104,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
 
   private def loadBmFooter(fin: FSDataInputStream): Array[Byte] = {
     bmFooterBuffer = new Array[Byte](BITMAP_FOOTER_SIZE)
-    fin.read(bmFooterOffset, bmFooterBuffer, 0, BITMAP_FOOTER_SIZE)
+    fin.readFully(bmFooterOffset, bmFooterBuffer, 0, BITMAP_FOOTER_SIZE)
     bmFooterBuffer
   }
 
@@ -123,7 +123,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     bmUniqueKeyListBuffer = new Array[Byte](bmUniqueKeyListTotalSize)
     // TODO: seems not supported yet on my local dev machine(hadoop is 2.7.3).
     // fin.setReadahead(bmUniqueKeyListTotalSize)
-    fin.read(bmUniqueKeyListOffset, bmUniqueKeyListBuffer, 0, bmUniqueKeyListTotalSize)
+    fin.readFully(bmUniqueKeyListOffset, bmUniqueKeyListBuffer, 0, bmUniqueKeyListTotalSize)
     bmUniqueKeyListBuffer
   }
 
@@ -148,13 +148,13 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
 
   private def loadBmEntryList(fin: FSDataInputStream): Array[Byte] = {
     bmEntryListBuffer = new Array[Byte](bmEntryListTotalSize)
-    fin.read(bmEntryListOffset, bmEntryListBuffer, 0, bmEntryListTotalSize)
+    fin.readFully(bmEntryListOffset, bmEntryListBuffer, 0, bmEntryListTotalSize)
     bmEntryListBuffer
   }
 
   private def loadBmOffsetList(fin: FSDataInputStream): Array[Byte] = {
     bmOffsetListBuffer = new Array[Byte](bmOffsetListTotalSize)
-    fin.read(bmOffsetListOffset, bmOffsetListBuffer, 0, bmOffsetListTotalSize)
+    fin.readFully(bmOffsetListOffset, bmOffsetListBuffer, 0, bmOffsetListTotalSize)
     bmOffsetListBuffer
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
@@ -30,7 +30,7 @@ private[oap] trait CommonIndexFile {
     val fs = file.getFileSystem(conf)
     val fin = fs.open(file)
     val bytes = new Array[Byte](8)
-    fin.read(bytes, 0, 8)
+    fin.readFully(bytes, 0, 8)
     fin.close()
     (bytes(6) << 8) + bytes(7)
   }
@@ -92,7 +92,7 @@ private[oap] case class PermutermIndexFile(file: Path) extends CommonIndexFile {
     val fin = fs.open(file)
     val bytes = new Array[Byte](pageLength)
 
-    fin.read(bytes, pageOffset.toInt, pageLength)
+    fin.readFully(bytes, pageOffset.toInt, pageLength)
     fin.close()
     putToFiberCache(bytes)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileHandle.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileHandle.scala
@@ -152,14 +152,14 @@ private[oap] object ColumnStatistics {
     val minLength = in.readInt()
     val min = if (minLength != 0) {
       val bytes = new Array[Byte](minLength)
-      in.read(bytes)
+      in.readFully(bytes)
       bytes
     } else null
 
     val maxLength = in.readInt()
     val max = if (maxLength != 0) {
       val bytes = new Array[Byte](maxLength)
-      in.read(bytes)
+      in.readFully(bytes)
       bytes
     } else null
 
@@ -309,7 +309,7 @@ private[oap] class OapDataFileHandle(
     val in = new DataInputStream(new ByteArrayInputStream(metaBytes))
 
     val buffer = new Array[Byte](MAGIC.length)
-    in.read(buffer)
+    in.readFully(buffer)
     val magic = UTF8String.fromBytes(buffer).toString
     if (magic != MAGIC) {
       throw new OapException("Not a valid Oap Data File")


### PR DESCRIPTION
## What changes were proposed in this pull request?


use readFully instead of read for HDFS file read.
According to 
https://stackoverflow.com/questions/12184975/why-hadoop-api-fsdatainputstream-read-less-than-buffer-size
we should avoid using read since it not always read fully bytes.


## How was this patch tested?

existed test

