### PR TITLE
[HOTFIX] follow-up #438 fail multi-column key with null fields

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -81,6 +81,9 @@ private[index] case class BTreeIndexRecordWriter(
     assert(uniqueKeys.size == partitionUniqueSize)
     val (nullKeys, nonNullKeys) = uniqueKeys.partition(_.anyNull)
     assert(nullKeys.length + nonNullKeys.length == partitionUniqueSize)
+    require(
+      nullKeys.isEmpty || keySchema.length == 1,
+      "No support for multi-column index building with null keys!")
     lazy val comparator: Comparator[InternalRow] = new Comparator[InternalRow]() {
       override def compare(o1: InternalRow, o2: InternalRow): Int = {
         if (o1 == null && o2 == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is follow-up of #438 , by using `.anyNull`, a row with columns that has null value is filtered out of index schema. It is somewhat complex to handle for now. Maybe for multi-column case we still need something like a row to write empty value properly.

## How was this patch tested?
N/A

