### PR TITLE
use spark QueryExecution to resolve relation during running index command

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -24,7 +24,6 @@ import org.antlr.v4.runtime.tree.TerminalNode
 
 import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.parser._
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
@@ -1413,7 +1412,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     withOrigin(ctx) {
       CreateIndexCommand(
         ctx.IDENTIFIER.getText,
-        UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())),
+        visitTableIdentifier(ctx.tableIdentifier()),
         visitIndexCols(ctx.indexCols),
         ctx.EXISTS != null, visitIndexType(ctx.indexType),
         Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
@@ -1429,7 +1428,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
   override def visitOapDropIndex(ctx: OapDropIndexContext): LogicalPlan = withOrigin(ctx) {
     DropIndexCommand(
       ctx.IDENTIFIER.getText,
-      UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier)),
+      visitTableIdentifier(ctx.tableIdentifier),
       ctx.EXISTS != null,
       Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
   }
@@ -1457,20 +1456,20 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
   override def visitOapRefreshIndices(ctx: OapRefreshIndicesContext): LogicalPlan =
     withOrigin(ctx) {
       RefreshIndexCommand(
-        UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier)),
+        visitTableIdentifier(ctx.tableIdentifier),
         Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
     }
 
   override def visitOapShowIndex(ctx: OapShowIndexContext): LogicalPlan = withOrigin(ctx) {
     val tableName = visitTableIdentifier(ctx.tableIdentifier)
-    OapShowIndexCommand(UnresolvedRelation(tableName), tableName.identifier)
+    OapShowIndexCommand(tableName, tableName.identifier)
   }
 
   override def visitOapCheckIndex(ctx: OapCheckIndexContext): LogicalPlan =
     withOrigin(ctx) {
       val tableIdentifier = visitTableIdentifier(ctx.tableIdentifier)
       OapCheckIndexCommand(
-        UnresolvedRelation(tableIdentifier),
+        tableIdentifier,
         tableIdentifier.identifier,
         Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -24,12 +24,10 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes._
-import org.apache.spark.sql.catalyst.catalog.SimpleCatalogRelation
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.oap._
@@ -42,20 +40,19 @@ import org.apache.spark.sql.types._
 /**
  * Creates an index for table on indexColumns
  */
-case class CreateIndex(
+case class CreateIndexCommand(
     indexName: String,
-    table: TableIdentifier,
+    unresolvedRelation: LogicalPlan,
     indexColumns: Array[IndexColumn],
     allowExists: Boolean,
     indexType: AnyIndexType,
     partitionSpec: Option[TablePartitionSpec]) extends RunnableCommand with Logging {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val relation =
-      EliminateSubqueryAliases(sparkSession.sessionState.catalog.lookupRelation(table)) match {
-        case r: SimpleCatalogRelation => (new FindDataSourceTable(sparkSession))(r)
-        case other => other
-      }
+    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    qe.assertAnalyzed()
+    val relation = qe.optimizedPlan
+
     val (fileCatalog, schema, readerClassName, identifier, fsRelation) = relation match {
       case LogicalRelation(
       _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id) =>
@@ -137,9 +134,6 @@ case class CreateIndex(
       (metaBuilder, parent, existOld)
     })
 
-    val partitionColumns = relation.resolve(
-      fsRelation.partitionSchema, fsRelation.sparkSession.sessionState.analyzer.resolver)
-
     val projectList = indexColumns.map { indexColumn =>
       relation.output.find(p => p.name == indexColumn.columnName).get.withMetadata(
         new MetadataBuilder().putBoolean("isAscending", indexColumn.isAscending).build())
@@ -203,20 +197,17 @@ case class CreateIndex(
 /**
  * Drops an index
  */
-case class DropIndex(
+case class DropIndexCommand(
     indexName: String,
-    table: TableIdentifier,
+    unresolvedRelation: UnresolvedRelation,
     allowNotExists: Boolean,
     partitionSpec: Option[TablePartitionSpec]) extends RunnableCommand {
 
-  override val output: Seq[Attribute] = Seq.empty
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val relation =
-      EliminateSubqueryAliases(sparkSession.sessionState.catalog.lookupRelation(table)) match {
-        case r: SimpleCatalogRelation => (new FindDataSourceTable(sparkSession))(r)
-        case other => other
-      }
+    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    qe.assertAnalyzed()
+    val relation = qe.optimizedPlan
+
     relation match {
       case LogicalRelation(HadoopFsRelation(fileCatalog, _, _, _, format, _), _, identifier)
           if format.isInstanceOf[OapFileFormat] || format.isInstanceOf[ParquetFileFormat] =>
@@ -271,18 +262,15 @@ case class DropIndex(
 /**
  * Refreshes an index for table
  */
-case class RefreshIndex(
-    table: TableIdentifier,
+case class RefreshIndexCommand(
+    unresolvedRelation: UnresolvedRelation,
     partitionSpec: Option[TablePartitionSpec]) extends RunnableCommand with Logging {
 
-  override val output: Seq[Attribute] = Seq.empty
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val relation =
-      EliminateSubqueryAliases(sparkSession.sessionState.catalog.lookupRelation(table)) match {
-        case r: SimpleCatalogRelation => (new FindDataSourceTable(sparkSession))(r)
-        case other => other
-      }
+    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    qe.assertAnalyzed()
+    val relation = qe.optimizedPlan
+
     val (fileCatalog, schema, readerClassName) = relation match {
       case LogicalRelation(
           HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, _) =>
@@ -432,7 +420,7 @@ case class RefreshIndex(
 /**
  * List indices for table
  */
-case class OapShowIndex(table: TableIdentifier, relationName: String)
+case class OapShowIndexCommand(unresolvedRelation: UnresolvedRelation, relationName: String)
     extends RunnableCommand with Logging {
 
   override val output: Seq[Attribute] = {
@@ -445,11 +433,10 @@ case class OapShowIndex(table: TableIdentifier, relationName: String)
   }
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val relation =
-      EliminateSubqueryAliases(sparkSession.sessionState.catalog.lookupRelation(table)) match {
-        case r: SimpleCatalogRelation => (new FindDataSourceTable(sparkSession))(r)
-        case other => other
-      }
+    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    qe.assertAnalyzed()
+    val relation = qe.optimizedPlan
+
     val (fileCatalog, schema) = relation match {
       case LogicalRelation(HadoopFsRelation(f, _, s, _, _, _), _, id) =>
         (f, s)
@@ -496,11 +483,11 @@ case class OapShowIndex(table: TableIdentifier, relationName: String)
  * 1. check existence of oap meta file
  * 2. check integrity of each partition directory of table for both data files
  *    and index files according to meta
- * @param table TableIdentifier of the specified table
+ * @param unresolvedRelation represents the unresolved table
  * @param tableName table name of the specified table
  */
-case class OapCheckIndex(
-    table: TableIdentifier,
+case class OapCheckIndexCommand(
+    unresolvedRelation: UnresolvedRelation,
     tableName: String,
     partitionSpec: Option[TablePartitionSpec]) extends RunnableCommand with Logging {
   override val output: Seq[Attribute] =
@@ -615,11 +602,9 @@ case class OapCheckIndex(
   }
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val relation =
-      EliminateSubqueryAliases(sparkSession.sessionState.catalog.lookupRelation(table)) match {
-        case r: SimpleCatalogRelation => (new FindDataSourceTable(sparkSession))(r)
-        case other => other
-      }
+    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    qe.assertAnalyzed()
+    val relation = qe.optimizedPlan
 
     val (fileCatalog, dataSchema) = relation match {
       case LogicalRelation(HadoopFsRelation(f, _, s, _, _, _), _, id) =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -42,14 +42,14 @@ import org.apache.spark.sql.types._
  */
 case class CreateIndexCommand(
     indexName: String,
-    unresolvedRelation: LogicalPlan,
+    table: LogicalPlan,
     indexColumns: Array[IndexColumn],
     allowExists: Boolean,
     indexType: AnyIndexType,
     partitionSpec: Option[TablePartitionSpec]) extends RunnableCommand with Logging {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    val qe = sparkSession.sessionState.executePlan(table)
     qe.assertAnalyzed()
     val relation = qe.optimizedPlan
 
@@ -199,12 +199,12 @@ case class CreateIndexCommand(
  */
 case class DropIndexCommand(
     indexName: String,
-    unresolvedRelation: UnresolvedRelation,
+    table: LogicalPlan,
     allowNotExists: Boolean,
     partitionSpec: Option[TablePartitionSpec]) extends RunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    val qe = sparkSession.sessionState.executePlan(table)
     qe.assertAnalyzed()
     val relation = qe.optimizedPlan
 
@@ -263,11 +263,11 @@ case class DropIndexCommand(
  * Refreshes an index for table
  */
 case class RefreshIndexCommand(
-    unresolvedRelation: UnresolvedRelation,
+    table: LogicalPlan,
     partitionSpec: Option[TablePartitionSpec]) extends RunnableCommand with Logging {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    val qe = sparkSession.sessionState.executePlan(table)
     qe.assertAnalyzed()
     val relation = qe.optimizedPlan
 
@@ -420,7 +420,7 @@ case class RefreshIndexCommand(
 /**
  * List indices for table
  */
-case class OapShowIndexCommand(unresolvedRelation: UnresolvedRelation, relationName: String)
+case class OapShowIndexCommand(table: LogicalPlan, relationName: String)
     extends RunnableCommand with Logging {
 
   override val output: Seq[Attribute] = {
@@ -433,7 +433,7 @@ case class OapShowIndexCommand(unresolvedRelation: UnresolvedRelation, relationN
   }
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    val qe = sparkSession.sessionState.executePlan(table)
     qe.assertAnalyzed()
     val relation = qe.optimizedPlan
 
@@ -483,11 +483,11 @@ case class OapShowIndexCommand(unresolvedRelation: UnresolvedRelation, relationN
  * 1. check existence of oap meta file
  * 2. check integrity of each partition directory of table for both data files
  *    and index files according to meta
- * @param unresolvedRelation represents the unresolved table
+ * @param table represents the unresolved table
  * @param tableName table name of the specified table
  */
 case class OapCheckIndexCommand(
-    unresolvedRelation: UnresolvedRelation,
+    table: LogicalPlan,
     tableName: String,
     partitionSpec: Option[TablePartitionSpec]) extends RunnableCommand with Logging {
   override val output: Seq[Attribute] =
@@ -602,7 +602,7 @@ case class OapCheckIndexCommand(
   }
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val qe = sparkSession.sessionState.executePlan(unresolvedRelation)
+    val qe = sparkSession.sessionState.executePlan(table)
     qe.assertAnalyzed()
     val relation = qe.optimizedPlan
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -24,7 +24,6 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}

--- a/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
@@ -22,19 +22,21 @@ import java.io.File
 import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
-import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.hive.test.TestHive
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.util.Utils
 
 
 // test OAP Index DDL&DML on Hive tables
 class HiveOapIndexDDLSuite
-  extends QueryTest with SQLTestUtils with TestHiveSingleton with BeforeAndAfterEach {
-  import spark.implicits._
+  extends QueryTest with SQLTestUtils with BeforeAndAfterEach {
+  import testImplicits._
+
+  override def spark: SparkSession = TestHive.sparkSession
 
   override def afterEach(): Unit = {
     try {
@@ -43,6 +45,11 @@ class HiveOapIndexDDLSuite
     } finally {
       super.afterEach()
     }
+  }
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
   }
 
 

--- a/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution
+
+import java.io.File
+
+import org.apache.hadoop.fs.Path
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
+import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.util.Utils
+
+
+// test OAP Index DDL&DML on Hive tables
+class HiveOapIndexDDLSuite
+  extends QueryTest with SQLTestUtils with TestHiveSingleton with BeforeAndAfterEach {
+  import spark.implicits._
+
+  override def afterEach(): Unit = {
+    try {
+      // drop all databases, tables and functions after each test
+      spark.sessionState.catalog.reset()
+    } finally {
+      super.afterEach()
+    }
+  }
+
+
+  test("create oap index on external tables in default database") {
+    withTempDir { tmpDir =>
+      val tabName = "tab1"
+      withTable(tabName) {
+        assert(tmpDir.listFiles.isEmpty)
+        (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b").createOrReplaceTempView("t")
+        sql(
+          s"""
+             |create table $tabName
+             |stored as parquet
+             |location '$tmpDir'
+             |as select * from t
+          """.stripMargin)
+
+        val hiveTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
+        assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
+
+        assert(tmpDir.listFiles.nonEmpty)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
+      }
+    }
+  }
+
+  test("drop oap index on external tables in default database") {
+    withTempDir { tmpDir =>
+      val tabName = "tab1"
+      withTable(tabName) {
+        assert(tmpDir.listFiles.isEmpty)
+        (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b").createOrReplaceTempView("t")
+        sql(
+          s"""
+             |create table $tabName
+             |stored as parquet
+             |location '$tmpDir'
+             |as select * from t
+          """.stripMargin)
+
+        val hiveTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
+        assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
+
+        assert(tmpDir.listFiles.nonEmpty)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+
+        sql(s"drop oindex idxa on $tabName")
+        checkAnswer(sql(s"show oindex from $tabName"), Nil)
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
+      }
+    }
+  }
+
+  test("refresh oap index on external tables in default database") {
+    withTempDir { tmpDir =>
+      val tabName = "tab1"
+      withTable(tabName) {
+        assert(tmpDir.listFiles.isEmpty)
+        (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b").createOrReplaceTempView("t")
+        sql(
+          s"""
+             |create table $tabName
+             |stored as parquet
+             |location '$tmpDir'
+             |as select * from t
+          """.stripMargin)
+
+        val hiveTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
+        assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
+
+        assert(tmpDir.listFiles.nonEmpty)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+
+        // test refresh oap index
+        (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
+          .createOrReplaceTempView("t2")
+        sql(s"insert into table $tabName select * from t2")
+        sql(s"refresh oindex on $tabName")
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
+      }
+    }
+  }
+
+  test("check oap index on external tables in default database") {
+    withTempDir { tmpDir =>
+      val tabName = "tab1"
+      withTable(tabName) {
+        assert(tmpDir.listFiles.isEmpty)
+        (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b").createOrReplaceTempView("t")
+        sql(
+          s"""
+             |create table $tabName
+             |stored as parquet
+             |location '$tmpDir'
+             |as select * from t
+          """.stripMargin)
+
+        val hiveTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
+        assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
+
+        assert(tmpDir.listFiles.nonEmpty)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+
+        // test check oap index
+        checkAnswer(sql(s"check oindex on $tabName"), Nil)
+        val dirPath = tmpDir.getAbsolutePath
+        val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(dirPath))
+        assert(metaOpt.nonEmpty)
+        assert(metaOpt.get.fileMetas.nonEmpty)
+        assert(metaOpt.get.indexMetas.nonEmpty)
+        val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+        // delete a data file
+        Utils.deleteRecursively(new File(dirPath, dataFileName))
+
+        // Check again
+        checkAnswer(
+          sql(s"check oindex on $tabName"),
+          Row(s"Data file: $dirPath/$dataFileName not found!"))
+
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Before performing index operations(create/drop/refresh/show/check index),
create `QueryExecution` to resolve `unresolvedRelations`

## How was this patch tested?
HiveOapIndexDDLSuite

  