### PR TITLE
remove LittleEndianDataOutputStream from code

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
@@ -28,8 +28,8 @@ private[oap] case class BTreeIndexFileReader(
     file: Path) {
 
   private val VERSION_SIZE = 8
-  private val FOOTER_LENGTH_SIZE = Integer.SIZE / 8
-  private val ROW_ID_LIST_LENGTH_SIZE = Integer.SIZE / 8
+  private val FOOTER_LENGTH_SIZE = IndexUtils.INT_SIZE
+  private val ROW_ID_LIST_LENGTH_SIZE = IndexUtils.INT_SIZE
 
   private val (reader, fileLength) = {
     val fs = file.getFileSystem(configuration)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileWriter.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.datasources.oap.index
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
 
 import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 
@@ -64,9 +63,8 @@ private case class BTreeIndexFileWriter(
   }
 
   def end(): Unit = {
-    val littleEndianWriter = new LittleEndianDataOutputStream(writer)
-    littleEndianWriter.writeInt(rowIdListSize)
-    littleEndianWriter.writeInt(footerSize)
+    IndexUtils.writeInt(writer, rowIdListSize)
+    IndexUtils.writeInt(writer, footerSize)
   }
 
   def close(): Unit = writer.close()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
@@ -228,17 +228,17 @@ private[index] object BTreeIndexRecordReader {
 
   private[index] case class BTreeFooter(fiberCache: FiberCache) {
     // TODO move to companion object
-    private val nodePosOffset = Integer.SIZE / 8
-    private val nodeSizeOffset = Integer.SIZE / 8 * 2
-    private val minPosOffset = Integer.SIZE / 8 * 3
-    private val maxPosOffset = Integer.SIZE / 8 * 4
-    private val nodeMetaStart = Integer.SIZE / 8 * 3
-    private val nodeMetaByteSize = Integer.SIZE / 8 * 5
-    private val statsLengthSize = Integer.SIZE / 8
+    private val nodePosOffset = IndexUtils.INT_SIZE
+    private val nodeSizeOffset = IndexUtils.INT_SIZE * 2
+    private val minPosOffset = IndexUtils.INT_SIZE * 3
+    private val maxPosOffset = IndexUtils.INT_SIZE * 4
+    private val nodeMetaStart = IndexUtils.INT_SIZE * 3
+    private val nodeMetaByteSize = IndexUtils.INT_SIZE * 5
+    private val statsLengthSize = IndexUtils.INT_SIZE
 
     def getNonNullKeyRecordCount: Int = fiberCache.getInt(0)
-    def getNullKeyRecordCount: Int = fiberCache.getInt(Integer.SIZE / 8)
-    def getNodesCount: Int = fiberCache.getInt(Integer.SIZE / 8 * 2)
+    def getNullKeyRecordCount: Int = fiberCache.getInt(IndexUtils.INT_SIZE)
+    def getNodesCount: Int = fiberCache.getInt(IndexUtils.INT_SIZE * 2)
     // get idx Node's max value
     def getMaxValue(idx: Int, schema: StructType): InternalRow =
       IndexUtils.readBasedOnSchema(fiberCache, getMaxValueOffset(idx), schema)
@@ -262,12 +262,12 @@ private[index] object BTreeIndexRecordReader {
   }
 
   private[index] case class BTreeRowIdList(fiberCache: FiberCache) {
-    def getRowId(idx: Int): Int = fiberCache.getInt(idx * Integer.SIZE / 8)
+    def getRowId(idx: Int): Int = fiberCache.getInt(idx * IndexUtils.INT_SIZE)
   }
 
   private[index] case class BTreeNodeData(fiberCache: FiberCache) {
-    private val posSectionStart = Integer.SIZE / 8
-    private val posEntrySize = Integer.SIZE / 8 * 2
+    private val posSectionStart = IndexUtils.INT_SIZE
+    private val posEntrySize = IndexUtils.INT_SIZE * 2
     private def valueSectionStart = posSectionStart + getKeyCount * posEntrySize
 
     def getKeyCount: Int = fiberCache.getInt(0)
@@ -277,6 +277,6 @@ private[index] object BTreeIndexRecordReader {
       IndexUtils.readBasedOnSchema(fiberCache, offset, schema)
     }
     def getRowIdPos(idx: Int): Int =
-      fiberCache.getInt(posSectionStart + idx * posEntrySize + Integer.SIZE / 8)
+      fiberCache.getInt(posSectionStart + idx * posEntrySize + IndexUtils.INT_SIZE)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -19,15 +19,13 @@ package org.apache.spark.sql.execution.datasources.oap.index
 
 import java.io.{ByteArrayOutputStream, DataOutputStream, OutputStream}
 
-import scala.collection.mutable
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
 import org.roaringbitmap.buffer.MutableRoaringBitmap
 
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.catalyst.expressions.FromUnsafeProjection
 import org.apache.spark.sql.catalyst.InternalRow
@@ -100,9 +98,8 @@ private[oap] class BitmapIndexRecordWriter(
     assert(keySchema.fields.size == 1)
     bmUniqueKeyList = rowMapBitmap.keySet.toList.sorted(ordering)
     val bos = new ByteArrayOutputStream()
-    val leDos = new LittleEndianDataOutputStream(bos)
     bmUniqueKeyList.foreach(key => {
-      IndexUtils.writeBasedOnDataType(leDos, key.get(0, keySchema.fields(0).dataType))
+      IndexUtils.writeBasedOnDataType(bos, key.get(0, keySchema.fields(0).dataType))
     })
     bmUniqueKeyListTotalSize = bos.size()
     bmUniqueKeyListCount = bmUniqueKeyList.size

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -21,8 +21,6 @@ import java.io.{ByteArrayOutputStream, OutputStream}
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
-
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
@@ -57,12 +55,11 @@ private[oap] class MinMaxStatistics extends Statistics {
     var offset = super.write(writer, sortedKeys)
     if (min != null) {
       val tempWriter = new ByteArrayOutputStream()
-      val littleEndianWriter = new LittleEndianDataOutputStream(tempWriter)
-      IndexUtils.writeBasedOnSchema(littleEndianWriter, min, schema)
+      IndexUtils.writeBasedOnSchema(tempWriter, min, schema)
       IndexUtils.writeInt(writer, tempWriter.size)
-      IndexUtils.writeBasedOnSchema(littleEndianWriter, max, schema)
+      IndexUtils.writeBasedOnSchema(tempWriter, max, schema)
       IndexUtils.writeInt(writer, tempWriter.size)
-      offset += Integer.SIZE / 8 * 2
+      offset += IndexUtils.INT_SIZE * 2
       writer.write(tempWriter.toByteArray)
       offset += tempWriter.size
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -21,8 +21,6 @@ import java.io.{ByteArrayOutputStream, OutputStream}
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
@@ -86,9 +84,8 @@ private[oap] class PartByValueStatistics extends Statistics {
     // start writing
     IndexUtils.writeInt(writer, metas.length)
     val tempWriter = new ByteArrayOutputStream()
-    val littleEndianWriter = new LittleEndianDataOutputStream(tempWriter)
     metas.foreach(meta => {
-      IndexUtils.writeBasedOnSchema(littleEndianWriter, meta.row, schema)
+      IndexUtils.writeBasedOnSchema(tempWriter, meta.row, schema)
       IndexUtils.writeInt(writer, meta.curMaxId)
       IndexUtils.writeInt(writer, meta.accumulatorCnt)
       IndexUtils.writeInt(writer, tempWriter.size())

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -21,7 +21,6 @@ import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
 
 import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.index.IndexUtils
@@ -63,8 +62,7 @@ class MemoryManagerSuite extends SharedSQLContext {
 
     fiberCache = {
       val buf = new ByteBufferOutputStream()
-      val writer = new LittleEndianDataOutputStream(buf)
-      values.foreach(value => IndexUtils.writeBasedOnDataType(writer, value))
+      values.foreach(value => IndexUtils.writeBasedOnDataType(buf, value))
       MemoryManager.putToDataFiberCache(buf.toByteArray)
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatisticsSuite.scala
@@ -20,8 +20,6 @@ import java.io.ByteArrayOutputStream
 
 import scala.util.Random
 
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexScanner, IndexUtils}
 
@@ -70,10 +68,9 @@ class MinMaxStatisticsSuite extends StatisticsTest {
 
     IndexUtils.writeInt(out, MinMaxStatisticsType.id)
     val tempWriter = new ByteArrayOutputStream()
-    val littleEndianWriter = new LittleEndianDataOutputStream(tempWriter)
-    IndexUtils.writeBasedOnSchema(littleEndianWriter, rowGen(1), schema)
+    IndexUtils.writeBasedOnSchema(tempWriter, rowGen(1), schema)
     IndexUtils.writeInt(out, tempWriter.size)
-    IndexUtils.writeBasedOnSchema(littleEndianWriter, rowGen(300), schema)
+    IndexUtils.writeBasedOnSchema(tempWriter, rowGen(300), schema)
     IndexUtils.writeInt(out, tempWriter.size)
     out.write(tempWriter.toByteArray)
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
@@ -21,8 +21,6 @@ import java.io.ByteArrayOutputStream
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexScanner, IndexUtils}
@@ -85,9 +83,8 @@ class PartByValueStatisticsSuite extends StatisticsTest{
     IndexUtils.writeInt(out, PartByValueStatisticsType.id)
     IndexUtils.writeInt(out, partNum)
     val tempWriter = new ByteArrayOutputStream()
-    val littleEndianWriter = new LittleEndianDataOutputStream(tempWriter)
     for (i <- content.indices) {
-      IndexUtils.writeBasedOnSchema(littleEndianWriter, rowGen(content(i)), schema)
+      IndexUtils.writeBasedOnSchema(tempWriter, rowGen(content(i)), schema)
       IndexUtils.writeInt(out, curMaxId(i))
       IndexUtils.writeInt(out, curAccumuCount(i))
       IndexUtils.writeInt(out, tempWriter.size())

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatisticsSuite.scala
@@ -22,8 +22,6 @@ import java.io.ByteArrayOutputStream
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
-import org.apache.parquet.bytes.LittleEndianDataOutputStream
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.execution.datasources.oap._
@@ -68,9 +66,8 @@ class SampleBasedStatisticsSuite extends StatisticsTest{
     IndexUtils.writeInt(out, size)
 
     val tempWriter = new ByteArrayOutputStream()
-    val littleEndianWriter = new LittleEndianDataOutputStream(tempWriter)
     for (idx <- 0 until size) {
-      IndexUtils.writeBasedOnSchema(littleEndianWriter, keys(idx), schema)
+      IndexUtils.writeBasedOnSchema(tempWriter, keys(idx), schema)
       IndexUtils.writeInt(out, tempWriter.size)
     }
     out.write(tempWriter.toByteArray)


### PR DESCRIPTION
## What changes were proposed in this pull request?

we instantiated a lot of `LittleEndianDataOutputStream` and that is not necessary.

## How was this patch tested?

Unit test.

