### PR TITLE
Cannot build write index when indexing 2G rows #457

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -195,8 +195,8 @@ private[index] case class BTreeIndexRecordWriter(
    */
   private def serializeRowIdLists(uniqueKeys: Seq[InternalRow]): Array[Byte] = {
     val buffer = new ByteArrayOutputStream()
-    uniqueKeys.flatMap(key =>
-      multiHashMap.get(key).asScala).foreach(IndexUtils.writeInt(buffer, _))
+    uniqueKeys.map(key => multiHashMap.get(key).asScala)
+      .foreach(_.foreach(IndexUtils.writeInt(buffer, _)))
     buffer.toByteArray
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
change BTreeIndexRecordWriter#serializeRowIdLists method implementation to avoid flatMap func apply 2G mem
## How was this patch tested?
existsing ut