### PR TITLE
Create a Simple Cache Strategy To Allow Fallback

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -99,11 +99,11 @@ object FiberCacheManager extends Logging {
     }
   }
 
-  def get(fiber: Fiber, conf: Configuration): FiberCache = {
+  def get(fiber: Fiber, conf: Configuration): FiberCache = synchronized {
     cacheBackend.get(fiber, conf)
   }
 
-  def removeIndexCache(indexName: String): Unit = {
+  def removeIndexCache(indexName: String): Unit = synchronized {
     logDebug(s"going to remove cache of $indexName, executor: ${SparkEnv.get.executorId}")
     logDebug("cache size before remove: " + cacheBackend.cacheCount)
     val fiberToBeRemoved = cacheBackend.getFibers.filter {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -201,6 +201,10 @@ case class DataFiber(file: DataFile, columnIndex: Int, rowGroupId: Int) extends 
         another.file.path.equals(file.path)
     case _ => false
   }
+
+  override def toString: String = {
+    s"type: DataFiber rowGroup: $rowGroupId column: $columnIndex\n\tfile: ${file.path}"
+  }
 }
 
 private[oap]
@@ -219,6 +223,10 @@ case class BTreeFiber(
         another.idx == idx &&
         another.file.equals(file)
     case _ => false
+  }
+
+  override def toString: String = {
+    s"type: BTreeFiber section: $section idx: $idx\n\tfile: $file"
   }
 }
 
@@ -241,6 +249,10 @@ case class BitmapFiber(
         another.file.equals(file)
     case _ => false
   }
+
+  override def toString: String = {
+    s"type: BitmapFiber section: $sectionIdxOfFile idx: $loadUnitIdxOfSection\n\tfile: $file"
+  }
 }
 
 private[oap] case class TestFiber(getData: () => FiberCache, name: String) extends Fiber {
@@ -251,5 +263,9 @@ private[oap] case class TestFiber(getData: () => FiberCache, name: String) exten
   override def equals(obj: Any): Boolean = obj match {
     case another: TestFiber => name.equals(another.name)
     case _ => false
+  }
+
+  override def toString: String = {
+    s"type: TestFiber name: $name"
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -17,10 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
-import java.util.concurrent.{Callable, LinkedBlockingQueue, TimeUnit}
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
 import java.util.concurrent.atomic.AtomicLong
-
-import scala.collection.JavaConverters._
 
 import com.google.common.cache._
 import org.apache.hadoop.conf.Configuration
@@ -28,6 +26,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.executor.custom.CustomManager
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.io._
 import org.apache.spark.sql.execution.datasources.oap.utils.CacheStatusSerDe
 import org.apache.spark.util.collection.BitSet
@@ -39,6 +38,43 @@ class OapFiberCacheHeartBeatMessager extends CustomManager with Logging {
   }
 }
 
+private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logging {
+
+  private val _pendingFiberSize: AtomicLong = new AtomicLong(0)
+
+  private val removalPendingQueue = new LinkedBlockingQueue[FiberCache]()
+
+  def pendingSize: Int = removalPendingQueue.size()
+
+  def addRemovalFiber(fiberCache: FiberCache): Unit = {
+    _pendingFiberSize.addAndGet(fiberCache.size())
+    removalPendingQueue.offer(fiberCache)
+    if (_pendingFiberSize.get() > maxMemory) {
+      logError("Fibers pending on removal use too much memory, " +
+          s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
+    }
+  }
+
+  override def run(): Unit = {
+    // Loop forever, TODO: provide a release function
+    while (true) {
+      val fiberCache = removalPendingQueue.take()
+      logDebug(s"Removing fiber $fiberCache ...")
+      // Block if fiber is in use.
+      while (!fiberCache.tryDispose(3000)) {
+        // Check memory usage every 3s while we are waiting fiber release.
+        if (_pendingFiberSize.get() > maxMemory) {
+          logError("Fibers pending on removal use too much memory, " +
+              s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
+        }
+      }
+      // TODO: Make log more readable
+      _pendingFiberSize.addAndGet(-fiberCache.size())
+      logDebug(s"Fiber $fiberCache removed successfully")
+    }
+  }
+}
+
 /**
  * Fiber Cache Manager
  *
@@ -46,123 +82,49 @@ class OapFiberCacheHeartBeatMessager extends CustomManager with Logging {
  */
 object FiberCacheManager extends Logging {
 
-  private class CacheGuardian(maxMemory: Long) extends Thread {
+  private val GUAVA_CACHE = "guava"
+  private val SIMPLE_CACHE = "simple"
+  private val DEFAULT_CACHE_STRATEGY = GUAVA_CACHE
 
-    private val _pendingFiberSize: AtomicLong = new AtomicLong(0)
-
-    private val removalPendingQueue = new LinkedBlockingQueue[FiberCache]()
-
-    def addRemovalFiber(fiberCache: FiberCache): Unit = {
-      _pendingFiberSize.addAndGet(fiberCache.size())
-      removalPendingQueue.offer(fiberCache)
-      if (_pendingFiberSize.get() > maxMemory) {
-        logError("Fibers pending on removal use too much memory, " +
-            s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
-      }
-    }
-
-    def pendingSize: Int = removalPendingQueue.size()
-
-    override def run(): Unit = {
-      // Loop forever, TODO: provide a release function
-      while (true) {
-        val fiberCache = removalPendingQueue.take()
-        logDebug(s"Removing fiber $fiberCache ...")
-        // Block if fiber is in use.
-        while (!fiberCache.tryDispose(3000)) {
-          // Check memory usage every 3s while we are waiting fiber release.
-          if (_pendingFiberSize.get() > maxMemory) {
-            logError("Fibers pending on removal use too much memory, " +
-                s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
-          }
-        }
-        // TODO: Make log more readable
-        _pendingFiberSize.addAndGet(-fiberCache.size())
-        logDebug(s"Fiber $fiberCache removed successfully")
-      }
+  private val cacheBackend: OapCache = {
+    val sparkEnv = SparkEnv.get
+    assert(sparkEnv != null, "Oap can't run without SparkContext")
+    val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
+    if (cacheName.equals(GUAVA_CACHE)) {
+      new GuavaOapCache(MemoryManager.cacheMemory, MemoryManager.cacheGuardianMemory)
+    } else if (cacheName.equals(SIMPLE_CACHE)) {
+      new SimpleOapCache()
+    } else {
+      throw new OapException("Unsupported cache strategy")
     }
   }
 
-  // TODO: CacheGuardian can also track cache statistics periodically
-  private val cacheGuardian = new CacheGuardian(MemoryManager.cacheGuardianMemory)
-
-  cacheGuardian.start()
-
-  // Used by test suite
-  private[filecache] def pendingSize: Int = cacheGuardian.pendingSize
+  def get(fiber: Fiber, conf: Configuration): FiberCache = {
+    cacheBackend.get(fiber, conf)
+  }
 
   def removeIndexCache(indexName: String): Unit = {
     logDebug(s"going to remove cache of $indexName, executor: ${SparkEnv.get.executorId}")
-    logDebug("cache size before remove: " + cache.size())
-    val fiberToBeRemoved = cache.asMap().keySet().asScala.filter {
+    logDebug("cache size before remove: " + cacheBackend.cacheCount)
+    val fiberToBeRemoved = cacheBackend.getFibers.filter {
       case BTreeFiber(_, file, _, _) => file.contains(indexName)
       case BitmapFiber(_, file, _, _) => file.contains(indexName)
       case _ => false
-    }.asJava
-    cache.invalidateAll(fiberToBeRemoved)
-    logDebug("cache size after remove: " + cache.size())
+    }
+    cacheBackend.invalidateAll(fiberToBeRemoved)
+    logDebug("cache size after remove: " + cacheBackend.cacheCount)
   }
 
   // Used by test suite
   private[filecache] def removeFiber(fiber: TestFiber): Unit = synchronized {
     // cache may be removed by other thread before invalidate
     // but it's ok since only used by test to simulate race condition
-    if (cache.getIfPresent(fiber) != null) cache.invalidate(fiber)
-  }
-
-  private val removalListener = new RemovalListener[Fiber, FiberCache] {
-    override def onRemoval(notification: RemovalNotification[Fiber, FiberCache]): Unit = {
-      // TODO: Change the log more readable
-      logDebug(s"Add Cache ${notification.getKey} into removal list")
-      cacheGuardian.addRemovalFiber(notification.getValue)
-      _cacheSize.addAndGet(-notification.getValue.size())
-    }
-  }
-
-  private val weigher = new Weigher[Fiber, FiberCache] {
-    override def weigh(key: Fiber, value: FiberCache): Int =
-      math.ceil(value.size() / MB).toInt
-  }
-
-  private val MB: Double = 1024 * 1024
-  private val MAX_WEIGHT = (MemoryManager.cacheMemory / MB).toInt
-
-  // Total cached size for debug purpose
-  private val _cacheSize: AtomicLong = new AtomicLong(0)
-
-  /**
-   * To avoid storing configuration in each Cache, use a loader.
-   * After all, configuration is not a part of Fiber.
-   */
-  private def cacheLoader(fiber: Fiber, configuration: Configuration) =
-    new Callable[FiberCache] {
-      override def call(): FiberCache = {
-        logDebug(s"Loading Cache $fiber")
-        val fiberCache = fiber.fiber2Data(configuration)
-        _cacheSize.addAndGet(fiberCache.size())
-        fiberCache
-      }
-    }
-
-  private val cache = CacheBuilder
-    .newBuilder()
-    .recordStats()
-    .removalListener(removalListener)
-    .maximumWeight(MAX_WEIGHT)
-    .weigher(weigher)
-    .build[Fiber, FiberCache]()
-
-  def get(fiber: Fiber, conf: Configuration): FiberCache = synchronized {
-    val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
-    // Avoid loading a fiber larger than MAX_WEIGHT / 4, 4 is concurrency number
-    assert(fiberCache.size() <= MAX_WEIGHT * MB / 4, "Can't cache fiber larger than MAX_WEIGHT / 4")
-    fiberCache.occupy()
-    fiberCache
+    if (cacheBackend.getIfPresent(fiber) != null) cacheBackend.invalidate(fiber)
   }
 
   // TODO: test case, consider data eviction, try not use DataFileHandle which my be costly
   private[filecache] def status: String = {
-    val dataFibers = cache.asMap().keySet().asScala.collect {
+    val dataFibers = cacheBackend.getFibers.collect {
       case fiber: DataFiber => fiber
     }
 
@@ -178,9 +140,12 @@ object FiberCacheManager extends Logging {
     CacheStatusSerDe.serialize(statusRawData)
   }
 
-  def cacheStats: CacheStats = cache.stats()
+  def cacheStats: CacheStats = cacheBackend.cacheStats
 
-  def cacheSize: Long = _cacheSize.get()
+  def cacheSize: Long = cacheBackend.cacheSize
+
+  // Used by test suite
+  private[filecache] def pendingSize: Int = cacheBackend.pendingSize
 }
 
 private[oap] object DataFileHandleCacheManager extends Logging {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -89,8 +89,7 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
 
   private val removalListener = new RemovalListener[Fiber, FiberCache] {
     override def onRemoval(notification: RemovalNotification[Fiber, FiberCache]): Unit = {
-      // TODO: Change the log more readable
-      logDebug(s"Add Cache ${notification.getKey} into removal list")
+      logDebug(s"Add Cache into removal list: ${notification.getKey}")
       cacheGuardian.addRemovalFiber(notification.getValue)
       _cacheSize.addAndGet(-notification.getValue.size())
     }
@@ -108,7 +107,7 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
   private def cacheLoader(fiber: Fiber, configuration: Configuration) =
     new Callable[FiberCache] {
       override def call(): FiberCache = {
-        logDebug(s"Loading Cache $fiber")
+        logDebug(s"Loading Cache: $fiber")
         val fiberCache = fiber.fiber2Data(configuration)
         _cacheSize.addAndGet(fiberCache.size())
         fiberCache

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.filecache
+
+import java.util.concurrent.Callable
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.collection.JavaConverters._
+
+import com.google.common.cache._
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.internal.Logging
+
+trait OapCache {
+  def get(fiber: Fiber, conf: Configuration): FiberCache
+  def getIfPresent(fiber: Fiber): FiberCache
+  def getFibers: Set[Fiber]
+  def invalidate(fiber: Fiber): Unit
+  def invalidateAll(fibers: Iterable[Fiber]): Unit
+  def cacheSize: Long
+  def cacheCount: Long
+  // TODO: To be compatible with some test cases. But we shouldn't rely on Guava in trait.
+  def cacheStats: CacheStats
+  def pendingSize: Int
+}
+
+class SimpleOapCache extends OapCache with Logging {
+
+  // We don't bother the memory use of Simple Cache
+  private val cacheGuardian = new CacheGuardian(Int.MaxValue)
+  cacheGuardian.start()
+
+  override def get(fiber: Fiber, conf: Configuration): FiberCache = {
+    val fiberCache = fiber.fiber2Data(conf)
+    // We only use fiber for once, and CacheGuardian will dispose it after release.
+    cacheGuardian.addRemovalFiber(fiberCache)
+    fiberCache
+  }
+
+  override def getIfPresent(fiber: Fiber): FiberCache = null
+
+  override def getFibers: Set[Fiber] = {
+    Set.empty
+  }
+
+  override def invalidate(fiber: Fiber): Unit = {}
+
+  override def invalidateAll(fibers: Iterable[Fiber]): Unit = {}
+
+  override def cacheSize: Long = 0
+
+  override def cacheStats: CacheStats = {
+    new CacheStats(0, 0, 0, 0, 0, 0)
+  }
+
+  override def cacheCount: Long = 0
+
+  override def pendingSize: Int = cacheGuardian.pendingSize
+}
+
+class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCache with Logging {
+
+  // TODO: CacheGuardian can also track cache statistics periodically
+  private val cacheGuardian = new CacheGuardian(cacheGuardianMemory)
+  cacheGuardian.start()
+
+  private val MB: Double = 1024 * 1024
+  private val MAX_WEIGHT = (cacheMemory / MB).toInt
+
+  // Total cached size for debug purpose
+  private val _cacheSize: AtomicLong = new AtomicLong(0)
+
+  private val removalListener = new RemovalListener[Fiber, FiberCache] {
+    override def onRemoval(notification: RemovalNotification[Fiber, FiberCache]): Unit = {
+      // TODO: Change the log more readable
+      logDebug(s"Add Cache ${notification.getKey} into removal list")
+      cacheGuardian.addRemovalFiber(notification.getValue)
+      _cacheSize.addAndGet(-notification.getValue.size())
+    }
+  }
+
+  private val weigher = new Weigher[Fiber, FiberCache] {
+    override def weigh(key: Fiber, value: FiberCache): Int =
+      math.ceil(value.size() / MB).toInt
+  }
+
+  /**
+   * To avoid storing configuration in each Cache, use a loader.
+   * After all, configuration is not a part of Fiber.
+   */
+  private def cacheLoader(fiber: Fiber, configuration: Configuration) =
+    new Callable[FiberCache] {
+      override def call(): FiberCache = {
+        logDebug(s"Loading Cache $fiber")
+        val fiberCache = fiber.fiber2Data(configuration)
+        _cacheSize.addAndGet(fiberCache.size())
+        fiberCache
+      }
+    }
+
+  private val cache = CacheBuilder.newBuilder()
+    .recordStats()
+    .removalListener(removalListener)
+    .maximumWeight(MAX_WEIGHT)
+    .weigher(weigher)
+    .build[Fiber, FiberCache]()
+
+  override def get(fiber: Fiber, conf: Configuration): FiberCache = synchronized {
+    val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
+    // Avoid loading a fiber larger than MAX_WEIGHT / 4, 4 is concurrency number
+    assert(fiberCache.size() <= MAX_WEIGHT * MB / 4, "Can't cache fiber larger than MAX_WEIGHT / 4")
+    fiberCache.occupy()
+    fiberCache
+  }
+
+  override def getIfPresent(fiber: Fiber): FiberCache = cache.getIfPresent(fiber)
+
+  override def getFibers: Set[Fiber] = {
+    cache.asMap().keySet().asScala.toSet
+  }
+
+  override def invalidate(fiber: Fiber): Unit = {
+    cache.invalidate(fiber)
+  }
+
+  override def invalidateAll(fibers: Iterable[Fiber]): Unit = {
+    cache.invalidateAll(fibers.asJava)
+  }
+
+  override def cacheSize: Long = _cacheSize.get()
+
+  override def cacheStats: CacheStats = cache.stats()
+
+  override def cacheCount: Long = cache.size()
+
+  override def pendingSize: Int = cacheGuardian.pendingSize
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -48,6 +48,7 @@ class SimpleOapCache extends OapCache with Logging {
 
   override def get(fiber: Fiber, conf: Configuration): FiberCache = {
     val fiberCache = fiber.fiber2Data(conf)
+    fiberCache.occupy()
     // We only use fiber for once, and CacheGuardian will dispose it after release.
     cacheGuardian.addRemovalFiber(fiberCache)
     fiberCache
@@ -121,7 +122,7 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
     .weigher(weigher)
     .build[Fiber, FiberCache]()
 
-  override def get(fiber: Fiber, conf: Configuration): FiberCache = synchronized {
+  override def get(fiber: Fiber, conf: Configuration): FiberCache = {
     val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
     // Avoid loading a fiber larger than MAX_WEIGHT / 4, 4 is concurrency number
     assert(fiberCache.size() <= MAX_WEIGHT * MB / 4, "Can't cache fiber larger than MAX_WEIGHT / 4")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -17,10 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
-import java.util.concurrent.{Callable, Executors, ThreadFactory, TimeUnit}
-import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.{Callable, Executors, TimeUnit}
 
-import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.util.Utils
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -242,4 +242,15 @@ class FiberCacheManagerSuite extends SharedOapContext {
     pool.awaitTermination(1000, TimeUnit.MILLISECONDS)
     assert(result.get())
   }
+
+  test("test Simple Cache Strategy") {
+    val cache = new SimpleOapCache()
+    val data = generateData(10 * kbSize)
+    val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), "test simple cache fiber")
+    val fiberCache = cache.get(fiber, configuration)
+    assert(fiberCache.toArray sameElements data)
+    fiberCache.release()
+    Thread.sleep(10)
+    assert(fiberCache.isDisposed)
+  }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -80,7 +80,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     }
     val threads = (0 until 5).map(i => new FiberTestRunner(i))
     threads.foreach(_.start())
-    threads.foreach(_.join(5000))
+    threads.foreach(_.join(10000))
     threads.foreach(t => assert(!t.isAlive))
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current cache may have potential problems, we should provide a more simple but stable strategy to fallback if anything happen.
Simple Strategy:
Every time, get entry from cache will compute the entry.
Every time, release entry will dispose the entry


## How was this patch tested?

Unit test pass, add one new test case
