### PR TITLE
move writeBasedOnSchema to IndexUtils

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -159,7 +159,7 @@ private[index] case class BTreeIndexRecordWriter(
     uniqueKeys.foreach { key =>
       output.writeInt(keyBuffer.size())
       output.writeInt(rowPos)
-      BTreeIndexRecordWriter.writeBasedOnSchema(keyOutput, key, keySchema)
+      IndexUtils.writeBasedOnSchema(keyOutput, key, keySchema)
       rowPos += multiHashMap.get(key).size()
     }
     buffer.toByteArray ++ keyBuffer.toByteArray
@@ -225,23 +225,13 @@ private[index] case class BTreeIndexRecordWriter(
       output.writeInt(node.byteSize)
       // Min Key Pos for each Child
       output.writeInt(keyBuffer.size())
-      BTreeIndexRecordWriter.writeBasedOnSchema(keyOutput, node.min, keySchema)
+      IndexUtils.writeBasedOnSchema(keyOutput, node.min, keySchema)
       // Max Key Pos for each Child
       output.writeInt(keyBuffer.size())
-      BTreeIndexRecordWriter.writeBasedOnSchema(keyOutput, node.max, keySchema)
+      IndexUtils.writeBasedOnSchema(keyOutput, node.max, keySchema)
       offset += node.byteSize
     }
     buffer.toByteArray ++ keyBuffer.toByteArray
-  }
-}
-
-private[index] object BTreeIndexRecordWriter {
-
-  private[index] def writeBasedOnSchema(
-      writer: LittleEndianDataOutputStream, row: InternalRow, schema: StructType): Unit = {
-    schema.zipWithIndex.foreach {
-      case (field, index) => IndexUtils.writeBasedOnDataType(writer, row.get(index, field.dataType))
-    }
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -22,6 +22,7 @@ import java.io.OutputStream
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.bytes.LittleEndianDataOutputStream
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
@@ -128,6 +129,13 @@ private[oap] object IndexUtils {
         val bytes = fiberCache.getBytes(offset + Integer.SIZE / 8, length)
         (bytes, Integer.SIZE / 8 + bytes.length)
       case other => throw new OapException(s"OAP index currently doesn't support data type $other")
+    }
+  }
+
+  def writeBasedOnSchema(
+      writer: LittleEndianDataOutputStream, row: InternalRow, schema: StructType): Unit = {
+    schema.zipWithIndex.foreach {
+      case (field, index) => IndexUtils.writeBasedOnDataType(writer, row.get(index, field.dataType))
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 
-abstract class Statistics{
+abstract class Statistics {
   val id: Int
   protected var schema: StructType = _
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
@@ -19,13 +19,22 @@ package org.apache.spark.sql.execution.datasources.oap.index
 
 import java.io.{ByteArrayOutputStream, DataOutputStream}
 
+import scala.util.Random
+
 import org.apache.hadoop.fs.Path
+import org.apache.parquet.bytes.LittleEndianDataOutputStream
 import org.junit.Assert._
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.unsafe.Platform
+import org.apache.spark.util.ByteBufferOutputStream
+
 
 class IndexUtilsSuite extends SparkFunSuite with Logging {
   test("write int to unsafe") {
@@ -94,5 +103,75 @@ class IndexUtilsSuite extends SparkFunSuite with Logging {
       (IndexFile.INDEX_VERSION >> 8).toByte)
     assert(Platform.getByte(bytes, Platform.BYTE_ARRAY_OFFSET + 7) ==
       (IndexFile.INDEX_VERSION & 0xFF).toByte)
+  }
+
+  private lazy val random = new Random(0)
+  private lazy val values = {
+    val booleans: Seq[Boolean] = Seq(true, false)
+    val bytes: Seq[Byte] = Seq(Byte.MinValue, 0, 10, 30, Byte.MaxValue)
+    val shorts: Seq[Short] = Seq(Short.MinValue, -100, 0, 10, 200, Short.MaxValue)
+    val ints: Seq[Int] = Seq(Int.MinValue, -100, 0, 100, 12346, Int.MaxValue)
+    val longs: Seq[Long] = Seq(Long.MinValue, -10000, 0, 20, Long.MaxValue)
+    val floats: Seq[Float] = Seq(Float.MinValue, Float.MinPositiveValue, Float.MaxValue)
+    val doubles: Seq[Double] = Seq(Double.MinValue, Double.MinPositiveValue, Double.MaxValue)
+    val strings: Seq[UTF8String] =
+      Seq("", "test", "b plus tree", "BTreeRecordReaderWriter").map(UTF8String.fromString)
+    val binaries: Seq[Array[Byte]] = (0 until 20 by 5).map{ size =>
+      val buf = new Array[Byte](size)
+      random.nextBytes(buf)
+      buf
+    }
+    val values = booleans ++ bytes ++ shorts ++ ints ++ longs ++
+      floats ++ doubles ++ strings ++ binaries ++ Nil
+    random.shuffle(values)
+  }
+  private def toSparkDataType(any: Any): DataType = {
+    any match {
+      case _: Boolean => BooleanType
+      case _: Short => ShortType
+      case _: Byte => ByteType
+      case _: Int => IntegerType
+      case _: Long => LongType
+      case _: Float => FloatType
+      case _: Double => DoubleType
+      case _: UTF8String => StringType
+      case _: Array[Byte] => BinaryType
+    }
+  }
+
+  test("Read/Write Based On Schema") {
+    values.grouped(10).foreach { valueSeq =>
+      val schema = StructType(valueSeq.zipWithIndex.map {
+        case (v, i) => StructField(s"col$i", toSparkDataType(v))
+      })
+      val row = InternalRow.fromSeq(valueSeq)
+      val buf = new ByteBufferOutputStream()
+      val writer = new LittleEndianDataOutputStream(buf)
+      IndexUtils.writeBasedOnSchema(writer, row, schema)
+      val answerRow = BTreeIndexRecordReader.readBasedOnSchema(
+        FiberCache(buf.toByteArray), 0L, schema)
+      assert(row.equals(answerRow))
+    }
+  }
+
+  test("Read/Write Based On Data Type") {
+    values.foreach { value =>
+      val buf = new ByteBufferOutputStream()
+      val writer = new LittleEndianDataOutputStream(buf)
+      IndexUtils.writeBasedOnDataType(writer, value)
+
+      val (answerValue, offset) = IndexUtils.readBasedOnDataType(
+        FiberCache(buf.toByteArray), 0L, toSparkDataType(value))
+
+      assert(value === answerValue, s"value: $value")
+      value match {
+        case x: UTF8String =>
+          assert(offset === x.getBytes.length + Integer.SIZE / 8, s"string: $x")
+        case y: Array[Byte] =>
+          assert(offset === y.length + Integer.SIZE / 8, s"binary: ${y.mkString(",")}")
+        case other =>
+          assert(offset === toSparkDataType(other).defaultSize, s"value $other")
+      }
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is to move writeBasedOnSchema to IndexUtils.
For statistic manager, we need to write some key down,
and let's reuse the logic.


## How was this patch tested?

unit tests.

