### PR TITLE
Manual forbid splitable status of ParquetFileFomat

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
+++ b/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
+import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
+import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.api.InitContext;
+import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.hadoop.api.RecordReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+import org.apache.spark.sql.execution.datasources.oap.io.OapReadSupportImpl;
+import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportHelper;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.StructType$;
+
+public abstract class SpecificOapRecordReaderBase<T> implements RecordReader<T> {
+
+    /**
+     * From SpecificParquetRecordReaderBase.
+     */
+    protected Path file;
+    protected MessageType fileSchema;
+    protected MessageType requestedSchema;
+    protected StructType sparkSchema;
+
+    /**
+     * The total number of rows this RecordReader will eventually read. The sum of the
+     * rows of all the row groups.
+     */
+    protected long totalRowCount;
+    protected ParquetFileReader reader;
+
+    /**
+     * SpecificOapRecordReaderBase need
+     */
+    protected Configuration configuration;
+    protected ParquetMetadata footer;
+
+
+    @Override
+    public void initialize() throws IOException, InterruptedException {
+        if(this.footer == null){
+            footer = readFooter(configuration, file, NO_FILTER);
+        }
+        this.fileSchema = footer.getFileMetaData().getSchema();
+
+        Map<String, String> fileMetadata = footer.getFileMetaData().getKeyValueMetaData();
+        ReadSupport.ReadContext readContext = new OapReadSupportImpl().init(new InitContext(
+                configuration, toSetMultiMap(fileMetadata), fileSchema));
+        this.requestedSchema = readContext.getRequestedSchema();
+        String sparkRequestedSchemaString =
+                configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
+        this.sparkSchema = StructType$.MODULE$.fromString(sparkRequestedSchemaString);
+        this.reader = ParquetFileReader.open(configuration, file,footer);
+        this.reader.filterRowGroups(getFilter(configuration));
+        this.reader.setRequestedSchema(requestedSchema);
+        for (BlockMetaData block : this.reader.getRowGroups()) {
+            this.totalRowCount += block.getRowCount();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (reader != null) {
+            reader.close();
+            reader = null;
+        }
+    }
+
+    // TODO duplicate of Collecionts3.toSetMultiMap in pr #575, replace it
+    protected static <K, V> Map<K, Set<V>> toSetMultiMap(Map<K, V> map) {
+        Map<K, Set<V>> setMultiMap = new HashMap<>();
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            Set<V> set = new HashSet<>();
+            set.add(entry.getValue());
+            setMultiMap.put(entry.getKey(), Collections.unmodifiableSet(set));
+        }
+        return Collections.unmodifiableMap(setMultiMap);
+    }
+}

