### PR TITLE
Correct the starting and ending index for range query in bitmap index.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -197,12 +197,12 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
       // If no starting key, assume to start from the first key.
       0
     } else {
-      // If no found, return -1.
+     // Find the first index to be > or >= range.start. If no found, return -1.
       val (idx, found) =
          IndexUtils.binarySearch(0, keyLength, keySeq(_), range.start, ordering.compare(_, _))
       if (found) {
         if (range.startInclude) idx else idx + 1
-      } else -1
+      } else if (ordering.compare(keySeq.head, range.start) > 0) 0 else -1
     }
     // If invalid starting index, just return.
     if (startIdx == -1 || startIdx == keyLength) return (-1, -1)
@@ -221,7 +221,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
          IndexUtils.binarySearch(0, keyLength, keySeq(_), range.end, ordering.compare(_, _))
       if (found) {
         if (range.endInclude) idx else idx - 1
-      } else -1
+      } else if (ordering.compare(keySeq.last, range.end) < 0) keyLength - 1 else -1
     }
     (startIdx, endIdx)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Binary search will get the exact index to match the start or end of
   the specific range.
2. If not, the range start may be less than the first key. Or the range
   end may be greater than the last key.
3. Otherwise, it's invalid range.

## How was this patch tested?
All of unit test passed.