### PR TITLE
[BRANCH-0.3] Use Global Lock For Each Fiber To Increase Concurrency

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -70,7 +70,6 @@ trait FiberCache extends Logging {
           writeLock.unlock()
         }
       }
-      Thread.sleep(100)
       logWarning(s"Fiber Cache Dispose waiting detected for ${this}")
     }
     false

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -67,7 +67,7 @@ class SimpleOapCache extends OapCache with Logging {
   override def cacheSize: Long = 0
 
   override def cacheStats: CacheStats = {
-    new CacheStats(0, 0, 0, 0, 0)
+    CacheStats(0, 0, 0, 0, 0)
   }
 
   override def cacheCount: Long = 0
@@ -83,6 +83,7 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
 
   private val KB: Double = 1024
   private val MAX_WEIGHT = (cacheMemory / KB).toInt
+  private val CONCURRENCY_LEVEL = 4
 
   // Total cached size for debug purpose
   private val _cacheSize: AtomicLong = new AtomicLong(0)
@@ -121,6 +122,7 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
     .removalListener(removalListener)
     .maximumWeight(MAX_WEIGHT)
     .weigher(weigher)
+    .concurrencyLevel(CONCURRENCY_LEVEL)
     .build[Fiber, FiberCache]()
 
   override def get(fiber: Fiber, conf: Configuration): FiberCache = {
@@ -128,10 +130,11 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
     readLock.lock()
     try {
       val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
-      // Avoid loading a fiber larger than MAX_WEIGHT / 4, 4 is concurrency number
-      assert(fiberCache.size() <= MAX_WEIGHT * KB / 4,
+      // Avoid loading a fiber larger than MAX_WEIGHT / CONCURRENCY_LEVEL
+      assert(fiberCache.size() <= MAX_WEIGHT * KB / CONCURRENCY_LEVEL,
         s"Failed to cache fiber(${Utils.bytesToString(fiberCache.size())}) " +
-            s"with cache's MAX_WEIGHT(${Utils.bytesToString(MAX_WEIGHT.toLong * KB.toLong)}) / 4")
+          s"with cache's MAX_WEIGHT" +
+          s"(${Utils.bytesToString(MAX_WEIGHT.toLong * KB.toLong)}) / $CONCURRENCY_LEVEL")
       fiberCache.occupy()
       fiberCache
     } finally {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -122,16 +122,21 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
     .weigher(weigher)
     .build[Fiber, FiberCache]()
 
-  override def get(fiber: Fiber, conf: Configuration): FiberCache =
-    FiberLockManager.getFiberLock(fiber).synchronized {
+  override def get(fiber: Fiber, conf: Configuration): FiberCache = {
+    val readLock = FiberLockManager.getFiberLock(fiber).readLock()
+    readLock.lock()
+    try {
       val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
       // Avoid loading a fiber larger than MAX_WEIGHT / 4, 4 is concurrency number
       assert(fiberCache.size() <= MAX_WEIGHT * KB / 4,
         s"Failed to cache fiber(${Utils.bytesToString(fiberCache.size())}) " +
-          s"with cache's MAX_WEIGHT(${Utils.bytesToString(MAX_WEIGHT.toLong * KB.toLong)}) / 4")
+            s"with cache's MAX_WEIGHT(${Utils.bytesToString(MAX_WEIGHT.toLong * KB.toLong)}) / 4")
       fiberCache.occupy()
       fiberCache
+    } finally {
+      readLock.unlock()
     }
+  }
 
   override def getIfPresent(fiber: Fiber): FiberCache = cache.getIfPresent(fiber)
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -228,7 +228,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     val data = generateData(kbSize)
     val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"get remove test")
     def occupyWork(): Boolean = {
-      (1 to 100000).foreach { _ =>
+      (1 to 100).foreach { _ =>
         val fiberCache = FiberCacheManager.get(fiber, configuration)
         if (fiberCache.isDisposed) {
           fiberCache.release()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -257,7 +257,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     val fiberCache = cache.get(fiber, configuration)
     assert(fiberCache.toArray sameElements data)
     fiberCache.release()
-    Thread.sleep(100)
+    Thread.sleep(500)
     assert(fiberCache.isDisposed)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -23,7 +23,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.utils.NonNullKeyWriter
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.sql.types._
@@ -155,18 +154,5 @@ class MemoryManagerSuite extends SharedOapContext {
         assert(fiberCache.getBytes(offset, length) === bytes)
         offset += length
     }
-  }
-
-  test("check invalidate FiberCache") {
-    // 1. disposed FiberCache
-    val bytes = new Array[Byte](1024)
-    val fiberCache = MemoryManager.putToDataFiberCache(bytes)
-    fiberCache.realDispose()
-    val exception = intercept[OapException]{
-      fiberCache.getByte(0)
-    }
-    assert(exception.getMessage == "Try to access a freed memory")
-
-    // 2. TODO: test Invalidate MemoryBlock
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use a global lock for each fiber.
fiber lock must be acquired before change this Fiber/FiberCache


## How was this patch tested?

Unit test

