### PR TITLE
[DO NOT MERGE] Add more metrics in OapFileFormat and CacheStats #506

### DIFF
--- a/src/main/resources/oap/static/oap-template.html
+++ b/src/main/resources/oap/static/oap-template.html
@@ -1,0 +1,76 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script id="cms-summary-template" type="text/html">
+    <h4 style="clear: left; display: inline-block;">Summary</h4>
+    <div class="container-fluid">
+        <div class="container-fluid">
+            <table id="summary-cms-table" class="table table-striped compact">
+                <thead>
+                <th></th>
+                <th><span data-toggle="tooltip"
+                          title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
+                </th>
+                <th>Cache Size/Count</th>
+                <th>BackendCache Size/Count</th>
+                <th>DataFiber Size/Count</th>
+                <th>IndexFiber Size/Count</th>
+                <th>PendingFiber Size/Count</th>
+                <th>Hit Rate(hit/miss)</th>
+                <th>Load Count</th>
+                <th><span data-toggle="tooltip"
+                          title="average time of load fiber">Load AvgTime(ms)</span></th>
+                <th>Eviction Count</th>
+                </thead>
+                <tbody>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <h4 style="clear: left; display: inline-block;">Executors</h4>
+    <div class="container-fluid">
+        <div class="container-fluid">
+            <table id="active-cms-table" class="table table-striped compact">
+                <thead>
+                <tr>
+                    <th><span data-toggle="tooltip" data-placement="right" title="ID of the executor">Executor ID</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="Address">Address</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="Status">Status</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
+                        Cache Size/Count</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="BackendCache Size/Count">
+                        BackendCache Size/Count</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="DataFiber Size/Count">
+                        DataFiber Size/Count</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="IndexFiber Size/Count">
+                        IndexFiber Size/Count</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top"
+                              title="PendingFiber Size/Count">PendingFiber Size/Count</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="Hit Rate (hit/miss)">Hit Rate
+                        (hit/miss)</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="Load Count">Load Count</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="Load AvgTime">Load AvgTime(ms)</span></th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="Load AvgTime">Eviction Count</span></th>
+                </tr>
+                </thead>
+                <tbody>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</script>

--- a/src/main/resources/oap/static/oap-template.html
+++ b/src/main/resources/oap/static/oap-template.html
@@ -16,61 +16,61 @@ limitations under the License.
 -->
 
 <script id="cms-summary-template" type="text/html">
-    <h4 style="clear: left; display: inline-block;">Summary</h4>
+  <h4 style="clear: left; display: inline-block;">Summary</h4>
+  <div class="container-fluid">
     <div class="container-fluid">
-        <div class="container-fluid">
-            <table id="summary-cms-table" class="table table-striped compact">
-                <thead>
-                <th></th>
-                <th><span data-toggle="tooltip"
-                          title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
-                </th>
-                <th>Cache Size/Count</th>
-                <th>BackendCache Size/Count</th>
-                <th>DataFiber Size/Count</th>
-                <th>IndexFiber Size/Count</th>
-                <th>PendingFiber Size/Count</th>
-                <th>Hit Rate(hit/miss)</th>
-                <th>Load Count</th>
-                <th><span data-toggle="tooltip"
-                          title="average time of load fiber">Load AvgTime(ms)</span></th>
-                <th>Eviction Count</th>
-                </thead>
-                <tbody>
-                </tbody>
-            </table>
-        </div>
+      <table id="summary-cms-table" class="table table-striped compact">
+        <thead>
+        <th></th>
+        <th><span data-toggle="tooltip"
+                  title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
+        </th>
+        <th>Cache Size/Count</th>
+        <th>BackendCache Size/Count</th>
+        <th>DataFiber Size/Count</th>
+        <th>IndexFiber Size/Count</th>
+        <th>PendingFiber Size/Count</th>
+        <th>Hit Rate(hit/miss)</th>
+        <th>Load Count</th>
+        <th><span data-toggle="tooltip"
+                  title="average time of load fiber">Load AvgTime(ms)</span></th>
+        <th>Eviction Count</th>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
     </div>
-    <h4 style="clear: left; display: inline-block;">Executors</h4>
+  </div>
+  <h4 style="clear: left; display: inline-block;">Executors</h4>
+  <div class="container-fluid">
     <div class="container-fluid">
-        <div class="container-fluid">
-            <table id="active-cms-table" class="table table-striped compact">
-                <thead>
-                <tr>
-                    <th><span data-toggle="tooltip" data-placement="right" title="ID of the executor">Executor ID</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="Address">Address</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="Status">Status</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
-                        Cache Size/Count</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="BackendCache Size/Count">
-                        BackendCache Size/Count</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="DataFiber Size/Count">
-                        DataFiber Size/Count</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="IndexFiber Size/Count">
-                        IndexFiber Size/Count</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top"
-                              title="PendingFiber Size/Count">PendingFiber Size/Count</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="Hit Rate (hit/miss)">Hit Rate
-                        (hit/miss)</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="Load Count">Load Count</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="Load AvgTime">Load AvgTime(ms)</span></th>
-                    <th><span data-toggle="tooltip" data-placement="top" title="Load AvgTime">Eviction Count</span></th>
-                </tr>
-                </thead>
-                <tbody>
-                </tbody>
-            </table>
-        </div>
+      <table id="active-cms-table" class="table table-striped compact">
+        <thead>
+        <tr>
+          <th><span data-toggle="tooltip" data-placement="right" title="ID of the executor">Executor ID</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Address">Address</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Status">Status</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
+              Cache Size/Count</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="BackendCache Size/Count">
+              BackendCache Size/Count</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="DataFiber Size/Count">
+              DataFiber Size/Count</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="IndexFiber Size/Count">
+              IndexFiber Size/Count</span></th>
+          <th><span data-toggle="tooltip" data-placement="top"
+                    title="PendingFiber Size/Count">PendingFiber Size/Count</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Hit Rate (hit/miss)">Hit Rate
+              (hit/miss)</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Load Count">Load Count</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Load AvgTime">Load AvgTime(ms)</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Load AvgTime">Eviction Count</span></th>
+        </tr>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
     </div>
+  </div>
 </script>

