### PR TITLE
Change Cache Unit from MB to KB

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -81,8 +81,8 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
   private val cacheGuardian = new CacheGuardian(cacheGuardianMemory)
   cacheGuardian.start()
 
-  private val MB: Double = 1024 * 1024
-  private val MAX_WEIGHT = (cacheMemory / MB).toInt
+  private val KB: Double = 1024
+  private val MAX_WEIGHT = (cacheMemory / KB).toInt
 
   // Total cached size for debug purpose
   private val _cacheSize: AtomicLong = new AtomicLong(0)
@@ -97,7 +97,7 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
 
   private val weigher = new Weigher[Fiber, FiberCache] {
     override def weigh(key: Fiber, value: FiberCache): Int =
-      math.ceil(value.size() / MB).toInt
+      math.ceil(value.size() / KB).toInt
   }
 
   /**
@@ -124,7 +124,7 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
   override def get(fiber: Fiber, conf: Configuration): FiberCache = {
     val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
     // Avoid loading a fiber larger than MAX_WEIGHT / 4, 4 is concurrency number
-    assert(fiberCache.size() <= MAX_WEIGHT * MB / 4, "Can't cache fiber larger than MAX_WEIGHT / 4")
+    assert(fiberCache.size() <= MAX_WEIGHT * KB / 4, "Can't cache fiber larger than MAX_WEIGHT / 4")
     fiberCache.occupy()
     fiberCache
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -35,7 +35,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
     val origStats = FiberCacheManager.cacheStats
     (1 to memorySizeInMB * 2).foreach { i =>
-      val data = generateData(kbSize)
+      val data = generateData(mbSize)
       val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #0.$i")
       val fiberCache = FiberCacheManager.get(fiber, configuration)
       val fiberCache2 = FiberCacheManager.get(fiber, configuration)
@@ -52,12 +52,12 @@ class FiberCacheManagerSuite extends SharedOapContext {
 
   test("remove a fiber is in use") {
     val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
-    val dataInUse = generateData(kbSize)
+    val dataInUse = generateData(mbSize)
     val fiberInUse =
       TestFiber(() => MemoryManager.putToDataFiberCache(dataInUse), s"test fiber #1.0")
     val fiberCacheInUse = FiberCacheManager.get(fiberInUse, configuration)
     (1 to memorySizeInMB * 2).foreach { i =>
-      val data = generateData(1024)
+      val data = generateData(mbSize)
       val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #1.$i")
       val fiberCache = FiberCacheManager.get(fiber, configuration)
       assert(fiberCache.toArray sameElements data)


### PR DESCRIPTION

## What changes were proposed in this pull request?

If use MB as Unit, we'll lose too much memory due to ceil.
Say, 100KB will ceil to 1MB, 90% memory is wasted.


## How was this patch tested?

Unit test pass

