### PR TITLE
Add hive strategies to oap session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@
 target/
 dependency-reduced-pom.xml
 derby.log
+metastore_db/
 

--- a/src/main/scala/org/apache/spark/sql/OapSession.scala
+++ b/src/main/scala/org/apache/spark/sql/OapSession.scala
@@ -209,7 +209,8 @@ object OapSession {
       return session
     }
   }
-  def builder(): SparkSession.Builder = new OapSessionBuilder
+  // Default catelog implementation is hive.
+  def builder(): SparkSession.Builder = (new OapSessionBuilder).enableHiveSupport()
 
   private[sql] val sqlListener = new AtomicReference[SQLListener]()
   private val activeThreadSession = new InheritableThreadLocal[OapSession]

--- a/src/main/scala/org/apache/spark/sql/TestOap.scala
+++ b/src/main/scala/org/apache/spark/sql/TestOap.scala
@@ -20,8 +20,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.internal.SQLConf
 
 
-object TestOap
-  extends TestOapContext(
+object TestOap extends TestOapContext(
   OapSession.builder.config(
     (new SparkConf).set("spark.master", "local[2]")
       .set("spark.app.name", "test-oap-context")

--- a/src/main/scala/org/apache/spark/sql/TestOap.scala
+++ b/src/main/scala/org/apache/spark/sql/TestOap.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.SparkConf
+
+object TestOap
+  extends TestOapContext(
+  OapSession.builder.config(
+    (new SparkConf).set("spark.master", "local[2]")
+      .set("spark.app.name", "test-oap-context")
+      .set("spark.sql.testkey", "true")
+      .set("spark.memory.offHeap.size", "100m")
+  ).enableHiveSupport().getOrCreate()) {
+}
+
+/**
+ * A locally running test instance of Oap engine.
+ */
+class TestOapContext(
+    @transient override val sparkSession: SparkSession)
+  extends SQLContext(sparkSession) {
+
+  protected def sqlContext: SQLContext = sparkSession.sqlContext
+
+  // OapStrategy conflicts with EXECUTOR_INDEX_SELECTION.
+  sqlContext.setConf(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "false")
+}
+

--- a/src/main/scala/org/apache/spark/sql/TestOap.scala
+++ b/src/main/scala/org/apache/spark/sql/TestOap.scala
@@ -16,8 +16,9 @@
  */
 package org.apache.spark.sql
 
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.internal.SQLConf
+
 
 object TestOap
   extends TestOapContext(

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -85,8 +85,7 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
       val end = System.currentTimeMillis()
       logDebug("Index Selection Time (Executor): " + (end - start) + "ms")
       if (!useIndex) {
-        logWarning("OAP index is skipped. Set below flags to force enable index,\n" +
-            "sqlContext.conf.setConfString(SQLConf.OAP_EXECUTOR_INDEX_SELECTION.key, false)")
+        logWarning("OAP index is skipped. Disable OAP_EXECUTOR_INDEX_SELECTION to use index.")
       } else {
         OapIndexInfo.partitionOapIndex.put(dataPath.toString, true)
         logInfo("Partition File " + dataPath.toString + " will use OAP index.\n")

--- a/src/main/scala/org/apache/spark/sql/hive/OapSessionState.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/OapSessionState.scala
@@ -35,18 +35,26 @@ class OapSessionState(sparkSession: OapSession) extends HiveSessionState(sparkSe
 
   override def planner: SparkPlanner = {
     new SparkPlanner(sparkSession.sparkContext, conf, experimentalMethods.extraStrategies)
-    with OapStrategies
+    with HiveStrategies with OapStrategies
     {
+      override val sparkSession: SparkSession = self.sparkSession
+
       override def strategies: Seq[Strategy] = {
-            experimentalMethods.extraStrategies ++ oapStrategies ++ (
-              FileSourceStrategy ::
-              DataSourceStrategy ::
-              DDLStrategy ::
-              SpecialLimits ::
-              Aggregation ::
-              JoinSelection ::
-              InMemoryScans ::
-              BasicOperators :: Nil)
+        experimentalMethods.extraStrategies ++
+          oapStrategies ++
+          Seq(
+            FileSourceStrategy,
+            DataSourceStrategy,
+            DDLStrategy,
+            SpecialLimits,
+            InMemoryScans,
+            HiveTableScans,
+            DataSinks,
+            Scripts,
+            Aggregation,
+            JoinSelection,
+            BasicOperators
+          )
       }
     }
   }

--- a/src/main/scala/org/apache/spark/sql/hive/OapSessionState.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/OapSessionState.scala
@@ -34,9 +34,10 @@ class OapSessionState(sparkSession: OapSession) extends HiveSessionState(sparkSe
   override lazy val sqlParser: ParserInterface = new OapSqlParser(conf)
 
   override def planner: SparkPlanner = {
-    new SparkPlanner(sparkSession.sparkContext, conf, experimentalMethods.extraStrategies)
-    with HiveStrategies with OapStrategies
-    {
+    new SparkPlanner(
+      sparkSession.sparkContext, conf, experimentalMethods.extraStrategies)
+      with HiveStrategies
+      with OapStrategies {
       override val sparkSession: SparkSession = self.sparkSession
 
       override def strategies: Seq[Strategy] = {
@@ -58,7 +59,6 @@ class OapSessionState(sparkSession: OapSession) extends HiveSessionState(sparkSe
       }
     }
   }
-
 }
 
 /**

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.util.Utils
 /**
  * OapPlannerSuite has its own spark context which initializes OapSession
  * instead of normal SparkSession. Now we have oapStrategies in planner
- * itself, so we don't need to
+ * itself, so we don't need to change extraStrategies.
  */
 class OapPlannerSuite
   extends QueryTest
@@ -35,9 +35,9 @@ class OapPlannerSuite
   with BeforeAndAfterEach
 {
   import testImplicits._
-  import TestOap._
 
-  protected override def spark = sparkSession
+  // Using TestOap as oap test context.
+  protected override def spark = TestOap.sparkSession
 
   override def beforeEach(): Unit = {
     val path1 = Utils.createTempDir().getAbsolutePath
@@ -64,7 +64,7 @@ class OapPlannerSuite
   }
 
   override def afterAll(): Unit = {
-    TestOap.sparkSession.stop()
+    spark.stop()
     super.afterAll()
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -19,11 +19,10 @@ package org.apache.spark.sql.execution.datasources.oap
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.{OapSession, QueryTest, Row, SparkSession}
+import org.apache.spark.sql._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.util.Utils
-import org.apache.spark.SparkConf
 
 /**
  * OapPlannerSuite has its own spark context which initializes OapSession
@@ -36,45 +35,9 @@ class OapPlannerSuite
   with BeforeAndAfterEach
 {
   import testImplicits._
+  import TestOap._
 
-  private var _spark: SparkSession = null
-
-  protected val sparkConf = new SparkConf()
-
-  protected override def spark: SparkSession = _spark
-
-  // avoid the overflow of offHeap memory
-  sparkConf.set("spark.memory.offHeap.size", "100m")
-  protected override def beforeAll(): Unit = {
-    SparkSession.sqlListener.set(null)
-    if (_spark == null) {
-      _spark = createOapSparkSession
-    }
-    super.beforeAll()
-    spark.sqlContext.setConf(SQLConf.OAP_BTREE_ROW_LIST_PART_SIZE, 64)
-    spark.sqlContext.setConf(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "false")
-  }
-
-  /**
-   * Stop the underlying [[org.apache.spark.SparkContext]], if any.
-   */
-  protected override def afterAll(): Unit = {
-    try {
-      if (_spark != null) {
-        _spark.stop()
-        _spark = null
-      }
-    } finally {
-      super.afterAll()
-    }
-  }
-
-  protected def createOapSparkSession: SparkSession = {
-    sparkConf.set("spark.master", "local[2]")
-    sparkConf.set("spark.app.name", "test-oap-context")
-    sparkConf.set("spark.sql.testkey", "true")
-    OapSession.builder.config(sparkConf).enableHiveSupport().getOrCreate()
-  }
+  protected override def spark = sparkSession
 
   override def beforeEach(): Unit = {
     val path1 = Utils.createTempDir().getAbsolutePath

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -17,9 +17,15 @@
 
 package org.apache.spark.sql.execution.datasources.oap
 
+import java.io.File
+
+import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.util.Utils
@@ -28,6 +34,15 @@ import org.apache.spark.util.Utils
  * OapPlannerSuite has its own spark context which initializes OapSession
  * instead of normal SparkSession. Now we have oapStrategies in planner
  * itself, so we don't need to change extraStrategies.
+ *
+ * Note: This function test OapSession with TestOAP context which involves
+ * Hive context. As 'instantiating multiple copies of the hive metastore seems
+ * to lead to weird non-deterministic failures' (see TestHive.scala), we merge
+ * all Hive context related cases into this Suite to avoid multi contexts
+ * conflict.
+ *
+ * TODO: Another way to avoid Hive error is making different warehouse Dirs for
+ * each hive related cases, do it in future if hive cases grow rapidly.
  */
 class OapPlannerSuite
   extends QueryTest
@@ -214,5 +229,145 @@ class OapPlannerSuite
     checkAnswer(baseDF, oapDF)
     spark.sqlContext.setConf(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "false")
     sql("drop oindex index1 on oap_fix_length_schema_table")
+  }
+
+  test("create oap index on external tables in default database") {
+    withTempDir { tmpDir =>
+      val tabName = "tab1"
+      withTable(tabName) {
+        assert(tmpDir.listFiles.isEmpty)
+        (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b").createOrReplaceTempView("t")
+        sql(
+          s"""
+             |create table $tabName
+             |stored as parquet
+             |location '$tmpDir'
+             |as select * from t
+          """.stripMargin)
+
+        val hiveTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
+        assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
+
+        assert(tmpDir.listFiles.nonEmpty)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
+      }
+    }
+  }
+
+  test("drop oap index on external tables in default database") {
+    withTempDir { tmpDir =>
+      val tabName = "tab1"
+      withTable(tabName) {
+        assert(tmpDir.listFiles.isEmpty)
+        (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b").createOrReplaceTempView("t")
+        sql(
+          s"""
+             |create table $tabName
+             |stored as parquet
+             |location '$tmpDir'
+             |as select * from t
+          """.stripMargin)
+
+        val hiveTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
+        assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
+
+        assert(tmpDir.listFiles.nonEmpty)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+
+        sql(s"drop oindex idxa on $tabName")
+        checkAnswer(sql(s"show oindex from $tabName"), Nil)
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
+      }
+    }
+  }
+
+  test("refresh oap index on external tables in default database") {
+    withTempDir { tmpDir =>
+      val tabName = "tab1"
+      withTable(tabName) {
+        assert(tmpDir.listFiles.isEmpty)
+        (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b").createOrReplaceTempView("t")
+        sql(
+          s"""
+             |create table $tabName
+             |stored as parquet
+             |location '$tmpDir'
+             |as select * from t
+          """.stripMargin)
+
+        val hiveTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
+        assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
+
+        assert(tmpDir.listFiles.nonEmpty)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+
+        // test refresh oap index
+        (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
+          .createOrReplaceTempView("t2")
+        sql(s"insert into table $tabName select * from t2")
+        sql(s"refresh oindex on $tabName")
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
+      }
+    }
+  }
+
+  test("check oap index on external tables in default database") {
+    withTempDir { tmpDir =>
+      val tabName = "tab1"
+      withTable(tabName) {
+        assert(tmpDir.listFiles.isEmpty)
+        (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b").createOrReplaceTempView("t")
+        sql(
+          s"""
+             |create table $tabName
+             |stored as parquet
+             |location '$tmpDir'
+             |as select * from t
+          """.stripMargin)
+
+        val hiveTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName, Some("default")))
+        assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
+
+        assert(tmpDir.listFiles.nonEmpty)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+
+        // test check oap index
+        checkAnswer(sql(s"check oindex on $tabName"), Nil)
+        val dirPath = tmpDir.getAbsolutePath
+        val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(dirPath))
+        assert(metaOpt.nonEmpty)
+        assert(metaOpt.get.fileMetas.nonEmpty)
+        assert(metaOpt.get.indexMetas.nonEmpty)
+        val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+        // delete a data file
+        Utils.deleteRecursively(new File(dirPath, dataFileName))
+
+        // Check again
+        checkAnswer(
+          sql(s"check oindex on $tabName"),
+          Row(s"Data file: $dirPath/$dataFileName not found!"))
+
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
+      }
+    }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
@@ -20,9 +20,8 @@ package org.apache.spark.sql.hive.execution
 import java.io.File
 
 import org.apache.hadoop.fs.Path
-import org.scalatest.BeforeAndAfterEach
-
-import org.apache.spark.sql.{QueryTest, Row, SparkSession}
+import org.scalatest.{BeforeAndAfterEach, Ignore}
+import org.apache.spark.sql.{QueryTest, Row, SparkSession, TestOap}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
@@ -31,7 +30,9 @@ import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.util.Utils
 
 
-// test OAP Index DDL&DML on Hive tables
+// test OAP Index DDL&DML on Hive tables. Ignored as cases were moved to OapPlannerSuite.
+// In future we can re-use this one if we offer individual warehouse dir for different suite.
+@Ignore
 class HiveOapIndexDDLSuite
   extends QueryTest with SQLTestUtils with BeforeAndAfterEach {
   import testImplicits._


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
1. Add hive related strategies to OapSessionState as it inherits from HiveSessionStage.
2. Create TestOap (just like TestHive in Spark) which takes the role of oap test context.
3. Modify related unit test to see if OapSession works fine.

## How was this patch tested?
mvn test passes.
