### PR TITLE
fix Enable/Disable using index test case of OapSuite

### DIFF
--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -136,6 +136,7 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
       And(GreaterThan("a", 9), LessThan("a", 14)))
     ScannerBuilder.build(filters, ic)
     val filterScanners = ic.getScanners
+    conf.setBoolean(SQLConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, false)
     val readerIndex = new OapDataReader(filePath, dataSourceMeta, filterScanners, requiredIds)
     val itIndex = readerIndex.initialize(conf)
     assert(itIndex.size == 4)


### PR DESCRIPTION
## What changes were proposed in this pull request?
minor fix for Enable/Disable using OAP index Test Case:
Set `OAP_ENABLE_EXECUTOR_INDEX_SELECTION` to `false` in order to
use index forcely
## How was this patch tested?
OapSuite