### PR TITLE
The assert(BitMap index supports the column with one single field) in…#486

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -103,8 +103,6 @@ private[oap] class BitmapIndexRecordWriter(
 
   private def writeUniqueKeyList(): Unit = {
     val ordering = GenerateOrdering.create(keySchema)
-    // Currently OAP index type supports the column with one single field.
-    assert(keySchema.fields.size == 1)
     bmUniqueKeyList = rowMapBitmap.keySet.toList.sorted(ordering)
     val bos = new ByteArrayOutputStream()
     bmUniqueKeyList.foreach(key => nnkw.writeKey(bos, key))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -115,10 +115,13 @@ case class CreateIndex(
             BTreeIndexEntry(schema.map(_.name).toIndexedSeq.indexOf(c.columnName), dir)
           })
           metaBuilder.addIndexMeta(new IndexMeta(indexName, time, BTreeIndex(entries)))
-        case BitMapIndexType =>
+        // Currently OAP index type supports the column with one single field.
+        case BitMapIndexType if indexColumns.length == 1 =>
           val entries = indexColumns.map(col =>
             schema.map(_.name).toIndexedSeq.indexOf(col.columnName))
           metaBuilder.addIndexMeta(new IndexMeta(indexName, time, BitMapIndex(entries)))
+        case BitMapIndexType =>
+          sys.error(s"BitMapIndexType supports the column with one single field")
         case _ =>
           sys.error(s"Not supported index type $indexType")
       }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexSuite.scala
@@ -129,4 +129,14 @@ class BitMapIndexSuite extends QueryTest with SharedOapContext with BeforeAndAft
       result.toDF("key", "value"))
     sql("drop oindex index_bf on oap_test")
   }
+
+  test("BitMap index supports the column with one single field") {
+    val data: Seq[(Int, String)] = (0 to 200).map {i => (i, null)}
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
+    val message = intercept[RuntimeException] {
+      sql("create oindex index_bf on oap_test (a, b) USING BITMAP")
+    }.getMessage
+    assert(message.equals("BitMapIndexType supports the column with one single field"))
+  }
 }


### PR DESCRIPTION
… Driver is better than in Executor.

## What changes were proposed in this pull request?
Add  assert in indexPlans.scala
Delete assert in BitmapIndexRecordWriter.scala

## How was this patch tested?
existing tests all passed.

add a new test in BitMapIndexSuite.scala 
test("BitMap index supports the column with one single field") 
