### PR TITLE
[DO NOT MERGE] Draft patch for Cache lock mechanism

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapEnv.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapEnv.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap
+
+import org.apache.spark.{SparkConf, SparkEnv}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberCacheManager, MemoryManager}
+
+class OapEnv(
+    val memoryManager: MemoryManager,
+    val fiberCacheManager: FiberCacheManager
+) extends Logging {
+
+  // TODO: for cleanup
+  def stop(): Unit = {
+    fiberCacheManager.stop()
+    memoryManager.stop()
+  }
+}
+
+object OapEnv {
+  private var env: OapEnv = create()
+  def get: OapEnv = env
+
+  private def set(e: OapEnv): Unit = env = e
+
+  private def create(): OapEnv = {
+    val sparkEnv = SparkEnv.get
+    if (sparkEnv == null) throw new OapException("Can't run OAP without SparkContext")
+
+    val memoryManager = new MemoryManager(sparkEnv.memoryManager, sparkEnv.conf)
+    val fiberCacheManager = new FiberCacheManager(memoryManager.maxMemory)
+    new OapEnv(memoryManager, fiberCacheManager)
+  }
+
+  /**
+   * Create a new OapEnv with latest SparkConf. For test purpose
+   */
+  def update(): Unit = {
+    // TODO: clean previous OapEnv
+    if (env != null) {
+      env.stop()
+      env = null
+    }
+    val oapEnv = create()
+    set(oapEnv)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapEnv.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapEnv.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.oap
 
-import org.apache.spark.{SparkConf, SparkEnv}
+import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.OapException
-import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberCacheManager, MemoryManager}
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCacheManager, MemoryManager}
 
 class OapEnv(
     val memoryManager: MemoryManager,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -46,7 +46,7 @@ case class FiberInputStream(is: InputStream, offset: Long, length: Int)
  *
  * TODO: change object to class for better initialization
  */
-class FiberCacheManager(memorySize: Long) extends Logging {
+class FiberCacheManager(memorySize: Long, concurrency: Int) extends Logging {
 
   private val removalListener = new RemovalListener[Fiber, FiberCache] {
     override def onRemoval(notification: RemovalNotification[Fiber, FiberCache]): Unit = {
@@ -86,7 +86,7 @@ class FiberCacheManager(memorySize: Long) extends Logging {
 
   private val cache: Cache[Fiber, FiberCache] = CacheBuilder.newBuilder()
       .recordStats()
-      .concurrencyLevel(4)
+      .concurrencyLevel(concurrency)
       .removalListener(removalListener)
       .maximumWeight(MAX_WEIGHT)
       .weigher(weigher)
@@ -128,6 +128,11 @@ class FiberCacheManager(memorySize: Long) extends Logging {
   }
 
   def getStats: CacheStats = cache.stats()
+}
+
+object FiberCacheManager {
+  val OAP_FIBER_CACHE_CONCURRENCY = "spark.oap.fiberCache.concurrency"
+  val OAP_FIBER_CACHE_CONCURRENCY_DEFAULT = 4
 }
 
 private[oap] object DataFileHandleCacheManager extends Logging {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -148,7 +148,7 @@ private[oap] case class IndexFiberCache(fiberData: MemoryBlock) extends FiberCac
  */
 private[oap] class MemoryManager(
     memoryManager: org.apache.spark.memory.MemoryManager,
-    conf: SparkConf) extends Logging {
+    fraction: Double) extends Logging {
 
   require(memoryManager.maxOffHeapStorageMemory > 0)
   /**
@@ -161,11 +161,8 @@ private[oap] class MemoryManager(
   private val DUMMY_BLOCK_ID = TestBlockId("oap_memory_request_block")
 
   private val _maxMemory = {
-    val oapFraction = conf.getDouble(
-      MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION,
-      MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION_DEFAULT)
 
-    val oapMaxMemory = (memoryManager.maxOffHeapStorageMemory * oapFraction).toLong
+    val oapMaxMemory = (memoryManager.maxOffHeapStorageMemory * fraction).toLong
     if (memoryManager.acquireStorageMemory(DUMMY_BLOCK_ID, oapMaxMemory, MemoryMode.OFF_HEAP)) {
       oapMaxMemory
     } else {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.oap.index
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.execution.datasources.oap.OapEnv
-import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, MemoryManager}
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberInputStream}
 import org.apache.spark.unsafe.Platform
 
 private[oap] case class BTreeIndexFileReader(
@@ -53,6 +53,18 @@ private[oap] case class BTreeIndexFileReader(
 
   private def getIntFromBuffer(buffer: Array[Byte], offset: Int) =
     Platform.getInt(buffer, Platform.BYTE_ARRAY_OFFSET + offset)
+
+  def getFooterInputStream: FiberInputStream = {
+    FiberInputStream(reader, footerIndex, footerLength)
+  }
+
+  def getRowIdListInputStream: FiberInputStream = {
+    FiberInputStream(reader, rowIdListIndex, rowIdListLength)
+  }
+
+  def getNodeInputStream(offset: Int, size: Int): FiberInputStream = {
+    FiberInputStream(reader, nodesIndex + offset, size)
+  }
 
   def readFooter(): FiberCache =
     memoryManager.putToIndexFiberCache(reader, footerIndex, footerLength)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.oap.index
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
+import org.apache.spark.sql.execution.datasources.oap.OapEnv
 import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, MemoryManager}
 import org.apache.spark.unsafe.Platform
 
@@ -27,6 +27,8 @@ private[oap] case class BTreeIndexFileReader(
     configuration: Configuration,
     file: Path) {
 
+  // TODO: make this in class constructor parameter list
+  private def memoryManager = OapEnv.get.memoryManager
   private val VERSION_SIZE = 8
   private val FOOTER_LENGTH_SIZE = Integer.SIZE / 8
   private val ROW_ID_LIST_LENGTH_SIZE = Integer.SIZE / 8
@@ -53,13 +55,13 @@ private[oap] case class BTreeIndexFileReader(
     Platform.getInt(buffer, Platform.BYTE_ARRAY_OFFSET + offset)
 
   def readFooter(): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, footerIndex, footerLength)
+    memoryManager.putToIndexFiberCache(reader, footerIndex, footerLength)
 
   def readRowIdList(): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, rowIdListIndex, rowIdListLength)
+    memoryManager.putToIndexFiberCache(reader, rowIdListIndex, rowIdListLength)
 
   def readNode(offset: Int, size: Int): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, nodesIndex + offset, size)
+    memoryManager.putToIndexFiberCache(reader, nodesIndex + offset, size)
 
   def close(): Unit = reader.close()
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
@@ -18,12 +18,14 @@
 package org.apache.spark.sql.execution.datasources.oap.index
 
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.OapEnv
-import org.apache.spark.sql.execution.datasources.oap.filecache.{BTreeFiber, FiberCache, FiberCacheManager}
+import org.apache.spark.sql.execution.datasources.oap.filecache.{BTreeFiber, FiberCache}
 import org.apache.spark.sql.types._
 
 private[index] case class BTreeIndexRecordReader(
@@ -51,12 +53,16 @@ private[index] case class BTreeIndexRecordReader(
   def initialize(path: Path, intervalArray: ArrayBuffer[RangeInterval]): Unit = {
     reader = BTreeIndexFileReader(configuration, path)
 
-    footerFiber = BTreeFiber(() => reader.readFooter(), reader.file.toString, 0, 0)
-    footerCache = fiberCacheManager.get(footerFiber, configuration)
+    footerFiber =
+        BTreeFiber(reader.file.toString, 0, 0)
+    footerCache =
+        fiberCacheManager.get(footerFiber, reader.getFooterInputStream)
     footer = BTreeFooter(footerCache)
 
-    rowIdListFiber = BTreeFiber(() => reader.readRowIdList(), reader.file.toString, 1, 0)
-    rowIdListCache = fiberCacheManager.get(rowIdListFiber, configuration)
+    rowIdListFiber =
+        BTreeFiber(reader.file.toString, 1, 0)
+    rowIdListCache =
+        fiberCacheManager.get(rowIdListFiber, reader.getRowIdListInputStream)
     rowIdList = BTreeRowIdList(rowIdListCache)
 
     internalIterator = intervalArray.toIterator.flatMap { interval =>
@@ -96,12 +102,14 @@ private[index] case class BTreeIndexRecordReader(
       findNext: Boolean): Int = {
 
     val nodeFiber = BTreeFiber(
-      () => reader.readNode(footer.getNodeOffset(nodeIdx), footer.getNodeSize(nodeIdx)),
       reader.file.toString,
       2,
       nodeIdx
     )
-    val nodeCache = fiberCacheManager.get(nodeFiber, configuration)
+    val offset = footer.getNodeOffset(nodeIdx)
+    val size = footer.getNodeSize(nodeIdx)
+    val nodeCache =
+      fiberCacheManager.get(nodeFiber, reader.getNodeInputStream(offset, size))
     val node = BTreeNodeData(nodeCache)
 
     val keyCount = node.getKeyCount
@@ -118,11 +126,12 @@ private[index] case class BTreeIndexRecordReader(
           val offset = footer.getNodeOffset(nodeIdx + 1)
           val size = footer.getNodeSize(nodeIdx + 1)
           val nextNodeFiber = BTreeFiber(
-            () => reader.readNode(offset, size),
             reader.file.toString,
             2,
             nodeIdx + 1)
-          val nextNodeCache = fiberCacheManager.get(nextNodeFiber, configuration)
+          val nextNodeCache =
+            fiberCacheManager
+                .get(nextNodeFiber, reader.getNodeInputStream(offset, size))
           val nextNode = BTreeNodeData(nextNodeCache)
           val rowPos = nextNode.getRowIdPos(0)
           releaseCache(nextNodeCache, nextNodeFiber)
@@ -194,6 +203,7 @@ private[index] case class BTreeIndexRecordReader(
 
   private def releaseCache(cache: FiberCache, fiber: BTreeFiber): Unit = {
     // TODO: Release FiberCache's usage number
+    cache.release()
   }
 
   def close(): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -18,14 +18,12 @@
 package org.apache.spark.sql.execution.datasources.oap.io
 
 import scala.util.{Failure, Success, Try}
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FSDataInputStream
 import org.apache.parquet.column.Dictionary
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.OapException
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberInputStream}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
@@ -36,7 +34,7 @@ abstract class DataFile {
   def configuration: Configuration
 
   def createDataFileHandle(): DataFileHandle
-  def getFiberData(groupId: Int, fiberId: Int, conf: Configuration): FiberCache
+  def getDataInputStream(rowGroupId: Int, columnIndex: Int, conf: Configuration): FiberInputStream
   def iterator(conf: Configuration, requiredIds: Array[Int]): Iterator[InternalRow]
   def iterator(conf: Configuration, requiredIds: Array[Int], rowIds: Array[Long])
   : Iterator[InternalRow]

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
@@ -19,8 +19,9 @@ package org.apache.spark.sql.execution.datasources.oap.io
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.OapEnv
-import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, MemoryManager}
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 
 private[oap] trait CommonIndexFile {
   def file: Path
@@ -37,6 +38,8 @@ private[oap] trait CommonIndexFile {
  * Read the index file into memory, and can be accessed as [[FiberCache]].
  */
 private[oap] case class IndexFile(file: Path) extends CommonIndexFile {
+  def getIndexFiberSize: Int = throw new OapException("IndexFile is not used")
+
   def getIndexFiberData(conf: Configuration): FiberCache = {
     val fs = file.getFileSystem(conf)
     val fin = fs.open(file)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.oap.io
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
+import org.apache.spark.sql.execution.datasources.oap.OapEnv
 import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, MemoryManager}
 
 private[oap] trait CommonIndexFile {
@@ -44,7 +44,7 @@ private[oap] case class IndexFile(file: Path) extends CommonIndexFile {
     // TODO check if enough to fit in Int
     val fileLength = fs.getContentSummary(file).getLength
 
-    val fiberCache = MemoryManager.putToIndexFiberCache(fin, 0, fileLength.toInt)
+    val fiberCache = OapEnv.get.memoryManager.putToIndexFiberCache(fin, 0, fileLength.toInt)
     fin.close()
     fiberCache
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.oap.io
 
+import java.io.ByteArrayInputStream
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.util.StringUtils
@@ -31,8 +33,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.CompletionIterator
 
 
-private[oap] case class OapDataFile(path: String, schema: StructType,
-                                    configuration: Configuration) extends DataFile {
+private[oap] case class OapDataFile(
+    path: String, schema: StructType,
+    configuration: Configuration) extends DataFile {
 
   private val dictionaries = new Array[Dictionary](schema.length)
   private val codecFactory = new CodecFactory(configuration)
@@ -66,7 +69,10 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
     } else dictionaries(fiberId)
   }
 
-  def getFiberData(groupId: Int, fiberId: Int, conf: Configuration): FiberCache = {
+  def getDataInputStream(
+      groupId: Int,
+      fiberId: Int,
+      conf: Configuration): FiberInputStream = {
     val groupMeta = meta.rowGroupsMeta(groupId)
     val decompressor: BytesDecompressor = codecFactory.getDecompressor(meta.codec)
 
@@ -107,11 +113,12 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
     // We have to read Array[Byte] from file and decode/decompress it before putToFiberCache
     // TODO: Try to finish this in off-heap memory
     val data = fiberParser.parse(decompressor.decompress(bytes, uncompressedLen), rowCount)
-    memoryManager.putToDataFiberCache(data)
+    FiberInputStream(new ByteArrayInputStream(data), 0, data.length)
   }
 
   def closeRowGroup(fiber: Fiber, fiberCache: FiberCache): Unit = {
     // TODO: Release fiberCache's usage number
+    fiberCache.release()
   }
 
   // full file scan
@@ -121,7 +128,8 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
     val iterator =
       (0 until meta.groupCount).iterator.flatMap { groupId =>
         val fiberCacheGroup = requiredIds.map(id =>
-          fiberCacheManager.get(DataFiber(this, id, groupId), conf))
+          fiberCacheManager
+              .get(DataFiber(this, id, groupId), getDataInputStream(groupId, id, conf)))
 
         val columns = fiberCacheGroup.zip(requiredIds).map { case (fiberCache, id) =>
           new ColumnValues(meta.rowCountInEachGroup, schema(id).dataType, fiberCache)
@@ -151,7 +159,8 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
       groupIds.iterator.flatMap {
         case (groupId, subRowIds) =>
           val fiberCacheGroup = requiredIds.map(id =>
-            fiberCacheManager.get(DataFiber(this, id, groupId), conf))
+            fiberCacheManager
+                .get(DataFiber(this, id, groupId), getDataInputStream(groupId, id, conf)))
 
           val columns = fiberCacheGroup.zip(requiredIds).map { case (fiberCache, id) =>
             new ColumnValues(meta.rowCountInEachGroup, schema(id).dataType, fiberCache)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -33,9 +33,11 @@ import org.apache.spark.sql.types.StructType
 private[oap] case class ParquetDataFile
 (path: String, schema: StructType, configuration: Configuration) extends DataFile {
 
-  def getFiberData(groupId: Int, fiberId: Int, conf: Configuration): FiberCache = {
-    // TODO data cache
-    throw new UnsupportedOperationException("Not support getFiberData Operation.")
+  def getDataInputStream(
+      rowGroupId: Int,
+      columnIndex: Int,
+      conf: Configuration): FiberInputStream = {
+    throw new UnsupportedOperationException("Not support getFiberSize Operation.")
   }
 
   def iterator(conf: Configuration, requiredIds: Array[Int]): Iterator[UnsafeRow] = {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -37,6 +37,8 @@ class FiberCacheManagerSuite extends SharedSQLContext {
   private def toInputStream(data: Array[Byte]): FiberInputStream = {
     FiberInputStream(new ByteArrayInputStream(data), 0, data.length)
   }
+  private val MB: Double = 1024 * 1024
+  private def maxMemoryInMB = (memoryManager.maxMemory / MB).toInt
 
   test("unit test") {
     val MB: Double = 1024 * 1024
@@ -94,5 +96,67 @@ class FiberCacheManagerSuite extends SharedSQLContext {
       TestFiber(s"test fiber #1")
     val fiberCache1 = fiberCacheManager.get(fiber1, toInputStream(data1))
     assert(fiberCache1 == null)
+  }
+
+  test("lock") {
+    // 1. in-used fiberCache can't be freed until the read lock is released.
+    // 2. current thread causes an eviction, and evicted fiberCache's read lock is hold by itself.
+    // 3. if fiberCache can't put into Cache Manager, caller should know.
+    // 4. Cache Manager can't store caches exceed the max memory.
+    //     cache is waiting on freeing memory should be counted or not?
+    //     no enough memory for cache will trigger cache eviction.
+    //     cache should be put failed if eviction can't free enough memory.
+    // put fiberCache #1, #2, #3, #1 is using, #3 will cause eviction.
+    // expect result, #1 should be disposed, no dead lock.
+    val originalConfig1 = sparkContext.conf.get(
+      MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION,
+      MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION_DEFAULT.toString)
+
+    val originalConfig2 = sparkContext.conf.get(
+      FiberCacheManager.OAP_FIBER_CACHE_CONCURRENCY,
+      FiberCacheManager.OAP_FIBER_CACHE_CONCURRENCY_DEFAULT.toString)
+
+    sparkContext.conf.set(FiberCacheManager.OAP_FIBER_CACHE_CONCURRENCY, "1")
+    sparkContext.conf.set(MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION, "0.07")
+    val data2m = generateData(2 * MB.toInt)
+    val data4m = generateData(4 * MB.toInt)
+    val data8m = generateData(8 * MB.toInt)
+
+    val fiber1 = TestFiber("test fiber #1")
+    val fiber2 = TestFiber("test fiber #2")
+    val fiber3 = TestFiber("test fiber #3")
+    val fiber4 = TestFiber("test fiber #4")
+
+    OapEnv.restart()
+    assert(maxMemoryInMB == 7)
+    // =========== TEST #1 ==============
+    val fiberCache1 = fiberCacheManager.get(fiber1, toInputStream(data2m))
+    val fiberCache2 = fiberCacheManager.get(fiber2, toInputStream(data2m))
+    fiberCache2.release()
+    val fiberCache3 = fiberCacheManager.get(fiber3, toInputStream(data4m))
+
+    // lock hold, should not be freed
+    assert(!fiberCache1.isDisposed)
+    // lock hold, eviction should happen, should be freed
+    assert(fiberCache2.isDisposed)
+    // new fiberCache, should cause eviction, should be put into cache after eviction
+    assert(fiberCache3 != null && !fiberCache3.isDisposed)
+
+    OapEnv.restart()
+    // ============== TEST #2 ============
+    val fiberCache21 = fiberCacheManager.get(fiber1, toInputStream(data2m))
+    val fiberCache22 = fiberCacheManager.get(fiber2, toInputStream(data2m))
+    val fiberCache23 = fiberCacheManager.get(fiber3, toInputStream(data4m))
+    assert(fiberCache23 == null)
+
+    OapEnv.restart()
+    // ============== TEST #2 ============
+    val fiberCache31 = fiberCacheManager.get(fiber4, toInputStream(data8m))
+    assert(fiberCache31 == null)
+
+    // restore back. TODO: use a function to update/restore config
+    sparkContext.conf.set(MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION, originalConfig1)
+    sparkContext.conf.set(FiberCacheManager.OAP_FIBER_CACHE_CONCURRENCY, originalConfig2)
+    OapEnv.restart()
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -76,13 +76,13 @@ class MemoryManagerSuite extends SharedSQLContext {
     assert(100 * 0.7 * 1024 * 1024 === memoryManager.maxMemory)
     // change to 0.9
     sparkContext.conf.set(MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION, "0.9")
-    OapEnv.update()
+    OapEnv.restart()
     assert(100 * 0.9 * 1024 * 1024 === memoryManager.maxMemory)
     // restore back
     sparkContext.conf.set(
       MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION,
       MemoryManager.OAP_OFF_HEAP_MEMORY_FRACTION_DEFAULT.toString)
-    OapEnv.update()
+    OapEnv.restart()
     assert(100 * 0.7 * 1024 * 1024 === memoryManager.maxMemory)
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeFileReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeFileReaderWriterSuite.scala
@@ -20,17 +20,12 @@ package org.apache.spark.sql.execution.datasources.oap.index
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
 
-class BTreeFileReaderWriterSuite extends SparkFunSuite {
+class BTreeFileReaderWriterSuite extends SharedSQLContext {
 
   test("BTree File Read/Write") {
-    new SparkContext(
-      "local[2]",
-      "BTreeFileReaderWriterSuite",
-      new SparkConf().set("spark.memory.offHeap.size", "100m"))
-
     val path = new Path(Utils.createTempDir().getAbsolutePath, "index")
     val configuration = new Configuration()
     val footer = "footer".getBytes("UTF-8")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/FileSkipSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/FileSkipSuite.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.sql.execution.datasources.oap.io
 
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.util.Utils
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.util.Utils
 
 class FileSkipSuite extends QueryTest with SharedSQLContext with BeforeAndAfterEach {
   import testImplicits._


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add a OapEnv for Oap initialize
2. Use Java's read write lock, to secure in-used cache not be freed
    2.1 hold a read lock before reading FiberCache (done in FiberCacheManager.get)
    2.2 Try to hold write lock in onRemove notify. if can't acquire, put cache back to Cache Manager
    2.3 create a dummy MemoryBlock without allocating memory when put into CacheManager
        -- 2.3.1 if put into cache success, hold read lock, allocate memory and load data
        -- 2.3.2 if put into cache fail, do nothing and return null to indicate no enough memory

## How was this patch tested?

Unit test pass