--- a/src/main/resources/oap/static/oap.js
+++ b/src/main/resources/oap/static/oap.js
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function formatStatus(status, type) {
+    if (type !== 'display') return status;
+    if (status) {
+        return "Active"
+    } else {
+        return "Dead"
+    }
+}
+
+jQuery.extend(jQuery.fn.dataTableExt.oSort, {
+    "title-numeric-pre": function (a) {
+        var x = a.match(/title="*(-?[0-9\.]+)/)[1];
+        return parseFloat(x);
+    },
+
+    "title-numeric-asc": function (a, b) {
+        return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+    },
+
+    "title-numeric-desc": function (a, b) {
+        return ((a < b) ? 1 : ((a > b) ? -1 : 0));
+    }
+});
+
+$(document).ajaxStop($.unblockUI);
+$(document).ajaxStart(function () {
+    $.blockUI({message: '<h3>Loading OAP Page...</h3>'});
+});
+
+function createTemplateURI(appId) {
+    var words = document.baseURI.split('/');
+    var ind = words.indexOf("proxy");
+    if (ind > 0) {
+        var baseURI = words.slice(0, ind + 1).join('/') + '/' + appId + '/static/oap/oap-template.html';
+        return baseURI;
+    }
+    ind = words.indexOf("history");
+    if(ind > 0) {
+        var baseURI = words.slice(0, ind).join('/') + '/static/oap/oap-template.html';
+        return baseURI;
+    }
+    return location.origin + "/static/oap/oap-template.html";
+}
+
+function getStandAloneppId(cb) {
+    var words = document.baseURI.split('/');
+    var ind = words.indexOf("proxy");
+    if (ind > 0) {
+        var appId = words[ind + 1];
+        cb(appId);
+        return;
+    }
+    ind = words.indexOf("history");
+    if (ind > 0) {
+        var appId = words[ind + 1];
+        cb(appId);
+        return;
+    }
+    //Looks like Web UI is running in standalone mode
+    //Let's get application-id using REST End Point
+    $.getJSON(location.origin + "/api/v1/applications", function(response, status, jqXHR) {
+        if (response && response.length > 0) {
+            var appId = response[0].id
+            cb(appId);
+            return;
+        }
+    });
+}
+
+function createRESTEndPoint(appId) {
+    var words = document.baseURI.split('/');
+    var ind = words.indexOf("proxy");
+    if (ind > 0) {
+        var appId = words[ind + 1];
+        var newBaseURI = words.slice(0, ind + 2).join('/');
+        return newBaseURI + "/api/v1/applications/" + appId + "/fibercachemanagers"
+    }
+    ind = words.indexOf("history");
+    if (ind > 0) {
+        var appId = words[ind + 1];
+        var attemptId = words[ind + 2];
+        var newBaseURI = words.slice(0, ind).join('/');
+        if (isNaN(attemptId)) {
+            return newBaseURI + "/api/v1/applications/" + appId + "/fibercachemanagers";
+        } else {
+            return newBaseURI + "/api/v1/applications/" + appId + "/" + attemptId + "/fibercachemanagers";
+        }
+    }
+    return location.origin + "/api/v1/applications/" + appId + "/fibercachemanagers";
+}
+
+function formatCount(bytes, type) {
+    if (type !== 'display') return bytes;
+    if (bytes == 0) return '0';
+    var k = 1000;
+    var dm = 1;
+    var sizes = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+    var i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + sizes[i];
+}
+
+$(document).ready(function () {
+    $.extend($.fn.dataTable.defaults, {
+        stateSave: true,
+        lengthMenu: [[20, 20, 20, 20, -1], [20, 20, 20, 20, "All"]],
+        pageLength: 20
+    });
+
+    fiberCacheManagersSummary = $("#active-cms");
+
+    getStandAloneppId(function (appId) {
+
+        var endPoint = createRESTEndPoint(appId);
+        $.getJSON(endPoint, function (response, status, jqXHR) {
+            var summary = [];
+            var allExecCnt = 0;
+            var allMemoryUsed = 0;
+            var allMaxMemory = 0;
+            var allCacheSize = 0;
+            var allCacheCount = 0;
+            var allBackendCacheSize = 0;
+            var allBackendCacheCount = 0;
+            var allDataFiberSize = 0;
+            var allDataFiberCount = 0;
+            var allIndexFiberSize = 0;
+            var allIndexFiberCount = 0;
+            var allPendingFiberSize = 0;
+            var allPendingFiberCount = 0;
+            var allHitCount = 0;
+            var allMissCount = 0;
+            var allLoadCount = 0;
+            var allLoadTime = 0;
+            var allEvictionCount = 0;
+
+            response.forEach(function (exec) {
+                allExecCnt += 1;
+                allMemoryUsed        += exec.memoryUsed;
+                allMaxMemory         += exec.maxMemory;
+                allCacheSize         += exec.cacheSize;
+                allCacheCount        += exec.cacheCount;
+                allBackendCacheSize  += exec.backendCacheSize;
+                allBackendCacheCount += exec.backendCacheCount;
+                allDataFiberSize     += exec.dataFiberSize;
+                allDataFiberCount    += exec.dataFiberCount;
+                allIndexFiberSize    += exec.indexFiberSize;
+                allIndexFiberCount   += exec.indexFiberCount;
+                allPendingFiberSize  += exec.pendingFiberSize;
+                allPendingFiberCount += exec.pendingFiberCount;
+                allHitCount          += exec.hitCount;
+                allMissCount         += exec.missCount;
+                allLoadCount         += exec.loadCount;
+                allLoadTime          += exec.loadTime;
+                allEvictionCount     += exec.evictionCount;
+            });
+
+            var totalSummary = {
+                "execCnt": ( "Total(" + allExecCnt + ")"),
+                "allMemoryUsed": allMemoryUsed,
+                "allMaxMemory": allMaxMemory,
+                "allCacheSize": allCacheSize,
+                "allCacheCount": allCacheCount,
+                "allBackendCacheSize": allBackendCacheSize,
+                "allBackendCacheCount": allBackendCacheCount,
+                "allDataFiberSize": allDataFiberSize,
+                "allDataFiberCount": allDataFiberCount,
+                "allIndexFiberSize": allIndexFiberSize,
+                "allIndexFiberCount": allIndexFiberCount,
+                "allPendingFiberSize": allPendingFiberSize,
+                "allPendingFiberCount": allPendingFiberCount,
+                "allHitCount": allHitCount,
+                "allMissCount": allMissCount,
+                "allLoadCount": allLoadCount,
+                "allLoadTime": allLoadTime,
+                "allEvictionCount": allEvictionCount
+            };
+
+            var data = {fibercachemanagers: response, "fiberCacheManagerSummary": [totalSummary]};
+            $.get(createTemplateURI(appId), function (template) {
+
+                fiberCacheManagersSummary.append(Mustache.render($(template).filter("#cms-summary-template").html(), data));
+                var selector = "#active-cms-table";
+                var conf = {
+                    "data": response,
+                    "columns": [
+                        {
+                            data: function (row, type) {
+                                return type !== 'display' ? (isNaN(row.id) ? 0 : row.id ) : row.id;
+                            }
+                        },
+                        {data: 'hostPort'},
+                        {data: 'isActive', render: formatStatus},
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.memoryUsed, type) + ' / '
+                                    + formatBytes(row.maxMemory, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.cacheSize, type)  + ' / '
+                                    + formatCount(row.cacheCount, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.backendCacheSize, type)  + ' / '
+                                    + formatCount(row.backendCacheCount, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.dataFiberSize, type)  + ' / '
+                                    + formatCount(row.dataFiberCount, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.indexFiberSize, type)  + ' / '
+                                    + formatCount(row.indexFiberCount, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.pendingFiberSize, type)  + ' / '
+                                    + formatCount(row.pendingFiberCount, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (row.hitCount * 100
+                                    / (row.hitCount + row.missCount)).toFixed(2)
+                                    + '% (' + formatCount(row.hitCount, type) + '/'
+                                    + formatCount(row.missCount, type) + ')' : 'Nan'
+                            }
+                        },
+                        {data: 'loadCount', render: formatCount},
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ?
+                                    formatDuration((row.loadTime / 1000000 / row.loadCount).toFixed(2)) : 'Nan'
+                            }
+                        },
+                        {data: 'evictionCount', render: formatCount}
+                    ],
+                    "order": [[0, "asc"]]
+                };
+
+                $(selector).DataTable(conf);
+                $('#active-cms [data-toggle="tooltip"]').tooltip();
+
+                var sumSelector = "#summary-cms-table";
+                var sumConf = {
+                    "data": [totalSummary],
+                    "columns": [
+                        {
+                            data: 'execCnt',
+                            "fnCreatedCell": function (nTd, sData, oData, iRow, iCol) {
+                                $(nTd).css('font-weight', 'bold');
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.allMemoryUsed, type)
+                                    + ' / ' + formatBytes(row.allMaxMemory, type)) : 'Nan';
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.allCacheSize, type)
+                                    + ' / ' + formatCount(row.allCacheCount, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.allBackendCacheSize, type)
+                                    + ' / ' + formatCount(row.allBackendCacheCount, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.allDataFiberSize, type)
+                                    + ' / ' + formatCount(row.allDataFiberCount, type)) : 'Nan'
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.allIndexFiberSize, type)
+                                    + ' / ' + formatCount(row.allIndexFiberCount, type)) : "Nan"
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (formatBytes(row.allPendingFiberSize, type)
+                                    + ' / ' + formatCount(row.allPendingFiberCount, type)) : "Nan"
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ? (row.allHitCount * 100
+                                    / (row.allHitCount + row.allMissCount)).toFixed(2)
+                                    + '% (' + formatCount(row.allHitCount, type) + '/'
+                                    + formatCount(row.allMissCount, type) + ')' : 'Nan'
+                            }
+                        },
+                        {data: 'allLoadCount', render: formatCount},
+                        {
+                            data: function (row, type) {
+                                return type === 'display' ?
+                                    formatDuration((row.allLoadTime / 1000000 / row.allLoadCount).toFixed(2)) : 'Nan'
+                            }
+                        },
+                        {data: "allEvictionCount", render: formatCount}
+                    ],
+                    "paging": false,
+                    "searching": false,
+                    "info": false
+
+                };
+
+                $(sumSelector).DataTable(sumConf);
+                $('#fiberCacheManagerSummary [data-toggle="tooltip"]').tooltip();
+
+            });
+        });
+    });
+});

