### PR TITLE
optimize indexscanner intersect

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -327,8 +327,8 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
       case _ =>
         actualUsedScanners.par.foreach(_.initialize(dataPath, conf))
         actualUsedScanners.map(_.toSet)
-          .reduce((left, right) => {
-            if (left.isEmpty) left
+          .reduce((left, right ) => {
+            if (left.isEmpty || right.isEmpty) Set.empty
             else left.intersect(right)
           }).iterator
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -327,7 +327,7 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
       case _ =>
         actualUsedScanners.par.foreach(_.initialize(dataPath, conf))
         actualUsedScanners.map(_.toSet)
-          .reduce((left, right ) => {
+          .reduce((left, right) => {
             if (left.isEmpty || right.isEmpty) Set.empty
             else left.intersect(right)
           }).iterator

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -326,8 +326,7 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
         actualUsedScanners.head.toArray.iterator
       case _ =>
         actualUsedScanners.par.foreach(_.initialize(dataPath, conf))
-        actualUsedScanners.map(_.toArray)
-          .sortBy(_.length)
+        actualUsedScanners.map(_.toSet)
           .reduce((left, right) => {
             if (left.isEmpty) left
             else left.intersect(right)


### PR DESCRIPTION
## What changes were proposed in this pull request?
For the purpose of intersection, we do not need to keep the order of collection. i test two seq.intersection and two seq.intersection with 150w collection size，and the performance of set is 7 times that of seq
1、IndexScanners.initialize：multi-indexscanner get intersection, use indexScanner.toSet instead of indexScanner.toArray

## How was this patch tested?
existing unit test