### PR TITLE
 Add IndexedVectorizedOapRecordReader

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -50,9 +50,9 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
     private IntList batchIds;
 
     private static final String IDS_MAP_STATE_ERROR_MSG =
-        "The divideRowIdsIntoPages method should not be called when idsMap is not empty.";
+      "The divideRowIdsIntoPages method should not be called when idsMap is not empty.";
     private static final String IDS_ITER_STATE_ERROR_MSG =
-        "The divideRowIdsIntoPages method should not be called when rowIdsIter hasNext if false.";
+      "The divideRowIdsIntoPages method should not be called when rowIdsIter hasNext if false.";
 
     public IndexedVectorizedOapRecordReader(
         Path file,

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -72,8 +72,8 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
 
     /**
      * Override initialize method, init footer if need,
-     * then init indexedFooter & rowIdsIter,
-     * then call super.initialize & initializeInternal
+     * then init indexedFooter and rowIdsIter,
+     * then call super.initialize and initializeInternal
      * @throws IOException
      * @throws InterruptedException
      */

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -61,8 +61,11 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
     private static final String IDS_ITER_STATE_ERROR_MSG =
       "The divideRowIdsIntoPages method should not be called when rowIdsIter hasNext if false.";
 
-    public IndexedVectorizedOapRecordReader(Path file, Configuration configuration,
-        ParquetMetadata footer, int[] globalRowIds) {
+    public IndexedVectorizedOapRecordReader(
+        Path file,
+        Configuration configuration,
+        ParquetMetadata footer,
+        int[] globalRowIds) {
       super(file, configuration, footer);
       this.globalRowIds = globalRowIds;
     }

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -42,18 +42,24 @@ import com.google.common.collect.Maps;
 
 public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader {
 
+    // pageNumber -> rowIdsList, use to decide：
+    // 1. Is this pageNumber has data to read ?
+    // 2. Use rowIdsList to mark which row need read.
     private Map<Integer, IntList> idsMap = Maps.newHashMap();
+    // Record current PageNumber
     private int currentPageNumber;
+    // Rowid list of file granularity
     private int[] globalRowIds;
+    // Rowid Iter of RowGroup granularity
     private Iterator<IntList> rowIdsIter;
-    // for returnColumnarBatch is false.
+    // for returnColumnarBatch is false branch,
+    // secondary indexes to call columnarBatch.getRow
     private IntList batchIds;
+    
     private static final String IDS_MAP_STATE_ERROR_MSG =
             "The divideRowIdsIntoPages method should not be called when idsMap is not empty.";
     private static final String IDS_ITER_STATE_ERROR_MSG =
             "The divideRowIdsIntoPages method should not be called when rowIdsIter hasNext if false.";
-    private static final String BATCH_IDS_NOT_NULL_ERROR_MSG =
-            "returnColumnarBatch is false, batchIds must not null.";
 
     public IndexedVectorizedOapRecordReader(
             Path file,

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
+import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.api.InitContext;
+import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.IndexedParquetMetadata;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.hadoop.utils.Collections3;
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.spark.sql.execution.datasources.oap.io.OapReadSupportImpl;
+import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportHelper;
+import org.apache.spark.sql.types.StructType$;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
+public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader {
+
+    private Map<Integer, IntList> idsMap = Maps.newHashMap();
+    private int currentPageNumber;
+    private int[] globalRowIds;
+    private Iterator<IntList> rowIdsIter;
+    // for returnColumnarBatch is false.
+    private IntList batchIds;
+    private static final String IDS_MAP_STATE_ERROR_MSG =
+            "The divideRowIdsIntoPages method should not be called when idsMap is not empty.";
+    private static final String IDS_ITER_STATE_ERROR_MSG =
+            "The divideRowIdsIntoPages method should not be called when rowIdsIter hasNext if false.";
+    private static final String BATCH_IDS_NOT_NULL_ERROR_MSG =
+            "returnColumnarBatch is false, batchIds must not null.";
+
+    public IndexedVectorizedOapRecordReader(
+            Path file,
+            Configuration configuration,
+            ParquetMetadata footer,
+            int[] globalRowIds) {
+        super(file, configuration, footer);
+        this.globalRowIds = globalRowIds;
+    }
+
+    @Override
+    public void initialize() throws IOException, InterruptedException {
+        if (this.footer == null) {
+            footer = readFooter(configuration, file, NO_FILTER);
+        }
+
+        IndexedParquetMetadata indexedFooter = IndexedParquetMetadata.from(footer, globalRowIds);
+        this.fileSchema = footer.getFileMetaData().getSchema();
+        Map<String, String> fileMetadata = footer.getFileMetaData().getKeyValueMetaData();
+        ReadSupport.ReadContext readContext = new OapReadSupportImpl().init(new InitContext(
+                configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema));
+        this.requestedSchema = readContext.getRequestedSchema();
+        String sparkRequestedSchemaString =
+                configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
+        this.sparkSchema = StructType$.MODULE$.fromString(sparkRequestedSchemaString);
+        this.reader = ParquetFileReader.open(configuration, file, indexedFooter);
+        this.reader.setRequestedSchema(requestedSchema);
+        this.rowIdsIter = indexedFooter.getRowIdsList().iterator();
+        for (BlockMetaData block : indexedFooter.getBlocks()) {
+            this.totalRowCount += block.getRowCount();
+        }
+        super.initializeInternal();
+    }
+
+    @Override
+    public Object getCurrentValue() throws IOException, InterruptedException {
+        if (returnColumnarBatch) return columnarBatch;
+        Preconditions.checkNotNull(batchIds, "returnColumnarBatch = false, batchIds must not null.");
+        Preconditions.checkArgument(batchIdx <= numBatched, "batchIdx can not be more than numBatched");
+        Preconditions.checkArgument(batchIdx >= 1, "call nextKeyValue before getCurrentValue");
+        // batchIds (IntArrayList) is random access.
+        return columnarBatch.getRow(batchIds.get(batchIdx - 1));
+    }
+
+    /**
+     * Advances to the next batch of rows. Returns false if there are no more.
+     */
+    @Override
+    public boolean nextBatch() throws IOException {
+        // if idsMap is Empty, needn't read remaining data in this row group
+        // rowsReturned = totalCountLoadedSoFar to skip remaining data
+        if (idsMap.isEmpty()) {
+            rowsReturned = totalCountLoadedSoFar;
+        }
+        return super.nextBatch() && filterRowsWithIndex();
+    }
+
+    @Override
+    protected void checkEndOfRowGroup() throws IOException {
+        if (rowsReturned != totalCountLoadedSoFar) return;
+        // if rowsReturned == totalCountLoadedSoFar
+        // readNextRowGroup & divideRowIdsIntoPages
+        super.readNextRowGroup();
+        this.divideRowIdsIntoPages();
+    }
+    
+    private boolean filterRowsWithIndex() throws IOException {
+        IntList ids = idsMap.remove(currentPageNumber);
+        if (ids == null || ids.isEmpty()) {
+            currentPageNumber++;
+            return this.nextBatch();
+        } else {
+            // if returnColumnarBatch, mark columnarBatch filtered status.
+            // else assignment batchIdsIter.
+            if(returnColumnarBatch) {
+                columnarBatch.markAllFiltered();
+                for (Integer rowid : ids) {
+                    columnarBatch.markValid(rowid);
+                }
+            } else {
+                batchIds = ids;
+                numBatched = ids.size();
+            }
+            currentPageNumber++;
+            return true;
+        }
+    }
+
+    private void divideRowIdsIntoPages() {
+        Preconditions.checkState(idsMap.isEmpty(), IDS_MAP_STATE_ERROR_MSG);
+        Preconditions.checkState(rowIdsIter.hasNext(), IDS_ITER_STATE_ERROR_MSG);
+        this.currentPageNumber = 0;
+        int pageSize = columnarBatch.capacity();
+        IntList currentIndexList = rowIdsIter.next();
+        for (int rowId : currentIndexList) {
+            int pageNumber = rowId / pageSize;
+            if (idsMap.containsKey(pageNumber)) {
+                idsMap.get(pageNumber).add(rowId - pageNumber * pageSize);
+            } else {
+                IntArrayList ids = new IntArrayList(pageSize / 2);
+                ids.add(rowId - pageNumber * pageSize);
+                idsMap.put(pageNumber, ids);
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -131,6 +131,18 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
             // if returnColumnarBatch, mark columnarBatch filtered status.
             // else assignment batchIdsIter.
             if(returnColumnarBatch) {
+                // we can do same operation use markFiltered as follow code:
+                // int current = 0;
+                // for (Integer target : ids)
+                // { while (current < target){
+                // columnarBatch.markFiltered(current);
+                // current++; }
+                // current++; }
+                // current++;
+                // while (current < numBatched){
+                // columnarBatch.markFiltered(current); current++; }
+                // it a little complex and use current version,
+                // we can revert use above code if need.
                 columnarBatch.markAllFiltered();
                 for (Integer rowId : ids) {
                     columnarBatch.markValid(rowId);

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -57,9 +57,9 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
     private IntList batchIds;
 
     private static final String IDS_MAP_STATE_ERROR_MSG =
-      "The divideRowIdsIntoPages method should not be called when idsMap is not empty.";
+        "The divideRowIdsIntoPages method should not be called when idsMap is not empty.";
     private static final String IDS_ITER_STATE_ERROR_MSG =
-      "The divideRowIdsIntoPages method should not be called when rowIdsIter hasNext if false.";
+        "The divideRowIdsIntoPages method should not be called when rowIdsIter hasNext if false.";
 
     public IndexedVectorizedOapRecordReader(
         Path file,
@@ -92,7 +92,9 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
 
     @Override
     public Object getCurrentValue() throws IOException, InterruptedException {
-      if (returnColumnarBatch) return columnarBatch;
+      if (returnColumnarBatch) {
+        return columnarBatch;
+      }
       Preconditions.checkNotNull(batchIds, "returnColumnarBatch = false, batchIds must not null.");
       Preconditions.checkArgument(batchIdx <= numBatched, "batchIdx can not be more than numBatched");
       Preconditions.checkArgument(batchIdx >= 1, "call nextKeyValue before getCurrentValue");
@@ -115,7 +117,9 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
 
     @Override
     protected void checkEndOfRowGroup() throws IOException {
-      if (rowsReturned != totalCountLoadedSoFar) return;
+      if (rowsReturned != totalCountLoadedSoFar) {
+        return;
+      }
       // if rowsReturned == totalCountLoadedSoFar
       // readNextRowGroup & divideRowIdsIntoPages
       super.readNextRowGroup();

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -25,17 +25,10 @@ import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.parquet.hadoop.api.InitContext;
-import org.apache.parquet.hadoop.api.ReadSupport;
-import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.IndexedParquetMetadata;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
-import org.apache.parquet.hadoop.utils.Collections3;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
-import org.apache.spark.sql.execution.datasources.oap.io.OapReadSupportImpl;
-import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportHelper;
-import org.apache.spark.sql.types.StructType$;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -55,7 +55,7 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
     // for returnColumnarBatch is false branch,
     // secondary indexes to call columnarBatch.getRow
     private IntList batchIds;
-    
+
     private static final String IDS_MAP_STATE_ERROR_MSG =
             "The divideRowIdsIntoPages method should not be called when idsMap is not empty.";
     private static final String IDS_ITER_STATE_ERROR_MSG =
@@ -132,8 +132,8 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
             // else assignment batchIdsIter.
             if(returnColumnarBatch) {
                 columnarBatch.markAllFiltered();
-                for (Integer rowid : ids) {
-                    columnarBatch.markValid(rowid);
+                for (Integer rowId : ids) {
+                    columnarBatch.markValid(rowId);
                 }
             } else {
                 batchIds = ids;

--- a/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
+++ b/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
@@ -60,8 +60,8 @@ public abstract class SpecificOapRecordReaderBase<T> implements RecordReader<T> 
      * @throws IOException
      * @throws InterruptedException
      */
-    protected void initialize(ParquetMetadata footer, Configuration configuration, boolean isFilterRowGroups) throws
-        IOException, InterruptedException {
+    protected void initialize(ParquetMetadata footer, Configuration configuration, boolean isFilterRowGroups)
+        throws IOException, InterruptedException {
       this.fileSchema = footer.getFileMetaData().getSchema();
       Map<String, String> fileMetadata = footer.getFileMetaData().getKeyValueMetaData();
       ReadSupport.ReadContext readContext = new OapReadSupportImpl().init(new InitContext(

--- a/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
+++ b/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
@@ -30,6 +30,7 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.utils.Collections3;
 import org.apache.parquet.schema.MessageType;
+
 import org.apache.spark.sql.execution.datasources.oap.io.OapReadSupportImpl;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportHelper;
 import org.apache.spark.sql.types.StructType;

--- a/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
+++ b/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
@@ -61,30 +61,30 @@ public abstract class SpecificOapRecordReaderBase<T> implements RecordReader<T> 
      * @throws InterruptedException
      */
     protected void initialize(ParquetMetadata footer, Configuration configuration, boolean isFilterRowGroups) throws
-            IOException, InterruptedException {
-        this.fileSchema = footer.getFileMetaData().getSchema();
-        Map<String, String> fileMetadata = footer.getFileMetaData().getKeyValueMetaData();
-        ReadSupport.ReadContext readContext = new OapReadSupportImpl().init(new InitContext(
-                configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema));
-        this.requestedSchema = readContext.getRequestedSchema();
-        String sparkRequestedSchemaString =
-                configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
-        this.sparkSchema = StructType$.MODULE$.fromString(sparkRequestedSchemaString);
-        this.reader = ParquetFileReader.open(configuration, file, footer);
-        if (isFilterRowGroups) {
-            this.reader.filterRowGroups(getFilter(configuration));
-        }
-        this.reader.setRequestedSchema(requestedSchema);
-        for (BlockMetaData block : this.reader.getRowGroups()) {
-            this.totalRowCount += block.getRowCount();
-        }
+        IOException, InterruptedException {
+      this.fileSchema = footer.getFileMetaData().getSchema();
+      Map<String, String> fileMetadata = footer.getFileMetaData().getKeyValueMetaData();
+      ReadSupport.ReadContext readContext = new OapReadSupportImpl().init(new InitContext(
+              configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema));
+      this.requestedSchema = readContext.getRequestedSchema();
+      String sparkRequestedSchemaString =
+              configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
+      this.sparkSchema = StructType$.MODULE$.fromString(sparkRequestedSchemaString);
+      this.reader = ParquetFileReader.open(configuration, file, footer);
+      if (isFilterRowGroups) {
+        this.reader.filterRowGroups(getFilter(configuration));
+      }
+      this.reader.setRequestedSchema(requestedSchema);
+      for (BlockMetaData block : this.reader.getRowGroups()) {
+        this.totalRowCount += block.getRowCount();
+      }
     }
 
     @Override
     public void close() throws IOException {
-        if (reader != null) {
-            reader.close();
-            reader = null;
-        }
+      if (reader != null) {
+        reader.close();
+        reader = null;
+      }
     }
 }

--- a/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
+++ b/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
@@ -16,16 +16,10 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
-import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
 import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -59,26 +53,16 @@ public abstract class SpecificOapRecordReaderBase<T> implements RecordReader<T> 
     protected ParquetFileReader reader;
 
     /**
-     * SpecificOapRecordReaderBase need
-     * configuration & footer use by initialize method,
-     * not belong to SpecificParquetRecordReaderBase
-     */
-    protected Configuration configuration;
-    protected ParquetMetadata footer;
-
-    /**
-     * SpecificOapRecordReaderBase init method,
-     * needn't taskAttemptContext & inputSplit
+     *
+     * @param footer parquet file footer∂
+     * @param configuration haddoop configuration
+     * @param isFilterRowGroups is do filterRowGroups
      * @throws IOException
      * @throws InterruptedException
      */
-    @Override
-    public void initialize() throws IOException, InterruptedException {
-        if(this.footer == null){
-            footer = readFooter(configuration, file, NO_FILTER);
-        }
+    protected void initialize(ParquetMetadata footer, Configuration configuration, boolean isFilterRowGroups) throws
+            IOException, InterruptedException {
         this.fileSchema = footer.getFileMetaData().getSchema();
-
         Map<String, String> fileMetadata = footer.getFileMetaData().getKeyValueMetaData();
         ReadSupport.ReadContext readContext = new OapReadSupportImpl().init(new InitContext(
                 configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema));
@@ -86,8 +70,10 @@ public abstract class SpecificOapRecordReaderBase<T> implements RecordReader<T> 
         String sparkRequestedSchemaString =
                 configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
         this.sparkSchema = StructType$.MODULE$.fromString(sparkRequestedSchemaString);
-        this.reader = ParquetFileReader.open(configuration, file,footer);
-        this.reader.filterRowGroups(getFilter(configuration));
+        this.reader = ParquetFileReader.open(configuration, file, footer);
+        if (isFilterRowGroups) {
+            this.reader.filterRowGroups(getFilter(configuration));
+        }
         this.reader.setRequestedSchema(requestedSchema);
         for (BlockMetaData block : this.reader.getRowGroups()) {
             this.totalRowCount += block.getRowCount();

--- a/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
+++ b/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
@@ -65,10 +65,10 @@ public abstract class SpecificOapRecordReaderBase<T> implements RecordReader<T> 
       this.fileSchema = footer.getFileMetaData().getSchema();
       Map<String, String> fileMetadata = footer.getFileMetaData().getKeyValueMetaData();
       ReadSupport.ReadContext readContext = new OapReadSupportImpl().init(new InitContext(
-              configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema));
+          configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema));
       this.requestedSchema = readContext.getRequestedSchema();
       String sparkRequestedSchemaString =
-              configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
+          configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
       this.sparkSchema = StructType$.MODULE$.fromString(sparkRequestedSchemaString);
       this.reader = ParquetFileReader.open(configuration, file, footer);
       if (isFilterRowGroups) {

--- a/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
+++ b/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
@@ -54,7 +54,7 @@ public abstract class SpecificOapRecordReaderBase<T> implements RecordReader<T> 
 
     /**
      *
-     * @param footer parquet file footer∂
+     * @param footer parquet file footer
      * @param configuration haddoop configuration
      * @param isFilterRowGroups is do filterRowGroups
      * @throws IOException
@@ -65,10 +65,10 @@ public abstract class SpecificOapRecordReaderBase<T> implements RecordReader<T> 
       this.fileSchema = footer.getFileMetaData().getSchema();
       Map<String, String> fileMetadata = footer.getFileMetaData().getKeyValueMetaData();
       ReadSupport.ReadContext readContext = new OapReadSupportImpl().init(new InitContext(
-          configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema));
+        configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema));
       this.requestedSchema = readContext.getRequestedSchema();
       String sparkRequestedSchemaString =
-          configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
+        configuration.get(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA());
       this.sparkSchema = StructType$.MODULE$.fromString(sparkRequestedSchemaString);
       this.reader = ParquetFileReader.open(configuration, file, footer);
       if (isFilterRowGroups) {

--- a/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
@@ -107,7 +107,7 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
 
     /**
      * SpecificOapRecordReaderBase need
-     * configuration & footer use by initialize method,
+     * configuration and footer use by initialize method,
      * not belong to SpecificParquetRecordReaderBase
      */
     protected Configuration configuration;
@@ -121,12 +121,12 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
      * @param footer
      */
     public VectorizedOapRecordReader(
-                        Path file,
-                        Configuration configuration,
-                        ParquetMetadata footer) {
-        this.file = file;
-        this.configuration = configuration;
-        this.footer = footer;
+        Path file,
+        Configuration configuration,
+        ParquetMetadata footer) {
+      this.file = file;
+      this.configuration = configuration;
+      this.footer = footer;
     }
 
     /**
@@ -137,12 +137,12 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
      */
     @Override
     public void initialize() throws IOException, InterruptedException {
-        if(this.footer == null){
-            footer = readFooter(configuration, file, NO_FILTER);
-        }
-        // no index to use, try do filterRowGroups to skip rowgroups.
-        initialize(footer, configuration, true);
-        initializeInternal();
+      if (this.footer == null) {
+        footer = readFooter(configuration, file, NO_FILTER);
+      }
+      // no index to use, try do filterRowGroups to skip rowgroups.
+      initialize(footer, configuration, true);
+      initializeInternal();
     }
 
     /**

--- a/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
@@ -16,6 +16,9 @@
  */
 package org.apache.parquet.hadoop;
 
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
+import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -103,6 +106,14 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
     protected static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.ON_HEAP;
 
     /**
+     * SpecificOapRecordReaderBase need
+     * configuration & footer use by initialize method,
+     * not belong to SpecificParquetRecordReaderBase
+     */
+    protected Configuration configuration;
+    protected ParquetMetadata footer;
+
+    /**
      * VectorizedOapRecordReader Contructor
      * new method
      * @param file
@@ -119,13 +130,18 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
     }
 
     /**
-     * Override SpecificOapRecordReaderBase.initialize
+     * Override initialize method, init footer if need,
+     * then call super.initialize & initializeInternal
      * @throws IOException
      * @throws InterruptedException
      */
     @Override
     public void initialize() throws IOException, InterruptedException {
-        super.initialize();
+        if(this.footer == null){
+            footer = readFooter(configuration, file, NO_FILTER);
+        }
+        // no index to use, try do filterRowGroups to skip rowgroups.
+        initialize(footer, configuration, true);
         initializeInternal();
     }
 

--- a/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
@@ -131,7 +131,7 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
 
     /**
      * Override initialize method, init footer if need,
-     * then call super.initialize & initializeInternal
+     * then call super.initialize and initializeInternal
      * @throws IOException
      * @throws InterruptedException
      */

--- a/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
+++ b/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
@@ -459,6 +459,25 @@ public final class ColumnarBatch {
   }
 
   /**
+   * Marks this row not filtered out. This means a subsequent iteration over the rows
+   * in this batch will include this row.
+   * For IndexedVectorizedOapRecordReader.
+   */
+  public void markValid(int rowId) {
+    assert(filteredRows[rowId]);
+    filteredRows[rowId] = false;
+    --numRowsFiltered;
+  }
+
+  /**
+   * For IndexedVectorizedOapRecordReader.
+   */
+  public void markAllFiltered() {
+    Arrays.fill(filteredRows, true);
+    numRowsFiltered = numRows;
+  }
+
+  /**
    * Marks a given column as non-nullable. Any row that has a NULL value for the corresponding
    * attribute is filtered out.
    */

--- a/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
+++ b/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
@@ -86,6 +86,11 @@ public final class ColumnarBatch {
     }
   }
 
+  // For DataSourceScanExec
+  public boolean isFiltered(int rowId) {
+    return filteredRows[rowId];
+  }
+
   /**
    * Adapter class to interop with existing components that expect internal row. A lot of
    * performance is lost with this translation.

--- a/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -580,6 +580,25 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(batch.numValidRows() == 1)
       val it4 = batch.rowIterator()
       rowEquals(it4.next(), Row(null, 2.2, 2, "abc"))
+
+      // mark all filtered and verify
+      batch.markAllFiltered()
+      assert(batch.numValidRows() == 0)
+
+      // mark row0 valid and verify
+      batch.markValid(0)
+      assert(batch.numValidRows() == 1)
+      val it5 = batch.rowIterator()
+      rowEquals(it5.next(), Row(null, 2.2, 2, "abc"))
+
+
+      // mark row0 valid and verify
+      batch.markValid(2)
+      assert(batch.numValidRows() == 2)
+      val it6 = batch.rowIterator()
+      rowEquals(it6.next(), Row(null, 2.2, 2, "abc"))
+      rowEquals(it6.next(), Row(4, 4.4, 4, "world"))
+      assert(!it6.hasNext)
       batch.close()
     }}
   }

--- a/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapEncodingSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapEncodingSuite.scala
@@ -52,8 +52,7 @@ class VectorizedOapEncodingSuite extends ParquetCompatibilityTest with SharedOap
           assert(batch.numRows() == n)
           var i = 0
           while (i < n) {
-            // TODO release following code after add method to ColumnarBatch
-            // assert(!batch.isFiltered(i))
+            assert(!batch.isFiltered(i))
             assert(batch.column(0).getByte(i) == 1)
             assert(batch.column(1).getInt(i) == 2)
             assert(batch.column(2).getLong(i) == 3)
@@ -86,8 +85,7 @@ class VectorizedOapEncodingSuite extends ParquetCompatibilityTest with SharedOap
           assert(batch.numRows() == n)
           var i = 0
           while (i < n) {
-            // TODO release following code after add method to ColumnarBatch
-            // assert(!batch.isFiltered(i))
+            assert(!batch.isFiltered(i))
             assert(batch.column(0).isNullAt(i))
             assert(batch.column(1).isNullAt(i))
             assert(batch.column(2).isNullAt(i))
@@ -123,8 +121,7 @@ class VectorizedOapEncodingSuite extends ParquetCompatibilityTest with SharedOap
           assert(reader.nextBatch())
 
           (0 until 512).foreach { i =>
-            // TODO release following code after add method to ColumnarBatch
-            // assert(!batch.isFiltered(i))
+            assert(!batch.isFiltered(i))
             assert(column.getUTF8String(3 * i).toString == i.toString)
             assert(column.getUTF8String(3 * i + 1).toString == i.toString)
             assert(column.getUTF8String(3 * i + 2).toString == i.toString)

--- a/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapIOSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapIOSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.vectorized
 import scala.collection.mutable
 
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.VectorizedOapRecordReader
+import org.apache.parquet.hadoop.{IndexedVectorizedOapRecordReader, VectorizedOapRecordReader}
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
@@ -166,6 +166,93 @@ class VectorizedOapIOSuite extends QueryTest with ParquetTest with SharedOapCont
           vectorizedReader.close()
         }
       }
+    }
+  }
+
+  test("IndexedVectorizedOapRecordReader - direct path read") {
+    val data = (0 to 6000).map(i => (i, (i + 'a').toChar.toString))
+    val rowIds = Array(1, 1001, 2001, 3001, 4001, 5001)
+    val expected = data.filter( item => rowIds.contains(item._1))
+    withTempPath { dir =>
+      val df = spark.createDataFrame(data)
+      val schema = df.schema.json
+      df.repartition(1).write.parquet(dir.getCanonicalPath)
+      val file = SpecificParquetRecordReaderBase.listDirectory(dir).get(0)
+      val path = new Path(file.asInstanceOf[String])
+
+    {
+      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, schema)
+      val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
+      try {
+        reader.initialize()
+        val result = mutable.ArrayBuffer.empty[(Int, String)]
+        while (reader.nextKeyValue()) {
+          val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+          val v = (row.getInt(0), row.getString(1))
+          result += v
+        }
+        assert(expected == result)
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+      } finally {
+        reader.close()
+      }
+    }
+
+      // Project just one column
+    {
+      val requestSchema = requestSchemaString(df.schema, Array(1))
+      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+      val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
+      try {
+        reader.initialize()
+        val result = mutable.ArrayBuffer.empty[(String)]
+        while (reader.nextKeyValue()) {
+          val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+          result += row.getString(0)
+        }
+        assert(expected.map(_._2) == result)
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+      } finally {
+        reader.close()
+      }
+    }
+
+      // Project columns in opposite order
+    {
+      val requestSchema = requestSchemaString(df.schema, Array(1, 0))
+      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+      val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
+      try {
+        reader.initialize()
+        val result = mutable.ArrayBuffer.empty[(String, Int)]
+        while (reader.nextKeyValue()) {
+          val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+          val v = (row.getString(0), row.getInt(1))
+          result += v
+        }
+        assert(expected.map { x => (x._2, x._1) } == result)
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+      } finally {
+        reader.close()
+      }
+    }
+      // Empty projection
+    {
+      val requestSchema = requestSchemaString(df.schema, Array())
+      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+      val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
+      try {
+        reader.initialize()
+        var result = 0
+        while (reader.nextKeyValue()) {
+          result += 1
+        }
+        assert(result == expected.length)
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
+      } finally {
+        reader.close()
+      }
+    }
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapIOSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapIOSuite.scala
@@ -180,79 +180,79 @@ class VectorizedOapIOSuite extends QueryTest with ParquetTest with SharedOapCont
       val file = SpecificParquetRecordReaderBase.listDirectory(dir).get(0)
       val path = new Path(file.asInstanceOf[String])
 
-    {
-      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, schema)
-      val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
-      try {
-        reader.initialize()
-        val result = mutable.ArrayBuffer.empty[(Int, String)]
-        while (reader.nextKeyValue()) {
-          val row = reader.getCurrentValue.asInstanceOf[InternalRow]
-          val v = (row.getInt(0), row.getString(1))
-          result += v
+      {
+        configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, schema)
+        val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
+        try {
+          reader.initialize()
+          val result = mutable.ArrayBuffer.empty[(Int, String)]
+          while (reader.nextKeyValue()) {
+            val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+            val v = (row.getInt(0), row.getString(1))
+            result += v
+          }
+          assert(expected == result)
+        } finally {
+          reader.close()
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
         }
-        assert(expected == result)
-      } finally {
-        reader.close()
-        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       }
-    }
 
-      // Project just one column
-    {
-      val requestSchema = requestSchemaString(df.schema, Array(1))
-      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
-      val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
-      try {
-        reader.initialize()
-        val result = mutable.ArrayBuffer.empty[(String)]
-        while (reader.nextKeyValue()) {
-          val row = reader.getCurrentValue.asInstanceOf[InternalRow]
-          result += row.getString(0)
+        // Project just one column
+      {
+        val requestSchema = requestSchemaString(df.schema, Array(1))
+        configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+        val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
+        try {
+          reader.initialize()
+          val result = mutable.ArrayBuffer.empty[(String)]
+          while (reader.nextKeyValue()) {
+            val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+            result += row.getString(0)
+          }
+          assert(expected.map(_._2) == result)
+        } finally {
+          reader.close()
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
         }
-        assert(expected.map(_._2) == result)
-      } finally {
-        reader.close()
-        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       }
-    }
 
-      // Project columns in opposite order
-    {
-      val requestSchema = requestSchemaString(df.schema, Array(1, 0))
-      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
-      val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
-      try {
-        reader.initialize()
-        val result = mutable.ArrayBuffer.empty[(String, Int)]
-        while (reader.nextKeyValue()) {
-          val row = reader.getCurrentValue.asInstanceOf[InternalRow]
-          val v = (row.getString(0), row.getInt(1))
-          result += v
+        // Project columns in opposite order
+      {
+        val requestSchema = requestSchemaString(df.schema, Array(1, 0))
+        configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+        val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
+        try {
+          reader.initialize()
+          val result = mutable.ArrayBuffer.empty[(String, Int)]
+          while (reader.nextKeyValue()) {
+            val row = reader.getCurrentValue.asInstanceOf[InternalRow]
+            val v = (row.getString(0), row.getInt(1))
+            result += v
+          }
+          assert(expected.map { x => (x._2, x._1) } == result)
+        } finally {
+          reader.close()
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
         }
-        assert(expected.map { x => (x._2, x._1) } == result)
-      } finally {
-        reader.close()
-        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       }
-    }
-      // Empty projection
-    {
-      val requestSchema = requestSchemaString(df.schema, Array())
-      configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
-      val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
-      try {
-        reader.initialize()
-        var result = 0
-        while (reader.nextKeyValue()) {
-          result += 1
+        // Empty projection
+      {
+        val requestSchema = requestSchemaString(df.schema, Array())
+        configuration.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchema)
+        val reader = new IndexedVectorizedOapRecordReader(path, configuration, null, rowIds)
+        try {
+          reader.initialize()
+          var result = 0
+          while (reader.nextKeyValue()) {
+            result += 1
+          }
+          assert(result == expected.length)
+        } finally {
+          reader.close()
+          configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
         }
-        assert(result == expected.length)
-      } finally {
-        reader.close()
-        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       }
-    }
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapIOSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/vectorized/VectorizedOapIOSuite.scala
@@ -192,9 +192,9 @@ class VectorizedOapIOSuite extends QueryTest with ParquetTest with SharedOapCont
           result += v
         }
         assert(expected == result)
-        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       } finally {
         reader.close()
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       }
     }
 
@@ -211,9 +211,9 @@ class VectorizedOapIOSuite extends QueryTest with ParquetTest with SharedOapCont
           result += row.getString(0)
         }
         assert(expected.map(_._2) == result)
-        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       } finally {
         reader.close()
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       }
     }
 
@@ -231,9 +231,9 @@ class VectorizedOapIOSuite extends QueryTest with ParquetTest with SharedOapCont
           result += v
         }
         assert(expected.map { x => (x._2, x._1) } == result)
-        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       } finally {
         reader.close()
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       }
     }
       // Empty projection
@@ -248,9 +248,9 @@ class VectorizedOapIOSuite extends QueryTest with ParquetTest with SharedOapCont
           result += 1
         }
         assert(result == expected.length)
-        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       } finally {
         reader.close()
+        configuration.unset(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA)
       }
     }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
#536 task 5
1. ColumnarBatch add 3 method: 

- boolean isFiltered(int rowId)  to  determine row is filtered by index

- void markAllFiltered() to mark all rows filtered

- void markValid(int rowId) to mark row is valid

2. Add IndexedVectorizedOapRecordReader let Indexed read can use Vectorized Read

3. Add test case to ColumnarBatchSuite to test ColumnarBatch 3 new method

4. Add test case named `IndexedVectorizedOapRecordReader - direct path read` to test IndexedVectorizedOapRecordReader

5.enable batch.isFiltered(i) assertion in `VectorizedOapEncodingSuite`

## How was this patch tested?
ColumnarBatchSuite & VectorizedOapIOSuite.scala