### PR TITLE
Check off-heap memory#493

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -154,6 +154,9 @@ private[oap] object MemoryManager extends Logging {
   def maxMemory: Long = _maxMemory
 
   private[filecache] def allocate(numOfBytes: Int): MemoryBlock = {
+    assert(numOfBytes <= maxMemory, "The off heap memory is overflow." +
+      " Please increase heap size using spark.memory.offHeap.enabled" +
+      " and spark.memory.offHeap.size in Spark configuration.")
     _memoryUsed.getAndAdd(numOfBytes)
     logDebug(s"allocate $numOfBytes memory, used: $memoryUsed")
     MemoryAllocator.UNSAFE.allocate(numOfBytes)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -169,4 +169,15 @@ class MemoryManagerSuite extends SharedOapContext {
 
     // 2. TODO: test Invalidate MemoryBlock
   }
+
+  test("check off-heap memory overflow") {
+    // The defalue value of 'spark.memory.offHeap.size' is 100M in test cases.
+    val bytes = new Array[Byte](1024*1024*1024)
+    val exception = intercept[AssertionError]{
+      val fiberCache = MemoryManager.putToDataFiberCache(bytes)
+    }
+    assert(exception.getMessage == "assertion failed: The off heap memory is overflow." +
+      " Please increase heap size using spark.memory.offHeap.enabled" +
+      " and spark.memory.offHeap.size in Spark configuration.")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
There exits two cases:
1、Off-heap memory is disabled by default in spark,  which may be ignored by some of users.
2、one FiberCache's size > oapMaxMemory.
The hint “increase heap size ” is better than "Try to access a freed memory".

Add assertion in MemoryManager.

## How was this patch tested?

All existing test cases passed.

Add a new case in MemoryManagerSuite.
test("check off-heap memory overflow") 

