### PR TITLE
RefreshIndex support specify partition.#456

### DIFF
--- a/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -136,7 +136,7 @@ statement
     | (DESC | DESCRIBE) TABLE? option=(EXTENDED | FORMATTED)?
         tableIdentifier partitionSpec? describeColName?                #describeTable
     | REFRESH TABLE tableIdentifier                                    #refreshTable
-    | REFRESH SINDEX ON tableIdentifier                                #oapRefreshIndices
+    | REFRESH SINDEX ON tableIdentifier partitionSpec?                 #oapRefreshIndices
     | REFRESH .*?                                                      #refreshResource
     | CACHE LAZY? TABLE tableIdentifier (AS? query)?                   #cacheTable
     | UNCACHE TABLE (IF EXISTS)? tableIdentifier                       #uncacheTable

--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1452,7 +1452,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
   override def visitOapRefreshIndices(ctx: OapRefreshIndicesContext): LogicalPlan =
     withOrigin(ctx) {
-      RefreshIndex(visitTableIdentifier(ctx.tableIdentifier))
+      RefreshIndex(visitTableIdentifier(ctx.tableIdentifier),
+        Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
     }
 
   override def visitOapShowIndex(ctx: OapShowIndexContext): LogicalPlan = withOrigin(ctx) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1.  Add `partitionSpec` option to  refreshTable in SqlBase.g4.
2. Modify class RefreshIndex signature in indexPlans.scala. 

## How was this patch tested?

Existing unit test all passed

Add more new unit tests:
- test refresh in parquet format on a partition
- test refresh in oap format on a partition
