### PR TITLE
disable index selection in filtersuite

### DIFF
--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -35,17 +35,17 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   import testImplicits._
 
   private var currentPath: String = _
+  private var defaultEis: Boolean = true
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     // In this suite we don't want to skip index even if the cost is higher.
-    spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION, false)
+    defaultEis = sqlConf.getConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)
+    sqlConf.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION, false)
   }
 
   override def afterAll(): Unit = {
-    spark.sqlContext.setConf(
-      OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION,
-      OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.defaultValue.getOrElse(true))
+    sqlConf.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION, defaultEis)
     super.afterAll()
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -36,6 +36,19 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
   private var currentPath: String = _
 
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // In this suite we don't want to skip index even if the cost is higher.
+    spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION, false)
+  }
+
+  override def afterAll(): Unit = {
+    spark.sqlContext.setConf(
+      OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION,
+      OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.defaultValue.getOrElse(true))
+    super.afterAll()
+  }
+
   override def beforeEach(): Unit = {
     val path = Utils.createTempDir().getAbsolutePath
     currentPath = path


### PR DESCRIPTION
## What changes were proposed in this pull request?

When running filter suite, a lot of tests will output
```
WARN org.apache.spark.sql.execution.datasources.oap.index.BPlusTreeScanner: OAP index is skipped. Disable OAP_EXECUTOR_INDEX_SELECTION to use index.
```
But this suite should test indexed filter, no matter the cost.

## How was this patch tested?

unit tests