--- a/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.Type;
+import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.datasources.parquet.VectorizedColumnReader;
+import org.apache.spark.sql.execution.datasources.parquet.VectorizedColumnReaderWrapper;
+import org.apache.spark.sql.execution.vectorized.ColumnVectorUtils;
+import org.apache.spark.sql.execution.vectorized.ColumnarBatch;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Object> {
+
+    /**
+     * Batch of rows that we assemble and the current index we've returned. Every time this
+     * batch is used up (batchIdx == numBatched), we populated the batch.
+     * From VectorizedParquetRecordReader, change private to protected.
+     */
+    protected int batchIdx = 0;
+    /**
+     * From VectorizedParquetRecordReader, change private to protected
+     */
+    protected int numBatched = 0;
+
+    /**
+     * For each request column, the reader to read this column. This is NULL if this column
+     * is missing from the file, in which case we populate the attribute with NULL.
+     * From VectorizedParquetRecordReader, change private to protected, wrapper VectorizedColumnReader.
+     */
+    protected VectorizedColumnReaderWrapper[] columnReaders;
+
+    /**
+     * The number of rows that have been returned.
+     * From VectorizedParquetRecordReader, change private to protected.
+     */
+    protected long rowsReturned;
+
+    /**
+     * The number of rows that have been reading, including the current in flight row group.
+     * From VectorizedParquetRecordReader, change private to protected.
+     */
+    protected long totalCountLoadedSoFar = 0;
+
+    /**
+     * For each column, true if the column is missing in the file and we'll instead return NULLs.
+     * From VectorizedParquetRecordReader, change private to protected.
+     */
+    protected boolean[] missingColumns;
+
+    /**
+     * columnBatch object that is used for batch decoding. This is created on first use and triggers
+     * batched decoding. It is not valid to interleave calls to the batched interface with the row
+     * by row RecordReader APIs.
+     * This is only enabled with additional flags for development. This is still a work in progress
+     * and currently unsupported cases will fail with potentially difficult to diagnose errors.
+     * This should be only turned on for development to work on this feature.
+     * <p>
+     * When this is set, the code will branch early on in the RecordReader APIs. There is no shared
+     * code between the path that uses the MR decoders and the vectorized ones.
+     * <p>
+     * TODOs:
+     * - Implement v2 page formats (just make sure we create the correct decoders).
+     * From VectorizedParquetRecordReader, change private to protected.
+     */
+    protected ColumnarBatch columnarBatch;
+
+    /**
+     * If true, this class returns batches instead of rows.
+     * From VectorizedParquetRecordReader, change private to protected.
+     */
+    protected boolean returnColumnarBatch;
+
+    /**
+     * The default config on whether columnarBatch should be offheap.
+     * From VectorizedParquetRecordReader, change private to protected.
+     */
+    protected static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.ON_HEAP;
+
+
+    public VectorizedOapRecordReader(
+                        Path file,
+                        Configuration configuration,
+                        ParquetMetadata footer) {
+        this.file = file;
+        this.configuration = configuration;
+        this.footer = footer;
+    }
+
+    @Override
+    public void initialize() throws IOException, InterruptedException {
+        super.initialize();
+        initializeInternal();
+    }
+
+    /**
+     * From VectorizedParquetRecordReader,no change.
+     * @throws IOException
+     */
+    @Override
+    public void close() throws IOException {
+        if (columnarBatch != null) {
+            columnarBatch.close();
+            columnarBatch = null;
+        }
+        super.close();
+    }
+
+    /**
+     * From VectorizedParquetRecordReader,no change.
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Override
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+        resultBatch();
+
+        if (returnColumnarBatch) return nextBatch();
+
+        if (batchIdx >= numBatched) {
+            if (!nextBatch()) return false;
+        }
+        ++batchIdx;
+        return true;
+    }
+
+    /**
+     * From VectorizedParquetRecordReader,no change.
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Override
+    public Object getCurrentValue() throws IOException, InterruptedException {
+        if (returnColumnarBatch) return columnarBatch;
+        return columnarBatch.getRow(batchIdx - 1);
+    }
+
+    /**
+     * From VectorizedParquetRecordReader,no change.
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Override
+    public float getProgress() throws IOException, InterruptedException {
+        return (float) rowsReturned / totalRowCount;
+    }
+
+    /**
+     * Returns the ColumnarBatch object that will be used for all rows returned by this reader.
+     * This object is reused. Calling this enables the vectorized reader. This should be called
+     * before any calls to nextKeyValue/nextBatch.
+     * From VectorizedParquetRecordReader,no change.
+     */
+
+    // Creates a columnar batch that includes the schema from the data files and the additional
+    // partition columns appended to the end of the batch.
+    // For example, if the data contains two columns, with 2 partition columns:
+    // Columns 0,1: data columns
+    // Column 2: partitionValues[0]
+    // Column 3: partitionValues[1]
+    public void initBatch(MemoryMode memMode, StructType partitionColumns,
+                          InternalRow partitionValues) {
+        StructType batchSchema = new StructType();
+        for (StructField f: sparkSchema.fields()) {
+            batchSchema = batchSchema.add(f);
+        }
+        if (partitionColumns != null) {
+            for (StructField f : partitionColumns.fields()) {
+                batchSchema = batchSchema.add(f);
+            }
+        }
+
+        columnarBatch = ColumnarBatch.allocate(batchSchema, memMode);
+        if (partitionColumns != null) {
+            int partitionIdx = sparkSchema.fields().length;
+            for (int i = 0; i < partitionColumns.fields().length; i++) {
+                ColumnVectorUtils.populate(columnarBatch.column(i + partitionIdx), partitionValues, i);
+                columnarBatch.column(i + partitionIdx).setIsConstant();
+            }
+        }
+
+        // Initialize missing columns with nulls.
+        for (int i = 0; i < missingColumns.length; i++) {
+            if (missingColumns[i]) {
+                columnarBatch.column(i).putNulls(0, columnarBatch.capacity());
+                columnarBatch.column(i).setIsConstant();
+            }
+        }
+    }
+
+    /**
+     * From VectorizedParquetRecordReader,no change.
+     */
+    public void initBatch() {
+        initBatch(DEFAULT_MEMORY_MODE, null, null);
+    }
+
+    /**
+     * From VectorizedParquetRecordReader,no change.
+     * @param partitionColumns
+     * @param partitionValues
+     */
+    public void initBatch(StructType partitionColumns, InternalRow partitionValues) {
+        initBatch(DEFAULT_MEMORY_MODE, partitionColumns, partitionValues);
+    }
+
+    /**
+     * From VectorizedParquetRecordReader,no change.
+     * @return
+     */
+    public ColumnarBatch resultBatch() {
+        if (columnarBatch == null) initBatch();
+        return columnarBatch;
+    }
+
+    /*
+     * Can be called before any rows are returned to enable returning columnar batches directly.
+     */
+    public void enableReturningBatches() {
+        returnColumnarBatch = true;
+    }
+
+    /**
+     * Advances to the next batch of rows. Returns false if there are no more.
+     * From VectorizedParquetRecordReader, no change.
+     */
+    public boolean nextBatch() throws IOException {
+        columnarBatch.reset();
+        if (rowsReturned >= totalRowCount) return false;
+        checkEndOfRowGroup();
+
+        int num = (int) Math.min((long) columnarBatch.capacity(), totalCountLoadedSoFar - rowsReturned);
+        for (int i = 0; i < columnReaders.length; ++i) {
+            if (columnReaders[i] == null) continue;
+            columnReaders[i].readBatch(num, columnarBatch.column(i));
+        }
+        rowsReturned += num;
+        columnarBatch.setNumRows(num);
+        numBatched = num;
+        batchIdx = 0;
+        return true;
+    }
+
+    /**
+     * From VectorizedParquetRecordReader, chanage private -> protected.
+     * @throws IOException
+     * @throws UnsupportedOperationException
+     */
+    protected void initializeInternal() throws IOException, UnsupportedOperationException {
+        missingColumns = new boolean[requestedSchema.getFieldCount()];
+        for (int i = 0; i < requestedSchema.getFieldCount(); ++i) {
+            Type t = requestedSchema.getFields().get(i);
+            if (!t.isPrimitive() || t.isRepetition(Type.Repetition.REPEATED)) {
+                throw new UnsupportedOperationException("Complex types not supported.");
+            }
+
+            String[] colPath = requestedSchema.getPaths().get(i);
+            if (fileSchema.containsPath(colPath)) {
+                ColumnDescriptor fd = fileSchema.getColumnDescription(colPath);
+                if (!fd.equals(requestedSchema.getColumns().get(i))) {
+                    throw new UnsupportedOperationException("Schema evolution not supported.");
+                }
+                missingColumns[i] = false;
+            } else {
+                if (requestedSchema.getColumns().get(i).getMaxDefinitionLevel() == 0) {
+                    // Column is missing in data but the required data is non-nullable. This file is invalid.
+                    throw new IOException("Required column is missing in data file. Col: " +
+                            Arrays.toString(colPath));
+                }
+                missingColumns[i] = true;
+            }
+        }
+    }
+
+    /**
+     * From VectorizedParquetRecordReader, chanage private -> protected.
+     * @throws IOException
+     */
+    protected void checkEndOfRowGroup() throws IOException {
+        if (rowsReturned != totalCountLoadedSoFar) return;
+        readNextRowGroup();
+    }
+
+    protected void readNextRowGroup() throws IOException {
+        PageReadStore pages = reader.readNextRowGroup();
+        if (pages == null) {
+            throw new IOException("expecting more rows but reached last block. Read "
+                    + rowsReturned + " out of " + totalRowCount);
+        }
+        List<ColumnDescriptor> columns = requestedSchema.getColumns();
+        columnReaders = new VectorizedColumnReaderWrapper[columns.size()];
+        for (int i = 0; i < columns.size(); ++i) {
+            if (missingColumns[i]) continue;
+            columnReaders[i] = new VectorizedColumnReaderWrapper(
+                    new VectorizedColumnReader(columns.get(i),
+                    pages.getPageReader(columns.get(i))));
+        }
+        totalCountLoadedSoFar += pages.getRowCount();
+    }
+}

