### PR TITLE
add more metrics into CacheStats and add FiberCacheManagerSensor to collect the metrics(sub-PR of #506)

### DIFF
--- a/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -38,7 +38,7 @@ private[spark] case class Heartbeat(
     executorId: String,
     accumUpdates: Array[(Long, Seq[AccumulatorV2[_, _]])], // taskId -> accumulator updates
     blockManagerId: BlockManagerId,
-    customizedInfo: Seq[String] = Nil)
+    customizedInfo: Seq[(String, String)] = Nil)
 
 /**
  * An event that SparkContext uses to notify HeartbeatReceiver that SparkContext.taskScheduler is
@@ -153,12 +153,12 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
       // Second is for oap index infor update.
       // The cusInfo is serialized string for fiber and oap index status.
       customizedInfo.foreach { cusInfo =>
-        if (cusInfo.contains("fiberFilePath")) {
-          sc.listenerBus.post(SparkListenerCustomInfoUpdate(blockManagerId.host, executorId,
-            cusInfo))
-        } else if (cusInfo.contains("useOapIndex")) {
+        if (cusInfo._2.contains("useOapIndex")) {
           sc.listenerBus.post(SparkListenerOapIndexInfoUpdate(blockManagerId.host, executorId,
-            cusInfo))
+            cusInfo._2))
+        } else { // for CostomInfoUpdate
+          sc.listenerBus.post(SparkListenerCustomInfoUpdate(blockManagerId.host, executorId,
+            cusInfo._1, cusInfo._2))
         }
       }
   }

--- a/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -33,6 +33,9 @@ import org.apache.spark.util._
  * components to convey liveness or execution information for in-progress tasks. It will also
  * expire the hosts that have not heartbeated for more than spark.network.timeout.
  * spark.executor.heartbeatInterval should be significantly less than spark.network.timeout.
+ *
+ * @param customizedInfo is added by OAP for deliver some metrics, whose (k,v) represents
+ *  (CustomClassName, CustomInfo)
  */
 private[spark] case class Heartbeat(
     executorId: String,

--- a/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -136,7 +136,9 @@ private[spark] class Executor(
 
   private val customInfoClassNameSeq = Seq(
     "org.apache.spark.sql.execution.datasources.oap.filecache.OapFiberCacheHeartBeatMessager",
-    "org.apache.spark.sql.execution.datasources.oap.io.OapIndexHeartBeatMessager")
+    "org.apache.spark.sql.execution.datasources.oap.io.OapIndexHeartBeatMessager",
+    "org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheManagerMessager"
+  )
   private val customManagerSeq: Seq[CustomManager] = customInfoClassNameSeq.map(cIC =>
     Utils.classForName(cIC).newInstance().asInstanceOf[CustomManager])
 
@@ -544,7 +546,8 @@ private[spark] class Executor(
       executorId,
       accumUpdates.toArray,
       env.blockManager.blockManagerId,
-      customManagerSeq.map(_.status(conf)))
+      customManagerSeq.map(m => (m.getClass.getName, m.status(conf)))
+        .filter(_._2.nonEmpty))
 
     try {
       val response = heartbeatReceiverRef.askWithRetry[HeartbeatResponse](

--- a/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -141,6 +141,7 @@ private[spark] case class SparkListenerLogStart(sparkVersion: String) extends Sp
 case class SparkListenerCustomInfoUpdate(
     hostName: String,
     executorId: String,
+    clazzName: String,
     customizedInfo: String) extends SparkListenerEvent
 
 /**

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
@@ -17,11 +17,57 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+
+case class CacheStatsInternal(size: Long, count: Long) {
+  require(size >= 0)
+  require(count >= 0)
+
+  def plus(other: CacheStatsInternal): CacheStatsInternal = this + other
+
+  def minus(other: CacheStatsInternal): CacheStatsInternal = this - other
+
+  def +(other: CacheStatsInternal): CacheStatsInternal =
+    CacheStatsInternal(size + other.size, count + other.count)
+
+  def -(other: CacheStatsInternal): CacheStatsInternal =
+    CacheStatsInternal(
+      math.max(0, size - other.size),
+      math.max(0, count - other.count))
+
+  override def toString: String = s"{size:$size, count:$count}"
+
+  def toJson: JValue = ("size" -> size) ~ ("count" -> count)
+}
+object CacheStatsInternal {
+  private implicit val format = DefaultFormats
+
+  def apply(): CacheStatsInternal = CacheStatsInternal(0, 0)
+
+  def apply(json: String): CacheStatsInternal = CacheStatsInternal(parse(json))
+
+  def apply(json: JValue): CacheStatsInternal = CacheStatsInternal(
+    (json \ "size").extract[Long],
+    (json \ "count").extract[Long]
+  )
+}
+
 /**
  * Immutable class to present statistics of Cache. To record the change of cache stat in runtime,
  * please consider a counter class. [[CacheStats]] can be a snapshot of the counter class.
  */
 case class CacheStats(
+    cache: CacheStatsInternal,
+    backEndCache: CacheStatsInternal,
+    dataFiberCache: CacheStatsInternal,
+    indexFiberCache: CacheStatsInternal,
+    pendingFiberCache: CacheStatsInternal,
     hitCount: Long,
     missCount: Long,
     loadCount: Long,
@@ -54,6 +100,11 @@ case class CacheStats(
 
   def +(other: CacheStats): CacheStats =
     CacheStats(
+      cache + other.cache,
+      backEndCache + other.backEndCache,
+      dataFiberCache + other.dataFiberCache,
+      indexFiberCache + other.indexFiberCache,
+      pendingFiberCache + other.pendingFiberCache,
       hitCount + other.hitCount,
       missCount + other.missCount,
       loadCount + other.loadCount,
@@ -62,6 +113,11 @@ case class CacheStats(
 
   def -(other: CacheStats): CacheStats =
     CacheStats(
+      cache - other.cache,
+      backEndCache - other.backEndCache,
+      dataFiberCache - other.dataFiberCache,
+      indexFiberCache - other.indexFiberCache,
+      pendingFiberCache - other.pendingFiberCache,
       math.max(0, hitCount - other.hitCount),
       math.max(0, missCount - other.missCount),
       math.max(0, loadCount - other.loadCount),
@@ -69,7 +125,58 @@ case class CacheStats(
       math.max(0, evictionCount - other.evictionCount))
 
   def toDebugString: String = {
-    s"CacheStats: { hitCount=$hitCount, missCount=$missCount, " +
-      s"totalLoadTime=$totalLoadTime ns, evictionCount=$evictionCount }"
+    s"CacheStats: { cache: $cache, backEndCache:$backEndCache, dataFiber:$dataFiberCache, " +
+      s"indexFiber:$indexFiberCache, pendingFiber:$pendingFiberCache hitCount=$hitCount, " +
+      s"missCount=$missCount, totalLoadTime=${totalLoadTime} ns, evictionCount=$evictionCount }"
+  }
+
+  def toJson: JValue = {
+    ("cache" -> cache.toJson)~
+      ("backEndCache" -> backEndCache.toJson)~
+      ("dataFiber" -> dataFiberCache.toJson)~
+      ("indexFiber" -> indexFiberCache.toJson)~
+      ("pendingFiber" -> pendingFiberCache.toJson)~
+      ("hitCount" -> hitCount)~
+      ("missCount" -> missCount) ~
+      ("loadCount" -> loadCount) ~
+      ("totalLoadTime" -> totalLoadTime) ~
+      ("evictionCount" -> evictionCount)
+  }
+}
+object CacheStats extends Logging {
+  private implicit val format = DefaultFormats
+  private var updateInterval: Long = -1
+  private var lastUpdateTime: Long = 0
+
+  def apply(): CacheStats = CacheStats(
+    CacheStatsInternal(), CacheStatsInternal(), CacheStatsInternal(),
+    CacheStatsInternal(), CacheStatsInternal(), 0, 0, 0, 0, 0)
+
+  def apply(json: String): CacheStats = CacheStats(parse(json))
+
+  def apply(json: JValue): CacheStats = CacheStats(
+    CacheStatsInternal(json \ "cache"),
+    CacheStatsInternal(json \ "backEndCache"),
+    CacheStatsInternal(json \ "dataFiber"),
+    CacheStatsInternal(json \ "indexFiber"),
+    CacheStatsInternal(json \ "pendingFiber"),
+      (json \ "hitCount").extract[Long],
+      (json \ "missCount").extract[Long],
+      (json \ "loadCount").extract[Long],
+      (json \ "totalLoadTime").extract[Long],
+      (json \ "evictionCount").extract[Long])
+
+  def status(cacheStats: CacheStats, conf: SparkConf): String = {
+    updateInterval = if (updateInterval != -1) {
+      updateInterval
+    } else {
+      conf.getLong("oap.update.fiber.cache.metrics.interval.sec", 60L) * 1000
+    }
+    if (System.currentTimeMillis() - lastUpdateTime > updateInterval) {
+      lastUpdateTime = System.currentTimeMillis()
+      compact(render(cacheStats.toJson))
+    } else {
+      ""
+    }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
@@ -24,6 +24,7 @@ import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.internal.oap.OapConf
 
 case class CacheStatsInternal(size: Long, count: Long) {
   require(size >= 0)
@@ -170,7 +171,7 @@ object CacheStats extends Logging {
     updateInterval = if (updateInterval != -1) {
       updateInterval
     } else {
-      conf.getLong("oap.update.fiber.cache.metrics.interval.sec", 60L) * 1000
+      conf.getLong(OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SCE.key, 60L) * 1000
     }
     if (System.currentTimeMillis() - lastUpdateTime > updateInterval) {
       lastUpdateTime = System.currentTimeMillis()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
@@ -164,4 +164,10 @@ object CacheStats extends Logging {
       ""
     }
   }
+
+  // used for unit test
+  def reset: Unit = {
+    updateInterval = -1
+    lastUpdateTime = 0
+  }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
@@ -154,8 +154,8 @@ object CacheStats extends Logging {
     updateInterval = if (updateInterval != -1) {
       updateInterval
     } else {
-      conf.getLong(OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SCE.key,
-        OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SCE.defaultValue.get) * 1000
+      conf.getLong(OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SEC.key,
+        OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SEC.defaultValue.get) * 1000
     }
     if (System.currentTimeMillis() - lastUpdateTime > updateInterval) {
       lastUpdateTime = System.currentTimeMillis()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -40,27 +40,26 @@ class OapFiberCacheHeartBeatMessager extends CustomManager with Logging {
   }
 }
 
-private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logging {
-
-  private val _pendingFiberSize: AtomicLong = new AtomicLong(0)
+private[filecache] class CacheGuardian(maxMemory: Long, oapCache: OapCache)
+  extends Thread with Logging {
 
   private val removalPendingQueue = new LinkedBlockingQueue[(Fiber, FiberCache)]()
 
   // Tell if guardian thread is trying to remove one Fiber.
   @volatile private var bRemoving: Boolean = false
 
-  def pendingSize: Int = if (bRemoving) {
+  def pendingFiberCount: Int = if (bRemoving) {
     removalPendingQueue.size() + 1
   } else {
     removalPendingQueue.size()
   }
 
   def addRemovalFiber(fiber: Fiber, fiberCache: FiberCache): Unit = {
-    _pendingFiberSize.addAndGet(fiberCache.size())
-    removalPendingQueue.offer(fiber, fiberCache)
-    if (_pendingFiberSize.get() > maxMemory) {
+    oapCache.pendingFiberSize.addAndGet(fiberCache.size())
+    removalPendingQueue.offer((fiber, fiberCache))
+    if (oapCache.pendingFiberSize.get() > maxMemory) {
       logWarning("Fibers pending on removal use too much memory, " +
-          s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
+          s"current: ${oapCache.pendingFiberSize.get()}, max: $maxMemory")
     }
   }
 
@@ -75,13 +74,14 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logg
         // Check memory usage every 3s while we are waiting fiber release.
         logDebug(s"Waiting fiber to be released timeout. Fiber: $fiber")
         removalPendingQueue.offer((fiber, fiberCache))
-        if (_pendingFiberSize.get() > maxMemory) {
+        if (oapCache.pendingFiberSize.get() > maxMemory) {
           logWarning("Fibers pending on removal use too much memory, " +
-            s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
+              s"current: ${oapCache.pendingFiberSize.get()}, max: $maxMemory")
         }
       } else {
         // TODO: Make log more readable
-        _pendingFiberSize.addAndGet(-fiberCache.size())
+        oapCache.addFiber(fiber, -1, -fiberCache.size())
+        oapCache.pendingFiberSize.addAndGet(-fiberCache.size())
         logDebug(s"Fiber removed successfully. Fiber: $fiber")
       }
       bRemoving = false
@@ -94,6 +94,11 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logg
  *
  * TODO: change object to class for better initialization
  */
+class FiberCacheManagerMessager extends CustomManager {
+  override def status(conf: SparkConf): String =
+    CacheStats.status(FiberCacheManager.cacheStats, conf)
+}
+
 object FiberCacheManager extends Logging {
 
   private val GUAVA_CACHE = "guava"
@@ -163,7 +168,7 @@ object FiberCacheManager extends Logging {
   def cacheSize: Long = cacheBackend.cacheSize
 
   // Used by test suite
-  private[filecache] def pendingSize: Int = cacheBackend.pendingSize
+  private[filecache] def pendingCount: Int = cacheBackend.pendingFiberCount
 
   // A description of this FiberCacheManager for debugging.
   def toDebugString: String = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -80,7 +80,7 @@ private[filecache] class CacheGuardian(maxMemory: Long)
         removalPendingQueue.offer((fiber, fiberCache))
         if (_pendingFiberSize.get() > maxMemory) {
           logWarning("Fibers pending on removal use too much memory, " +
-              s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
+            s"current: ${_pendingFiberSize.get()}, max: $maxMemory")
         }
       } else {
         _pendingFiberSize.addAndGet(-fiberCache.size())
@@ -146,6 +146,9 @@ object FiberCacheManager extends Logging {
       cacheBackend.invalidate(fiber)
     }
   }
+
+  // Used by test suite
+  private[filecache] def clearAllFibers(): Unit = cacheBackend.cleanUp
 
   // TODO: test case, consider data eviction, try not use DataFileHandle which my be costly
   private[filecache] def status: String = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -19,8 +19,9 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 
 import java.util.concurrent.ConcurrentHashMap
 
-import com.google.common.base.Throwables
 import scala.collection.JavaConverters._
+
+import com.google.common.base.Throwables
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -19,6 +19,9 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 
 import java.util.concurrent.ConcurrentHashMap
 
+import com.google.common.base.Throwables
+import scala.collection.JavaConverters._
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate
 import org.apache.spark.sql.execution.datasources.oap.IndexMeta
@@ -89,3 +92,25 @@ private[oap] trait AbstractFiberSensor extends Logging {
 }
 
 object FiberSensor extends AbstractFiberSensor
+
+object FiberCacheManagerSensor extends AbstractFiberSensor {
+  val executorToCacheManager = new ConcurrentHashMap[String, CacheStats]()
+
+  def summary(): CacheStats = executorToCacheManager.asScala.toMap.values
+    .foldLeft(CacheStats())((sum, cache) => sum + cache)
+
+  override def update(fiberInfo: SparkListenerCustomInfoUpdate): Unit = {
+    if (fiberInfo.customizedInfo.nonEmpty) {
+      try {
+        val cacheMetrics = CacheStats(fiberInfo.customizedInfo)
+        executorToCacheManager.put(fiberInfo.executorId, cacheMetrics)
+        logDebug(s"execID:${fiberInfo.executorId}, host:${fiberInfo.hostName}," +
+          s" ${cacheMetrics.toDebugString}")
+      } catch {
+        case t: Throwable =>
+          val stack = Throwables.getStackTraceAsString(t)
+          logError(s"FiberCacheManagerSensor parse json failed, $stack")
+      }
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/listener/FiberInfoListener.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/listener/FiberInfoListener.scala
@@ -18,11 +18,15 @@
 package org.apache.spark.sql.execution.datasources.oap.listener
 
 import org.apache.spark.scheduler.{SparkListener, SparkListenerCustomInfoUpdate}
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberSensor
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCacheManagerSensor, FiberSensor}
 
 class FiberInfoListener extends SparkListener {
   override def onCustomInfoUpdate(fiberInfo: SparkListenerCustomInfoUpdate): Unit = {
-    FiberSensor.update(fiberInfo)
+    if (fiberInfo.clazzName.contains("OapFiberCacheHeartBeatMessager")) {
+      FiberSensor.update(fiberInfo)
+    } else if (fiberInfo.clazzName.contains("FiberCacheManagerMessager")) {
+      FiberCacheManagerSensor.update(fiberInfo)
+    }
   }
 
   // TODO: implements other events like `onExecutorAdded`, `onExecutorRemoved`, etc. to maintain

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -184,9 +184,9 @@ object OapConf {
     .createWithDefault("")
 
   val OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SCE =
-    SQLConfigBuilder("oap.update.fiber.cache.metrics.interval.sec")
+    SQLConfigBuilder("spark.sql.oap.update.fiber.cache.metrics.interval.sec")
       .internal()
       .doc("The interval of fiber cache metrics update")
       .longConf
-      .createWithDefault(60L)
+      .createWithDefault(10L)
 }

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -183,7 +183,7 @@ object OapConf {
     .stringConf
     .createWithDefault("")
 
-  val OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SCE =
+  val OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SEC =
     SQLConfigBuilder("spark.sql.oap.update.fiber.cache.metrics.interval.sec")
       .internal()
       .doc("The interval of fiber cache metrics update")

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -183,4 +183,10 @@ object OapConf {
     .stringConf
     .createWithDefault("")
 
+  val OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SCE =
+    SQLConfigBuilder("oap.update.fiber.cache.metrics.interval.sec")
+      .internal()
+      .doc("The interval of fiber cache metrics update")
+      .longConf
+      .createWithDefault(60L)
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -143,16 +143,16 @@ class FiberCacheManagerSuite extends SharedOapContext {
     // release fibers so it has chance to be disposed immediately
     fibers.foreach(FiberCacheManager.get(_, configuration).release())
     Thread.sleep(1000)
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
     // Hold the fiber, so it can't be disposed until release
     val fiberCaches = fibers.map(FiberCacheManager.get(_, configuration))
     Thread.sleep(1000)
-    assert(FiberCacheManager.pendingSize > 0)
+    assert(FiberCacheManager.pendingCount > 0)
     // After release, CacheGuardian should be back to work
     fiberCaches.foreach(_.release())
     // Wait some time for CacheGuardian being waken-up
     Thread.sleep(1000)
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
   }
 
   class TestRunner(work: () => Unit) extends Runnable {
@@ -205,7 +205,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     pool.awaitTermination(1000, TimeUnit.MILLISECONDS)
     Thread.sleep(100)
     results.foreach(r => r.get())
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
   }
 
   // refCount should be correct
@@ -287,7 +287,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
 
     // Put into cache and make it use
     val fiberCacheInUse = FiberCacheManager.get(fiberInUse, configuration)
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
 
     // make fiber in use the 1st element in release queue.
     FiberCacheManager.removeFiber(fiberInUse)
@@ -304,9 +304,9 @@ class FiberCacheManagerSuite extends SharedOapContext {
     // Wait for clean.
     Thread.sleep(6000)
     // There should be only one in-use fiber.
-    assert(FiberCacheManager.pendingSize == 1)
+    assert(FiberCacheManager.pendingCount == 1)
     fiberCacheInUse.release()
     Thread.sleep(6000)
-    assert(FiberCacheManager.pendingSize == 0)
+    assert(FiberCacheManager.pendingCount == 0)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileHandle
 import org.apache.spark.sql.execution.datasources.oap.listener.FiberInfoListener
 import org.apache.spark.sql.execution.datasources.oap.utils.CacheStatusSerDe
+import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.util.collection.BitSet
 
 class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Logging {
@@ -44,7 +45,7 @@ class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Loggi
 
     // Test normal msg
     val conf: SparkConf = new SparkConf()
-    conf.set("oap.update.fiber.cache.metrics.interval.sec", 0L.toString)
+    conf.set(OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SCE.key, 0L.toString)
     val cacheStats = CacheStats(CacheStatsInternal(12, 21),
       CacheStatsInternal(12, 21), CacheStatsInternal(2, 19),
       CacheStatsInternal(10, 2), CacheStatsInternal(0, 0),

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
+import org.scalatest.BeforeAndAfterEach
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -46,10 +46,7 @@ class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Loggi
     // Test normal msg
     val conf: SparkConf = new SparkConf()
     conf.set(OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SCE.key, 0L.toString)
-    val cacheStats = CacheStats(CacheStatsInternal(12, 21),
-      CacheStatsInternal(12, 21), CacheStatsInternal(2, 19),
-      CacheStatsInternal(10, 2), CacheStatsInternal(0, 0),
-      213, 23, 23, 123131, 2)
+    val cacheStats = CacheStats(2, 19, 10, 2, 0, 0, 213, 23, 23, 123131, 2)
     new FiberInfoListener onCustomInfoUpdate SparkListenerCustomInfoUpdate(
       host, execID, messager, CacheStats.status(cacheStats, conf))
     assertResult(1)(FiberCacheManagerSensor.executorToCacheManager.size())

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -17,14 +17,44 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileHandle
+import org.apache.spark.sql.execution.datasources.oap.listener.FiberInfoListener
 import org.apache.spark.sql.execution.datasources.oap.utils.CacheStatusSerDe
 import org.apache.spark.util.collection.BitSet
 
 class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Logging {
+
+  test("test FiberCacheManagerSensor") {
+    val host = "0.0.0.0"
+    val execID = "exec1"
+    val messager = "FiberCacheManagerMessager"
+
+    // Test json empty
+    new FiberInfoListener onCustomInfoUpdate SparkListenerCustomInfoUpdate(
+      host, execID, messager, "")
+    assertResult(0)(FiberCacheManagerSensor.executorToCacheManager.size())
+
+    // Test json error
+    new FiberInfoListener onCustomInfoUpdate SparkListenerCustomInfoUpdate(
+      host, execID, messager, "error msg")
+    assertResult(0)(FiberCacheManagerSensor.executorToCacheManager.size())
+
+    // Test normal msg
+    val conf: SparkConf = new SparkConf()
+    conf.set("oap.update.fiber.cache.metrics.interval.sec", 0L.toString)
+    val cacheStats = CacheStats(CacheStatsInternal(12, 21),
+      CacheStatsInternal(12, 21), CacheStatsInternal(2, 19),
+      CacheStatsInternal(10, 2), CacheStatsInternal(0, 0),
+      213, 23, 23, 123131, 2)
+    new FiberInfoListener onCustomInfoUpdate SparkListenerCustomInfoUpdate(
+      host, execID, messager, CacheStats.status(cacheStats, conf))
+    assertResult(1)(FiberCacheManagerSensor.executorToCacheManager.size())
+    assertResult(cacheStats.toJson)(
+      FiberCacheManagerSensor.executorToCacheManager.get(execID).toJson)
+  }
 
   test("test get hosts from FiberSensor") {
     val filePath = "file1"
@@ -38,7 +68,8 @@ class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Loggi
     bitSet1.set(1)
     bitSet1.set(2)
     val fcs = Seq(FiberCacheStatus(filePath, bitSet1, dataFileMeta))
-    val fiberInfo = SparkListenerCustomInfoUpdate(host1, execId1, CacheStatusSerDe.serialize(fcs))
+    val fiberInfo = SparkListenerCustomInfoUpdate(host1, execId1,
+      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe.serialize(fcs))
     this.update(fiberInfo)
     assert(this.getHosts(filePath) contains (FiberSensor.OAP_CACHE_HOST_PREFIX + host1 +
       FiberSensor.OAP_CACHE_EXECUTOR_PREFIX + execId1))
@@ -54,8 +85,9 @@ class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Loggi
     bitSet2.set(7)
     bitSet2.set(8)
 
-    val fiberInfo2 = SparkListenerCustomInfoUpdate(host2, execId2, CacheStatusSerDe
-      .serialize(Seq(FiberCacheStatus(filePath, bitSet2, dataFileMeta))))
+    val fiberInfo2 = SparkListenerCustomInfoUpdate(host2, execId2,
+      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
+        .serialize(Seq(FiberCacheStatus(filePath, bitSet2, dataFileMeta))))
     this.update(fiberInfo2)
     assert(this.getHosts(filePath) contains  (FiberSensor.OAP_CACHE_HOST_PREFIX + host2 +
       FiberSensor.OAP_CACHE_EXECUTOR_PREFIX + execId2))
@@ -68,8 +100,9 @@ class FiberSensorSuite extends SparkFunSuite with AbstractFiberSensor with Loggi
     bitSet3.set(8)
     bitSet3.set(9)
     bitSet3.set(10)
-    val fiberInfo3 = SparkListenerCustomInfoUpdate(host3, execId3, CacheStatusSerDe
-      .serialize(Seq(FiberCacheStatus(filePath, bitSet3, dataFileMeta))))
+    val fiberInfo3 = SparkListenerCustomInfoUpdate(host3, execId3,
+      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
+        .serialize(Seq(FiberCacheStatus(filePath, bitSet3, dataFileMeta))))
     this.update(fiberInfo3)
     assert(this.getHosts(filePath) === Some(FiberSensor.OAP_CACHE_HOST_PREFIX + host2 +
       FiberSensor.OAP_CACHE_EXECUTOR_PREFIX + execId2))

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -98,11 +98,11 @@ class FiberSensorSuite extends QueryTest with SharedOapContext
     assertResult(1)(FiberCacheManagerSensor.executorToCacheManager.size())
     assertResult(dataFileCount * 4)(summary.dataFiberCount)
 
-    // all data are cached when rerun the same sql.
+    // all data are cached when run another sql.
     // Expect: 1.hitCount increase; 2.missCount equal
     // wait for a heartbeat period
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 500 AND a < 2500"),
-      data.filter(r => r._1 > 500 && r._1 < 2500).map(r => Row(r._1, r._2)))
+    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 200 AND a < 2400"),
+      data.filter(r => r._1 > 200 && r._1 < 2400).map(r => Row(r._1, r._2)))
     Thread.sleep(15 * 1000)
     val summary2 = FiberCacheManagerSensor.summary()
     logInfo(s"Summary2: ${summary2.toDebugString}")
@@ -130,7 +130,7 @@ class FiberSensorSuite extends QueryTest with SharedOapContext
     assertResult(0)(FiberCacheManagerSensor.executorToCacheManager.size())
 
     // Test normal msg
-    Thread.sleep(1000)
+    CacheStats.reset
     val conf: SparkConf = new SparkConf()
     conf.set(OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SEC.key, 0L.toString)
     val cacheStats = CacheStats(2, 19, 10, 2, 0, 0, 213, 23, 23, 123131, 2)


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
1. add more metrics in CacheStats
2. add FiberCacheManagerSensor, executors report CacheStats metrics to the Sensor in driver

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Unit Test

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

