### PR TITLE
[DO NOT MERGE] Support FiberCache compression.#541

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -52,7 +52,9 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
     // This is called before the scanner call `initialize`
     val reader = BTreeIndexFileReader(conf, indexPath)
     val footerFiber = BTreeFiber(
-      () => reader.readFooter(), reader.file.toString, reader.footerSectionId, 0)
+      (enableCompress: Boolean) => reader.readFooter(enableCompress), reader.file.toString,
+      reader.footerSectionId, 0, enableCompress = true)
+
     val footerCache = FiberCacheManager.get(footerFiber, conf)
     val footer = BTreeFooter(footerCache, keySchema)
     val offset = footer.getStatsOffset

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReader.scala
@@ -73,10 +73,10 @@ private[oap] case class BTreeIndexFileReader(
     }
   }
 
-  def readFooter(): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, footerIndex, footerLength)
+  def readFooter(enableCompress: Boolean): FiberCache =
+    MemoryManager.putToIndexFiberCache(reader, footerIndex, footerLength, enableCompress)
 
-  def readRowIdList(partIdx: Int): FiberCache = {
+  def readRowIdList(partIdx: Int, enableCompress: Boolean): FiberCache = {
     val partSize = rowIdListSizePerSection.toLong * IndexUtils.INT_SIZE
     val readLength = if (partIdx * partSize + partSize > rowIdListLength) {
       rowIdListLength % partSize
@@ -85,15 +85,16 @@ private[oap] case class BTreeIndexFileReader(
     }
     assert(readLength <= Int.MaxValue, "Size of each row id list partition is too large!")
     MemoryManager.putToIndexFiberCache(reader, rowIdListIndex + partIdx * partSize,
-      readLength.toInt)
+      readLength.toInt, enableCompress)
   }
 
   @deprecated("no need to read the whole row id list", "v0.3")
-  def readRowIdList(): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, rowIdListIndex, rowIdListLength.toInt)
+  def readRowIdList(enableCompress: Boolean): FiberCache =
+    MemoryManager.putToIndexFiberCache(reader, rowIdListIndex, rowIdListLength.toInt,
+      enableCompress)
 