--- a/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -38,7 +38,7 @@ private[spark] case class Heartbeat(
     executorId: String,
     accumUpdates: Array[(Long, Seq[AccumulatorV2[_, _]])], // taskId -> accumulator updates
     blockManagerId: BlockManagerId,
-    customizedInfo: Seq[String] = Nil)
+    customizedInfo: Seq[(String, String)] = Nil)
 
 /**
  * An event that SparkContext uses to notify HeartbeatReceiver that SparkContext.taskScheduler is
@@ -153,12 +153,12 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
       // Second is for oap index infor update.
       // The cusInfo is serialized string for fiber and oap index status.
       customizedInfo.foreach { cusInfo =>
-        if (cusInfo.contains("fiberFilePath")) {
-          sc.listenerBus.post(SparkListenerCustomInfoUpdate(blockManagerId.host, executorId,
-            cusInfo))
-        } else if (cusInfo.contains("useOapIndex")) {
+        if (cusInfo._2.contains("useOapIndex")) {
           sc.listenerBus.post(SparkListenerOapIndexInfoUpdate(blockManagerId.host, executorId,
-            cusInfo))
+            cusInfo._2))
+        } else { // for CostomInfoUpdate
+          sc.listenerBus.post(SparkListenerCustomInfoUpdate(blockManagerId.host, executorId,
+            cusInfo._1, cusInfo._2))
         }
       }
   }

--- a/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -136,7 +136,9 @@ private[spark] class Executor(
 
   private val customInfoClassNameSeq = Seq(
     "org.apache.spark.sql.execution.datasources.oap.filecache.OapFiberCacheHeartBeatMessager",
-    "org.apache.spark.sql.execution.datasources.oap.io.OapIndexHeartBeatMessager")
+    "org.apache.spark.sql.execution.datasources.oap.io.OapIndexHeartBeatMessager",
+    "org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheManagerMessager"
+  )
   private val customManagerSeq: Seq[CustomManager] = customInfoClassNameSeq.map(cIC =>
     Utils.classForName(cIC).newInstance().asInstanceOf[CustomManager])
 
@@ -544,7 +546,8 @@ private[spark] class Executor(
       executorId,
       accumUpdates.toArray,
       env.blockManager.blockManagerId,
-      customManagerSeq.map(_.status(conf)))
+      customManagerSeq.map(m => (m.getClass.getName, m.status(conf)))
+        .filter(_._2.nonEmpty))
 
     try {
       val response = heartbeatReceiverRef.askWithRetry[HeartbeatResponse](

--- a/src/main/scala/org/apache/spark/oap/ui/FiberCacheManagerPage.scala
+++ b/src/main/scala/org/apache/spark/oap/ui/FiberCacheManagerPage.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.oap.ui
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.xml.Node
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.oap.filecache.{CacheStats, FiberCacheManagerSensor}
+import org.apache.spark.ui.{UIUtils, WebUIPage}
+import org.apache.spark.ui.exec.ExecutorsListener
+
+private[ui] class FiberCacheManagerPage(parent: OapTab) extends WebUIPage("") with Logging {
+
+  def render(request: HttpServletRequest): Seq[Node] = {
+    val content =
+      <div>
+        {
+        <div id="active-cms"></div> ++
+          <script src={UIUtils.prependBaseUri("/static/utils.js")}></script> ++
+          <script src={UIUtils.prependBaseUri("/static/oap/oap.js")}></script>
+        }
+      </div>
+
+    UIUtils.headerSparkPage("FiberCacheManager", content, parent, useDataTables = true)
+  }
+
+}
+
+private[spark] object FiberCacheManagerPage {
+  /** Represent an executor's info as a map given a storage status index */
+  def getFiberCacheManagerInfo(
+      listener: ExecutorsListener,
+      statusId: Int): FiberCacheManagerSummary = {
+    val status = listener.activeStorageStatusList(statusId)
+    val execId = status.blockManagerId.executorId
+    val hostPort = status.blockManagerId.hostPort
+    val memUsed = status.memUsed
+    val maxMem = status.maxMem
+    val cacheStats = FiberCacheManagerSensor.executorToCacheManager
+      .getOrDefault(execId, CacheStats())
+
+    new FiberCacheManagerSummary(
+      execId,
+      hostPort,
+      true,
+      memUsed,
+      maxMem,
+      cacheStats.cache.size,
+      cacheStats.cache.count,
+      cacheStats.backEndCache.size,
+      cacheStats.backEndCache.count,
+      cacheStats.dataFiberCache.size,
+      cacheStats.dataFiberCache.count,
+      cacheStats.indexFiberCache.size,
+      cacheStats.indexFiberCache.count,
+      cacheStats.pendingFiberCache.size,
+      cacheStats.pendingFiberCache.count,
+      cacheStats.hitCount,
+      cacheStats.missCount,
+      cacheStats.loadCount,
+      cacheStats.totalLoadTime,
+      cacheStats.evictionCount
+    )
+  }
+}
+
+
+class FiberCacheManagerSummary private[spark](
+    val id: String,
+    val hostPort: String,
+    val isActive: Boolean,
+    val memoryUsed: Long,
+    val maxMemory: Long,
+    val cacheSize: Long,
+    val cacheCount: Long,
+    val backendCacheSize: Long,
+    val backendCacheCount: Long,
+    val dataFiberSize: Long,
+    val dataFiberCount: Long,
+    val indexFiberSize: Long,
+    val indexFiberCount: Long,
+    val pendingFiberSize: Long,
+    val pendingFiberCount: Long,
+    val hitCount: Long,
+    val missCount: Long,
+    val loadCount: Long,
+    val loadTime: Long,
+    val evictionCount: Long)

