### PR TITLE
Add support for travis cluster test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: java
-script: mvn test
+cache:
+  directories:
+    - $HOME/.m2
+script: mvn test -q -e

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/ClusterTestSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/ClusterTestSuite.scala
@@ -44,8 +44,6 @@ class ClusterTestSuite extends QueryTest with ClusterTestContext {
     assert((s"wget -q -t ${wgetRetryTimes} -P ${workDir}" +
       s" https://archive.apache.org/dist/spark/spark-2.1.0/${sparkVersion}.tgz" !) == 0)
     assert((s"tar -xf ${workDir}/${sparkVersion}.tgz -C ${workDir}" !) == 0)
-    assert((("echo \"spark.yarn.jars=" + sparkHome + "/jars/*.jar\" > " +
-      sparkHome + "/conf/spark-defaults.conf") !) == 0)
     assert(("echo \"localhost\" > " + s"${sparkHome}/conf/slaves" !) == 0)
     assert((s"${sparkHome}/sbin/start-master.sh --ip localhost --port 7077" #&&
       s"${sparkHome}/sbin/start-slave.sh spark://localhost:7077" !) == 0)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/ClusterTestSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/ClusterTestSuite.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import sys.process._
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.oap.ClusterTestContext
+import org.apache.spark.util.Utils
+
+class ClusterTestSuite extends QueryTest with ClusterTestContext {
+
+  import testImplicits._
+
+  private val wgetRetryTimes = 25
+  private var currentPath: String = _
+
+  private val workDir = ("pwd" !!).replace("\n", "") + "/spark"
+  private val sparkVersion = "spark-2.1.0-bin-hadoop2.7"
+  private val sparkHome = s"${workDir}/${sparkVersion}"
+
+  /**
+   * Prepare Spark in Travis Platform and other work.
+   */
+  override def beforeAll(): Unit = {
+    // prepare spark and start it in standalone mode
+    assert(("test -e spark" #|| "mkdir spark" !) == 0)
+    assert((s"wget -q -t ${wgetRetryTimes} -P ${workDir}" +
+      s" https://archive.apache.org/dist/spark/spark-2.1.0/${sparkVersion}.tgz" !) == 0)
+    assert((s"tar -xf ${workDir}/${sparkVersion}.tgz -C ${workDir}" !) == 0)
+    assert((("echo \"spark.yarn.jars=" + sparkHome + "/jars/*.jar\" > " +
+      sparkHome + "/conf/spark-defaults.conf") !) == 0)
+    assert(("echo \"localhost\" > " + s"${sparkHome}/conf/slaves" !) == 0)
+    assert((s"${sparkHome}/sbin/start-master.sh --ip localhost --port 7077" #&&
+      s"${sparkHome}/sbin/start-slave.sh spark://localhost:7077" !) == 0)
+    super.beforeAll()
+  }
+
+  /**
+   * Clean related directory.
+   */
+  protected override def afterAll(): Unit = {
+    super.afterAll()
+    assert((s"${sparkHome}/sbin/stop-master.sh" #&&
+      s"${sparkHome}/sbin/stop-slave.sh" !) == 0)
+    assert((s"rm -rf ${workDir}/../spark" !) == 0)
+  }
+
+  override def beforeEach(): Unit = {
+    spark.conf.set(SQLConf.OAP_INDEXER_CHOICE_MAX_SIZE.key, "2")
+    spark.conf.set(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "true")
+    spark.conf.set(SQLConf.OAP_INDEX_FILE_SIZE_MAX_RATIO.key, "1000")
+    val path = Utils.createTempDir().getAbsolutePath
+    currentPath = path
+    sql(
+      s"""CREATE TEMPORARY VIEW oap_test (a INT, b INT, c INT)
+         | USING oap
+         | OPTIONS (path '$path')""".stripMargin)
+
+    sql(
+      s"""CREATE TEMPORARY VIEW parquet_test (a INT, b INT, c INT)
+         | USING parquet
+         | OPTIONS (path '$path')""".stripMargin)
+  }
+
+  override def afterEach(): Unit = {
+    sqlContext.dropTempTable("oap_test")
+    sqlContext.dropTempTable("parquet_test")
+    spark.conf.unset(SQLConf.OAP_INDEXER_CHOICE_MAX_SIZE.key)
+    spark.conf.unset(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key)
+    spark.conf.unset(SQLConf.OAP_INDEX_FILE_SIZE_MAX_RATIO.key)
+  }
+
+  test("filtering parquet in cluster mode") {
+    val data: Seq[(Int, Int, Int)] = (1 to 200).map { i => (i % 13, (300 - i) % 17, i) }
+    data.toDF("a", "b", "c").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
+    sql("create oindex index1 on parquet_test (a)")
+    sql("create oindex index2 on parquet_test (b) USING BITMAP")
+
+    checkAnswer(sql("SELECT c FROM parquet_test WHERE a = 1 and b = 10"),
+      Row(1) :: Nil)
+
+    checkAnswer(sql("SELECT c FROM parquet_test WHERE a > 3 and a < 5 and b = 14"),
+      Row(82) :: Nil)
+
+    checkAnswer(sql("SELECT c FROM parquet_test WHERE a > 3 and a < 5 and b = 14 and c > 30"),
+      Row(82) :: Nil)
+
+    sql("drop oindex index1 on parquet_test")
+    sql("drop oindex index2 on parquet_test")
+
+    sql("create oindex index1 on parquet_test (a,b)")
+    sql("create oindex index2 on parquet_test (c)")
+
+    checkAnswer(sql("SELECT c FROM parquet_test WHERE a = 3 and b > 14 and c > 30"),
+      Row(81) :: Nil)
+
+    checkAnswer(sql("SELECT c FROM parquet_test WHERE a = 3 and b > 14 and c > 300"),
+      Nil)
+
+    sql("drop oindex index1 on parquet_test")
+    sql("drop oindex index2 on parquet_test")
+  }
+
+  test("filtering oap in cluster mode") {
+    val data: Seq[(Int, Int, Int)] = (1 to 200).map { i => (i % 13, (300 - i) % 17, i) }
+    data.toDF("a", "b", "c").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
+    sql("create oindex index1 on oap_test (a)")
+    sql("create oindex index2 on oap_test (b)  USING BITMAP")
+
+    checkAnswer(sql("SELECT c FROM oap_test WHERE a = 1 and b = 10"),
+      Row(1) :: Nil)
+
+    checkAnswer(sql("SELECT c FROM oap_test WHERE a > 3 and a < 5 and b = 14"),
+      Row(82) :: Nil)
+
+    checkAnswer(sql("SELECT c FROM oap_test WHERE a > 3 and a < 5 and b = 14 and c > 30"),
+      Row(82) :: Nil)
+
+    sql("drop oindex index1 on oap_test")
+    sql("drop oindex index2 on oap_test ")
+
+
+    sql("create oindex index1 on oap_test (a,b)")
+    sql("create oindex index2 on oap_test (c)")
+
+    checkAnswer(sql("SELECT c FROM oap_test WHERE a = 3 and b > 14 and c > 30"),
+      Row(81) :: Nil)
+
+    checkAnswer(sql("SELECT c FROM oap_test WHERE a = 3 and b > 14 and c > 300"), Nil)
+
+    sql("drop oindex index1 on oap_test")
+    sql("drop oindex index2 on oap_test")
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/test/oap/ClusterTestContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/ClusterTestContext.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test.oap
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.{DebugFilesystem, SparkConf, SparkContext}
+import org.apache.spark.sql.{SparkSession, SQLContext}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+
+
+/**
+ * Helper trait for SQL test suites for OAP in cluster mode.
+ * All cluster tests share a single [[ClusterTestSparkSession]].
+ */
+trait ClusterTestContext extends SQLTestUtils with BeforeAndAfterEach {
+
+  protected val sparkConf = new SparkConf()
+
+  // avoid the overflow of offHeap memory
+  sparkConf.set("spark.memory.offHeap.size", "100m")
+
+  protected lazy val configuration: Configuration = sparkContext.hadoopConfiguration
+
+  protected implicit def sqlConf: SQLConf = sqlContext.conf
+
+  /**
+   * The [[ClusterTestSparkSession]] to use for all tests in this suite.
+   */
+  private var _spark: ClusterTestSparkSession = null
+
+  /**
+   * The [[ClusterTestSparkSession]] to use for all tests in this suite.
+   */
+  protected implicit def spark: SparkSession = _spark
+
+  /**
+   * The [[ClusterTestSQLContext]] to use for all tests in this suite.
+   */
+  protected implicit def sqlContext: SQLContext = _spark.sqlContext
+
+  protected def createSparkSession: ClusterTestSparkSession = {
+    new ClusterTestSparkSession(
+      sparkConf.set("spark.hadoop.fs.file.impl", classOf[DebugFilesystem].getName))
+  }
+
+  /**
+   * Initialize the [[ClusterTestSparkSession]].
+   */
+  protected override def beforeAll(): Unit = {
+    SparkSession.sqlListener.set(null)
+    if (_spark == null) {
+      SparkContext.clearActiveContext()
+      _spark = createSparkSession
+    }
+    _spark.sqlContext.setConf(SQLConf.OAP_BTREE_ROW_LIST_PART_SIZE, 64)
+    // Ensure we have initialized the context before calling parent code
+    super.beforeAll()
+  }
+
+  /**
+   * Stop the underlying [[org.apache.spark.SparkContext]], if any.
+   */
+  protected override def afterAll(): Unit = {
+    try {
+      if (_spark != null) {
+        _spark.stop()
+        _spark = null
+      }
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  protected override def beforeEach(): Unit = {
+    super.beforeEach()
+    DebugFilesystem.clearOpenStreams()
+  }
+
+  protected override def afterEach(): Unit = {
+    super.afterEach()
+    DebugFilesystem.assertNoOpenStreams()
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/test/oap/ClusterTestSparkSession.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/ClusterTestSparkSession.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test.oap
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.{SessionState, SQLConf}
+import org.apache.spark.sql.test.SQLTestData
+
+/**
+ * A special [[SparkSession]] prepared for testing OAP in cluster mode.
+ * Test in standalone mode instead of local mode in [[org.apache.spark.sql.test.TestSparkSession]].
+ */
+private[sql] class ClusterTestSparkSession(sc: SparkContext) extends SparkSession(sc) {
+  self =>
+  protected val sparkConf = new SparkConf()
+
+  def this(sparkConf: SparkConf) {
+    this(new SparkContext("spark://localhost:7077", "test-sql-context",
+      sparkConf.set("spark.sql.testkey", "true")))
+  }
+
+  def this() {
+    this(new SparkConf)
+  }
+
+  @transient
+  protected[sql] override lazy val sessionState: SessionState = new SessionState(self) {
+    override lazy val conf: SQLConf = {
+      new SQLConf {
+        clear()
+
+        override def clear(): Unit = {
+          super.clear()
+          // Make sure we start with the default test configs even after clear
+          ClusterTestSQLContext.overrideConfs.foreach {
+            case (key, value) => setConfString(key, value)
+          }
+        }
+      }
+    }
+  }
+
+  // Needed for Java tests
+  def loadTestData(): Unit = {
+    testData.loadTestData()
+  }
+
+  private object testData extends SQLTestData {
+    protected override def spark: SparkSession = self
+  }
+
+}
+
+
+private[sql] object ClusterTestSQLContext {
+
+  /**
+   * A map used to store all confs that need to be overridden in sql/core unit tests.
+   */
+  val overrideConfs: Map[String, String] =
+    Map(
+      // Fewer shuffle partitions to speed up testing.
+      SQLConf.SHUFFLE_PARTITIONS.key -> "5")
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

To simulate cluster test on travis platform, a new cluster test spark session and context are added.
This uses a standalone environment instead of local mode. Besides, a new suite for cluster test is added, which configs spark environment through calling shell commands via scala.


## How was this patch tested?

Tested successfully on travis for all test cases in current suites.


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