--- a/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReaderWrapper.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReaderWrapper.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet;
+
+import java.io.IOException;
+
+import org.apache.spark.sql.execution.vectorized.ColumnVector;
+
+/**
+ * VectorizedColumnReaderWrapper let readBatch method can be used
+ * outside "org.apache.spark.sql.execution.datasources.parquet" package
+ */
+public class VectorizedColumnReaderWrapper {
+
+    private VectorizedColumnReader reader;
+
+    public VectorizedColumnReaderWrapper(VectorizedColumnReader reader) {
+        this.reader = reader;
+    }
+
+    public void readBatch(int total, ColumnVector column) throws IOException {
+        reader.readBatch(total, column);
+    }
+
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -63,11 +63,12 @@ case class CreateIndexCommand(
       _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id) =>
         (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, id, _fsRelation)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, _: ParquetFileFormat, _), _, id) =>
+      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), _, id) =>
         if (!sparkSession.conf.get(SQLConf.OAP_PARQUET_ENABLED)) {
           throw new OapException(s"turn on ${
             SQLConf.OAP_PARQUET_ENABLED.key} to allow index building on parquet files")
         }
+        format.forbidSplit
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, id, _fsRelation)
       case other =>
         throw new OapException(s"We don't support index building for ${other.simpleString}")
