### PR TITLE
throw exception when indexing more than 2g rows

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
+import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.statistics.StatisticsManager
 import org.apache.spark.sql.execution.datasources.oap.utils.{BTreeNode, BTreeUtils, NonNullKeyWriter}
 import org.apache.spark.sql.types._
@@ -52,6 +53,9 @@ private[index] case class BTreeIndexRecordWriter(
     val v = genericProjector(value).copy()
     multiHashMap.put(v, recordCount)
     statisticsManager.addOapKey(v)
+    if (recordCount == Int.MaxValue) {
+      throw new OapException("Cannot support indexing more than 2G rows!")
+    }
     recordCount += 1
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -29,6 +29,7 @@ import org.roaringbitmap.RoaringBitmap
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.FromUnsafeProjection
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
+import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 import org.apache.spark.sql.execution.datasources.oap.statistics.StatisticsManager
 import org.apache.spark.sql.execution.datasources.oap.utils.NonNullKeyWriter
@@ -96,6 +97,9 @@ private[oap] class BitmapIndexRecordWriter(
       rowMapBitmap.put(v, bm)
     } else {
       rowMapBitmap.get(v).get.add(recordCount)
+    }
+    if (recordCount == Int.MaxValue) {
+      throw new OapException("Cannot support indexing more than 2G rows!")
     }
     recordCount += 1
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Throw OapException when indexing more than 2g rows. Currently just check the recordCount in index record writer and if it exceeds Int.MaxValue, we throw an OapException.


## How was this patch tested?

Tested on tpcds1000 dataset with more than 2g rows for only one partition. 


Fixes #448 

