### PR TITLE
Fix guava cache equality issue which causes 0 hit in cache.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -169,11 +169,6 @@ case class DataFiber(file: DataFile, columnIndex: Int, rowGroupId: Int) extends 
 }
 
 private[oap]
-case class IndexFiber(file: IndexFile) extends Fiber {
-  override def fiber2Data(conf: Configuration): FiberCache = file.getIndexFiberData(conf)
-}
-
-private[oap]
 case class BTreeFiber(
     getFiberData: () => FiberCache,
     file: String,
@@ -181,14 +176,13 @@ case class BTreeFiber(
     idx: Int) extends Fiber {
   override def fiber2Data(conf: Configuration): FiberCache = getFiberData()
 
-  override def hashCode(): Int = (getFiberData.toString() + file + section + idx).hashCode
+  override def hashCode(): Int = (file + section + idx).hashCode
 
   override def equals(obj: Any): Boolean = obj match {
     case another: BTreeFiber =>
       another.section == section &&
         another.idx == idx &&
-        another.file == file &&
-        another.getFiberData.toString() == getFiberData.toString()
+        another.file == file
     case _ => false
   }
 }
@@ -203,15 +197,13 @@ case class BitmapFiber(
     loadUnitIdxOfSection: Int) extends Fiber {
   override def fiber2Data(conf: Configuration): FiberCache = getFiberData()
 
-  override def hashCode(): Int =
-    (getFiberData.toString() + file + sectionIdxOfFile + loadUnitIdxOfSection).hashCode
+  override def hashCode(): Int = (file + sectionIdxOfFile + loadUnitIdxOfSection).hashCode
 
   override def equals(obj: Any): Boolean = obj match {
     case another: BitmapFiber =>
       another.sectionIdxOfFile == sectionIdxOfFile &&
         another.loadUnitIdxOfSection == loadUnitIdxOfSection &&
-        another.file == file &&
-        another.getFiberData.toString() == getFiberData.toString()
+        another.file == file
     case _ => false
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
-import com.google.common.cache._
 import java.util.concurrent.{Callable, TimeUnit}
 import java.util.concurrent.atomic.AtomicLong
+
+import com.google.common.cache._
 import org.apache.hadoop.conf.Configuration
 import scala.collection.JavaConverters._
 
@@ -164,7 +165,7 @@ case class DataFiber(file: DataFile, columnIndex: Int, rowGroupId: Int) extends 
     case another: DataFiber =>
       another.columnIndex == columnIndex &&
         another.rowGroupId == rowGroupId &&
-        another.file.path == file.path
+        another.file.path.equals(file.path)
     case _ => false
   }
 }
@@ -183,7 +184,7 @@ case class BTreeFiber(
     case another: BTreeFiber =>
       another.section == section &&
         another.idx == idx &&
-        another.file == file
+        another.file.equals(file)
     case _ => false
   }
 }
@@ -204,7 +205,7 @@ case class BitmapFiber(
     case another: BitmapFiber =>
       another.sectionIdxOfFile == sectionIdxOfFile &&
         another.loadUnitIdxOfSection == loadUnitIdxOfSection &&
-        another.file == file
+        another.file.equals(file)
     case _ => false
   }
 }
