### PR TITLE
Change one logError to logWarning

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -64,7 +64,7 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logg
       while (!fiberCache.tryDispose(3000)) {
         // Check memory usage every 3s while we are waiting fiber release.
         if (_pendingFiberSize.get() > maxMemory) {
-          logError("Fibers pending on removal use too much memory, " +
+          logWarning("Fibers pending on removal use too much memory, " +
               s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
         }
       }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -50,7 +50,7 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logg
     _pendingFiberSize.addAndGet(fiberCache.size())
     removalPendingQueue.offer(fiberCache)
     if (_pendingFiberSize.get() > maxMemory) {
-      logError("Fibers pending on removal use too much memory, " +
+      logWarning("Fibers pending on removal use too much memory, " +
           s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check pending removal fiber memory usage may output a logError
It will confuse user during unit test. change to logWarning

## How was this patch tested?

Unit test pass
