### PR TITLE
Merge two similar iterator functions in OapDataFile

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -107,32 +107,39 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
     MemoryManager.putToDataFiberCache(data)
   }
 
-  // full file scan
-  // TODO: [linhong] two iterator functions are similar. Can we merge them?
-  def iterator(conf: Configuration, requiredIds: Array[Int]): OapIterator[InternalRow] = {
-    val row = new BatchColumn()
+  private def buildIterator(
+      conf: Configuration,
+      requiredIds: Array[Int],
+      rowIds: Option[Array[Int]]): OapIterator[InternalRow] = {
+    val rows = new BatchColumn()
+    val groupIdToRowIds = rowIds.map(_.groupBy(rowId => rowId / meta.rowCountInEachGroup))
+    val groupIds = groupIdToRowIds.map(_.keys).getOrElse(0 until meta.groupCount)
     var fiberCacheGroup: Array[WrappedFiberCache] = null
-    val iterator =
-      (0 until meta.groupCount).iterator.flatMap { groupId =>
-        fiberCacheGroup = requiredIds.map(id =>
-          WrappedFiberCache(FiberCacheManager.get(DataFiber(this, id, groupId), conf)))
-
-        val columns = fiberCacheGroup.zip(requiredIds).map { case (fiberCache, id) =>
-          new ColumnValues(meta.rowCountInEachGroup, schema(id).dataType, fiberCache.fc)
-        }
-
-        val iterator = if (groupId < meta.groupCount - 1) {
-          // not the last row group
-          row.reset(meta.rowCountInEachGroup, columns).toIterator
-        } else {
-          row.reset(meta.rowCountInLastGroup, columns).toIterator
-        }
-        CompletionIterator[InternalRow, Iterator[InternalRow]](iterator,
-          fiberCacheGroup.zip(requiredIds).foreach {
-            case (fiberCache, id) => fiberCache.release()
-          }
-        )
+    val iterator = groupIds.iterator.flatMap { groupId =>
+      fiberCacheGroup = requiredIds.map { id =>
+        WrappedFiberCache(FiberCacheManager.get(DataFiber(this, id, groupId), conf))
       }
+
+      val columns = fiberCacheGroup.zip(requiredIds).map { case (fiberCache, id) =>
+        new ColumnValues(meta.rowCountInEachGroup, schema(id).dataType, fiberCache.fc)
+      }
+
+      val rowCount =
+        if (groupId < meta.groupCount - 1) meta.rowCountInEachGroup else meta.rowCountInLastGroup
+      rows.reset(rowCount, columns)
+
+      val iter = groupIdToRowIds match {
+        case Some(map) =>
+          map(groupId).iterator.map(rowId => rows.moveToRow(rowId % meta.rowCountInEachGroup))
+        case None => rows.toIterator
+      }
+
+      CompletionIterator[InternalRow, Iterator[InternalRow]](iter,
+        fiberCacheGroup.zip(requiredIds).foreach {
+          case (fiberCache, id) => fiberCache.release()
+        }
+      )
+    }
     new OapIterator[InternalRow](iterator) {
       override def close(): Unit = {
         // To ensure if any exception happens, caches are still released after calling close()
@@ -142,47 +149,17 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
     }
   }
 
+  // full file scan
+  def iterator(conf: Configuration, requiredIds: Array[Int]): OapIterator[InternalRow] = {
+    buildIterator(conf, requiredIds, None)
+  }
+
   // scan by given row ids, and we assume the rowIds are sorted
   def iterator(
       conf: Configuration,
       requiredIds: Array[Int],
       rowIds: Array[Int]): OapIterator[InternalRow] = {
-    val row = new BatchColumn()
-    val groupIds = rowIds.groupBy(rowId => rowId / meta.rowCountInEachGroup)
-    var fiberCacheGroup: Array[WrappedFiberCache] = null
-    val iterator =
-      groupIds.iterator.flatMap {
-        case (groupId, subRowIds) =>
-          fiberCacheGroup = requiredIds.map(id =>
-            WrappedFiberCache(FiberCacheManager.get(DataFiber(this, id, groupId), conf)))
-
-          val columns = fiberCacheGroup.zip(requiredIds).map { case (fiberCache, id) =>
-            new ColumnValues(meta.rowCountInEachGroup, schema(id).dataType, fiberCache.fc)
-          }
-
-          if (groupId < meta.groupCount - 1) {
-            // not the last row group
-            row.reset(meta.rowCountInEachGroup, columns)
-          } else {
-            row.reset(meta.rowCountInLastGroup, columns)
-          }
-
-          val iterator =
-            subRowIds.iterator.map(rowId => row.moveToRow(rowId % meta.rowCountInEachGroup))
-
-          CompletionIterator[InternalRow, Iterator[InternalRow]](iterator,
-            fiberCacheGroup.zip(requiredIds).foreach {
-              case (fiberCache, id) => fiberCache.release()
-            }
-          )
-      }
-    new OapIterator[InternalRow](iterator) {
-      override def close(): Unit = {
-        // To ensure if any exception happens, caches are still released after calling close()
-        if (fiberCacheGroup != null) fiberCacheGroup.foreach(_.release())
-        OapDataFile.this.close()
-      }
-    }
+    buildIterator(conf, requiredIds, Some(rowIds))
   }
 
   def close(): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -151,7 +151,7 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
 
   // full file scan
   def iterator(conf: Configuration, requiredIds: Array[Int]): OapIterator[InternalRow] = {
-    buildIterator(conf, requiredIds, None)
+    buildIterator(conf, requiredIds, rowIds = None)
   }
 
   // scan by given row ids, and we assume the rowIds are sorted


### PR DESCRIPTION
## What changes were proposed in this pull request?
The codes in two iterator function are similar. Simplify the code in a single internal function.
We may also change the base DataFile class to only have a single iterator function.

## How was this patch tested?
Existing tests.

