### PR TITLE
Create CacheGuardian To Handle Fiber Removal

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -96,6 +96,7 @@ object FiberCacheManager extends Logging {
       // TODO: Change the log more readable
       logDebug(s"Add Cache ${notification.getKey} into removal list")
       removalPendingQueue.offer(notification.getValue)
+      // TODO: Reduce cache size until CacheGuardian removed it?
       _cacheSize.addAndGet(-notification.getValue.size())
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -128,15 +128,15 @@ object FiberCacheManager extends Logging {
   private val cache = CacheBuilder
     .newBuilder()
     .recordStats()
-    .concurrencyLevel(4)
+    .concurrencyLevel(4) // TODO: Make 4 configurable
     .removalListener(removalListener)
     .maximumWeight(MAX_WEIGHT)
     .weigher(weigher)
     .build[Fiber, FiberCache]()
 
   def get(fiber: Fiber, conf: Configuration): FiberCache = {
-    // TODO: Should avoid loading a fiber larger than MAX_WEIGHT
     val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
+    // Avoid loading a fiber larger than MAX_WEIGHT / 4, 4 is concurrency number
     assert(fiberCache.size() <= MAX_WEIGHT * MB / 4, "Can't cache fiber larger than MAX_WEIGHT / 4")
     fiberCache.occupy()
     fiberCache

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -56,7 +56,7 @@ object FiberCacheManager extends Logging {
         val fiberCache = queue.take()
         logDebug(s"Removing fiber $fiberCache ...")
         // Block if fiber is in use.
-        while (!fiberCache.dispose(3000, TimeUnit.MILLISECONDS)) {
+        while (!fiberCache.tryDispose(3000, TimeUnit.MILLISECONDS)) {
           // Check memory usage every 3s while we are waiting fiber release.
           if (queue.asScala.map(_.size()).sum > maxMemory) {
             logWarning("Fibers pending on removal use too much memory")

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -104,7 +104,7 @@ object FiberCacheManager extends Logging {
   }
 
   // Used by test suite
-  private[filecache] def removeFiber(fiber: TestFiber): Unit = {
+  private[filecache] def removeFiber(fiber: TestFiber): Unit = synchronized {
     // cache may be removed by other thread before invalidate
     // but it's ok since only used by test to simulate race condition
     if (cache.getIfPresent(fiber) != null) cache.invalidate(fiber)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -111,7 +111,11 @@ object FiberCacheManager extends Logging {
   def get(fiber: Fiber, conf: Configuration): FiberCache = synchronized {
     // Used a flag called disposed in FiberCache to indicate if this FiberCache is removed
     val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
-    if (exceptionFlag) throw new OapException("Can't remove in-used fiber within 3 seconds")
+    if (exceptionFlag) {
+      // Here we don't check the refCount since we will throw exception
+      cache.asMap().values().asScala.foreach(_.dispose())
+      throw new OapException("Can't remove in-used fiber within 3 seconds")
+    }
     fiberCache.refCount.incrementAndGet()
     fiberCache
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -103,6 +103,13 @@ object FiberCacheManager extends Logging {
     logDebug("cache size after remove: " + cache.size())
   }
 
+  // Used by test suite
+  private[filecache] def removeFiber(fiber: TestFiber): Unit = {
+    // cache may be removed by other thread before invalidate
+    // but it's ok since only used by test to simulate race condition
+    if (cache.getIfPresent(fiber) != null) cache.invalidate(fiber)
+  }
+
   private val removalListener = new RemovalListener[Fiber, FiberCache] {
     override def onRemoval(notification: RemovalNotification[Fiber, FiberCache]): Unit = {
       // TODO: Change the log more readable

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.{Condition, ReentrantLock}
+import javax.annotation.concurrent.GuardedBy
 
 import org.apache.hadoop.fs.FSDataInputStream
 
@@ -39,6 +40,7 @@ trait FiberCache {
   // In our design, fiberData should be a internal member.
   protected def fiberData: MemoryBlock
 
+  @GuardedBy("lock")
   private var _refCount: Long = 0L
   def refCount: Long = _refCount
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.{Condition, ReentrantLock}
 
 import org.apache.hadoop.fs.FSDataInputStream
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -66,7 +66,7 @@ trait FiberCache {
     }
   }
 
-  def dispose(time: Long, unit: TimeUnit): Boolean = {
+  def tryDispose(time: Long, unit: TimeUnit): Boolean = {
     var nanos = unit.toNanos(time)
     lock.lockInterruptibly()
     try {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -55,7 +55,7 @@ trait FiberCache extends Logging {
   def tryDispose(timeout: Long): Boolean = synchronized {
     val startTime = System.currentTimeMillis()
     // Give caller a chance to deal with the long wait case.
-    while (System.currentTimeMillis() - startTime > timeout) {
+    while (System.currentTimeMillis() - startTime <= timeout) {
       if (_refCount > 0) {
         try {
           wait(100)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -38,11 +38,17 @@ trait FiberCache {
   protected def fiberData: MemoryBlock
 
   val refCount = new AtomicLong(0)
-  val nonUsed: Condition = new ReentrantLock().newCondition()
+  val lock = new ReentrantLock()
+  val nonUsed: Condition = lock.newCondition()
 
   def release(): Unit = {
     if (refCount.decrementAndGet() == 0) {
-      nonUsed.signal()
+      lock.lock()
+      try {
+        nonUsed.signal()
+      } finally {
+        lock.unlock()
+      }
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -58,7 +58,9 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
     val offset = footer.getStatsOffset
 
     val stats = StatisticsManager.read(footerCache, offset, keySchema)
-    StatisticsManager.analyse(stats, intervalArray, conf)
+    val result = StatisticsManager.analyse(stats, intervalArray, conf)
+    footerCache.release()
+    result
   }
 
   override def hasNext: Boolean = recordReader.hasNext

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
@@ -186,7 +186,7 @@ private[index] case class BTreeIndexRecordReader(
   }
 
   private def releaseCache(cache: FiberCache, fiber: BTreeFiber): Unit = {
-    // TODO: Release FiberCache's usage number
+    cache.release()
   }
 
   def close(): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -83,19 +83,23 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
       true
     } else {
       if (bmFooterFiber != null) {
-        // TODO: release bmFooterCache usage number
+        bmFooterCache.release()
       }
 
       if (bmUniqueKeyListFiber != null) {
-        // TODO: release bmUniqueKeyListCache usage number
+        bmUniqueKeyListCache.release()
       }
 
       if (bmOffsetListFiber != null) {
-        // TODO: release bmOffsetListCache usage number
+        bmOffsetListCache.release()
       }
 
       if (bmEntryListFiber != null) {
-        // TODO: release bmEntryListCache usage number
+        bmEntryListCache.release()
+      }
+
+      if (bmNullListFiber != null) {
+        bmNullListCache.release()
       }
       false
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -108,7 +108,7 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
   }
 
   def closeRowGroup(fiber: Fiber, fiberCache: FiberCache): Unit = {
-    // TODO: Release fiberCache's usage number
+    fiberCache.release()
   }
 
   // full file scan

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -115,15 +115,15 @@ class FiberCacheManagerSuite extends SharedOapContext {
     // release fibers so it has chance to be disposed immediately
     fibers.foreach(FiberCacheManager.get(_, configuration).release())
     Thread.sleep(1000)
-    assert(FiberCacheManager.removalPendingQueueSize == 0)
+    assert(FiberCacheManager.pendingSize == 0)
     // Hold the fiber, so it can't be disposed until release
     val fiberCaches = fibers.map(FiberCacheManager.get(_, configuration))
     Thread.sleep(1000)
-    assert(FiberCacheManager.removalPendingQueueSize > 0)
+    assert(FiberCacheManager.pendingSize > 0)
     // After release, CacheGuardian should be back to work
     fiberCaches.foreach(_.release())
     // Wait some time for CacheGuardian being waken-up
     Thread.sleep(1000)
-    assert(FiberCacheManager.removalPendingQueueSize == 0)
+    assert(FiberCacheManager.pendingSize == 0)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -80,7 +80,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     }
     val threads = (0 until 5).map(i => new FiberTestRunner(i))
     threads.foreach(_.start())
-    threads.foreach(_.join(3000))
+    threads.foreach(_.join(5000))
     threads.foreach(t => assert(!t.isAlive))
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
-import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.util.Utils
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -106,22 +106,24 @@ class FiberCacheManagerSuite extends SharedOapContext {
   }
 
   test("cache guardian remove pending fibers") {
-    Thread.sleep(500) // Wait some time for CacheGuardian to remove pending fibers
+    Thread.sleep(1000) // Wait some time for CacheGuardian to remove pending fibers
     val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
     val fibers = (1 to memorySizeInMB * 2).map { i =>
       val data = generateData(mbSize)
       TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #0.$i")
     }
-    // release some fibers so it has chance to be disposed immediately
+    // release fibers so it has chance to be disposed immediately
     fibers.foreach(FiberCacheManager.get(_, configuration).release())
-    assert(FiberCacheManager.removalPendingQueue.size() == 0)
+    Thread.sleep(1000)
+    assert(FiberCacheManager.removalPendingQueueSize == 0)
     // Hold the fiber, so it can't be disposed until release
     val fiberCaches = fibers.map(FiberCacheManager.get(_, configuration))
-    assert(FiberCacheManager.removalPendingQueue.size() > 0)
+    Thread.sleep(1000)
+    assert(FiberCacheManager.removalPendingQueueSize > 0)
     // After release, CacheGuardian should be back to work
     fiberCaches.foreach(_.release())
     // Wait some time for CacheGuardian being waken-up
-    Thread.sleep(500)
-    assert(FiberCacheManager.removalPendingQueue.size() == 0)
+    Thread.sleep(1000)
+    assert(FiberCacheManager.removalPendingQueueSize == 0)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -39,6 +39,8 @@ class FiberCacheManagerSuite extends SharedOapContext {
       val fiberCache2 = FiberCacheManager.get(fiber, configuration)
       assert(fiberCache.toArray sameElements data)
       assert(fiberCache2.toArray sameElements data)
+      fiberCache.release()
+      fiberCache2.release()
     }
     val stats = FiberCacheManager.cacheStats.minus(origStats)
     assert(stats.missCount() == memorySizeInMB * 2)
@@ -56,8 +58,10 @@ class FiberCacheManagerSuite extends SharedOapContext {
       val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #$i")
       val fiberCache = FiberCacheManager.get(fiber, configuration)
       assert(fiberCache.toArray sameElements data)
+      fiberCache.release()
     }
     assert(fiberCacheInUse.isDisposed)
+    fiberCacheInUse.release()
   }
 
   test("add a very large fiber") {
@@ -66,6 +70,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     val data = generateData(memorySizeInMB * mbSize / 8)
     val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #0")
     val fiberCache = FiberCacheManager.get(fiber, configuration)
+    fiberCache.release()
     assert(!fiberCache.isDisposed)
 
     val data1 = generateData(memorySizeInMB * mbSize / 2)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -80,7 +80,8 @@ class FiberCacheManagerSuite extends SharedOapContext {
     }
     val threads = (0 until 5).map(i => new FiberTestRunner(i))
     threads.foreach(_.start())
-    threads.foreach(_.join())
+    threads.foreach(_.join(3000))
+    threads.foreach(t => assert(!t.isAlive))
   }
 
   test("add a very large fiber") {
@@ -183,7 +184,8 @@ class FiberCacheManagerSuite extends SharedOapContext {
     val data = generateData(kbSize)
     val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"release test")
     val fiberCaches = (1 to 5).map(_ => FiberCacheManager.get(fiber, configuration))
-    fiberCaches.foreach{ fiberCache =>
+    assert(fiberCaches.head.refCount == 5)
+    fiberCaches.foreach { fiberCache =>
       pool.execute(new TestRunner(fiberCache.release()))
     }
     pool.shutdown()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -106,6 +106,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
   }
 
   test("cache guardian remove pending fibers") {
+    Thread.sleep(500) // Wait some time for CacheGuardian to remove pending fibers
     val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
     val fibers = (1 to memorySizeInMB * 2).map { i =>
       val data = generateData(mbSize)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -161,7 +161,7 @@ class MemoryManagerSuite extends SharedOapContext {
     // 1. disposed FiberCache
     val bytes = new Array[Byte](1024)
     val fiberCache = MemoryManager.putToDataFiberCache(bytes)
-    fiberCache.dispose()
+    fiberCache.realDispose()
     val exception = intercept[OapException]{
       fiberCache.getByte(0)
     }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexScannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexScannerSuite.scala
@@ -76,7 +76,6 @@ class BTreeIndexScannerSuite extends SharedOapContext {
 
   test("test binarySearch") {
     val schema = StructType(StructField("col1", IntegerType) :: Nil)
-    val reader = BTreeIndexRecordReader(configuration, schema)
     val values = Seq(1, 11, 21, 31, 41, 51, 61, 71, 81, 91)
     def keyAt(idx: Int): InternalRow = InternalRow(values(idx))
     val ordering = GenerateOrdering.create(schema)
@@ -152,6 +151,7 @@ class BTreeIndexScannerSuite extends SharedOapContext {
     // 1 <= x <= 1
     assert(reader.findRowIdRange(RangeInterval(
       InternalRow(1), InternalRow(1), includeStart = true, includeEnd = true)) === (0, 1))
+    reader.close()
   }
 
   test("findRowIdRange for isNull filter predicate: empty result") {
@@ -174,6 +174,7 @@ class BTreeIndexScannerSuite extends SharedOapContext {
           includeStart = true,
           includeEnd = true,
           isNull = true)) === (150, 150))
+    reader.close()
   }
 
   test("findRowIdRange for isNull filter predicate") {
@@ -197,6 +198,7 @@ class BTreeIndexScannerSuite extends SharedOapContext {
           includeStart = true,
           includeEnd = true,
           isNull = true)) === (150, 155))
+    reader.close()
   }
 
   test("findRowIdRange for isNotNull filter predicate: empty result") {
@@ -218,6 +220,7 @@ class BTreeIndexScannerSuite extends SharedOapContext {
           IndexScanner.DUMMY_KEY_END,
           includeStart = true,
           includeEnd = true)) === (0, 0))
+    reader.close()
   }
 
   test("findRowIdRange for isNotNull filter predicate") {
@@ -240,5 +243,6 @@ class BTreeIndexScannerSuite extends SharedOapContext {
           IndexScanner.DUMMY_KEY_END,
           includeStart = true,
           includeEnd = true)) === (0, 150))
+    reader.close()
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use a `refCount` to track fiber usage number
Only add fiber to a pending queue in onRemoval
Create a CacheGuardian to handle pending removal fibers
CacheGuardian will Wait fiber release if refCount > 0
Changed some code to ensure Fiber is release after using


## How was this patch tested?

Unit test pass, add a new test case
