### PR TITLE
ensure close reader, release fiberCache properly and remove unused code#560

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache._
 import org.apache.spark.sql.execution.datasources.oap.index.BTreeIndexRecordReader.BTreeFooter
-import org.apache.spark.sql.execution.datasources.oap.statistics.StatisticsManager
+import org.apache.spark.sql.execution.datasources.oap.statistics.{StaticsAnalysisResult, StatisticsManager}
 
 // we scan the index from the smallest to the largest,
 // this will scan the B+ Tree (index) leaf node.
@@ -50,17 +50,28 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
   override protected def analyzeStatistics(indexPath: Path, conf: Configuration): Double = {
     // TODO decouple with btreeindexrecordreader
     // This is called before the scanner call `initialize`
-    val reader = BTreeIndexFileReader(conf, indexPath)
-    val footerFiber = BTreeFiber(
-      () => reader.readFooter(), reader.file.toString, reader.footerSectionId, 0)
-    val footerCache = FiberCacheManager.get(footerFiber, conf)
-    val footer = BTreeFooter(footerCache, keySchema)
-    val offset = footer.getStatsOffset
+    var reader: BTreeIndexFileReader = null
+    var footerCache: FiberCache = null
+    try {
+      reader = BTreeIndexFileReader(conf, indexPath)
+      val footerFiber = BTreeFiber(
+        () => reader.readFooter(), reader.file.toString, reader.footerSectionId, 0)
+      footerCache = FiberCacheManager.get(footerFiber, conf)
+      val footer = BTreeFooter(footerCache, keySchema)
+      val offset = footer.getStatsOffset
 
-    val stats = StatisticsManager.read(footerCache, offset, keySchema)
-    val result = StatisticsManager.analyse(stats, intervalArray, conf)
-    footerCache.release()
-    result
+      val stats = StatisticsManager.read(footerCache, offset, keySchema)
+      StatisticsManager.analyse(stats, intervalArray, conf)
+    } finally {
+      // The reader should be closed.
+      if (reader != null) {
+        reader.close()
+      }
+      // The fiberCache should be released.
+      if (footerCache != null) {
+        footerCache.release()
+      }
+    }
   }
 
   override def hasNext: Boolean = recordReader.hasNext

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -231,8 +231,6 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     bmNullListFiber = BitmapFiber(
       () => loadBmNullList(fin), idxPath.toString, BitmapIndexSectionId.entryNullSection, 0)
     bmNullListCache = FiberCacheManager.get(bmNullListFiber, conf)
-
-    fin.close()
   }
 
   private def getStartIdxOffset(fiberCache: FiberCache, baseOffset: Long, startIdx: Int): Int = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
@@ -17,39 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.oap.io
 
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, MemoryManager}
-
-private[oap] trait CommonIndexFile {
-  def file: Path
-  def version(conf: Configuration): Int = {
-    val fs = file.getFileSystem(conf)
-    val fin = fs.open(file)
-    val bytes = new Array[Byte](8)
-    fin.readFully(bytes, 0, 8)
-    fin.close()
-    (bytes(6) << 8) + bytes(7)
-  }
-}
-/**
- * Read the index file into memory, and can be accessed as [[FiberCache]].
- */
-private[oap] case class IndexFile(file: Path) extends CommonIndexFile {
-  def getIndexFiberData(conf: Configuration): FiberCache = {
-    val fs = file.getFileSystem(conf)
-    val fin = fs.open(file)
-    // wind to end of file to get tree root
-    // TODO check if enough to fit in Int
-    val fileLength = fs.getContentSummary(file).getLength
-
-    val fiberCache = MemoryManager.putToIndexFiberCache(fin, 0, fileLength.toInt)
-    fin.close()
-    fiberCache
-  }
-}
-
 private[oap] object IndexFile {
   val VERSION_LENGTH = 8
   val VERSION_PREFIX = "OAPIDX"


### PR DESCRIPTION
## What changes were proposed in this pull request?

File handle leak:
1. BPlusTreeScanner.analyzeStatistics: reader is not closed.
2. BitMapScanner.analyzeStatistics: reader is not closed when the result is not equal USE_INDEX.

FiberCache leak:
1. BitMapScanner.analyzeStatistics: fiberCache is not released when the result is not equal USE_INDEX.

Unused code:
1. BitMapScanner
2. IndexFile

It may be a good choice to close reader and release fibreCache using 'try {} finally {}'.
1. BitMapScanner.initialize
2. BitMapScanner.cacheBitmapFooterSegment
3. BTreeIndexRecordReader.initialize
4. DataSourceMeta.initialize

Notes: 
1. The meaning of 'release' is to decrease the reference count of cache，instead of really free cache memory.

## How was this patch tested?

All exist tests passed.

