### PR TITLE
Chagne IndexScanner to extends Iterator[Int]

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/InternalOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/InternalOapRecordReader.java
@@ -31,7 +31,7 @@ import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.metadata.IndexedParquetMetadata;
 import org.apache.parquet.io.*;
 import org.apache.parquet.io.api.RecordMaterializer;
-import org.apache.parquet.it.unimi.dsi.fastutil.longs.LongList;
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.parquet.schema.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +62,7 @@ public class InternalOapRecordReader<T> {
 
     private RecordReader<T> recordReader;
 
-    private Iterator<LongList> rowIdsIter;
+    private Iterator<IntList> rowIdsIter;
 
     private String createdBy;
 
@@ -91,7 +91,7 @@ public class InternalOapRecordReader<T> {
             }
             MessageColumnIO columnIO =
                     columnIOFactory.getColumnIO(requestedSchema, fileSchema, strictTypeChecking);
-            LongList rowIdList = rowIdsIter.next();
+            IntList rowIdList = rowIdsIter.next();
             this.recordReader = getRecordReader(columnIO,pages,rowIdList);
             metrics.startRecordAssemblyTime();
             totalCountLoadedSoFar += rowIdList.size();
@@ -99,7 +99,7 @@ public class InternalOapRecordReader<T> {
         }
     }
 
