### PR TITLE
Support querying null/non-null key using B+ Tree index

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -338,6 +338,7 @@ private[oap] case class DataSourceMeta(
     dataReaderClassName: String,
     @transient fileHeader: FileHeader) extends Serializable {
 
+    // Check whether this expression is supported by index or not
     def isSupportedByIndex(exp: Expression, requirement: Option[IndexType] = None): Boolean = {
     var attr: String = null
     def checkInMetaSet(attrRef: AttributeReference): Boolean = {
@@ -384,6 +385,8 @@ private[oap] case class DataSourceMeta(
       case In(attrRef: AttributeReference, _) =>
         checkInMetaSet(attrRef)
       case IsNotNull(attrRef: AttributeReference) =>
+        checkInMetaSet(attrRef)
+      case IsNull(attrRef: AttributeReference) =>
         checkInMetaSet(attrRef)
       case _ => false
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileWriter.scala
@@ -55,12 +55,12 @@ private case class BTreeIndexFileWriter(
 
   def writeRowIdList(buf: Array[Byte]): Unit = {
     writer.write(buf)
-    rowIdListSize = buf.length
+    rowIdListSize += buf.length
   }
 
   def writeFooter(footer: Array[Byte]): Unit = {
     writer.write(footer)
-    footerSize = footer.length
+    footerSize += footer.length
   }
 
   def end(): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
@@ -60,14 +60,17 @@ private[index] case class BTreeIndexRecordReader(
     internalIterator = intervalArray.toIterator.flatMap { interval =>
       val (start, end) = findRowIdRange(interval)
       (start until end).toIterator.map(rowIdList.getRowId)
-    }
+    } // get the row ids
   }
-
+  // find the row id list start pos, end pos of the range interval
   private[index] def findRowIdRange(interval: RangeInterval): (Int, Int) = {
+    val recordCount = footer.getNonNullKeyRecordCount
+    if (interval.isNullPredicate) { // process "isNull" predicate
+      return (recordCount, recordCount + footer.getNullKeyRecordCount)
+    }
     val (nodeIdxForStart, isStartFound) = findNodeIdx(interval.start, isStart = true)
     val (nodeIdxForEnd, isEndFound) = findNodeIdx(interval.end, isStart = false)
 
-    val recordCount = footer.getRecordCount
     if (nodeIdxForStart == nodeIdxForEnd && !isStartFound && !isEndFound) {
       (0, 0)
     } else {
@@ -111,7 +114,7 @@ private[index] case class BTreeIndexRecordReader(
 
     val rowPos =
       if (keyPos == keyCount) {
-        if (nodeIdx + 1 == footer.getNodesCount) footer.getRecordCount
+        if (nodeIdx + 1 == footer.getNodesCount) footer.getNonNullKeyRecordCount
         else {
           val offset = footer.getNodeOffset(nodeIdx + 1)
           val size = footer.getNodeSize(nodeIdx + 1)
@@ -223,11 +226,13 @@ private[index] object BTreeIndexRecordReader {
     private val nodeSizeOffset = Integer.SIZE / 8 * 2
     private val minPosOffset = Integer.SIZE / 8 * 3
     private val maxPosOffset = Integer.SIZE / 8 * 4
-    private val nodeMetaStart = Integer.SIZE / 8 * 2
+    private val nodeMetaStart = Integer.SIZE / 8 * 3
     private val nodeMetaByteSize = Integer.SIZE / 8 * 5
 
-    def getRecordCount: Int = fiberCache.getInt(0)
-    def getNodesCount: Int = fiberCache.getInt(Integer.SIZE / 8)
+    def getNonNullKeyRecordCount: Int = fiberCache.getInt(0)
+    def getNullKeyRecordCount: Int = fiberCache.getInt(Integer.SIZE / 8)
+    def getNodesCount: Int = fiberCache.getInt(Integer.SIZE / 8 * 2)
+    // get idx Node's max value
     def getMaxValue(idx: Int, schema: StructType): InternalRow =
       IndexUtils.readBasedOnSchema(fiberCache, getMaxValueOffset(idx), schema)
     def getMinValue(idx: Int, schema: StructType): InternalRow =

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -118,7 +118,8 @@ private[index] case class BTreeIndexRecordWriter(
     val nodes =
       children.map { node =>
         val keyCount = sumKeyCount(node) // total number of keys of this node
-        val nodeUniqueKeys = nonNullUniqueKeys.slice(startPosInKeyList, startPosInKeyList + keyCount)
+        val nodeUniqueKeys =
+          nonNullUniqueKeys.slice(startPosInKeyList, startPosInKeyList + keyCount)
         // total number of row ids of this node
         val rowCount = nodeUniqueKeys.map(multiHashMap.get(_).size()).sum
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -134,8 +134,10 @@ private[index] case class BTreeIndexRecordWriter(
         }
         else BTreeNodeMetaData(rowCount, nodeBuf.length, nodeUniqueKeys.head, nodeUniqueKeys.last)
       }
-    // Write Row Id List
-    fileWriter.writeRowIdList(serializeRowIdLists(nonNullUniqueKeys ++ nullKeys))
+    // Write Non-null key Row Id List
+    fileWriter.writeRowIdList(serializeRowIdLists(nonNullUniqueKeys))
+    // Write Null key Row Id List
+    fileWriter.writeRowIdList(serializeRowIdLists(nullKeys))
     // Write Footer
     val nullKeyRowCount = nullKeys.map(multiHashMap.get(_).size()).sum
     fileWriter.writeFooter(serializeFooter(nullKeyRowCount, nodes))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -172,8 +172,7 @@ private[oap] object ScannerBuilder extends Logging {
     leftMap
   }
 
-  def optimizeFilterBound(filter: Filter, ic: IndexContext)
-  : mutable.HashMap[String, ArrayBuffer[RangeInterval]] = {
+  def optimizeFilterBound(filter: Filter, ic: IndexContext): IntervalArrayMap = {
     filter match {
       case And(leftFilter, rightFilter) =>
         val leftMap = optimizeFilterBound(leftFilter, ic)
@@ -185,27 +184,60 @@ private[oap] object ScannerBuilder extends Logging {
         combineIntervalMaps(leftMap, rightMap, ic, needMerge = false)
       case In(attribute, ic(keys)) =>
         val eqBounds = keys.distinct
-          .map(key => new RangeInterval(key, key, true, true))
+          .map(key => RangeInterval(key, key, includeStart = true, includeEnd = true))
           .to[ArrayBuffer]
-        scala.collection.mutable.HashMap(attribute -> eqBounds)
+        mutable.HashMap(attribute -> eqBounds)
       case EqualTo(attribute, ic(key)) =>
-        val ranger = new RangeInterval(key, key, true, true)
-        scala.collection.mutable.HashMap(attribute -> ArrayBuffer(ranger))
+        val ranger = RangeInterval(key, key, includeStart = true, includeEnd = true)
+        mutable.HashMap(attribute -> ArrayBuffer(ranger))
       case GreaterThanOrEqual(attribute, ic(key)) =>
-        val ranger = new RangeInterval(key, IndexScanner.DUMMY_KEY_END, true, true)
+        val ranger =
+          RangeInterval(
+            key,
+            IndexScanner.DUMMY_KEY_END,
+            includeStart = true,
+            includeEnd = true)
         mutable.HashMap(attribute -> ArrayBuffer(ranger))
       case GreaterThan(attribute, ic(key)) =>
-        val ranger = new RangeInterval(key, IndexScanner.DUMMY_KEY_END, false, true)
+        val ranger =
+          RangeInterval(
+            key,
+            IndexScanner.DUMMY_KEY_END,
+            includeStart = false,
+            includeEnd = true)
         mutable.HashMap(attribute -> ArrayBuffer(ranger))
       case LessThanOrEqual(attribute, ic(key)) =>
-        val ranger = new RangeInterval(IndexScanner.DUMMY_KEY_START, key, true, true)
+        val ranger =
+          RangeInterval(
+            IndexScanner.DUMMY_KEY_START,
+            key,
+            includeStart = true,
+            includeEnd = true)
         mutable.HashMap(attribute -> ArrayBuffer(ranger))
       case LessThan(attribute, ic(key)) =>
-        val ranger = new RangeInterval(IndexScanner.DUMMY_KEY_START, key, true, false)
+        val ranger =
+          RangeInterval(
+            IndexScanner.DUMMY_KEY_START,
+            key,
+            includeStart = true,
+            includeEnd = false)
         mutable.HashMap(attribute -> ArrayBuffer(ranger))
       case IsNotNull(attribute) =>
         val ranger =
-          new RangeInterval(IndexScanner.DUMMY_KEY_START, IndexScanner.DUMMY_KEY_END, true, true)
+          RangeInterval(
+            IndexScanner.DUMMY_KEY_START,
+            IndexScanner.DUMMY_KEY_END,
+            includeStart = true,
+            includeEnd = true)
+        mutable.HashMap(attribute -> ArrayBuffer(ranger))
+      case IsNull(attribute) =>
+        val ranger =
+          RangeInterval(
+            IndexScanner.DUMMY_KEY_START,
+            IndexScanner.DUMMY_KEY_END,
+            includeStart = true,
+            includeEnd = true,
+            isNull = true)
         mutable.HashMap(attribute -> ArrayBuffer(ranger))
       case _ => mutable.HashMap.empty
     }
@@ -231,7 +263,7 @@ private[oap] object ScannerBuilder extends Logging {
     if (filters == null || filters.isEmpty) return filters
     logDebug("Transform filters into Intervals:")
     val intervalMapArray = filters.map(optimizeFilterBound(_, ic))
-    // reduce multiple hashMap to one hashMap(AND operation)
+    // reduce multiple hashMap to one hashMap("AND" operation)
     val intervalMap = intervalMapArray.reduce(
       (leftMap, rightMap) =>
         if (leftMap == null || leftMap.isEmpty) rightMap

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -145,6 +145,7 @@ private[oap] object IndexUtils {
 
   def writeBasedOnSchema(
       writer: LittleEndianDataOutputStream, row: InternalRow, schema: StructType): Unit = {
+    require(row != null)
     schema.zipWithIndex.foreach {
       case (field, index) => writeBasedOnDataType(writer, row.get(index, field.dataType))
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/UnsafeIndexTree.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/UnsafeIndexTree.scala
@@ -210,15 +210,25 @@ private[oap] class CurrentKey(node: IndexNode, keyIdx: Int, valueIdx: Int, index
   def isEnd: Boolean = currentNode == null || currentKey == IndexScanner.DUMMY_KEY_END
 }
 
-private [oap] class RangeInterval(s: Key, e: Key, includeStart: Boolean, includeEnd: Boolean)
-  extends Serializable {
+private [oap] class RangeInterval(
+    s: Key,
+    e: Key,
+    includeStart: Boolean,
+    includeEnd: Boolean,
+    isNull: Boolean) extends Serializable {
   var start = s
   var end = e
   var startInclude = includeStart
   var endInclude = includeEnd
+  val isNullPredicate = isNull
 }
 
 private [oap] object RangeInterval{
-  def apply(s: Key, e: Key, includeStart: Boolean, includeEnd: Boolean): RangeInterval
-  = new RangeInterval(s, e, includeStart, includeEnd)
+  def apply(
+      s: Key,
+      e: Key,
+      includeStart: Boolean,
+      includeEnd: Boolean,
+      isNull: Boolean = false): RangeInterval =
+    new RangeInterval(s, e, includeStart, includeEnd, isNull)
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexScannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexScannerSuite.scala
@@ -33,6 +33,10 @@ import org.apache.spark.util.Utils
 class BTreeIndexScannerSuite extends SharedSQLContext {
   sparkConf.set("spark.memory.offHeap.size", "100m")
 
+  // Override afterEach because we do not want to check open streams
+  override def beforeEach(): Unit = {}
+  override def afterEach(): Unit = {}
+
   test("test rowOrdering") {
     // Only check Integer is enough. We use [[GenerateOrdering]] to handle different data types.
     val fields = StructField("col1", IntegerType) :: StructField("col2", IntegerType) :: Nil

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexScannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexScannerSuite.scala
@@ -22,14 +22,16 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
+import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
-import org.apache.spark.util.{ByteBufferOutputStream, Utils}
+import org.apache.spark.util.Utils
 
-class BTreeIndexScannerSuite extends SparkFunSuite {
+
+class BTreeIndexScannerSuite extends SharedSQLContext {
+  sparkConf.set("spark.memory.offHeap.size", "100m")
 
   test("test rowOrdering") {
     // Only check Integer is enough. We use [[GenerateOrdering]] to handle different data types.
@@ -103,10 +105,10 @@ class BTreeIndexScannerSuite extends SparkFunSuite {
     assertPosition(91, 9, exists = true)
   }
 
-  test("test findRowIdRange") {
+  test("test findRowIdRange for normal case") {
     val configuration = new Configuration()
     val schema = StructType(StructField("col", IntegerType) :: Nil)
-    val path = new Path(Utils.createTempDir().getAbsolutePath, "temp")
+    val path = new Path(Utils.createTempDir().getAbsolutePath, "tempIndexFile")
     val fileWriter = BTreeIndexFileWriter(configuration, path)
     val writer = BTreeIndexRecordWriter(configuration, fileWriter, schema)
     // Values structure depends on BTreeUtils.generate2()
@@ -149,5 +151,97 @@ class BTreeIndexScannerSuite extends SparkFunSuite {
     // 1 <= x <= 1
     assert(reader.findRowIdRange(RangeInterval(
       InternalRow(1), InternalRow(1), includeStart = true, includeEnd = true)) === (0, 1))
+  }
+
+  test("findRowIdRange for isNull filter predicate: empty result") {
+    val configuration = new Configuration()
+    val schema = StructType(StructField("col", IntegerType) :: Nil)
+    val path = new Path(Utils.createTempDir().getAbsolutePath, "tempIndexFile")
+    val fileWriter = BTreeIndexFileWriter(configuration, path)
+    val writer = BTreeIndexRecordWriter(configuration, fileWriter, schema)
+
+    (1 to 300 by 2).map(InternalRow(_)).foreach(writer.write(null, _))
+    writer.close(null)
+
+    val reader = BTreeIndexRecordReader(configuration, schema)
+    reader.initialize(path, new ArrayBuffer[RangeInterval]())
+
+    assert(
+      reader.findRowIdRange(
+        RangeInterval(
+          IndexScanner.DUMMY_KEY_START,
+          IndexScanner.DUMMY_KEY_END,
+          includeStart = true,
+          includeEnd = true,
+          isNull = true)) === (150, 150))
+  }
+
+  test("findRowIdRange for isNull filter predicate") {
+    val configuration = new Configuration()
+    val schema = StructType(StructField("col", IntegerType) :: Nil)
+    val path = new Path(Utils.createTempDir().getAbsolutePath, "tempIndexFile")
+    val fileWriter = BTreeIndexFileWriter(configuration, path)
+    val writer = BTreeIndexRecordWriter(configuration, fileWriter, schema)
+
+    (1 to 300 by 2).map(InternalRow(_)).foreach(writer.write(null, _))
+    (1 to 5).map(_ => InternalRow(null)).foreach(writer.write(null, _))
+    writer.close(null)
+
+    val reader = BTreeIndexRecordReader(configuration, schema)
+    reader.initialize(path, new ArrayBuffer[RangeInterval]())
+
+    assert(
+      reader.findRowIdRange(
+        RangeInterval(
+          IndexScanner.DUMMY_KEY_START,
+          IndexScanner.DUMMY_KEY_END,
+          includeStart = true,
+          includeEnd = true,
+          isNull = true)) === (150, 155))
+  }
+
+  test("findRowIdRange for isNotNull filter predicate: empty result") {
+    val configuration = new Configuration()
+    val schema = StructType(StructField("col", IntegerType) :: Nil)
+    val path = new Path(Utils.createTempDir().getAbsolutePath, "tempIndexFile")
+    val fileWriter = BTreeIndexFileWriter(configuration, path)
+    val writer = BTreeIndexRecordWriter(configuration, fileWriter, schema)
+
+    (1 to 5).map(_ => InternalRow(null)).foreach(writer.write(null, _))
+    writer.close(null)
+
+    val reader = BTreeIndexRecordReader(configuration, schema)
+    reader.initialize(path, new ArrayBuffer[RangeInterval]())
+
+    assert(
+      reader.findRowIdRange(
+        RangeInterval(
+          IndexScanner.DUMMY_KEY_START,
+          IndexScanner.DUMMY_KEY_END,
+          includeStart = true,
+          includeEnd = true)) === (0, 0))
+  }
+
+  test("findRowIdRange for isNotNull filter predicate") {
+    val configuration = new Configuration()
+    val schema = StructType(StructField("col", IntegerType) :: Nil)
+    val path = new Path(Utils.createTempDir().getAbsolutePath, "tempIndexFile")
+    val fileWriter = BTreeIndexFileWriter(configuration, path)
+    val writer = BTreeIndexRecordWriter(configuration, fileWriter, schema)
+
+    (1 to 300 by 2).map(InternalRow(_)).foreach(writer.write(null, _))
+    (1 to 5).map(_ => InternalRow(null)).foreach(writer.write(null, _))
+    writer.close(null)
+
+    val reader = BTreeIndexRecordReader(configuration, schema)
+    reader.initialize(path, new ArrayBuffer[RangeInterval]())
+
+    assert(
+      reader.findRowIdRange(
+        RangeInterval(
+          IndexScanner.DUMMY_KEY_START,
+          IndexScanner.DUMMY_KEY_END,
+          includeStart = true,
+          includeEnd = true)) === (0, 150))
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterSuite.scala
@@ -78,7 +78,7 @@ class BTreeRecordReaderWriterSuite extends SparkFunSuite {
   test("check read/write footer") {
     val footer = BTreeIndexRecordReader.BTreeFooter(FiberCache(fileWriter.footer))
     val nodeCount = footer.getNodesCount
-    assert(footer.getRecordCount === records.size)
+    assert(footer.getNonNullKeyRecordCount === records.size)
     assert(nodeCount === fileWriter.nodes.size)
 
     val nodeSizeSeq = (0 until nodeCount).map(footer.getNodeSize)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterSuite.scala
@@ -39,14 +39,14 @@ class BTreeRecordReaderWriterSuite extends SparkFunSuite {
   private class TestBTreeIndexFileWriter(conf: Configuration)
       extends BTreeIndexFileWriter(conf, new Path(Utils.createTempDir().getAbsolutePath, "temp")) {
     val nodes = new ArrayBuffer[Array[Byte]]()
-    var footer: Array[Byte] = new Array[Byte](0)
-    var rowIdList: Array[Byte] = new Array[Byte](0)
+    var footer: Array[Byte] = _
+    var rowIdList: Array[Byte] = _
     override def start(): Unit = {}
     override def end(): Unit = {}
     override def close(): Unit = {}
     override def writeNode(buf: Array[Byte]): Unit = nodes.append(buf)
-    override def writeRowIdList(buf: Array[Byte]): Unit = rowIdList = rowIdList ++ buf
-    override def writeFooter(buf: Array[Byte]): Unit = footer = footer ++ buf
+    override def writeRowIdList(buf: Array[Byte]): Unit = rowIdList = buf
+    override def writeFooter(buf: Array[Byte]): Unit = footer = buf
   }
   // Only test simple Int type since read/write based on schema can cover data type test
   private val schema = StructType(StructField("col", IntegerType) :: Nil)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterSuite.scala
@@ -22,14 +22,13 @@ import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.util.{ByteBufferOutputStream, Utils}
+import org.apache.spark.util.Utils
+
 
 class BTreeRecordReaderWriterSuite extends SparkFunSuite {
 
@@ -51,12 +50,14 @@ class BTreeRecordReaderWriterSuite extends SparkFunSuite {
   }
   // Only test simple Int type since read/write based on schema can cover data type test
   private val schema = StructType(StructField("col", IntegerType) :: Nil)
-  private val records = (0 until 1000).map(_ => random.nextInt(1000 / 2))
+  private val nonNullKeyRecords = (0 until 1000).map(_ => random.nextInt(1000 / 2))
+  private val nullKeyRecords = (1 to 5).map(_ => null)
   private val fileWriter = {
     val configuration = new Configuration()
     val fileWriter = new TestBTreeIndexFileWriter(configuration)
     val writer = BTreeIndexRecordWriter(configuration, fileWriter, schema)
-    records.map(InternalRow(_)).foreach(writer.write(null, _))
+    nonNullKeyRecords.map(InternalRow(_)).foreach(writer.write(null, _))
+    nullKeyRecords.map(InternalRow(_)).foreach(writer.write(null, _))
     writer.close(null)
     fileWriter
   }
@@ -67,18 +68,23 @@ class BTreeRecordReaderWriterSuite extends SparkFunSuite {
       val node = BTreeIndexRecordReader.BTreeNodeData(FiberCache(buf))
       (0 until node.getKeyCount).map(i => (node.getRowIdPos(i), node.getKey(i, schema).getInt(0)))
     }
-    assert(answer === records.sorted.distinct.map(v => (records.sorted.indexOf(v), v)))
+    assert(answer ===
+      nonNullKeyRecords.sorted.distinct.map(v => (nonNullKeyRecords.sorted.indexOf(v), v)))
   }
 
   test("check read/write rowIdList") {
     val rowIdList = BTreeIndexRecordReader.BTreeRowIdList(FiberCache(fileWriter.rowIdList))
-    assert(records.sorted === records.indices.map(rowIdList.getRowId).map(records(_)))
+    assert(nonNullKeyRecords.sorted ===
+      nonNullKeyRecords.indices.map(rowIdList.getRowId).map(nonNullKeyRecords(_)))
+    assert(nullKeyRecords.indices.map(idx => nonNullKeyRecords.size + idx) ===
+      nullKeyRecords.indices.map(idx => rowIdList.getRowId(nonNullKeyRecords.size + idx)))
   }
 
   test("check read/write footer") {
     val footer = BTreeIndexRecordReader.BTreeFooter(FiberCache(fileWriter.footer))
     val nodeCount = footer.getNodesCount
-    assert(footer.getNonNullKeyRecordCount === records.size)
+    assert(footer.getNonNullKeyRecordCount === nonNullKeyRecords.size)
+    assert(footer.getNullKeyRecordCount === nullKeyRecords.size)
     assert(nodeCount === fileWriter.nodes.size)
 
     val nodeSizeSeq = (0 until nodeCount).map(footer.getNodeSize)
@@ -89,7 +95,7 @@ class BTreeRecordReaderWriterSuite extends SparkFunSuite {
     val keyOffsetSeq = (0 until nodeCount).map ( i =>
       BTreeIndexRecordReader.BTreeNodeData(FiberCache(fileWriter.nodes(i))).getKeyCount
     ).scanLeft(0)(_ + _)
-    val uniqueValues = records.sorted.distinct
+    val uniqueValues = nonNullKeyRecords.sorted.distinct
     (0 until nodeCount).foreach { i =>
       assert(uniqueValues(keyOffsetSeq(i)) === footer.getMinValue(i, schema).getInt(0))
       assert(uniqueValues(keyOffsetSeq(i + 1) - 1) === footer.getMaxValue(i, schema).getInt(0))

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterSuite.scala
@@ -39,14 +39,14 @@ class BTreeRecordReaderWriterSuite extends SparkFunSuite {
   private class TestBTreeIndexFileWriter(conf: Configuration)
       extends BTreeIndexFileWriter(conf, new Path(Utils.createTempDir().getAbsolutePath, "temp")) {
     val nodes = new ArrayBuffer[Array[Byte]]()
-    var footer: Array[Byte] = _
-    var rowIdList: Array[Byte] = _
+    var footer: Array[Byte] = new Array[Byte](0)
+    var rowIdList: Array[Byte] = new Array[Byte](0)
     override def start(): Unit = {}
     override def end(): Unit = {}
     override def close(): Unit = {}
     override def writeNode(buf: Array[Byte]): Unit = nodes.append(buf)
-    override def writeRowIdList(buf: Array[Byte]): Unit = rowIdList = buf
-    override def writeFooter(buf: Array[Byte]): Unit = footer = buf
+    override def writeRowIdList(buf: Array[Byte]): Unit = rowIdList = rowIdList ++ buf
+    override def writeFooter(buf: Array[Byte]): Unit = footer = footer ++ buf
   }
   // Only test simple Int type since read/write based on schema can cover data type test
   private val schema = StructType(StructField("col", IntegerType) :: Nil)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support query for isNull/isNotNull in B+ tree index:
`attribute is null` , `attribute is not null` now is supported by B+ tree index
## How was this patch tested?
unit test
