### PR TITLE
Remove a dup toArray.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -349,7 +349,6 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
       case 0 => Iterator.empty
       case 1 =>
         actualUsedScanners.head.initialize(dataPath, conf)
-        actualUsedScanners.head.toArray.iterator
       case _ =>
         actualUsedScanners.par.foreach(_.initialize(dataPath, conf))
         actualUsedScanners.map(_.toSet)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove a single line which may cause duplicate toArray action.

## How was this patch tested?
MVN test passed.