--- a/src/main/scala/org/apache/spark/oap/ui/FiberCacheManagerPage.scala
+++ b/src/main/scala/org/apache/spark/oap/ui/FiberCacheManagerPage.scala
@@ -53,8 +53,11 @@ private[spark] object FiberCacheManagerPage {
     val hostPort = status.blockManagerId.hostPort
     val memUsed = status.memUsed
     val maxMem = status.maxMem
-    val cacheStats = FiberCacheManagerSensor.executorToCacheManager
-      .getOrDefault(execId, CacheStats())
+    val cacheStats = if (FiberCacheManagerSensor.executorToCacheManager.containsKey(execId)) {
+      FiberCacheManagerSensor.executorToCacheManager.get(execId)
+    } else {
+      CacheStats()
+    }
 
     new FiberCacheManagerSummary(
       execId,

--- a/src/main/scala/org/apache/spark/oap/ui/OapTab.scala
+++ b/src/main/scala/org/apache/spark/oap/ui/OapTab.scala
@@ -15,20 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.datasources.oap.listener
+package org.apache.spark.oap.ui
 
-import org.apache.spark.scheduler.{SparkListener, SparkListenerCustomInfoUpdate}
-import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCacheManagerSensor, FiberSensor}
+import org.apache.spark.internal.Logging
+import org.apache.spark.ui.{SparkUI, SparkUITab}
 
-class FiberInfoListener extends SparkListener {
-  override def onCustomInfoUpdate(fiberInfo: SparkListenerCustomInfoUpdate): Unit = {
-    if (fiberInfo.clazzName.contains("OapFiberCacheHeartBeatMessager")) {
-      FiberSensor.update(fiberInfo)
-    } else if (fiberInfo.clazzName.contains("FiberCacheManagerMessager")) {
-      FiberCacheManagerSensor.update(fiberInfo)
-    }
-  }
+class OapTab(parent: SparkUI) extends SparkUITab(parent, "OAP") with Logging {
+  val listener = parent.executorsListener
 
-  // TODO: implements other events like `onExecutorAdded`, `onExecutorRemoved`, etc. to maintain
-  // the whole info picture on driver side.
+  attachPage(new FiberCacheManagerPage(this))
+
+  parent.attachTab(this)
+  parent.addStaticHandler(OapTab.STATIC_RESOURCE_DIR, "/static/oap")
+}
+
+object OapTab {
+  private val STATIC_RESOURCE_DIR = "oap/static"
 }

--- a/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -141,6 +141,7 @@ private[spark] case class SparkListenerLogStart(sparkVersion: String) extends Sp
 case class SparkListenerCustomInfoUpdate(
     hostName: String,
     executorId: String,
+    clazzName: String,
     customizedInfo: String) extends SparkListenerEvent
 
 /**

--- a/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -250,25 +250,28 @@ case class FileSourceScanExec(
     withOptPartitionCount
   }
 
+  private def initOapAccumulator(format: OapFileFormat): Unit = {
+    // set Task-level Accumulator
+    format.totalTasks = Some(metrics("totalTasks"))
+    format.skipForStatisticTasks = Some(metrics("skipForStatisticTasks"))
+    format.hitIndexTasks = Some(metrics("hitIndexTasks"))
+    format.ignoreIndexTasks = Some(metrics("ignoreIndexTasks"))
+    format.missIndexTasks = Some(metrics("missIndexTasks"))
+
+    // set row-level Accumulator
+    format.totalRows = Some(metrics("totalRows"))
+    format.rowsSkippedForStatistic = Some(metrics("rowsSkippedForStatistic"))
+    format.rowsReadWhenHitIndex = Some(metrics("rowsReadWhenHitIndex"))
+    format.rowsSkippedWhenHitIndex = Some(metrics("rowsSkippedWhenHitIndex"))
+    format.rowsReadWhenIgnoreIndex = Some(metrics("rowsReadWhenIgnoreIndex"))
+    format.rowsReadWhenMissIndex = Some(metrics("rowsReadWhenMissIndex"))
+  }
+
   private lazy val inputRDD: RDD[InternalRow] = {
+    // init accumulator before buildReader
     relation.fileFormat match {
       case format: OapFileFormat =>
-        def oapMetric(name: String): SQLMetric = {
-          metrics(name)
-        }
-        // set Accumulator
-        format.totalTasks = Some(oapMetric("totalTasks"))
-        format.skipForStatisticTasks = Some(oapMetric("skipForStatisticTasks"))
-        format.hitIndexTasks = Some(oapMetric("hitIndexTasks"))
-        format.ignoreIndexTasks = Some(oapMetric("ignoreIndexTasks"))
-        format.missIndexTasks = Some(oapMetric("missIndexTasks"))
-
-        format.totalRows = Some(oapMetric("totalRows"))
-        format.rowsSkippedForStatistic = Some(oapMetric("rowsSkippedForStatistic"))
-        format.rowsReadWhenHitIndex = Some(oapMetric("rowsReadWhenHitIndex"))
-        format.rowsSkippedWhenHitIndex = Some(oapMetric("rowsSkippedWhenHitIndex"))
-        format.rowsReadWhenIgnoreIndex = Some(oapMetric("rowsReadWhenIgnoreIndex"))
-        format.rowsReadWhenMissIndex = Some(oapMetric("rowsReadWhenMissIndex"))
+        initOapAccumulator(format)
       case _ => Unit
     }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
@@ -17,11 +17,57 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+
+case class CacheStatsInternal(size: Long, count: Long) {
+  require(size >= 0)
+  require(count >= 0)
+
+  def plus(other: CacheStatsInternal): CacheStatsInternal = this + other
+
+  def minus(other: CacheStatsInternal): CacheStatsInternal = this - other
+
+  def +(other: CacheStatsInternal): CacheStatsInternal =
+    CacheStatsInternal(size + other.size, count + other.count)
+
+  def -(other: CacheStatsInternal): CacheStatsInternal =
+    CacheStatsInternal(
+      math.max(0, size - other.size),
+      math.max(0, count - other.count))
+
+  override def toString: String = s"{size:$size, count:$count}"
+
+  def toJson: JValue = ("size" -> size) ~ ("count" -> count)
+}
+object CacheStatsInternal {
+  private implicit val format = DefaultFormats
+
+  def apply(): CacheStatsInternal = CacheStatsInternal(0, 0)
+
+  def apply(json: String): CacheStatsInternal = CacheStatsInternal(parse(json))
+
+  def apply(json: JValue): CacheStatsInternal = CacheStatsInternal(
+    (json \ "size").extract[Long],
+    (json \ "count").extract[Long]
+  )
+}
+
 /**
  * Immutable class to present statistics of Cache. To record the change of cache stat in runtime,
  * please consider a counter class. [[CacheStats]] can be a snapshot of the counter class.
  */
 case class CacheStats(
+    cache: CacheStatsInternal,
+    backEndCache: CacheStatsInternal,
+    dataFiberCache: CacheStatsInternal,
+    indexFiberCache: CacheStatsInternal,
+    pendingFiberCache: CacheStatsInternal,
     hitCount: Long,
     missCount: Long,
     loadCount: Long,
@@ -54,6 +100,11 @@ case class CacheStats(
 
   def +(other: CacheStats): CacheStats =
     CacheStats(
+      cache + other.cache,
+      backEndCache + other.backEndCache,
+      dataFiberCache + other.dataFiberCache,
+      indexFiberCache + other.indexFiberCache,
+      pendingFiberCache + other.pendingFiberCache,
       hitCount + other.hitCount,
       missCount + other.missCount,
       loadCount + other.loadCount,
@@ -62,6 +113,11 @@ case class CacheStats(
 
   def -(other: CacheStats): CacheStats =
     CacheStats(
+      cache - other.cache,
+      backEndCache - other.backEndCache,
+      dataFiberCache - other.dataFiberCache,
+      indexFiberCache - other.indexFiberCache,
+      pendingFiberCache - other.pendingFiberCache,
       math.max(0, hitCount - other.hitCount),
       math.max(0, missCount - other.missCount),
       math.max(0, loadCount - other.loadCount),
@@ -69,7 +125,58 @@ case class CacheStats(
       math.max(0, evictionCount - other.evictionCount))
 
   def toDebugString: String = {
-    s"CacheStats: { hitCount=$hitCount, missCount=$missCount, " +
-      s"totalLoadTime=$totalLoadTime ns, evictionCount=$evictionCount }"
+    s"CacheStats: { cache: $cache, backEndCache:$backEndCache, dataFiber:$dataFiberCache, " +
+      s"indexFiber:$indexFiberCache, pendingFiber:$pendingFiberCache hitCount=$hitCount, " +
+      s"missCount=$missCount, totalLoadTime=${totalLoadTime} ns, evictionCount=$evictionCount }"
+  }
+
+  def toJson: JValue = {
+    ("cache" -> cache.toJson)~
+      ("backEndCache" -> backEndCache.toJson)~
+      ("dataFiber" -> dataFiberCache.toJson)~
+      ("indexFiber" -> indexFiberCache.toJson)~
+      ("pendingFiber" -> pendingFiberCache.toJson)~
+      ("hitCount" -> hitCount)~
+      ("missCount" -> missCount) ~
+      ("loadCount" -> loadCount) ~
+      ("totalLoadTime" -> totalLoadTime) ~
+      ("evictionCount" -> evictionCount)
+  }
+}
+object CacheStats extends Logging {
+  private implicit val format = DefaultFormats
+  private var updateInterval: Long = -1
+  private var lastUpdateTime: Long = 0
+
+  def apply(): CacheStats = CacheStats(
+    CacheStatsInternal(), CacheStatsInternal(), CacheStatsInternal(),
+    CacheStatsInternal(), CacheStatsInternal(), 0, 0, 0, 0, 0)
+
+  def apply(json: String): CacheStats = CacheStats(parse(json))
+
+  def apply(json: JValue): CacheStats = CacheStats(
+    CacheStatsInternal(json \ "cache"),
+    CacheStatsInternal(json \ "backEndCache"),
+    CacheStatsInternal(json \ "dataFiber"),
+    CacheStatsInternal(json \ "indexFiber"),
+    CacheStatsInternal(json \ "pendingFiber"),
+      (json \ "hitCount").extract[Long],
+      (json \ "missCount").extract[Long],
+      (json \ "loadCount").extract[Long],
+      (json \ "totalLoadTime").extract[Long],
+      (json \ "evictionCount").extract[Long])
+
+  def status(cacheStats: CacheStats, conf: SparkConf): String = {
+    updateInterval = if (updateInterval != -1) {
+      updateInterval
+    } else {
+      conf.getLong("oap.update.fiber.cache.metrics.interval.sec", 60L) * 1000
+    }
+    if (System.currentTimeMillis() - lastUpdateTime > updateInterval) {
+      lastUpdateTime = System.currentTimeMillis()
+      compact(render(cacheStats.toJson))
+    } else {
+      ""
+    }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -45,7 +45,14 @@ private[filecache] class CacheGuardian(maxMemory: Long, oapCache: OapCache)
 
   private val removalPendingQueue = new LinkedBlockingQueue[(Fiber, FiberCache)]()
 
-  def pendingFiberCount: Int = removalPendingQueue.size()
+  // Tell if guardian thread is trying to remove one Fiber.
+  @volatile private var bRemoving: Boolean = false
+
+  def pendingFiberCount: Int = if (bRemoving) {
+    removalPendingQueue.size() + 1
+  } else {
+    removalPendingQueue.size()
+  }
 
   def addRemovalFiber(fiber: Fiber, fiberCache: FiberCache): Unit = {
     oapCache.pendingFiberSize.addAndGet(fiberCache.size())
@@ -60,21 +67,24 @@ private[filecache] class CacheGuardian(maxMemory: Long, oapCache: OapCache)
     // Loop forever, TODO: provide a release function
     while (true) {
       val (fiber, fiberCache) = removalPendingQueue.take()
+      bRemoving = true
       logDebug(s"Removing fiber: $fiber")
       // Block if fiber is in use.
-      while (!fiberCache.tryDispose(fiber, 3000)) {
+      if (!fiberCache.tryDispose(fiber, 3000)) {
         // Check memory usage every 3s while we are waiting fiber release.
         logDebug(s"Waiting fiber to be released timeout. Fiber: $fiber")
+        removalPendingQueue.offer((fiber, fiberCache))
         if (oapCache.pendingFiberSize.get() > maxMemory) {
           logWarning("Fibers pending on removal use too much memory, " +
               s"current: ${oapCache.pendingFiberSize.get()}, max: $maxMemory")
         }
-
+      } else {
+        // TODO: Make log more readable
+        oapCache.addFiber(fiber, -1, -fiberCache.size())
+        oapCache.pendingFiberSize.addAndGet(-fiberCache.size())
+        logDebug(s"Fiber removed successfully. Fiber: $fiber")
       }
-      // TODO: Make log more readable
-      oapCache.addFiber(fiber, -1, -fiberCache.size())
-      oapCache.pendingFiberSize.addAndGet(-fiberCache.size())
-      logDebug(s"Fiber removed successfully. Fiber: $fiber")
+      bRemoving = false
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -19,6 +19,9 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 
 import java.util.concurrent.ConcurrentHashMap
 
+import com.google.common.base.Throwables
+import scala.collection.JavaConverters._
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate
 import org.apache.spark.sql.execution.datasources.oap.IndexMeta
@@ -87,3 +90,25 @@ private[oap] trait AbstractFiberSensor extends Logging {
 }
 
 object FiberSensor extends AbstractFiberSensor
+
+object FiberCacheManagerSensor extends AbstractFiberSensor {
+  val executorToCacheManager = new ConcurrentHashMap[String, CacheStats]()
+
+  def summary(): CacheStats = executorToCacheManager.asScala.toMap.values
+    .foldLeft(CacheStats())((sum, cache) => sum + cache)
+
+  override def update(fiberInfo: SparkListenerCustomInfoUpdate): Unit = {
+    if (fiberInfo.customizedInfo.nonEmpty) {
+      try {
+        val cacheMetrics = CacheStats(fiberInfo.customizedInfo)
+        executorToCacheManager.put(fiberInfo.executorId, cacheMetrics)
+        logDebug(s"execID:${fiberInfo.executorId}, host:${fiberInfo.hostName}," +
+          s" ${cacheMetrics.toDebugString}")
+      } catch {
+        case t: Throwable =>
+          val stack = Throwables.getStackTraceAsString(t)
+          logError(s"FiberCacheManagerSensor parse json failed, $stack")
+      }
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -60,18 +60,26 @@ trait FiberCache extends Logging {
     val writeLock = FiberLockManager.getFiberLock(fiber).writeLock()
     // Give caller a chance to deal with the long wait case.
     while (System.currentTimeMillis() - startTime <= timeout) {
-      if (writeLock.tryLock(200, TimeUnit.MILLISECONDS)) {
-        try {
-          if (refCount == 0) {
-            realDispose(fiber)
-            return true
+      if (refCount != 0) {
+        // LRU access (get and occupy) done, but fiber was still occupied by at least one reader,
+        // so it needs to sleep some time to see if the reader done.
+        // Otherwise, it becomes a polling loop.
+        // TODO: use lock/sync-obj to leverage the concurrency APIs instead of explicit sleep.
+        Thread.sleep(100)
+      } else {
+        if (writeLock.tryLock(200, TimeUnit.MILLISECONDS)) {
+          try {
+            if (refCount == 0) {
+              realDispose(fiber)
+              return true
+            }
+          } finally {
+            writeLock.unlock()
           }
-        } finally {
-          writeLock.unlock()
         }
       }
-      logWarning(s"Fiber Cache Dispose waiting detected for ${this}")
     }
+    logWarning(s"Fiber Cache Dispose waiting detected for ${fiber}")
     false
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -191,7 +191,8 @@ private[oap] class OapDataReader(
   filterScanners: Option[IndexScanners],
   requiredIds: Array[Int]) extends Logging {
 
-  var selectedRows: Option[Long] = None
+  var rowsReadWhenHitIndex: Option[Long] = None
+  var ignoreIndex: Boolean = false
 
   def initialize(
       conf: Configuration,
@@ -200,8 +201,16 @@ private[oap] class OapDataReader(
     // TODO how to save the additional FS operation to get the Split size
     val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf)
 
+    def getFullScanIter: Iterator[InternalRow] = {
+      val start = System.currentTimeMillis()
+      val iter = fileScanner.iterator(conf, requiredIds)
+      val end = System.currentTimeMillis()
+      logDebug("Contruct File Iterator: " + (end - start) + " ms")
+      iter
+    }
+
     filterScanners match {
-      case Some(indexScanners) if indexScanners.indexIsAvailable(path, conf) =>
+      case Some(indexScanners) =>
         def getRowIds(options: Map[String, String]): Array[Int] = {
           indexScanners.initialize(path, conf)
 
@@ -223,21 +232,21 @@ private[oap] class OapDataReader(
           else rowIds
         }
 
-        val start = System.currentTimeMillis()
-        val rows = getRowIds(options)
-        val iter = fileScanner.iterator(conf, requiredIds, rows)
-        val end = System.currentTimeMillis()
+        if (indexScanners.indexIsAvailable(path, conf)) {
+          val start = System.currentTimeMillis()
+          val rows = getRowIds(options)
+          val iter = fileScanner.iterator(conf, requiredIds, rows)
+          val end = System.currentTimeMillis()
 
-        selectedRows = Some(rows.length)
-        logDebug("Construct File Iterator: " + (end - start) + "ms")
-        iter
+          rowsReadWhenHitIndex = Some(rows.length)
+          logDebug("Construct File Iterator: " + (end - start) + "ms")
+          iter
+        } else {
+          ignoreIndex = true
+          getFullScanIter
+        }
       case _ =>
-        val start = System.currentTimeMillis()
-        val iter = fileScanner.iterator(conf, requiredIds)
-        val end = System.currentTimeMillis()
-        logDebug("Construct File Iterator: " + (end - start) + "ms")
-
-        iter
+        getFullScanIter
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
@@ -21,6 +21,7 @@ import java.io.PrintStream
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
+import org.apache.spark.oap.ui.OapTab
 import org.apache.spark.sql.{OapSession, SQLContext}
 import org.apache.spark.sql.execution.datasources.oap.listener.{FiberInfoListener, OapIndexInfoListener}
 import org.apache.spark.sql.hive.{HiveUtils, OapSessionState}
@@ -70,6 +71,8 @@ private[hive] object OapEnv extends Logging {
 
     SparkSQLEnv.sparkContext = sparkContext
     SparkSQLEnv.sqlContext = sqlContext
+
+    sparkContext.ui.foreach(new OapTab(_))
   }
 
   /** Cleans up and shuts down the Spark SQL environments. */

--- a/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
+++ b/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.status.api.v1
+
+import java.util.zip.ZipOutputStream
+import javax.servlet.ServletContext
+import javax.ws.rs._
+import javax.ws.rs.core.{Context, Response}
+
+import org.eclipse.jetty.server.handler.ContextHandler
+import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
+import org.glassfish.jersey.server.ServerProperties
+import org.glassfish.jersey.servlet.ServletContainer
+
+import org.apache.spark.SecurityManager
+import org.apache.spark.ui.SparkUI
+
+/**
+ * Main entry point for serving spark application metrics as json, using JAX-RS.
+ *
+ * Each resource should have endpoints that return **public** classes defined in api.scala.  Mima
+ * binary compatibility checks ensure that we don't inadvertently make changes that break the api.
+ * The returned objects are automatically converted to json by jackson with JacksonMessageWriter.
+ * In addition, there are a number of tests in HistoryServerSuite that compare the json to "golden
+ * files".  Any changes and additions should be reflected there as well -- see the notes in
+ * HistoryServerSuite.
+ */
+@Path("/v1")
+private[v1] class ApiRootResource extends UIRootFromServletContext {
+
+  @Path("applications")
+  def getApplicationList(): ApplicationListResource = {
+    new ApplicationListResource(uiRoot)
+  }
+
+  @Path("applications/{appId}")
+  def getApplication(): OneApplicationResource = {
+    new OneApplicationResource(uiRoot)
+  }
+
+  @Path("applications/{appId}/{attemptId}/jobs")
+  def getJobs(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): AllJobsResource = {
+    uiRoot.withSparkUI(appId, Some(attemptId)) { ui =>
+      new AllJobsResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/jobs")
+  def getJobs(@PathParam("appId") appId: String): AllJobsResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new AllJobsResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/jobs/{jobId: \\d+}")
+  def getJob(@PathParam("appId") appId: String): OneJobResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new OneJobResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/{attemptId}/jobs/{jobId: \\d+}")
+  def getJob(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): OneJobResource = {
+    uiRoot.withSparkUI(appId, Some(attemptId)) { ui =>
+      new OneJobResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/executors")
+  def getExecutors(@PathParam("appId") appId: String): ExecutorListResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new ExecutorListResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/allexecutors")
+  def getAllExecutors(@PathParam("appId") appId: String): AllExecutorListResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new AllExecutorListResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/{attemptId}/executors")
+  def getExecutors(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): ExecutorListResource = {
+    uiRoot.withSparkUI(appId, Some(attemptId)) { ui =>
+      new ExecutorListResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/{attemptId}/allexecutors")
+  def getAllExecutors(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): AllExecutorListResource = {
+    uiRoot.withSparkUI(appId, Some(attemptId)) { ui =>
+      new AllExecutorListResource(ui)
+    }
+  }
+
+
+  @Path("applications/{appId}/stages")
+  def getStages(@PathParam("appId") appId: String): AllStagesResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new AllStagesResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/{attemptId}/stages")
+  def getStages(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): AllStagesResource = {
+    uiRoot.withSparkUI(appId, Some(attemptId)) { ui =>
+      new AllStagesResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/stages/{stageId: \\d+}")
+  def getStage(@PathParam("appId") appId: String): OneStageResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new OneStageResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/{attemptId}/stages/{stageId: \\d+}")
+  def getStage(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): OneStageResource = {
+    uiRoot.withSparkUI(appId, Some(attemptId)) { ui =>
+      new OneStageResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/storage/rdd")
+  def getRdds(@PathParam("appId") appId: String): AllRDDResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new AllRDDResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/{attemptId}/storage/rdd")
+  def getRdds(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): AllRDDResource = {
+    uiRoot.withSparkUI(appId, Some(attemptId)) { ui =>
+      new AllRDDResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/storage/rdd/{rddId: \\d+}")
+  def getRdd(@PathParam("appId") appId: String): OneRDDResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new OneRDDResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/{attemptId}/storage/rdd/{rddId: \\d+}")
+  def getRdd(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): OneRDDResource = {
+    uiRoot.withSparkUI(appId, Some(attemptId)) { ui =>
+      new OneRDDResource(ui)
+    }
+  }
+
+  @Path("applications/{appId}/logs")
+  def getEventLogs(@PathParam("appId") appId: String): EventLogDownloadResource = {
+    new EventLogDownloadResource(uiRoot, appId, None)
+  }
+
+  @Path("applications/{appId}/{attemptId}/logs")
+  def getEventLogs(@PathParam("appId") appId: String,
+      @PathParam("attemptId") attemptId: String): EventLogDownloadResource = {
+    new EventLogDownloadResource(uiRoot, appId, Some(attemptId))
+  }
+
+  @Path("version")
+  def getVersion(): VersionResource = {
+    new VersionResource(uiRoot)
+  }
+
+  /**
+   * Added for OAP FiberCacheManager Metrics
+   * @param appId
+   * @return impl instance
+   */
+  @Path("applications/{appId}/fibercachemanagers")
+  def getCacheManagers(@PathParam("appId") appId: String): AllFiberCacheManagerListResource = {
+    uiRoot.withSparkUI(appId, None) { ui =>
+      new AllFiberCacheManagerListResource(ui)
+    }
+  }
+}
+
+private[spark] object ApiRootResource {
+
+  def getServletHandler(uiRoot: UIRoot): ServletContextHandler = {
+    val jerseyContext = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
+    jerseyContext.setContextPath("/api")
+    val holder: ServletHolder = new ServletHolder(classOf[ServletContainer])
+    holder.setInitParameter(ServerProperties.PROVIDER_PACKAGES, "org.apache.spark.status.api.v1")
+    UIRootFromServletContext.setUiRoot(jerseyContext, uiRoot)
+    jerseyContext.addServlet(holder, "/*")
+    jerseyContext
+  }
+}
+
+/**
+ * This trait is shared by the all the root containers for application UI information --
+ * the HistoryServer and the application UI.  This provides the common
+ * interface needed for them all to expose application info as json.
+ */
+private[spark] trait UIRoot {
+  def getSparkUI(appKey: String): Option[SparkUI]
+  def getApplicationInfoList: Iterator[ApplicationInfo]
+  def getApplicationInfo(appId: String): Option[ApplicationInfo]
+
+  /**
+   * Write the event logs for the given app to the [[ZipOutputStream]] instance. If attemptId is
+   * [[None]], event logs for all attempts of this application will be written out.
+   */
+  def writeEventLogs(appId: String, attemptId: Option[String], zipStream: ZipOutputStream): Unit = {
+    Response.serverError()
+      .entity("Event logs are only available through the history server.")
+      .status(Response.Status.SERVICE_UNAVAILABLE)
+      .build()
+  }
+
+  /**
+   * Get the spark UI with the given appID, and apply a function
+   * to it.  If there is no such app, throw an appropriate exception
+   */
+  def withSparkUI[T](appId: String, attemptId: Option[String])(f: SparkUI => T): T = {
+    val appKey = attemptId.map(appId + "/" + _).getOrElse(appId)
+    getSparkUI(appKey) match {
+      case Some(ui) =>
+        f(ui)
+      case None => throw new NotFoundException("no such app: " + appId)
+    }
+  }
+  def securityManager: SecurityManager
+}
+
+private[v1] object UIRootFromServletContext {
+
+  private val attribute = getClass.getCanonicalName
+
+  def setUiRoot(contextHandler: ContextHandler, uiRoot: UIRoot): Unit = {
+    contextHandler.setAttribute(attribute, uiRoot)
+  }
+
+  def getUiRoot(context: ServletContext): UIRoot = {
+    context.getAttribute(attribute).asInstanceOf[UIRoot]
+  }
+}
+
+private[v1] trait UIRootFromServletContext {
+  @Context
+  var servletContext: ServletContext = _
+
+  def uiRoot: UIRoot = UIRootFromServletContext.getUiRoot(servletContext)
+}
+
+private[v1] class NotFoundException(msg: String) extends WebApplicationException(
+  new NoSuchElementException(msg),
+  Response
+    .status(Response.Status.NOT_FOUND)
+    .entity(ErrorWrapper(msg))
+    .build()
+)
+
+private[v1] class BadParameterException(msg: String) extends WebApplicationException(
+  new IllegalArgumentException(msg),
+  Response
+    .status(Response.Status.BAD_REQUEST)
+    .entity(ErrorWrapper(msg))
+    .build()
+) {
+  def this(param: String, exp: String, actual: String) = {
+    this(raw"""Bad value for parameter "$param".  Expected a $exp, got "$actual"""")
+  }
+}
+
+/**
+ * Signal to JacksonMessageWriter to not convert the message into json (which would result in an
+ * extra set of quotes).
+ */
+private[v1] case class ErrorWrapper(s: String)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -30,13 +30,23 @@ class FiberCacheManagerSuite extends SharedOapContext {
   private def generateData(size: Int): Array[Byte] =
     Utils.randomizeInPlace(new Array[Byte](size))
 
+  private var fiberGroupId: Int = 0
+
+  // Each test calls this to create a new fiber group Id.
+  // To avoid cache hit by mistake.
+  private def newFiberGroup = {
+    fiberGroupId += 1
+    fiberGroupId
+  }
 
   test("unit test") {
     val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
     val origStats = FiberCacheManager.cacheStats
+    newFiberGroup
     (1 to memorySizeInMB * 2).foreach { i =>
       val data = generateData(mbSize)
-      val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #0.$i")
+      val fiber =
+        TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #$fiberGroupId.$i")
       val fiberCache = FiberCacheManager.get(fiber, configuration)
       val fiberCache2 = FiberCacheManager.get(fiber, configuration)
       assert(fiberCache.toArray sameElements data)
@@ -53,12 +63,13 @@ class FiberCacheManagerSuite extends SharedOapContext {
   test("remove a fiber is in use") {
     val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
     val dataInUse = generateData(mbSize)
-    val fiberInUse =
-      TestFiber(() => MemoryManager.putToDataFiberCache(dataInUse), s"test fiber #1.0")
+    val fiberInUse = TestFiber(
+        () => MemoryManager.putToDataFiberCache(dataInUse), s"test fiber #${newFiberGroup}.0")
     val fiberCacheInUse = FiberCacheManager.get(fiberInUse, configuration)
     (1 to memorySizeInMB * 2).foreach { i =>
       val data = generateData(mbSize)
-      val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #1.$i")
+      val fiber =
+        TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #$fiberGroupId.$i")
       val fiberCache = FiberCacheManager.get(fiber, configuration)
       assert(fiberCache.toArray sameElements data)
       fiberCache.release()
@@ -68,11 +79,13 @@ class FiberCacheManagerSuite extends SharedOapContext {
   }
 
   test("wait for other thread release the fiber") {
+    newFiberGroup
     class FiberTestRunner(i: Int) extends Thread {
       override def run(): Unit = {
         val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
         val data = generateData(memorySizeInMB / 4 * mbSize)
-        val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #2.$i")
+        val fiber = TestFiber(
+          () => MemoryManager.putToDataFiberCache(data), s"test fiber #$fiberGroupId.$i")
         val fiberCache = FiberCacheManager.get(fiber, configuration)
         Thread.sleep(2000)
         fiberCache.release()
@@ -91,7 +104,8 @@ class FiberCacheManagerSuite extends SharedOapContext {
         """with cache's MAX_WEIGHT\(\d+\.\d [TGMK]?B\) / 4""").r
     val exception = intercept[AssertionError] {
       val data = generateData(memorySizeInMB * mbSize / 2)
-      val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #3.1")
+      val fiber = TestFiber(
+        () => MemoryManager.putToDataFiberCache(data), s"test fiber #${newFiberGroup}.1")
       val fiberCache = FiberCacheManager.get(fiber, configuration)
       fiberCache.release()
     }
@@ -103,12 +117,15 @@ class FiberCacheManagerSuite extends SharedOapContext {
   }
 
   test("fiber key equality test") {
+    newFiberGroup
     val data = generateData(kbSize)
     val origStats = FiberCacheManager.cacheStats
-    val fiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber")
+    val fiber = TestFiber(
+      () => MemoryManager.putToDataFiberCache(data), s"test fiber #$fiberGroupId.0")
     val fiberCache1 = FiberCacheManager.get(fiber, configuration)
     assert(FiberCacheManager.cacheStats.minus(origStats).missCount == 1)
-    val sameFiber = TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber")
+    val sameFiber = TestFiber(
+      () => MemoryManager.putToDataFiberCache(data), s"test fiber #$fiberGroupId.0")
     val fiberCache2 = FiberCacheManager.get(sameFiber, configuration)
     assert(FiberCacheManager.cacheStats.minus(origStats).hitCount == 1)
     fiberCache1.release()
@@ -116,11 +133,12 @@ class FiberCacheManagerSuite extends SharedOapContext {
   }
 
   test("cache guardian remove pending fibers") {
+    newFiberGroup
     Thread.sleep(1000) // Wait some time for CacheGuardian to remove pending fibers
     val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
     val fibers = (1 to memorySizeInMB * 2).map { i =>
       val data = generateData(mbSize)
-      TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #0.$i")
+      TestFiber(() => MemoryManager.putToDataFiberCache(data), s"test fiber #$fiberGroupId.$i")
     }
     // release fibers so it has chance to be disposed immediately
     fibers.foreach(FiberCacheManager.get(_, configuration).release())
@@ -259,5 +277,36 @@ class FiberCacheManagerSuite extends SharedOapContext {
     fiberCache.release()
     Thread.sleep(500)
     assert(fiberCache.isDisposed)
+  }
+
+  test("LRU blocks memory free") {
+    val memorySizeInMB = (MemoryManager.cacheMemory / mbSize).toInt
+    val dataInUse = generateData(mbSize)
+    val fiberInUse = TestFiber(
+      () => MemoryManager.putToDataFiberCache(dataInUse), s"test fiber #${newFiberGroup}.0")
+
+    // Put into cache and make it use
+    val fiberCacheInUse = FiberCacheManager.get(fiberInUse, configuration)
+    assert(FiberCacheManager.pendingSize == 0)
+
+    // make fiber in use the 1st element in release queue.
+    FiberCacheManager.removeFiber(fiberInUse)
+
+    (1 to memorySizeInMB * 2).foreach { i =>
+      val data = generateData(mbSize)
+      val fiber = TestFiber(
+        () => MemoryManager.putToDataFiberCache(data), s"test fiber #$fiberGroupId.$i")
+      val fiberCache = FiberCacheManager.get(fiber, configuration)
+      assert(fiberCache.toArray sameElements data)
+      fiberCache.release()
+    }
+
+    // Wait for clean.
+    Thread.sleep(6000)
+    // There should be only one in-use fiber.
+    assert(FiberCacheManager.pendingSize == 1)
+    fiberCacheInUse.release()
+    Thread.sleep(6000)
+    assert(FiberCacheManager.pendingSize == 0)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -287,7 +287,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
 
     // Put into cache and make it use
     val fiberCacheInUse = FiberCacheManager.get(fiberInUse, configuration)
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
 
     // make fiber in use the 1st element in release queue.
     FiberCacheManager.removeFiber(fiberInUse)
@@ -304,9 +304,9 @@ class FiberCacheManagerSuite extends SharedOapContext {
     // Wait for clean.
     Thread.sleep(6000)
     // There should be only one in-use fiber.
-    assert(FiberCacheManager.pendingSize == 1)
+    assert(FiberCacheManager.pendingCount == 1)
     fiberCacheInUse.release()
     Thread.sleep(6000)
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -125,16 +125,16 @@ class FiberCacheManagerSuite extends SharedOapContext {
     // release fibers so it has chance to be disposed immediately
     fibers.foreach(FiberCacheManager.get(_, configuration).release())
     Thread.sleep(1000)
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
     // Hold the fiber, so it can't be disposed until release
     val fiberCaches = fibers.map(FiberCacheManager.get(_, configuration))
     Thread.sleep(1000)
-    assert(FiberCacheManager.pendingSize > 0)
+    assert(FiberCacheManager.pendingCount > 0)
     // After release, CacheGuardian should be back to work
     fiberCaches.foreach(_.release())
     // Wait some time for CacheGuardian being waken-up
     Thread.sleep(1000)
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
   }
 
   class TestRunner(work: () => Unit) extends Runnable {
@@ -187,7 +187,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     pool.awaitTermination(1000, TimeUnit.MILLISECONDS)
     Thread.sleep(100)
     results.foreach(r => r.get())
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
   }
 
   // refCount should be correct

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -17,15 +17,45 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileHandle
+import org.apache.spark.sql.execution.datasources.oap.listener.FiberInfoListener
 import org.apache.spark.sql.execution.datasources.oap.utils.CacheStatusSerDe
 import org.apache.spark.util.collection.BitSet
 
 
 class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Logging {
+
+  test("test FiberCacheManagerSensor") {
+    val host = "0.0.0.0"
+    val execID = "exec1"
+    val messager = "FiberCacheManagerMessager"
+
+    // Test json empty
+    new FiberInfoListener onCustomInfoUpdate SparkListenerCustomInfoUpdate(
+      host, execID, messager, "")
+    assertResult(0)(FiberCacheManagerSensor.executorToCacheManager.size())
+
+    // Test json error
+    new FiberInfoListener onCustomInfoUpdate SparkListenerCustomInfoUpdate(
+      host, execID, messager, "error msg")
+    assertResult(0)(FiberCacheManagerSensor.executorToCacheManager.size())
+
+    // Test normal msg
+    val conf: SparkConf = new SparkConf()
+    conf.set("oap.update.fiber.cache.metrics.interval.sec", 0L.toString)
+    val cacheStats = CacheStats(CacheStatsInternal(12, 21),
+      CacheStatsInternal(12, 21), CacheStatsInternal(2, 19),
+      CacheStatsInternal(10, 2), CacheStatsInternal(0, 0),
+      213, 23, 23, 123131, 2)
+    new FiberInfoListener onCustomInfoUpdate SparkListenerCustomInfoUpdate(
+      host, execID, messager, CacheStats.status(cacheStats, conf))
+    assertResult(1)(FiberCacheManagerSensor.executorToCacheManager.size())
+    assertResult(cacheStats.toJson)(
+      FiberCacheManagerSensor.executorToCacheManager.get(execID).toJson)
+  }
 
   test("test get hosts from FiberSensor") {
     val filePath = "file1"
@@ -39,7 +69,8 @@ class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Loggi
     bitSet1.set(1)
     bitSet1.set(2)
     val fcs = Seq(FiberCacheStatus(filePath, bitSet1, dataFileMeta))
-    val fiberInfo = SparkListenerCustomInfoUpdate(host1, execId1, CacheStatusSerDe.serialize(fcs))
+    val fiberInfo = SparkListenerCustomInfoUpdate(host1, execId1,
+      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe.serialize(fcs))
     this.update(fiberInfo)
     assert(this.getHosts(filePath) contains (FiberSensor.OAP_CACHE_HOST_PREFIX + host1 +
       FiberSensor.OAP_CACHE_EXECUTOR_PREFIX + execId1))
@@ -55,8 +86,9 @@ class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Loggi
     bitSet2.set(7)
     bitSet2.set(8)
 
-    val fiberInfo2 = SparkListenerCustomInfoUpdate(host2, execId2, CacheStatusSerDe
-      .serialize(Seq(FiberCacheStatus(filePath, bitSet2, dataFileMeta))))
+    val fiberInfo2 = SparkListenerCustomInfoUpdate(host2, execId2,
+      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
+        .serialize(Seq(FiberCacheStatus(filePath, bitSet2, dataFileMeta))))
     this.update(fiberInfo2)
     assert(this.getHosts(filePath) contains  (FiberSensor.OAP_CACHE_HOST_PREFIX + host2 +
       FiberSensor.OAP_CACHE_EXECUTOR_PREFIX + execId2))
@@ -69,8 +101,9 @@ class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Loggi
     bitSet3.set(8)
     bitSet3.set(9)
     bitSet3.set(10)
-    val fiberInfo3 = SparkListenerCustomInfoUpdate(host3, execId3, CacheStatusSerDe
-      .serialize(Seq(FiberCacheStatus(filePath, bitSet3, dataFileMeta))))
+    val fiberInfo3 = SparkListenerCustomInfoUpdate(host3, execId3,
+      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
+        .serialize(Seq(FiberCacheStatus(filePath, bitSet3, dataFileMeta))))
     this.update(fiberInfo3)
     assert(this.getHosts(filePath) === Some(FiberSensor.OAP_CACHE_HOST_PREFIX + host2 +
       FiberSensor.OAP_CACHE_EXECUTOR_PREFIX + execId2))


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

* **report cache information by heartbeat, modify customizedInfo -> Seq[(className, customInfo)]**
* **CacheStats support Ser/Deser to/from json, add more metrics into CacheStats:**
    * cache Metrics
    * backendCache Metrics
    * dataFiber Metrics
    * indexFiber Metrics
    * pendingFiber Metrics
* **add a OAP tab in SparkUI that monitor FiberCacheManager:**
    * involve the Spark root resource class ApiRootResource
    * page is similar to Executor Page
    * support RESTful API: /api/v1/applications/fibercachemanagers
* **modify and add OapFileFormat accumulators, which are SQL-level.**

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
UT test, and UI Test

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Accumulator: Job-Level -> SQL-Level
![image](https://user-images.githubusercontent.com/4183289/35476738-dfbf5010-03ef-11e8-86d5-168a65ed964d.png)

OAP UI: FiberCacheManagers
![image](https://user-images.githubusercontent.com/4183289/35476744-032a8de4-03f0-11e8-8b50-a2466e23a31f.png)
