### PR TITLE
Partial Load RowIdList Fiber

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
@@ -64,7 +64,12 @@ private[oap] case class BTreeIndexFileReader(
 
   def readRowIdList(partIdx: Int): FiberCache = {
     val partSize = rowIdListSizePerSection * Integer.SIZE / 8
-    MemoryManager.putToIndexFiberCache(reader, rowIdListIndex + partIdx * partSize, partSize)
+    val readLength = if (partIdx * partSize + partSize > rowIdListLength) {
+      rowIdListLength % rowIdListSizePerSection
+    } else {
+      partSize
+    }
+    MemoryManager.putToIndexFiberCache(reader, rowIdListIndex + partIdx * partSize, readLength)
   }
 
   @deprecated("no need to read the whole row id list", "v0.3")

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
@@ -36,6 +36,8 @@ private[oap] case class BTreeIndexFileReader(
   val rowIdListSectionId: Int = 1
   val nodeSectionId: Int = 2
 
+  val rowIdListSizePerSection: Int = 1024 * 1024
+
   private val (reader, fileLength) = {
     val fs = file.getFileSystem(configuration)
     (fs.open(file), fs.getFileStatus(file).getLen)
@@ -60,6 +62,12 @@ private[oap] case class BTreeIndexFileReader(
   def readFooter(): FiberCache =
     MemoryManager.putToIndexFiberCache(reader, footerIndex, footerLength)
 
+  def readRowIdList(partIdx: Int): FiberCache = {
+    val partSize = rowIdListSizePerSection * Integer.SIZE / 8
+    MemoryManager.putToIndexFiberCache(reader, rowIdListIndex + partIdx * partSize, partSize)
+  }
+
+  @deprecated("no need to read the whole row id list", "v0.3")
   def readRowIdList(): FiberCache =
     MemoryManager.putToIndexFiberCache(reader, rowIdListIndex, rowIdListLength)
 

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -740,6 +740,13 @@ object SQLConf {
       .intConf
       .createWithDefault(1)
 
+  val OAP_BTREE_ROW_LIST_PART_SIZE =
+    SQLConfigBuilder("spark.sql.oap.btree.rowList.part.size")
+        .internal()
+        .doc("The row count of each part of row list in btree index")
+        .intConf
+        .createWithDefault(1024 * 1024)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -26,6 +26,10 @@ trait SharedOapContext extends SharedSQLContext {
 
   // avoid the overflow of offHeap memory
   sparkConf.set("spark.memory.offHeap.size", "100m")
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.sqlContext.setConf(SQLConf.OAP_BTREE_ROW_LIST_PART_SIZE, 64)
+  }
 
   protected lazy val configuration: Configuration = sparkContext.hadoopConfiguration
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

For 2G rows index file, RowIdList Fiber size is 8GB. This is too large.
With partial loading, each fiber contains 1M rows maximum.
So fiber size is 4MB maximum. This is better.


## How was this patch tested?

Unit test passed