-    private RecordReader<T> getRecordReader(MessageColumnIO columnIO, PageReadStore pages, LongList rowIdList) {
+    private RecordReader<T> getRecordReader(MessageColumnIO columnIO, PageReadStore pages, IntList rowIdList) {
         return RecordReaderFactory.getRecordReader(columnIO, pages, recordConverter, createdBy, rowIdList);
     }
 
@@ -124,9 +124,9 @@ public class InternalOapRecordReader<T> {
         this.recordConverter = readSupport.prepareForRead(
                 configuration, fileMetadata, fileSchema, readContext);
         this.strictTypeChecking = configuration.getBoolean(STRICT_TYPE_CHECKING, true);
-        List<LongList> rowIdsList = ((IndexedParquetMetadata)parquetFileReader.getFooter()).getRowIdsList();
+        List<IntList> rowIdsList = ((IndexedParquetMetadata)parquetFileReader.getFooter()).getRowIdsList();
         this.rowIdsIter = rowIdsList.iterator();
-        for (LongList rowIdList : rowIdsList) {
+        for (IntList rowIdList : rowIdsList) {
             total += rowIdList.size();
         }
         this.reader.setRequestedSchema(requestedSchema);

--- a/src/main/java/org/apache/parquet/hadoop/OapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/OapRecordReader.java
@@ -34,14 +34,14 @@ import org.apache.parquet.hadoop.metadata.IndexedParquetMetadata;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 
 import com.google.common.collect.Lists;
-import org.apache.parquet.it.unimi.dsi.fastutil.longs.LongArrayList;
-import org.apache.parquet.it.unimi.dsi.fastutil.longs.LongList;
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 
 public class OapRecordReader<T> implements RecordReader<T> {
 
     private Configuration configuration;
     private Path file;
-    private long[] globalRowIds;
+    private int[] globalRowIds;
     private ParquetMetadata footer;
 
     private InternalOapRecordReader<T> internalReader;
@@ -51,7 +51,7 @@ public class OapRecordReader<T> implements RecordReader<T> {
     OapRecordReader(ReadSupport<T> readSupport,
                         Path file,
                         Configuration configuration,
-                        long[] globalRowIds,
+                        int[] globalRowIds,
                         ParquetMetadata footer) {
         Preconditions.checkNotNull(globalRowIds,"index collection can not be null!");
         this.readSupport = readSupport;
@@ -86,18 +86,18 @@ public class OapRecordReader<T> implements RecordReader<T> {
 
         List<BlockMetaData> inputBlockList = Lists.newArrayList();
 
-        List<LongList> rowIdsList = Lists.newArrayList();
+        List<IntList> rowIdsList = Lists.newArrayList();
 
-        long nextRowGroupStartRowId = 0;
+        int nextRowGroupStartRowId = 0;
         int totalCount = globalRowIds.length;
         int index = 0;
 
         for (BlockMetaData block : blocks) {
-            long currentRowGroupStartRowId = nextRowGroupStartRowId;
+            int currentRowGroupStartRowId = nextRowGroupStartRowId;
             nextRowGroupStartRowId += block.getRowCount();
-            LongList rowIdList = new LongArrayList();
+            IntList rowIdList = new IntArrayList();
             while (index < totalCount) {
-                long globalRowGroupId = globalRowIds[index];
+                int globalRowGroupId = globalRowIds[index];
                 if (globalRowGroupId < nextRowGroupStartRowId) {
                     rowIdList.add(globalRowGroupId - currentRowGroupStartRowId);
                     index++;

--- a/src/main/java/org/apache/parquet/hadoop/RecordReaderBuilder.java
+++ b/src/main/java/org/apache/parquet/hadoop/RecordReaderBuilder.java
@@ -16,7 +16,7 @@ public class RecordReaderBuilder<T> {
     private final ReadSupport<T> readSupport;
     private final Path file;
     private Configuration conf;
-    private long[] globalRowIds = new long[0];
+    private int[] globalRowIds = new int[0];
     private ParquetMetadata footer;
 
     private RecordReaderBuilder(ReadSupport<T> readSupport, Path path, Configuration conf) {
@@ -31,7 +31,7 @@ public class RecordReaderBuilder<T> {
         this.conf = new Configuration();
     }
 
-    public RecordReaderBuilder<T> withGlobalRowIds(long[] globalRowIds) {
+    public RecordReaderBuilder<T> withGlobalRowIds(int[] globalRowIds) {
         this.globalRowIds = globalRowIds;
         return this;
     }

--- a/src/main/java/org/apache/parquet/hadoop/metadata/IndexedParquetMetadata.java
+++ b/src/main/java/org/apache/parquet/hadoop/metadata/IndexedParquetMetadata.java
@@ -1,20 +1,20 @@
 package org.apache.parquet.hadoop.metadata;
 
 
-import org.apache.parquet.it.unimi.dsi.fastutil.longs.LongList;
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 
 import java.util.List;
 
 public class IndexedParquetMetadata extends ParquetMetadata {
 
-    private List<LongList> rowIdsList;
+    private List<IntList> rowIdsList;
 
-    public IndexedParquetMetadata(FileMetaData fileMetaData, List<BlockMetaData> blocks, List<LongList> rowIdsList) {
+    public IndexedParquetMetadata(FileMetaData fileMetaData, List<BlockMetaData> blocks, List<IntList> rowIdsList) {
         super(fileMetaData, blocks);
         this.rowIdsList = rowIdsList;
     }
 
-    public List<LongList> getRowIdsList() {
+    public List<IntList> getRowIdsList() {
         return rowIdsList;
     }
 }

--- a/src/main/java/org/apache/parquet/io/PositionableRecordReaderImpl.java
+++ b/src/main/java/org/apache/parquet/io/PositionableRecordReaderImpl.java
@@ -20,17 +20,15 @@ import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.io.api.RecordMaterializer;
-import org.apache.parquet.it.unimi.dsi.fastutil.longs.LongList;
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 
 public class PositionableRecordReaderImpl<T> extends RecordReaderImplementation<T> {
 
     private final long recordMaxCount;
 
-    private long recordsRead = 0;
+    private int recordsRead = 0;
 
-    private Long currentRowId = -1L;
-
-    private LongList rowIdList = null;
+    private IntList rowIdList = null;
 
     private int currentIndex = 0;
 
@@ -38,7 +36,7 @@ public class PositionableRecordReaderImpl<T> extends RecordReaderImplementation<
                                         RecordMaterializer<T> recordMaterializer,
                                         ColumnReadStoreImpl columnStore,
                                         long recordCount,
-                                        LongList rowIdList) {
+                                        IntList rowIdList) {
         super(root, recordMaterializer, false, columnStore);
         Preconditions.checkNotNull(rowIdList,"rowIdList can not be null.");
         Preconditions.checkArgument(!rowIdList.isEmpty(), "rowIdList must has item.");
@@ -47,7 +45,7 @@ public class PositionableRecordReaderImpl<T> extends RecordReaderImplementation<
     }
 
     public T read() {
-        currentRowId = rowIdList.getLong(currentIndex);
+        int currentRowId = rowIdList.getInt(currentIndex);
         seek(currentRowId);
 
         if (recordsRead == recordMaxCount) {
@@ -59,7 +57,7 @@ public class PositionableRecordReaderImpl<T> extends RecordReaderImplementation<
         return super.read();
     }
 
-    private void seek(long position) {
+    private void seek(int position) {
 
         Preconditions.checkArgument(position >= recordsRead,
                 "Not support seek to backward position, recordsRead: %s want to read: %s", recordsRead, position);

--- a/src/main/java/org/apache/parquet/io/RecordReaderFactory.java
+++ b/src/main/java/org/apache/parquet/io/RecordReaderFactory.java
@@ -4,7 +4,7 @@ package org.apache.parquet.io;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.io.api.RecordMaterializer;
-import org.apache.parquet.it.unimi.dsi.fastutil.longs.LongList;
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 
 import java.util.List;
 
@@ -15,7 +15,7 @@ public class RecordReaderFactory {
     public static <T> RecordReader<T> getRecordReader(MessageColumnIO root, PageReadStore columns,
                                                RecordMaterializer<T> recordMaterializer,
                                                String createdBy,
-                                               LongList rowIdList) {
+                                                      IntList rowIdList) {
         checkNotNull(root, "messageColumnIO");
         checkNotNull(columns, "columns");
         checkNotNull(recordMaterializer, "recordMaterializer");

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -48,5 +48,5 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
 
   override def hasNext: Boolean = recordReader.hasNext
 
-  override def next(): Long = recordReader.next()
+  override def next(): Int = recordReader.next()
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -90,7 +90,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     }
   }
 
-  override def next(): Long = bmRowIdIterator.next().toLong
+  override def next(): Int = bmRowIdIterator.next()
 
   private def loadBmFooter(fin: FSDataInputStream): FiberCache = {
     MemoryManager.putToIndexFiberCache(fin, bmFooterOffset, BITMAP_FOOTER_SIZE)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -38,7 +38,7 @@ private[oap] object IndexScanner {
 }
 
 private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
-  extends Iterator[Long] with Serializable with Logging{
+  extends Iterator[Int] with Serializable with Logging{
 
   // TODO Currently, only B+ tree supports indexs, so this flag is toggled only in
   // BPlusTreeScanner we can add other index-aware stats for other type of index later
@@ -138,7 +138,7 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
 private[oap] object DUMMY_SCANNER extends IndexScanner(null) {
   override def initialize(path: Path, configuration: Configuration): IndexScanner = { this }
   override def hasNext: Boolean = false
-  override def next(): Long = throw new NoSuchElementException("end of iterating.")
+  override def next(): Int = throw new NoSuchElementException("end of iterating.")
   override def meta: IndexMeta = throw new NotImplementedError()
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -38,7 +38,7 @@ abstract class DataFile {
   def createDataFileHandle(): DataFileHandle
   def getFiberData(groupId: Int, fiberId: Int, conf: Configuration): FiberCache
   def iterator(conf: Configuration, requiredIds: Array[Int]): Iterator[InternalRow]
-  def iterator(conf: Configuration, requiredIds: Array[Int], rowIds: Array[Long])
+  def iterator(conf: Configuration, requiredIds: Array[Int], rowIds: Array[Int])
   : Iterator[InternalRow]
   def getDictionary(fiberId: Int, conf: Configuration): Dictionary
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -140,10 +140,10 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
   }
 
   // scan by given row ids, and we assume the rowIds are sorted
-  def iterator(conf: Configuration, requiredIds: Array[Int], rowIds: Array[Long])
+  def iterator(conf: Configuration, requiredIds: Array[Int], rowIds: Array[Int])
   : Iterator[InternalRow] = {
     val row = new BatchColumn()
-    val groupIds = rowIds.groupBy(rowId => (rowId / meta.rowCountInEachGroup).toInt)
+    val groupIds = rowIds.groupBy(rowId => rowId / meta.rowCountInEachGroup)
     val iterator =
       groupIds.iterator.flatMap {
         case (groupId, subRowIds) =>
@@ -162,7 +162,7 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
           }
 
           val iterator =
-            subRowIds.iterator.map(rowId => row.moveToRow((rowId % meta.rowCountInEachGroup).toInt))
+            subRowIds.iterator.map(rowId => row.moveToRow(rowId % meta.rowCountInEachGroup))
 
           CompletionIterator[InternalRow, Iterator[InternalRow]](iterator,
             fiberCacheGroup.zip(requiredIds).foreach {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -199,7 +199,7 @@ private[oap] class OapDataReader(
 
     filterScanner match {
       case Some(indexScanner) if indexScanner.indexIsAvailable(path, conf) =>
-        def getRowIds(options: Map[String, String]): Array[Long] = {
+        def getRowIds(options: Map[String, String]): Array[Int] = {
           indexScanner.initialize(path, conf)
 
           // total Row count can be get from the index scanner

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -48,9 +48,9 @@ private[oap] case class ParquetDataFile
 
   def iterator(conf: Configuration,
                requiredIds: Array[Int],
-               rowIds: Array[Long]): Iterator[UnsafeRow] = {
+               rowIds: Array[Int]): Iterator[UnsafeRow] = {
     if (rowIds == null || rowIds.length == 0) {
-      ParquetDataFile.emptyIterator
+      Iterator.empty
     } else {
       val recordReader = recordReaderBuilder(conf, requiredIds)
         .withGlobalRowIds(rowIds).buildIndexed()
@@ -109,14 +109,4 @@ private[oap] case class ParquetDataFile
   }
 
   override def getDictionary(fiberId: Int, conf: Configuration): Dictionary = null
-}
-
-private[oap] object  ParquetDataFile {
-
-  val emptyIterator = new Iterator[UnsafeRow] {
-    override def hasNext: Boolean = false
-
-    override def next(): UnsafeRow =
-      throw new java.util.NoSuchElementException("Input is Empty RowIds Array")
-  }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/NestedDataParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/NestedDataParquetDataFileSuite.scala
@@ -143,7 +143,7 @@ class NestedDataParquetDataFileSuite extends org.apache.spark.SparkFunSuite
 
     val requiredIds = Array(0, 1, 2)
 
-    val rowIds = Array(1L)
+    val rowIds = Array(1)
 
     val iterator = reader.iterator(DataGenerator.configuration, requiredIds, rowIds)
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -65,7 +65,7 @@ class ParquetDataFileSuite extends org.apache.spark.SparkFunSuite
 
     val requiredIds = Array(0, 1)
 
-    val rowIds = Array(0L, 1L, 7L, 8L, 120L, 121L, 381L, 382L)
+    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382)
 
     val iterator = reader.iterator(DataGenerator.configuration, requiredIds, rowIds)
 
@@ -89,7 +89,7 @@ class ParquetDataFileSuite extends org.apache.spark.SparkFunSuite
 
     val requiredIds = Array(0, 1)
 
-    val rowIds = new Array[Long](0)
+    val rowIds = Array.emptyIntArray
 
     val iterator = reader.iterator(DataGenerator.configuration, requiredIds, rowIds)
 
@@ -99,7 +99,7 @@ class ParquetDataFileSuite extends org.apache.spark.SparkFunSuite
       iterator.next()
     }.getMessage
 
-    assert(e.contains("Input is Empty RowIds Array"))
+    assert(e.contains("next on empty iterator"))
   }
 
   test("read by columnIds ") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1、IndexScanner(and implation) change to extends Iterator[Int]
2、DataFile (and implation) : iterator(conf: Configuration, requiredIds: Array[Int], rowIds: Array[Long])
->iterator(conf: Configuration, requiredIds: Array[Int], rowIds: Array[Int])
3、parquet read with "long[] rowids" -> "int[] rowids" 

## How was this patch tested?

Existing tests