### PR TITLE
Use SharedSQLContext For Consistency

### DIFF
--- a/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -42,7 +42,12 @@ import org.apache.spark.util.Utils
 class FileSourceStrategySuite extends QueryTest with SharedSQLContext with PredicateHelper {
   import testImplicits._
 
-  protected override val sparkConf = new SparkConf().set("spark.default.parallelism", "1")
+  protected override val sparkConf =
+    new SparkConf().set("spark.default.parallelism", "1").set("spark.memory.offHeap.size", "100m")
+
+  // Override afterEach because we don't want to check open streams
+  override def beforeEach(): Unit = {}
+  override def afterEach(): Unit = {}
 
   test("unpartitioned table, single partition") {
     val table =

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -27,7 +27,6 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 import org.apache.spark.util.Utils
@@ -51,6 +50,10 @@ class DataSourceMetaSuite extends SharedSQLContext with BeforeAndAfter {
       super.afterAll()
     }
   }
+
+  // Override afterEach because we don't want to check open streams
+  override def beforeEach(): Unit = {}
+  override def afterEach(): Unit = {}
 
   private def writeMetaFile(path: Path): Unit = {
     val oapMeta = DataSourceMeta.newBuilder()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -21,9 +21,10 @@ import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.sql.test.SharedSQLContext
 
-class FiberCacheManagerSuite extends SparkFunSuite {
+class FiberCacheManagerSuite extends SharedSQLContext {
+  sparkConf.set("spark.memory.offHeap.size", "100m")
   private val random = new Random(0)
   private def generateData(size: Int): Array[Byte] = {
     val bytes = new Array[Byte](size)
@@ -32,11 +33,6 @@ class FiberCacheManagerSuite extends SparkFunSuite {
   }
 
   test("unit test") {
-    new SparkContext(
-      "local[2]",
-      "FiberCacheManagerSuite",
-      new SparkConf().set("spark.memory.offHeap.size", "100m")
-    )
     val configuration = new Configuration()
     val MB: Double = 1024 * 1024
     val memorySizeInMB = (MemoryManager.maxMemory / MB).toInt
@@ -56,11 +52,6 @@ class FiberCacheManagerSuite extends SparkFunSuite {
   }
 
   test("remove a fiber is in use") {
-    new SparkContext(
-      "local[2]",
-      "FiberCacheManagerSuite",
-      new SparkConf().set("spark.memory.offHeap.size", "100m")
-    )
     val configuration = new Configuration()
     val MB: Double = 1024 * 1024
     val memorySizeInMB = (MemoryManager.maxMemory / MB).toInt
@@ -78,11 +69,6 @@ class FiberCacheManagerSuite extends SparkFunSuite {
   }
 
   test("add a very large fiber") {
-    new SparkContext(
-      "local[2]",
-      "FiberCacheManagerSuite",
-      new SparkConf().set("spark.memory.offHeap.size", "100m")
-    )
     val configuration = new Configuration()
     val MB: Double = 1024 * 1024
     val memorySizeInMB = (MemoryManager.maxMemory / MB).toInt

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
@@ -23,7 +23,7 @@ import java.io.File
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
-import org.apache.spark.SparkConf
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.execution.datasources.oap.{DataSourceMeta, OapFileFormat}
@@ -50,6 +50,10 @@ class FiberSuite extends SharedSQLContext with Logging {
     Utils.deleteRecursively(file)
     super.afterAll()
   }
+
+  // Override afterEach because we don't want to check open streams
+  override def beforeEach(): Unit = {}
+  override def afterEach(): Unit = {}
 
   test("test reading / writing oap file") {
     val schema = (new StructType)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -31,34 +31,51 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.{ByteBufferOutputStream, Utils}
 
 class MemoryManagerSuite extends SharedSQLContext {
-  sparkConf.set("spark.memory.offHeap.size", "100m")
 
-  private val random = new Random(0)
-  private val values = {
-    val booleans: Seq[Boolean] = Seq(true, false)
-    val bytes: Seq[Byte] = Seq(Byte.MinValue, 0, 10, 30, Byte.MaxValue)
-    val shorts: Seq[Short] = Seq(Short.MinValue, -100, 0, 10, 200, Short.MaxValue)
-    val ints: Seq[Int] = Seq(Int.MinValue, -100, 0, 100, 12346, Int.MaxValue)
-    val longs: Seq[Long] = Seq(Long.MinValue, -10000, 0, 20, Long.MaxValue)
-    val floats: Seq[Float] = Seq(Float.MinValue, Float.MinPositiveValue, Float.MaxValue)
-    val doubles: Seq[Double] = Seq(Double.MinValue, Double.MinPositiveValue, Double.MaxValue)
-    val strings: Seq[UTF8String] =
-      Seq("", "test", "b plus tree", "MemoryManagerSuite").map(UTF8String.fromString)
-    val binaries: Seq[Array[Byte]] = (0 until 20 by 5).map{ size =>
-      val buf = new Array[Byte](size)
-      random.nextBytes(buf)
-      buf
+  sparkConf.set("spark.memory.offHeap.size", "100m")
+  private var random: Random = _
+  private var values: Seq[Any] = _
+  private var fiberCache: FiberCache = _
+
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    random = new Random(0)
+    values = {
+      val booleans: Seq[Boolean] = Seq(true, false)
+      val bytes: Seq[Byte] = Seq(Byte.MinValue, 0, 10, 30, Byte.MaxValue)
+      val shorts: Seq[Short] = Seq(Short.MinValue, -100, 0, 10, 200, Short.MaxValue)
+      val ints: Seq[Int] = Seq(Int.MinValue, -100, 0, 100, 12346, Int.MaxValue)
+      val longs: Seq[Long] = Seq(Long.MinValue, -10000, 0, 20, Long.MaxValue)
+      val floats: Seq[Float] = Seq(Float.MinValue, Float.MinPositiveValue, Float.MaxValue)
+      val doubles: Seq[Double] = Seq(Double.MinValue, Double.MinPositiveValue, Double.MaxValue)
+      val strings: Seq[UTF8String] =
+        Seq("", "test", "b plus tree", "MemoryManagerSuite").map(UTF8String.fromString)
+      val binaries: Seq[Array[Byte]] = (0 until 20 by 5).map{ size =>
+        val buf = new Array[Byte](size)
+        random.nextBytes(buf)
+        buf
+      }
+      booleans ++ bytes ++ shorts ++ ints ++ longs ++
+          floats ++ doubles ++ strings ++ binaries ++ Nil
     }
-    val values = booleans ++ bytes ++ shorts ++ ints ++ longs ++
-        floats ++ doubles ++ strings ++ binaries ++ Nil
     random.shuffle(values)
+
+    fiberCache = {
+      val buf = new ByteBufferOutputStream()
+      val writer = new LittleEndianDataOutputStream(buf)
+      values.foreach(value => IndexUtils.writeBasedOnDataType(writer, value))
+      MemoryManager.putToDataFiberCache(buf.toByteArray)
+    }
   }
-  private val fiberCache = {
-    val buf = new ByteBufferOutputStream()
-    val writer = new LittleEndianDataOutputStream(buf)
-    values.foreach(value => IndexUtils.writeBasedOnDataType(writer, value))
-    MemoryManager.putToDataFiberCache(buf.toByteArray)
+
+  protected override def afterAll(): Unit = {
+    super.afterAll()
   }
+
+  // Override afterEach because we don't want to check open streams
+  override def beforeEach(): Unit = {}
+  override def afterEach(): Unit = {}
 
   test("test data in IndexFiberCache") {
     // TODO: find a nice way to create FSDataInputStream

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -23,18 +23,15 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
 import org.apache.parquet.bytes.LittleEndianDataOutputStream
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.index.IndexUtils
+import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.{ByteBufferOutputStream, Utils}
 
-class MemoryManagerSuite extends SparkFunSuite {
-  new SparkContext(
-    "local[2]",
-    "MemoryManagerSuite",
-    new SparkConf().set("spark.memory.offHeap.size", "100m"))
+class MemoryManagerSuite extends SharedSQLContext {
+  sparkConf.set("spark.memory.offHeap.size", "100m")
 
   private val random = new Random(0)
   private val values = {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeFileReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeFileReaderWriterSuite.scala
@@ -20,17 +20,17 @@ package org.apache.spark.sql.execution.datasources.oap.index
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
 
-class BTreeFileReaderWriterSuite extends SparkFunSuite {
+class BTreeFileReaderWriterSuite extends SharedSQLContext {
+  sparkConf.set("spark.memory.offHeap.size", "100m")
+
+  // Override afterEach because we don't want to check open streams
+  override def beforeEach(): Unit = {}
+  override def afterEach(): Unit = {}
 
   test("BTree File Read/Write") {
-    new SparkContext(
-      "local[2]",
-      "BTreeFileReaderWriterSuite",
-      new SparkConf().set("spark.memory.offHeap.size", "100m"))
-
     val path = new Path(Utils.createTempDir().getAbsolutePath, "index")
     val configuration = new Configuration()
     val footer = "footer".getBytes("UTF-8")

--- a/src/test/scala/org/apache/spark/sql/hive/execution/OapQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/OapQuerySuite.scala
@@ -29,11 +29,13 @@ import org.apache.spark.sql.internal.SQLConf
 // Ignore because in separate package will encounter problem with shaded spark source.
 @Ignore
 class OapQuerySuite extends HiveComparisonTest with BeforeAndAfter  {
-  private val originalTimeZone = TimeZone.getDefault
-  private val originalLocale = Locale.getDefault
+  private lazy val originalTimeZone = TimeZone.getDefault
+  private lazy val originalLocale = Locale.getDefault
   import org.apache.spark.sql.hive.test.TestHive._
 
-  private val originalCrossJoinEnabled = TestHive.conf.crossJoinEnabled
+  // Note: invoke TestHive will create a SparkContext which can't be configured by us.
+  // So be careful this may affect current using SparkContext and cause strange problem.
+  private lazy val originalCrossJoinEnabled = TestHive.conf.crossJoinEnabled
 
   override def beforeAll() {
     super.beforeAll()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use SharedSQLContext For Consistency
Otherwise, we'll encounter below warning:
Multiple running SparkContexts detected in the same JVM

## How was this patch tested?

Unit test passed

