### PR TITLE
Enable executor side statistics check during index scanning.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
@@ -39,19 +39,12 @@ import org.apache.spark.util.Utils
 trait OapStrategies extends Logging {
 
   def oapStrategies: Seq[Strategy] = {
-    // If executor index selection (EIS) is enabled, oapStrategies are disabled.
-    // TODO: a profile to control those which can be applied even if EIS is enabled.
-    val conf = SparkSession.getActiveSession.get.sessionState.conf
-    if (conf.getConf(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)) {
-      Nil
-    } else {
       // BtreeIndex applicable strategies.
       OapSortLimitStrategy ::
       // BitMapIndex applicable strategies.
       OapSemiJoinStrategy ::
       // No requirement.
       OapGroupAggregateStrategy :: Nil
-    }
   }
 
   /**
@@ -285,6 +278,12 @@ trait OapStrategies extends Logging {
       oapOption: Map[String, String],
       indexHint: Seq[Expression],
       indexRequirements: Seq[IndexType]): Option[SparkPlan] = {
+    // If executor index selection (EIS) is enabled, oapStrategies are disabled.
+    val conf = SparkSession.getActiveSession.get.sessionState.conf
+    if (conf.getConf(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)) {
+      return None
+    }
+
     // Filters on this relation fall into four categories based
     // on where we can use them to avoid
     // reading unneeded data:

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
@@ -39,12 +39,12 @@ import org.apache.spark.util.Utils
 trait OapStrategies extends Logging {
 
   def oapStrategies: Seq[Strategy] = {
-      // BtreeIndex applicable strategies.
-      OapSortLimitStrategy ::
-      // BitMapIndex applicable strategies.
-      OapSemiJoinStrategy ::
-      // No requirement.
-      OapGroupAggregateStrategy :: Nil
+    // BtreeIndex applicable strategies.
+    OapSortLimitStrategy ::
+    // BitMapIndex applicable strategies.
+    OapSemiJoinStrategy ::
+    // No requirement.
+    OapGroupAggregateStrategy :: Nil
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -86,7 +86,6 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
       logDebug("Index Selection Time (Executor): " + (end - start) + "ms")
       if (!useIndex) {
         logWarning("OAP index is skipped. Set below flags to force enable index,\n" +
-            "sqlContext.conf.setConfString(SQLConf.OAP_USE_INDEX_FOR_DEVELOPERS.key, true) or \n" +
             "sqlContext.conf.setConfString(SQLConf.OAP_EXECUTOR_INDEX_SELECTION.key, false)")
       } else {
         OapIndexInfo.partitionOapIndex.put(dataPath.toString, true)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -55,6 +55,51 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
       idx: Int, row: InternalRow, curMaxId: Int, accumulatorCnt: Int)
   protected lazy val metas: ArrayBuffer[PartedByValueMeta] = new ArrayBuffer[PartedByValueMeta]()
 
+  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
+    var offset = super.write(writer, sortedKeys)
+    val hashMap = new java.util.HashMap[Key, Int]()
+    val uniqueKeys: ArrayBuffer[Key] = new ArrayBuffer[Key]()
+
+    var prev: Key = null
+    var prevCnt: Int = 0
+
+    for (key <- sortedKeys) {
+      if (prev == null) {
+        prev = key
+        prevCnt += 1
+      } else {
+        if (ordering.compare(prev, key) == 0) prevCnt += 1
+        else {
+          hashMap.put(prev, prevCnt)
+          uniqueKeys.append(prev)
+          prevCnt = 1
+          prev = key
+        }
+      }
+    }
+    if (prev != null) {
+      hashMap.put(prev, prevCnt)
+      uniqueKeys.append(prev)
+    }
+
+    buildPartMeta(uniqueKeys, hashMap)
+
+    // start writing
+    IndexUtils.writeInt(writer, metas.length)
+    offset += IndexUtils.INT_SIZE
+    val tempWriter = new ByteArrayOutputStream()
+    metas.foreach(meta => {
+      nnkw.writeKey(tempWriter, meta.row)
+      IndexUtils.writeInt(writer, meta.curMaxId)
+      IndexUtils.writeInt(writer, meta.accumulatorCnt)
+      IndexUtils.writeInt(writer, tempWriter.size())
+      offset += 12
+    })
+    writer.write(tempWriter.toByteArray)
+    offset += tempWriter.size
+    offset
+  }
+
   override def read(fiberCache: FiberCache, offset: Int): Int = {
     var readOffset = super.read(fiberCache, offset) + offset
 
@@ -105,33 +150,37 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
   }
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double = {
-    val wholeCount = metas.last.accumulatorCnt
+    if (metas.nonEmpty) {
+      val wholeCount = metas.last.accumulatorCnt
 
-    val start = intervalArray.head
-    val end = intervalArray.last
+      val start = intervalArray.head
+      val end = intervalArray.last
 
-    val left = getIntervalIdxForStart(start.start, start.startInclude)
-    val right = getIntervalIdxForEnd(end.end, end.endInclude)
+      val left = getIntervalIdxForStart(start.start, start.startInclude)
+      val right = getIntervalIdxForEnd(end.end, end.endInclude)
 
-    if (left == -1 || right == 0) {
-      // interval.min > partition.max || interval.max < partition.min
-      StaticsAnalysisResult.SKIP_INDEX
+      if (left == -1 || right == 0) {
+        // interval.min > partition.max || interval.max < partition.min
+        StaticsAnalysisResult.SKIP_INDEX
+      } else {
+        var cover: Double =
+          if (right != -1) metas(right).accumulatorCnt else metas.last.accumulatorCnt
+
+        if (left > 0) {
+          cover -= metas(left - 1).accumulatorCnt
+          cover += 0.5 * (metas(left).accumulatorCnt - metas(left - 1).accumulatorCnt)
+        }
+
+        if (right != -1) {
+          cover -= 0.5 * (metas(right).accumulatorCnt - metas(right - 1).accumulatorCnt)
+        }
+
+        if (cover > wholeCount) StaticsAnalysisResult.FULL_SCAN
+        else if (cover < 0) StaticsAnalysisResult.USE_INDEX
+        else cover / wholeCount
+      }
     } else {
-      var cover: Double =
-        if (right != -1) metas(right).accumulatorCnt else metas.last.accumulatorCnt
-
-      if (left > 0) {
-        cover -= metas(left - 1).accumulatorCnt
-        cover += 0.5 * (metas(left).accumulatorCnt - metas(left - 1).accumulatorCnt)
-      }
-
-      if (right != -1) {
-        cover -= 0.5 * (metas(right).accumulatorCnt - metas(right - 1).accumulatorCnt)
-      }
-
-      if (cover > wholeCount) 1.0
-      else if (cover < 0) 0.0
-      else cover / wholeCount
+      StaticsAnalysisResult.USE_INDEX
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -55,51 +55,6 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
       idx: Int, row: InternalRow, curMaxId: Int, accumulatorCnt: Int)
   protected lazy val metas: ArrayBuffer[PartedByValueMeta] = new ArrayBuffer[PartedByValueMeta]()
 
-  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
-    var offset = super.write(writer, sortedKeys)
-    val hashMap = new java.util.HashMap[Key, Int]()
-    val uniqueKeys: ArrayBuffer[Key] = new ArrayBuffer[Key]()
-
-    var prev: Key = null
-    var prevCnt: Int = 0
-
-    for (key <- sortedKeys) {
-      if (prev == null) {
-        prev = key
-        prevCnt += 1
-      } else {
-        if (ordering.compare(prev, key) == 0) prevCnt += 1
-        else {
-          hashMap.put(prev, prevCnt)
-          uniqueKeys.append(prev)
-          prevCnt = 1
-          prev = key
-        }
-      }
-    }
-    if (prev != null) {
-      hashMap.put(prev, prevCnt)
-      uniqueKeys.append(prev)
-    }
-
-    buildPartMeta(uniqueKeys, hashMap)
-
-    // start writing
-    IndexUtils.writeInt(writer, metas.length)
-    offset += IndexUtils.INT_SIZE
-    val tempWriter = new ByteArrayOutputStream()
-    metas.foreach(meta => {
-      nnkw.writeKey(tempWriter, meta.row)
-      IndexUtils.writeInt(writer, meta.curMaxId)
-      IndexUtils.writeInt(writer, meta.accumulatorCnt)
-      IndexUtils.writeInt(writer, tempWriter.size())
-      offset += 12
-    })
-    writer.write(tempWriter.toByteArray)
-    offset += tempWriter.size
-    offset
-  }
-
   override def read(fiberCache: FiberCache, offset: Int): Int = {
     var readOffset = super.read(fiberCache, offset) + offset
 
@@ -228,6 +183,7 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
 
     // start writing
     IndexUtils.writeInt(writer, metas.length)
+    offset += IndexUtils.INT_SIZE
     val tempWriter = new ByteArrayOutputStream()
     metas.foreach(meta => {
       nnkw.writeKey(tempWriter, meta.row)
@@ -236,8 +192,8 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
       IndexUtils.writeInt(writer, tempWriter.size())
       offset += 12
     })
-    offset += tempWriter.size
     writer.write(tempWriter.toByteArray)
+    offset += tempWriter.size
     offset
   }
 

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -724,7 +724,21 @@ object SQLConf {
       .internal()
       .doc("To indicate if enable/disable index cbo which helps to choose a fast query path")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
+
+  val OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY =
+    SQLConfigBuilder("spark.sql.oap.oindex.file.policy")
+      .internal()
+      .doc("To indicate if enable/disable file based index selection")
+      .booleanConf
+      .createWithDefault(true)
+
+  val OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY =
+    SQLConfigBuilder("spark.sql.oap.oindex.statistics.policy")
+      .internal()
+      .doc("To indicate if enable/disable statistics based index selection")
+      .booleanConf
+      .createWithDefault(true)
 
   val OAP_INDEX_FILE_SIZE_MAX_RATIO =
     SQLConfigBuilder("spark.sql.oap.oindex.size.ratio")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -51,6 +51,7 @@ class OapPlannerSuite
            | USING oap
            | OPTIONS (path '$path3')""".stripMargin)
 
+    spark.conf.set(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, false)
     spark.experimental.extraStrategies = oapStrategies
   }
 

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -35,6 +35,9 @@ trait SharedOapContext extends SharedSQLContext {
     spark.sqlContext.setConf(SQLConf.OAP_BTREE_ROW_LIST_PART_SIZE, 64)
   }
 
+  // disable file based cbo for all test suite, as it always fails.
+  sparkConf.set(SQLConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.key, "false")
+
   protected lazy val configuration: Configuration = sparkContext.hadoopConfiguration
 
   protected implicit def sqlConf: SQLConf = sqlContext.conf


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Enable OAP_ENABLE_EXECUTOR_INDEX_SELECTION to let executors use statistics.
2. Add 2 sub-settings to control file size policy and statistics policy.
3. Fix statistics issue causes incorrect statistics reading on the full null data file.
4. Move OAP_ENABLE_EXECUTOR_INDEX_SELECTION check from oapStrategies init
   to oapStrategies apply function so that we can enable/disable them on the fly.

## How was this patch tested?
mvn test passed.
