### PR TITLE
Fix issue 502: all test should use configuration from ShareOapContext.

### DIFF
--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -122,7 +122,7 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
     val df = sqlContext.read.format("oap").load(dir.getAbsolutePath)
     df.createOrReplaceTempView("oap_table")
     sql("create oindex oap_idx on oap_table (a)")
-    val conf = spark.sparkContext.hadoopConfiguration
+    val conf = configuration
     val filePath = new Path(oapDataFile.toString)
     val metaPath = new Path(oapMetaFile.toString)
     val dataSourceMeta = DataSourceMeta.initialize(metaPath, conf)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -104,6 +104,8 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
         }
       }
     })
+    // Restore compression type back to default.
+    sqlConf.setConfString(SQLConf.OAP_COMPRESSION.key, SQLConf.OAP_COMPRESSION.defaultValueString)
   }
 
   test("Enable/disable using OAP index after the index is created already") {

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -38,7 +38,7 @@ trait SharedOapContext extends SharedSQLContext {
   // disable file based cbo for all test suite, as it always fails.
   sparkConf.set(SQLConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.key, "false")
 
-  protected lazy val configuration: Configuration = sparkContext.hadoopConfiguration
+  protected lazy val configuration: Configuration = spark.sessionState.newHadoopConf()
 
   protected implicit def sqlConf: SQLConf = sqlContext.conf
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix issue 502, all case suites based on ShareOapContext should use
configuration in it.

## How was this patch tested?
mvn passes.
