### PR TITLE
No need to set hadoopConf in buildReaderWithPartitionValues

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -274,10 +274,6 @@ private[sql] class OapFileFormat extends FileFormat
         val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
         val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
-        hadoopConf.setDouble(OapConf.OAP_FULL_SCAN_THRESHOLD.key,
-          sparkSession.conf.get(OapConf.OAP_FULL_SCAN_THRESHOLD))
-        hadoopConf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key,
-          sparkSession.conf.get(OapConf.OAP_ENABLE_OINDEX))
         val broadcastedHadoopConf =
           sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The hadoopConf already contains all OAP confs if they are set. Just like we didn't set other OAP confs like OAP_ENABLE_EXECUTOR_INDEX_SELECTION here, there is no need to set these two OAP confs.

## How was this patch tested?
Existing Tests.