@@ -215,7 +216,7 @@ private[oap] case class TestFiber(getData: () => FiberCache, name: String) exten
   override def hashCode(): Int = name.hashCode()
 
   override def equals(obj: Any): Boolean = obj match {
-    case another: TestFiber => name == another.name
+    case another: TestFiber => name.equals(another.name)
     case _ => false
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -210,4 +210,11 @@ case class BitmapFiber(
 
 private[oap] case class TestFiber(getData: () => FiberCache, name: String) extends Fiber {
   override def fiber2Data(conf: Configuration): FiberCache = getData()
+
+  override def hashCode(): Int = name.hashCode()
+
+  override def equals(obj: Any): Boolean = obj match {
+    case another: TestFiber => name == another.name
+    case _ => false
+  }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -20,9 +20,10 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 import java.util.concurrent.{Callable, TimeUnit}
 import java.util.concurrent.atomic.AtomicLong
 
+import scala.collection.JavaConverters._
+
 import com.google.common.cache._
 import org.apache.hadoop.conf.Configuration
-import scala.collection.JavaConverters._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.executor.custom.CustomManager

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -33,7 +33,6 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
   @transient protected var currentKeyArray: Array[CurrentKey] = _
 
   var currentKeyIdx = 0
-  var indexFiber: IndexFiber = _
   var recordReader: BTreeIndexRecordReader = _
 
   def initialize(dataPath: Path, conf: Configuration): IndexScanner = {
@@ -52,7 +51,8 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
     // TODO decouple with btreeindexrecordreader
     // This is called before the scanner call `initialize`
     val reader = BTreeIndexFileReader(conf, indexPath)
-    val footerFiber = BTreeFiber(() => reader.readFooter(), reader.file.toString, 0, 0)
+    val footerFiber = BTreeFiber(
+      () => reader.readFooter(), reader.file.toString, reader.footerSectionId, 0)
     val footerCache = FiberCacheManager.get(footerFiber, conf)
     val footer = BTreeFooter(footerCache, keySchema)
     val offset = footer.getStatsOffset

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
@@ -31,6 +31,11 @@ private[oap] case class BTreeIndexFileReader(
   private val FOOTER_LENGTH_SIZE = IndexUtils.INT_SIZE
   private val ROW_ID_LIST_LENGTH_SIZE = IndexUtils.INT_SIZE
 
+  // Section ID for fiber cache reading.
+  val footerSectionId: Int = 0
+  val rowIdListSectionId: Int = 1
+  val nodeSectionId: Int = 2
+
   private val (reader, fileLength) = {
     val fs = file.getFileSystem(configuration)
     (fs.open(file), fs.getFileStatus(file).getLen)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -142,7 +142,8 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     val idxFileSize = fs.getFileStatus(idxPath).getLen.toInt
     bmFooterOffset = idxFileSize - BITMAP_FOOTER_SIZE
     // Cache the segments after first loading from file.
-    bmFooterFiber = BitmapFiber(() => loadBmFooter(fin), idxPath.toString, 6, 0)
+    bmFooterFiber = BitmapFiber(
+      () => loadBmFooter(fin), idxPath.toString, BitmapIndexSectionId.footerSection, 0)
     bmFooterCache = FiberCacheManager.get(bmFooterFiber, conf)
     readBmFooterFromCache(bmFooterCache)
 
@@ -151,13 +152,16 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     bmEntryListOffset = bmUniqueKeyListOffset + bmUniqueKeyListTotalSize
     bmOffsetListOffset = bmEntryListOffset + bmEntryListTotalSize
 
-    bmUniqueKeyListFiber = BitmapFiber(() => loadBmKeyList(fin), idxPath.toString, 2, 0)
+    bmUniqueKeyListFiber = BitmapFiber(
+        () => loadBmKeyList(fin), idxPath.toString, BitmapIndexSectionId.keyListSection, 0)
     bmUniqueKeyListCache = FiberCacheManager.get(bmUniqueKeyListFiber, conf)
 
-    bmEntryListFiber = BitmapFiber(() => loadBmEntryList(fin), idxPath.toString, 3, 0)
+    bmEntryListFiber = BitmapFiber(
+      () => loadBmEntryList(fin), idxPath.toString, BitmapIndexSectionId.entryListSection, 0)
     bmEntryListCache = FiberCacheManager.get(bmEntryListFiber, conf)
 
-    bmOffsetListFiber = BitmapFiber(() => loadBmOffsetList(fin), idxPath.toString, 4, 0)
+    bmOffsetListFiber = BitmapFiber(
+      () => loadBmOffsetList(fin), idxPath.toString, BitmapIndexSectionId.entryOffsetsSection, 0)
     bmOffsetListCache = FiberCacheManager.get(bmOffsetListFiber, conf)
     fin.close()
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -39,7 +39,7 @@ private[oap] object BitmapIndexSectionId {
   val keyListSection      : Int = 2 // sorted unique key list (index column unique values)
   val entryListSection    : Int = 3 // bitmap entry list
   val entryOffsetsSection : Int = 4 // bitmap entry offset list
-  val statisticsSection   : Int = 5 // keep the original statistics, not changed than before.
+  val statisticsSection   : Int = 5 // keep the original statistics, not changed than before
   val footerSection       : Int = 6 // footer to save total key list size and length
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -40,7 +40,7 @@ private[oap] object BitmapIndexSectionId {
   val entryListSection    : Int = 3 // bitmap entry list
   val entryOffsetsSection : Int = 4 // bitmap entry offset list
   val statisticsSection   : Int = 5 // keep the original statistics, not changed than before.
-  val footerSection       : Int = 6 // footer to save total key list size and length, total entry
+  val footerSection       : Int = 6 // footer to save total key list size and length
 }
 
 /* Below is the bitmap index general layout and sections.

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -34,16 +34,25 @@ import org.apache.spark.sql.execution.datasources.oap.statistics.StatisticsManag
 import org.apache.spark.sql.execution.datasources.oap.utils.NonNullKeyWriter
 import org.apache.spark.sql.types._
 
+private[oap] object BitmapIndexSectionId {
+  val headerSection       : Int = 1 // header
+  val keyListSection      : Int = 2 // sorted unique key list (index column unique values)
+  val entryListSection    : Int = 3 // bitmap entry list
+  val entryOffsetsSection : Int = 4 // bitmap entry offset list
+  val statisticsSection   : Int = 5 // keep the original statistics, not changed than before.
+  val footerSection       : Int = 6 // footer to save total key list size and length, total entry
+}
+
 /* Below is the bitmap index general layout and sections.
- * #section id     section size(B) section description
- *    1              4               header
- *    2              varied          sorted unique key list (index column unique values)
- *    3              varied          bitmap entry list
- *    4              varied          bitmap entry offset list
- *    5              varied          keep the original statistics, not changed than before.
- *    6              40(5*8)         footer to save total key list size and length, total entry
- *                                   list size and total offset list size, and also the original
- *                                   index end.
+ * #section id        section size(B) section description
+ * headerSection      4               header
+ * keyListSection     varied          sorted unique key list (index column unique values)
+ * entryListSection   varied          bitmap entry list
+ * entryOffsetSection varied          bitmap entry offset list
+ * statisticsSection  varied          keep the original statistics, not changed than before.
+ * footerSection      40(5*8)         footer to save total key list size and length, total entry
+ *                                    list size and total offset list size, and also the original
+ *                                    index end.
  *
  * TODO: 1. Bitmap index is suitable for the enumeration columns which actually has not many
  *          unique values, thus we will load the key list and offset list respectively as a
@@ -64,9 +73,7 @@ private[oap] class BitmapIndexRecordWriter(
   private val rowMapBitmap = new mutable.HashMap[InternalRow, MutableRoaringBitmap]()
   private var recordCount: Int = 0
 
-  private var bmUniqueKeyListOffset: Int = _
   private var bmEntryListOffset: Int = _
-  private var bmOffsetListOffset: Int = _
 
   private var bmUniqueKeyList: immutable.List[InternalRow] = _
   private var bmOffsetListBuffer: mutable.ListBuffer[Int] = _

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -31,7 +31,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
 
   test("unit test") {
     val memorySizeInMB = (MemoryManager.maxMemory / mbSize).toInt
-    val origStats = FiberCacheManager.getStats
+    val origStats = FiberCacheManager.cacheStats
     (1 to memorySizeInMB * 2).foreach { i =>
       val data = generateData(kbSize)
       val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #$i")
@@ -40,7 +40,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
       assert(fiberCache.toArray sameElements data)
       assert(fiberCache2.toArray sameElements data)
     }
-    val stats = FiberCacheManager.getStats.minus(origStats)
+    val stats = FiberCacheManager.cacheStats.minus(origStats)
     assert(stats.missCount() == memorySizeInMB * 2)
     assert(stats.hitCount() == memorySizeInMB * 2)
     assert(stats.evictionCount() >= memorySizeInMB)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -73,4 +73,15 @@ class FiberCacheManagerSuite extends SharedOapContext {
     val fiberCache1 = FiberCacheManager.get(fiber1, configuration)
     assert(fiberCache1.isDisposed)
   }
+
+  test("fiber key equality test") {
+    val data = generateData(kbSize)
+    val origStats = FiberCacheManager.cacheStats
+    val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber")
+    FiberCacheManager.get(fiber, configuration)
+    assert(FiberCacheManager.cacheStats.minus(origStats).missCount() == 1)
+    val sameFiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber")
+    FiberCacheManager.get(sameFiber, configuration)
+    assert(FiberCacheManager.cacheStats.minus(origStats).hitCount() == 1)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix fiber cache equality issue by overriding hashcode & equals functions.
2. Remove all related magic numbers in fiber cache reading part.
3. Add test case to indicate the equality issue.
4. Add cache size statistics to tell the cache memory capacity/usage for future statistics report.

## How was this patch tested?
mvn test passes.