### PR TITLE
[Minor] remove initialize in statistics

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BloomFilter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BloomFilter.scala
@@ -23,8 +23,8 @@ import scala.util.hashing.{MurmurHash3 => MH3}
 /**
  * Implementation for Bloom filter.
  */
-class BloomFilter(maxBitCount: Int, numOfHashFunc: Int)
-                 (var bloomBitSet: mutable.BitSet = null) {
+class BloomFilter(
+    maxBitCount: Int, numOfHashFunc: Int)(var bloomBitSet: mutable.BitSet = null) {
 //  private var bloomBitSet: mutable.BitSet = new mutable.BitSet(maxBitCount)
   private val hashFunctions: Array[BloomHashFunction] =
     BloomHashFunction.getMurmurHashFunction(maxBitCount, numOfHashFunc)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -28,18 +28,12 @@ import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.types.StructType
 
 
-private[oap] class MinMaxStatistics extends Statistics {
+private[oap] class MinMaxStatistics(schema: StructType) extends Statistics(schema) {
   override val id: Int = MinMaxStatisticsType.id
   @transient private lazy val ordering = GenerateOrdering.create(schema)
 
   protected var min: Key = _
   protected var max: Key = _
-
-  override def initialize(schema: StructType): Unit = {
-    super.initialize(schema)
-    min = null
-    max = null
-  }
 
   override def addOapKey(key: Key): Unit = {
     if (min == null || max == null) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.StructType
 // (241,  "test#241")   240            241
 // (300,  "test#300")   299            300
 
-private[oap] class PartByValueStatistics extends Statistics {
+private[oap] class PartByValueStatistics(schema: StructType) extends Statistics(schema) {
   override val id: Int = PartByValueStatisticsType.id
 
   private lazy val maxPartNum: Int = StatisticsManager.partNumber

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.types.StructType
 
 
-private[oap] class SampleBasedStatistics extends Statistics {
+private[oap] class SampleBasedStatistics(schema: StructType) extends Statistics(schema) {
   override val id: Int = SampleBasedStatisticsType.id
 
   lazy val sampleRate: Double = StatisticsManager.sampleRate

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -29,13 +29,8 @@ import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.types._
 
 
-abstract class Statistics {
+abstract class Statistics(schema: StructType) {
   val id: Int
-  protected var schema: StructType = _
-
-  def initialize(schema: StructType): Unit = {
-    this.schema = schema
-  }
 
   /**
    * For MinMax & Bloom Filter, every time a key is inserted, then

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -87,16 +87,15 @@ class StatisticsManager {
         SQLConf.OAP_STATISTICS_TYPES.defaultValueString).split(",").map(_.trim)
       typeFromConfig.contains(statType.name)
     }
+    schema = s
     stats = statsTypes.map {
-      case MinMaxStatisticsType => new MinMaxStatistics
-      case SampleBasedStatisticsType => new SampleBasedStatistics
-      case PartByValueStatisticsType => new PartByValueStatistics
-      case BloomFilterStatisticsType => new BloomFilterStatistics
+      case MinMaxStatisticsType => new MinMaxStatistics(s)
+      case SampleBasedStatisticsType => new SampleBasedStatistics(s)
+      case PartByValueStatisticsType => new PartByValueStatistics(s)
+      case BloomFilterStatisticsType => new BloomFilterStatistics(s)
       case t => throw new UnsupportedOperationException(s"non-supported statistic type $t")
     }
-    schema = s
     content = new ArrayBuffer[Key]()
-    stats.foreach(stat => stat.initialize(schema))
   }
 
   def addOapKey(key: Key): Unit = {
@@ -142,16 +141,15 @@ class StatisticsManager {
 
       for (i <- 0 until numOfStats) {
         fiberCache.getInt(offset + readOffset) match {
-          case MinMaxStatisticsType.id => stats(i) = new MinMaxStatistics
-          case SampleBasedStatisticsType.id => stats(i) = new SampleBasedStatistics
-          case PartByValueStatisticsType.id => stats(i) = new PartByValueStatistics
-          case BloomFilterStatisticsType.id => stats(i) = new BloomFilterStatistics
+          case MinMaxStatisticsType.id => stats(i) = new MinMaxStatistics(s)
+          case SampleBasedStatisticsType.id => stats(i) = new SampleBasedStatistics(s)
+          case PartByValueStatisticsType.id => stats(i) = new PartByValueStatistics(s)
+          case BloomFilterStatisticsType.id => stats(i) = new BloomFilterStatistics(s)
           case _ => throw new UnsupportedOperationException("unsupport statistics id")
         }
         readOffset += 4
       }
       for (stat <- stats) {
-        stat.initialize(s)
         readOffset += stat.read(fiberCache, offset + readOffset)
       }
     }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
@@ -21,11 +21,12 @@ import scala.util.Random
 
 import org.apache.spark.sql.catalyst.expressions.{BoundReference, UnsafeProjection}
 import org.apache.spark.sql.execution.datasources.oap.index.{BloomFilter, IndexUtils}
+import org.apache.spark.sql.types.StructType
 
 
 class BloomFilterStatisticsSuite extends StatisticsTest {
 
-  class TestBloomFilter extends BloomFilterStatistics {
+  class TestBloomFilter(schema: StructType) extends BloomFilterStatistics(schema) {
     def getBloomFilter: BloomFilter = bfIndex
   }
 
@@ -53,8 +54,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
     val projectors = boundReference.toSet.subsets().filter(_.nonEmpty).map(s =>
       UnsafeProjection.create(s.toArray)).toArray
 
-    val testBloomFilter = new TestBloomFilter
-    testBloomFilter.initialize(schema)
+    val testBloomFilter = new TestBloomFilter(schema)
     for (key <- keys) {
       testBloomFilter.addOapKey(key)
       projectors.foreach(p => bfIndex.addValue(p(key).getBytes))
@@ -106,8 +106,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
 
     val fiber = wrapToFiberCache(out)
 
-    val testBloomFilter = new TestBloomFilter
-    testBloomFilter.initialize(schema)
+    val testBloomFilter = new TestBloomFilter(schema)
     testBloomFilter.read(fiber, 0)
 
     checkBloomFilter(testBloomFilter.getBloomFilter, bfIndex)
@@ -128,8 +127,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
       projectors.foreach(p => bfIndex.addValue(p(key).getBytes))
     }
 
-    val bloomFilterWrite = new TestBloomFilter
-    bloomFilterWrite.initialize(schema)
+    val bloomFilterWrite = new TestBloomFilter(schema)
     for (key <- keys) {
       bloomFilterWrite.addOapKey(key)
     }
@@ -137,8 +135,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
 
     val fiber = wrapToFiberCache(out)
 
-    val bloomFilterRead = new TestBloomFilter
-    bloomFilterRead.initialize(schema)
+    val bloomFilterRead = new TestBloomFilter(schema)
     bloomFilterRead.read(fiber, 0)
 
     val bfIndexFromFile = bloomFilterRead.getBloomFilter
@@ -163,8 +160,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
       projectors.foreach(p => bfIndex.addValue(p(key).getBytes))
     }
 
-    val bloomFilterWrite = new TestBloomFilter
-    bloomFilterWrite.initialize(schema)
+    val bloomFilterWrite = new TestBloomFilter(schema)
     for (key <- keys) {
       bloomFilterWrite.addOapKey(key)
     }
@@ -172,8 +168,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
 
     val fiber = wrapToFiberCache(out)
 
-    val bloomFilterRead = new TestBloomFilter
-    bloomFilterRead.initialize(schema)
+    val bloomFilterRead = new TestBloomFilter(schema)
     bloomFilterRead.read(fiber, 0)
 
     for (i <- 1 until 300) {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsSuite.scala
@@ -35,13 +35,12 @@ class StatisticsSuite extends StatisticsTest with BeforeAndAfterAll {
   val row2 = InternalRow(2.0)
   val row3 = InternalRow(3.0)
 
-  class TestStatistics extends Statistics {
+  class TestStatistics(schema: StructType) extends Statistics(schema) {
     override val id: Int = 6662
   }
 
   test("Statistics write function test") {
-    val test = new TestStatistics
-    test.initialize(schema)
+    val test = new TestStatistics(schema)
     val writtenBytes = test.write(out, null)
     assert(writtenBytes == 4)
 
@@ -51,7 +50,7 @@ class StatisticsSuite extends StatisticsTest with BeforeAndAfterAll {
   }
 
   test("Statistics read function test") {
-    val test = new TestStatistics
+    val test = new TestStatistics(schema)
     IndexUtils.writeInt(out, test.id)
 
     val fiber = wrapToFiberCache(out)
@@ -61,7 +60,7 @@ class StatisticsSuite extends StatisticsTest with BeforeAndAfterAll {
   }
 
   test("Statistics default analyzer test") {
-    val test = new TestStatistics
+    val test = new TestStatistics(schema)
     IndexUtils.writeInt(out, test.id)
 
     val fiber = wrapToFiberCache(out)


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove function `initialize` in statistics.
Currently we need to initialize before both write and read statistics,
so merge it to object instantiation stage.

## How was this patch tested?

modified tests.