-  def readNode(offset: Int, size: Int): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, nodesIndex + offset, size)
+  def readNode(offset: Int, size: Int, enableCompress: Boolean): FiberCache =
+    MemoryManager.putToIndexFiberCache(reader, nodesIndex + offset, size, enableCompress)
 
   def close(): Unit = reader.close()
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -36,7 +36,8 @@ abstract class DataFile {
   def configuration: Configuration
 
   def createDataFileHandle(): DataFileHandle
-  def getFiberData(groupId: Int, fiberId: Int, conf: Configuration): FiberCache
+  def getFiberData(groupId: Int, fiberId: Int, conf: Configuration,
+                   enableCompress: Boolean): FiberCache
   def iterator(conf: Configuration, requiredIds: Array[Int]): Iterator[InternalRow]
   def iterator(conf: Configuration, requiredIds: Array[Int], rowIds: Array[Int])
   : Iterator[InternalRow]

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
@@ -44,7 +44,7 @@ private[oap] case class IndexFile(file: Path) extends CommonIndexFile {
     // TODO check if enough to fit in Int
     val fileLength = fs.getContentSummary(file).getLength
 
-    val fiberCache = MemoryManager.putToIndexFiberCache(fin, 0, fileLength.toInt)
+    val fiberCache = MemoryManager.putToIndexFiberCache(fin, 0, fileLength.toInt, false)
     fin.close()
     fiberCache
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -33,7 +33,8 @@ import org.apache.spark.sql.types.StructType
 private[oap] case class ParquetDataFile
 (path: String, schema: StructType, configuration: Configuration) extends DataFile {
 
-  def getFiberData(groupId: Int, fiberId: Int, conf: Configuration): FiberCache = {
+  def getFiberData(groupId: Int, fiberId: Int, conf: Configuration,
+                   enableCompress: Boolean): FiberCache = {
     // TODO data cache
     throw new UnsupportedOperationException("Not support getFiberData Operation.")
   }

--- a/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -761,6 +761,40 @@ object SQLConf {
         .intConf
         .createWithDefault(1024 * 1024)
 
+  val OAP_ENABLE_INDEX_FIBER_CACHE_COMPRESSION =
+    SQLConfigBuilder("spark.oap.index.fiber.cache.compress.enable")
+      .internal()
+      .doc("To indicate if enable/disable index fiber cache compression")
+      .booleanConf
+      .createWithDefault(false)
+
+  val OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION =
+    SQLConfigBuilder("spark.oap.data.fiber.cache.compress.enable")
+      .internal()
+      .doc("To indicate if enable/disable data fiber cache compression")
+      .booleanConf
+      .createWithDefault(false)
+
+  val OAP_INDEX_FIBER_CACHE_COMPRESSION_Codec =
+    SQLConfigBuilder("spark.oap.index.fiber.cache.compression.codec")
+    .internal()
+    .doc("Sets the compression codec use when writing index fiber cache. " +
+      "Acceptable values include: uncompressed, snappy, gzip, lzo.")
+    .stringConf
+    .transform(_.toUpperCase())
+    .checkValues(Set("UNCOMPRESSED", "SNAPPY", "GZIP", "LZO"))
+    .createWithDefault("GZIP")
+
+  val OAP_DATA_FIBER_CACHE_COMPRESSION_Codec =
+    SQLConfigBuilder("spark.oap.data.fiber.cache.compression.codec")
+      .internal()
+      .doc("Sets the compression codec use when writing data fiber cache." +
+        " Acceptable values include: uncompressed, snappy, gzip, lzo.")
+      .stringConf
+      .transform(_.toUpperCase())
+      .checkValues(Set("UNCOMPRESSED", "SNAPPY", "GZIP", "LZO"))
+      .createWithDefault("GZIP")
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/CacheCompressionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/CacheCompressionSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.oap
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheManager
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.util.Utils
+
+class CacheCompressionSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach{
+  import testImplicits._
+
+  private var currentPath: String = _
+
+  override def beforeEach(): Unit = {
+    val path = Utils.createTempDir().getAbsolutePath
+    currentPath = path
+    sql(s"""CREATE TEMPORARY VIEW oap_test (a INT, b INT)
+           | USING oap
+           | OPTIONS (path '$path')""".stripMargin)
+
+    sql(s"""CREATE TEMPORARY VIEW parquet_test (a INT, b INT)
+           | USING parquet
+           | OPTIONS (path '$path')""".stripMargin)
+  }
+
+  override def afterEach(): Unit = {
+    sqlContext.dropTempTable("oap_test")
+    sqlContext.dropTempTable("parquet_test")
+  }
+
+  test("filtering parquet with compressed FiberCache") {
+    FiberCacheManager.setCompressionConf(indexEnable = true, indexCodec = "SNAPPY")
+    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i*2) }
+    data.toDF("a", "b").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
+    sql("create oindex index1 on parquet_test (a) USING BTREE")
+    sql("create oindex index2 on parquet_test (b) USING BITMAP")
+
+    checkAnswer(sql("SELECT b FROM parquet_test WHERE a = 2"),
+      Row(4) :: Nil)
+
+    checkAnswer(sql("SELECT a, b FROM parquet_test WHERE  b < 9"),
+      Row(1, 2) :: Row(2, 4) ::  Row(3, 6) ::  Row(4, 8) :: Nil)
+
+    sql("drop oindex index1 on parquet_test")
+    sql("drop oindex index2 on parquet_test")
+    FiberCacheManager.setCompressionConf()
+  }
+
+  test("filtering oap with compressed FiberCache") {
+    FiberCacheManager.setCompressionConf(indexEnable = true, dataEnable = true,
+      indexCodec = "SNAPPY", dataCodec = "SNAPPY")
+    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i*2) }
+    data.toDF("a", "b").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
+    sql("create oindex index1 on oap_test (a) USING BTREE")
+    sql("create oindex index2 on oap_test (b) USING BITMAP")
+
+    checkAnswer(sql("SELECT b FROM oap_test WHERE a = 2"),
+      Row(4) :: Nil)
+
+    checkAnswer(sql("SELECT a, b FROM oap_test WHERE  b < 9"),
+      Row(1, 2) :: Row(2, 4) ::  Row(3, 6) ::  Row(4, 8) :: Nil)
+  }
+}
+

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeFileReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeFileReaderWriterSuite.scala
@@ -43,10 +43,10 @@ class BTreeFileReaderWriterSuite extends SharedOapContext {
     writer.close()
     // Read content from File
     val reader = BTreeIndexFileReader(configuration, path)
-    val footerRead = reader.readFooter().toArray
-    val rowIdListRead = reader.readRowIdList().toArray
+    val footerRead = reader.readFooter(false).toArray
+    val rowIdListRead = reader.readRowIdList(false).toArray
     val nodesRead = (0 until 5).map(i =>
-      reader.readNode(nodes.slice(0, i).map(_.length).sum, nodes(i).length).toArray)
+      reader.readNode(nodes.slice(0, i).map(_.length).sum, nodes(i).length, false).toArray)
     // Check result
     assert(footer === footerRead)
     assert(rowIdList === rowIdListRead)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsTest.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsTest.scala
@@ -79,5 +79,6 @@ abstract class StatisticsTest extends SparkFunSuite with BeforeAndAfterEach {
       val bytes = out.toByteArray
       override protected def fiberData: MemoryBlock =
         new MemoryBlock(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length)
+      override def decompressLength: Int = bytes.length
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Memory is not enough，but cpu is free in Baidu spark production environment.  Introduction of FiberCache compression can save some memory, that is to say, which can improve cache hit ratio in the same size of memory.

1. The Compression function of IndexCache and DataCache is specified separately by configuration, the default value is false.
2、Fiber add a new interface ‘isCompress’ which is to identify whether corresponding cache will be compressed.  Because not all cache are suitable for compression.
3、Change function signature of subclass of fiber:  (getFiberData: () => FiberCache) => (getFiberData: (Boolean) => FiberCache)  to decide which fiberCache need to be compressed in fiber caching.

The test results of compression ratio with different  compression algorithm is in issue #541.

## How was this patch tested?

All exist unit test passed.
Add CacheCompressionSuite.
Add some new test in MemoryManagerSuite and FiberCacheManagerSuite.