### PR TITLE
[Branch-0.3]ignore isNotNull when parquetFileFormat call hasAvailableIndex #555

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -386,8 +386,8 @@ private[oap] case class DataSourceMeta(
       case In(attrRef: AttributeReference, _) =>
         checkInMetaSet(attrRef)
       // TODO: only ParquetFileFormat use this function, details in #555
-      // case IsNotNull(attrRef: AttributeReference) =>
-      //   checkInMetaSet(attrRef)
+      case IsNotNull(attrRef: AttributeReference) if requirement.isDefined =>
+         checkInMetaSet(attrRef)
       case IsNull(attrRef: AttributeReference) =>
         checkInMetaSet(attrRef)
       case _ => false

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -340,7 +340,7 @@ private[oap] case class DataSourceMeta(
     @transient fileHeader: FileHeader) extends Serializable {
 
     // Check whether this expression is supported by index or not
-    def isSupportedByIndex(exp: Expression, requirement: Option[IndexType] = None): Boolean = {
+  def isSupportedByIndex(exp: Expression, requirement: Option[IndexType] = None): Boolean = {
     var attr: String = null
     def checkInMetaSet(attrRef: AttributeReference): Boolean = {
       if (attr ==  null || attr == attrRef.name) {
@@ -385,8 +385,9 @@ private[oap] case class DataSourceMeta(
         checkInMetaSet(attrRef)
       case In(attrRef: AttributeReference, _) =>
         checkInMetaSet(attrRef)
-      case IsNotNull(attrRef: AttributeReference) =>
-        checkInMetaSet(attrRef)
+      // TODO: only ParquetFileFormat use this function, details in #555
+      // case IsNotNull(attrRef: AttributeReference) =>
+      //   checkInMetaSet(attrRef)
       case IsNull(attrRef: AttributeReference) =>
         checkInMetaSet(attrRef)
       case _ => false

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -399,7 +399,8 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     hashSetList.append(bitmapIndexAttrSet)
 
     // Query "select * from t where b == 1" will generate IsNotNull expr which is unsupportted
-    val isNotNull = Seq(IsNotNull(AttributeReference("b", IntegerType)()))
+    val isNotNull = Seq(IsNotNull(AttributeReference("b", IntegerType)()),
+      IsNotNull(AttributeReference("a", IntegerType)()))
     val eq = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)))
     val eq2 = Seq(EqualTo(AttributeReference("b", IntegerType)(), Literal(1)))
     val eq3 = Seq(EqualTo(Literal(1), AttributeReference("a", IntegerType)()))


### PR DESCRIPTION
Change-Id: I6a92c341a451d5de5875fee87125b65a4dc09b73

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

ignore isNotNull when parquetFileFormat call hasAvailableIndex #555

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

add ut

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