@@ -285,7 +286,8 @@ case class RefreshIndexCommand(
           HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, _) =>
         (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME)
       case LogicalRelation(
-          HadoopFsRelation(f, _, s, _, _: ParquetFileFormat, _), _, _) =>
+          HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), _, _) =>
+        format.forbidSplit
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME)
       case other =>
         throw new OapException(s"We don't support index refreshing for ${other.simpleString}")

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -67,6 +67,10 @@ class ParquetFileFormat
 
   override def equals(other: Any): Boolean = other.isInstanceOf[ParquetFileFormat]
 
+  @transient protected var splitable = true
+
+  def forbidSplit: Unit = splitable = false
+
   override def prepareWrite(
       sparkSession: SparkSession,
       job: Job,
@@ -271,9 +275,7 @@ class ParquetFileFormat
   override def isSplitable(
       sparkSession: SparkSession,
       options: Map[String, String],
-      path: Path): Boolean = {
-      !sparkSession.conf.get(SQLConf.OAP_PARQUET_ENABLED)
-  }
+      path: Path): Boolean = splitable
 
   override def buildReaderWithPartitionValues(
       sparkSession: SparkSession,

--- a/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapEncodingSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapEncodingSuite.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.vectorized
+
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
+import org.apache.parquet.hadoop.{ParquetFileReader, ParquetOutputFormat, VectorizedOapRecordReader}
+
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetCompatibilityTest, ParquetReadSupportHelper, SpecificParquetRecordReaderBase}
+import org.apache.spark.sql.test.oap.SharedOapContext
+
+class VectorizedOapEncodingSuite extends ParquetCompatibilityTest with SharedOapContext{
+
+  import testImplicits._
+
+  private val ROW = (1.toByte, 2, 3L, "abc")
+  private val NULL_ROW = (
+    null.asInstanceOf[java.lang.Byte],
+    null.asInstanceOf[Integer],
+    null.asInstanceOf[java.lang.Long],
+    null.asInstanceOf[String])
+
+  test("All Types Dictionary") {
+    (1 :: 1000 :: Nil).foreach { n => {
+      withTempPath { dir =>
+        val df = List.fill(n)(ROW).toDF
+        df.repartition(1).write.parquet(dir.getCanonicalPath)
+        val schema = df.schema.json
+        val file = SpecificParquetRecordReaderBase.listDirectory(dir).toArray.head
+        val path = new Path(file.asInstanceOf[String])
+        val footer = ParquetFileReader.readFooter(configuration, path, NO_FILTER)
+        (footer :: null :: Nil).foreach { f =>
+          configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, schema)
+          val reader = new VectorizedOapRecordReader(path, configuration, f)
+          reader.initialize()
+          val batch = reader.resultBatch()
+          assert(reader.nextBatch())
+          assert(batch.numRows() == n)
+          var i = 0
+          while (i < n) {
+            // TODO release following code after add method to ColumnarBatch
+            // assert(!batch.isFiltered(i))
+            assert(batch.column(0).getByte(i) == 1)
+            assert(batch.column(1).getInt(i) == 2)
+            assert(batch.column(2).getLong(i) == 3)
+            assert(batch.column(3).getUTF8String(i).toString == "abc")
+            i += 1
+          }
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+          reader.close()
+        }
+      }
+    }
+    }
+  }
+
+  test("All Types Null") {
+    (1 :: 100 :: Nil).foreach { n => {
+      withTempPath { dir =>
+        val df = List.fill(n)(NULL_ROW).toDF
+        df.repartition(1).write.parquet(dir.getCanonicalPath)
+        val schema = df.schema.json
+        val file = SpecificParquetRecordReaderBase.listDirectory(dir).toArray.head
+        val path = new Path(file.asInstanceOf[String])
+        val footer = ParquetFileReader.readFooter(configuration, path, NO_FILTER)
+        (footer :: null :: Nil).foreach { f =>
+          configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, schema)
+          val reader = new VectorizedOapRecordReader(path, configuration, f)
+          reader.initialize()
+          val batch = reader.resultBatch()
+          assert(reader.nextBatch())
+          assert(batch.numRows() == n)
+          var i = 0
+          while (i < n) {
+            // TODO release following code after add method to ColumnarBatch
+            // assert(!batch.isFiltered(i))
+            assert(batch.column(0).isNullAt(i))
+            assert(batch.column(1).isNullAt(i))
+            assert(batch.column(2).isNullAt(i))
+            assert(batch.column(3).isNullAt(i))
+            i += 1
+          }
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+          reader.close()
+        }
+      }
+    }
+    }
+  }
+
+  test("Read row group containing both dictionary and plain encoded pages") {
+    withSQLConf(ParquetOutputFormat.DICTIONARY_PAGE_SIZE -> "2048",
+      ParquetOutputFormat.PAGE_SIZE -> "4096") {
+      withTempPath { dir =>
+        val data = (0 until 512).flatMap(i => Seq.fill(3)(i.toString))
+        val df = data.toDF("f")
+        df.coalesce(1).write.parquet(dir.getCanonicalPath)
+        val schema = df.schema.json
+        val file = SpecificParquetRecordReaderBase.listDirectory(dir).toArray.head
+        val path = new Path(file.asInstanceOf[String])
+        val footer = ParquetFileReader.readFooter(configuration, path, NO_FILTER)
+
+        (footer :: null:: Nil).foreach { f =>
+          configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, schema)
+          val reader = new VectorizedOapRecordReader(path, configuration, f)
+          reader.initialize()
+          val batch = reader.resultBatch()
+          val column = batch.column(0)
+          assert(reader.nextBatch())
+
+          (0 until 512).foreach { i =>
+            // TODO release following code after add method to ColumnarBatch
+            // assert(!batch.isFiltered(i))
+            assert(column.getUTF8String(3 * i).toString == i.toString)
+            assert(column.getUTF8String(3 * i + 1).toString == i.toString)
+            assert(column.getUTF8String(3 * i + 2).toString == i.toString)
+          }
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+          reader.close()
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapIOSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapIOSuite.scala
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.vectorized
+
+import scala.collection.mutable
+
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.VectorizedOapRecordReader
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetReadSupportHelper, ParquetTest, SpecificParquetRecordReaderBase}
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.types.{StructType, _}
+import org.apache.spark.unsafe.types.UTF8String
+
+class VectorizedOapIOSuite extends QueryTest with ParquetTest with SharedOapContext {
+  import testImplicits._
+
+  test("VectorizedOapRecordReader - direct path read") {
+    val data = (0 to 10).map(i => (i, (i + 'a').toChar.toString))
+    withTempPath { dir =>
+      val df = spark.createDataFrame(data)
+      val schema = df.schema.json
+      df.repartition(1).write.parquet(dir.getCanonicalPath)
+      val file = SpecificParquetRecordReaderBase.listDirectory(dir).get(0)
+      val path = new Path(file.asInstanceOf[String])
+
+      {
+        configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, schema)
+        val reader = new VectorizedOapRecordReader(path, configuration, null)
+        try {
+          reader.initialize()
+          val result = mutable.ArrayBuffer.empty[(Int, String)]
+          while (reader.nextKeyValue()) {
+            val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+            val v = (row.getInt(0), row.getString(1))
+            result += v
+          }
+          assert(data == result)
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+        } finally {
+          reader.close()
+        }
+
+      }
+
+      // Project just one column
+    {
+      val requestSchema = requestSchemaString(df.schema, Array(1))
+      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+      val reader = new VectorizedOapRecordReader(path, configuration, null)
+      try {
+        reader.initialize()
+        val result = mutable.ArrayBuffer.empty[(String)]
+        while (reader.nextKeyValue()) {
+          val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+          result += row.getString(0)
+        }
+        assert(data.map(_._2) == result)
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+      } finally {
+        reader.close()
+      }
+    }
+
+      // Project columns in opposite order
+    {
+      val requestSchema = requestSchemaString(df.schema, Array(1, 0))
+      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+      val reader = new VectorizedOapRecordReader(path, configuration, null)
+      try {
+        reader.initialize()
+        val result = mutable.ArrayBuffer.empty[(String, Int)]
+        while (reader.nextKeyValue()) {
+          val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+          val v = (row.getString(0), row.getInt(1))
+          result += v
+        }
+        assert(data.map { x => (x._2, x._1) } == result)
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+      } finally {
+        reader.close()
+      }
+    }
+      // Empty projection
+    {
+      val requestSchema = requestSchemaString(df.schema, Array())
+      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+      val reader = new VectorizedOapRecordReader(path, configuration, null)
+      try {
+        reader.initialize()
+        var result = 0
+        while (reader.nextKeyValue()) {
+          result += 1
+        }
+        assert(result == data.length)
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+      } finally {
+        reader.close()
+      }
+    }
+    }
+  }
+
+  test("VectorizedParquetRecordReader - partition column types") {
+    withTempPath { dir =>
+      Seq(1).toDF().repartition(1).write.parquet(dir.getCanonicalPath)
+
+      val dataTypes =
+        Seq(StringType, BooleanType, ByteType, ShortType, IntegerType, LongType,
+          FloatType, DoubleType, DecimalType(25, 5), DateType, TimestampType)
+
+      val constantValues =
+        Seq(
+          UTF8String.fromString("a string"),
+          true,
+          1.toByte,
+          2.toShort,
+          3,
+          Long.MaxValue,
+          0.25.toFloat,
+          0.75D,
+          Decimal("1234.23456"),
+          DateTimeUtils.fromJavaDate(java.sql.Date.valueOf("2015-01-01")),
+          DateTimeUtils.fromJavaTimestamp(java.sql.Timestamp.valueOf("2015-01-01 23:50:59.123")))
+
+      dataTypes.zip(constantValues).foreach { case (dt, v) =>
+        val schema = StructType(StructField("pcol", dt) :: Nil)
+        configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, schema.json)
+        val file = SpecificParquetRecordReaderBase.listDirectory(dir).get(0)
+        val path = new Path(file)
+        val vectorizedReader = new VectorizedOapRecordReader(path, configuration, null)
+        val partitionValues = new GenericInternalRow(Array(v))
+
+
+        try {
+          vectorizedReader.initialize()
+          vectorizedReader.initBatch(schema, partitionValues)
+          vectorizedReader.nextKeyValue()
+          val row = vectorizedReader.getCurrentValue.asInstanceOf[InternalRow]
+
+          // Use `GenericMutableRow` by explicitly copying rather than `ColumnarBatch`
+          // in order to use get(...) method which is not implemented in `ColumnarBatch`.
+          val actual = row.copy().get(1, dt)
+          val expected = v
+          assert(actual == expected)
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+        } finally {
+          vectorizedReader.close()
+        }
+      }
+    }
+  }
+
+  private def requestSchemaString(schema: StructType, requiredIds: Array[Int]): String = {
+    var requestSchema = new StructType
+    for (index <- requiredIds) {
+      requestSchema = requestSchema.add(schema(index))
+    }
+    requestSchema.json
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a splitable status and forbidSplitable method to ParquetFileFomat, then ParquetFileFomat.isSplitable should return false when  "create Index" and "refresh Index", other case should return true to increasing task parallelism and block localization read ratio.

## How was this patch tested?
existing test