### PR TITLE
Fix code style of if/else

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -415,7 +415,7 @@ case class FileSourceScanExec(
     dataType: DataType, nullable: Boolean): ExprCode = {
     val javaType = ctx.javaType(dataType)
     val value = ctx.getValue(columnVar, dataType, ordinal)
-    val isNullVar = if (nullable) ctx.freshName("isNull") else "false"
+    val isNullVar = if (nullable) { ctx.freshName("isNull") } else { "false" }
     val valueVar = ctx.freshName("value")
     val str = s"columnVector[$columnVar, $ordinal, ${dataType.simpleString}]"
     val code = s"${ctx.registerComment(str)}\n" + (if (nullable) {

--- a/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -415,7 +415,7 @@ case class FileSourceScanExec(
     dataType: DataType, nullable: Boolean): ExprCode = {
     val javaType = ctx.javaType(dataType)
     val value = ctx.getValue(columnVar, dataType, ordinal)
-    val isNullVar = if (nullable) { ctx.freshName("isNull") } else { "false" }
+    val isNullVar = if (nullable) ctx.freshName("isNull") else "false"
     val valueVar = ctx.freshName("value")
     val str = s"columnVector[$columnVar, $ordinal, ${dataType.simpleString}]"
     val code = s"${ctx.registerComment(str)}\n" + (if (nullable) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -436,7 +436,7 @@ object DataSourceStrategy extends Strategy with Logging {
       // Mark filters which are handled by the underlying DataSource with an Astrisk
       if (pushedFilters.nonEmpty) {
         val markedFilters = for (filter <- pushedFilters) yield {
-          if (handledFilters.contains(filter)) s"*$filter" else s"$filter"
+            if (handledFilters.contains(filter)) s"*$filter" else s"$filter"
         }
         pairs += ("PushedFilters" -> markedFilters.mkString("[", ", ", "]"))
       }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -436,7 +436,7 @@ object DataSourceStrategy extends Strategy with Logging {
       // Mark filters which are handled by the underlying DataSource with an Astrisk
       if (pushedFilters.nonEmpty) {
         val markedFilters = for (filter <- pushedFilters) yield {
-            if (handledFilters.contains(filter)) s"*$filter" else s"$filter"
+          if (handledFilters.contains(filter)) s"*$filter" else s"$filter"
         }
         pairs += ("PushedFilters" -> markedFilters.mkString("[", ", ", "]"))
       }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -357,7 +357,9 @@ private[oap] case class DataSourceMeta(
             case _ => false
           }
         }
-      } else false
+      } else {
+        false
+      }
     }
 
     def checkAttribute(filter: Expression): Boolean = filter match {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -347,7 +347,9 @@ private[sql] class OapFileFormat extends FileFormat
           }
         case _ => false
       }
-    } else false
+    } else {
+      false
+    }
   }
 }
 
@@ -401,7 +403,9 @@ private[oap] class OapOutputWriterFactory(
       val oldMeta = m.get
       val existsIndexes = oldMeta.indexMetas
       val existsData = oldMeta.fileMetas
-      if (existsData != null) existsData.foreach(builder.addFileMeta(_))
+      if (existsData != null) {
+        existsData.foreach(builder.addFileMeta(_))
+      }
       if (existsIndexes != null) {
         existsIndexes.foreach(builder.addIndexMeta(_))
       }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
@@ -112,8 +112,9 @@ trait OapStrategies extends Logging {
             case Some(fastScan) => OapOrderLimitFileScanExec(limit, order, projectList, fastScan)
             case None => PlanLater(child)
           }
+        } else {
+          PlanLater(child)
         }
-        else PlanLater(child)
       case _ => PlanLater(child)
     }
   }
@@ -175,7 +176,9 @@ trait OapStrategies extends Logging {
             case Some(fastScan) => OapDistinctFileScanExec(scanNumber = 1, projectList, fastScan)
             case None => PlanLater(child)
           }
-        } else PlanLater(child)
+        } else {
+          PlanLater(child)
+        }
       case _ => PlanLater(child)
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -134,7 +134,9 @@ object FiberCacheManager extends Logging {
 
   // Used by test suite
   private[filecache] def removeFiber(fiber: TestFiber): Unit = {
-    if (cacheBackend.getIfPresent(fiber) != null) cacheBackend.invalidate(fiber)
+    if (cacheBackend.getIfPresent(fiber) != null) {
+      cacheBackend.invalidate(fiber)
+    }
   }
 
   // TODO: test case, consider data eviction, try not use DataFileHandle which my be costly

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -104,7 +104,9 @@ trait FiberCache extends Logging {
   protected def getBaseObj: AnyRef = {
     // NOTE: A trick here. Since every function need to get memory data has to get here first.
     // So, here check the if the memory has been freed.
-    if (disposed) throw new OapException("Try to access a freed memory")
+    if (disposed) {
+      throw new OapException("Try to access a freed memory")
+    }
     fiberData.getBaseObject
   }
   protected def getBaseOffset: Long = fiberData.getBaseOffset

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -64,8 +64,12 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
       val result = StatisticsManager.analyse(stats, intervalArray, conf)
       result
     } finally {
-      if (footerCache != null) footerCache.release()
-      if (reader != null) reader.close()
+      if (footerCache != null) {
+        footerCache.release()
+      }
+      if (reader != null) {
+        reader.close()
+      }
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
@@ -92,18 +92,22 @@ private[index] case class BTreeIndexRecordReader(
     if (nodeIdxForStart == nodeIdxForEnd && !isStartFound && !isEndFound) {
       (0, 0) // not found in B+ tree
     } else {
-      val start = if (interval.start == IndexScanner.DUMMY_KEY_START) 0
-      else {
-        nodeIdxForStart.map { idx =>
-          findRowIdPos(idx, interval.start, isStart = true, !interval.startInclude)
-        }.getOrElse(recordCount)
-      }
-      val end = if (interval.end == IndexScanner.DUMMY_KEY_END) recordCount
-      else {
-        nodeIdxForEnd.map { idx =>
-          findRowIdPos(idx, interval.end, isStart = false, interval.endInclude)
-        }.getOrElse(recordCount)
-      }
+      val start =
+        if (interval.start == IndexScanner.DUMMY_KEY_START) {
+          0
+        } else {
+          nodeIdxForStart.map { idx =>
+            findRowIdPos(idx, interval.start, isStart = true, !interval.startInclude)
+          }.getOrElse(recordCount)
+        }
+      val end =
+        if (interval.end == IndexScanner.DUMMY_KEY_END) {
+          recordCount
+        } else {
+          nodeIdxForEnd.map { idx =>
+            findRowIdPos(idx, interval.end, isStart = false, interval.endInclude)
+          }.getOrElse(recordCount)
+        }
       (start, end)
     }
   }
@@ -134,8 +138,9 @@ private[index] case class BTreeIndexRecordReader(
 
     val rowPos =
       if (keyPos == keyCount) {
-        if (nodeIdx + 1 == footer.getNodesCount) footer.getNonNullKeyRecordCount
-        else {
+        if (nodeIdx + 1 == footer.getNodesCount) {
+          footer.getNonNullKeyRecordCount
+        } else {
           val offset = footer.getNodeOffset(nodeIdx + 1)
           val size = footer.getNodeSize(nodeIdx + 1)
           val nextNodeFiber = BTreeFiber(
@@ -150,7 +155,9 @@ private[index] case class BTreeIndexRecordReader(
           nextNodeCache.release()
           rowPos
         }
-      } else node.getRowIdPos(keyPos)
+      } else {
+        node.getRowIdPos(keyPos)
+      }
     nodeCache.release()
     rowPos
   }
@@ -186,7 +193,9 @@ private[index] case class BTreeIndexRecordReader(
       val cmp = partialOrdering.compare(x, y)
       if (cmp == 0) {
         if (isStart) -1 else 1
-      } else cmp
+      } else {
+        cmp
+      }
     } else {
       -rowOrdering(y, x, isStart) // Keep x.numFields <= y.numFields to simplify
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -187,8 +187,7 @@ private[index] case class BTreeIndexRecordWriter(
 
   // TODO: BTreeNode can be re-write. It doesn't carry any values.
   private def sumKeyCount(node: BTreeNode): Int = {
-    if (node.children.nonEmpty) node.children.map(sumKeyCount).sum
-    else node.root
+    if (node.children.nonEmpty) node.children.map(sumKeyCount).sum else node.root
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -98,9 +98,15 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   private def cacheBitmapFooterSegment(idxPath: Path, conf: Configuration): Unit = {
     val fs = idxPath.getFileSystem(conf)
     // Cache the file inputstream rather than opening it each query.
-    if (fin == null) fin = fs.open(idxPath)
-    if (idxFileSize == 0L) idxFileSize = fs.getFileStatus(idxPath).getLen
-    if (bmFooterOffset == 0) bmFooterOffset = idxFileSize.toInt - BITMAP_FOOTER_SIZE
+    if (fin == null) {
+      fin = fs.open(idxPath)
+    }
+    if (idxFileSize == 0L) {
+      idxFileSize = fs.getFileStatus(idxPath).getLen
+    }
+    if (bmFooterOffset == 0) {
+      bmFooterOffset = idxFileSize.toInt - BITMAP_FOOTER_SIZE
+    }
 
     if (bmFooterFiber == null) {
       bmFooterFiber = BitmapFiber(
@@ -234,7 +240,9 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
       bmNullListCache = WrappedFiberCache(FiberCacheManager.get(bmNullListFiber, conf))
     } finally {
       try {
-        if (fin != null) fin.close()
+        if (fin != null) {
+          fin.close()
+        }
       } catch {
         case e: Exception =>
           if (!ShutdownHookManager.inShutdown()) {
@@ -264,10 +272,16 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
          IndexUtils.binarySearch(0, keyLength, keySeq(_), range.start, ordering.compare(_, _))
       if (found) {
         if (range.startInclude) idx else idx + 1
-      } else if (ordering.compare(keySeq.head, range.start) > 0) 0 else -1
+      } else if (ordering.compare(keySeq.head, range.start) > 0) {
+        0
+      } else {
+        -1
+      }
     }
     // If invalid starting index, just return.
-    if (startIdx == -1 || startIdx == keyLength) return (-1, -1)
+    if (startIdx == -1 || startIdx == keyLength) {
+      return (-1, -1)
+    }
     // If equal query, no need to find endIdx.
     if (range.start == range.end && range.start != IndexScanner.DUMMY_KEY_START) {
       return (startIdx, startIdx)
@@ -283,7 +297,11 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
          IndexUtils.binarySearch(0, keyLength, keySeq(_), range.end, ordering.compare(_, _))
       if (found) {
         if (range.endInclude) idx else idx - 1
-      } else if (ordering.compare(keySeq.last, range.end) < 0) keyLength - 1 else -1
+      } else if (ordering.compare(keySeq.last, range.end) < 0) {
+        keyLength - 1
+      } else {
+        -1
+      }
     }
     (startIdx, endIdx)
   }
@@ -299,7 +317,9 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
         bmEntry.deserialize(bmStream)
         bmEntry
       })
-    } else IndexedSeq.empty
+    } else {
+      IndexedSeq.empty
+    }
   }
 
   private def getDesiredBitmapArray: mutable.ArrayBuffer[RoaringBitmap] = {
@@ -356,11 +376,21 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   }
 
   def closeCache(): Unit = {
-    if (bmFooterCache != null) bmFooterCache.release()
-    if (bmUniqueKeyListCache != null) bmUniqueKeyListCache.release()
-    if (bmOffsetListCache != null) bmOffsetListCache.release()
-    if (bmEntryListCache != null) bmEntryListCache.release()
-    if (bmNullListCache != null) bmNullListCache.release()
+    if (bmFooterCache != null) {
+      bmFooterCache.release()
+    }
+    if (bmUniqueKeyListCache != null) {
+      bmUniqueKeyListCache.release()
+    }
+    if (bmOffsetListCache != null) {
+      bmOffsetListCache.release()
+    }
+    if (bmEntryListCache != null) {
+      bmEntryListCache.release()
+    }
+    if (bmNullListCache != null) {
+      bmNullListCache.release()
+    }
   }
 
   override def toString: String = "BitMapScanner"
@@ -404,10 +434,14 @@ private[oap] class BitmapDataInputStream(bitsStream: FiberCache) extends DataInp
  }
 
  override def readFully(readBuffer: Array[Byte], offset: Int, length: Int): Unit = {
-   if (length < 0) throw new IndexOutOfBoundsException("read length is inlegal for bitmap index.\n")
+   if (length < 0) {
+     throw new IndexOutOfBoundsException("read length is inlegal for bitmap index.\n")
+   }
    var curPos = pos
    pos += length
-   if (pos > bitsSize - 1) throw new EOFException("read is ending of file for bitmap index.\n")
+   if (pos > bitsSize - 1) {
+     throw new EOFException("read is ending of file for bitmap index.\n")
+   }
    (offset until (offset + length)).foreach(idx => {
      readBuffer(idx) = bitsStream.getByte(curPos)
      curPos += 1

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BloomFilter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BloomFilter.scala
@@ -48,12 +48,7 @@ class BloomFilter(
   }
 
   def checkExist(value: String): Boolean = {
-    val indices = getIndices(value)
-    for (i <- indices)
-      if (!bloomBitSet.contains(i)) {
-        return false
-      }
-    true
+    getIndices(value).forall(bloomBitSet.contains)
   }
 
   def addValue(data: Array[Byte]): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BloomFilter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BloomFilter.scala
@@ -50,7 +50,9 @@ class BloomFilter(
   def checkExist(value: String): Boolean = {
     val indices = getIndices(value)
     for (i <- indices)
-      if (!bloomBitSet.contains(i)) return false
+      if (!bloomBitSet.contains(i)) {
+        return false
+      }
     true
   }
 
@@ -62,7 +64,9 @@ class BloomFilter(
   def checkExist(data: Array[Byte]): Boolean = {
     val indices = getIndices(data)
     for (i <- indices)
-      if (!bloomBitSet.contains(i)) return false
+      if (!bloomBitSet.contains(i)) {
+        return false
+      }
     true
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexContext.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexContext.scala
@@ -386,8 +386,7 @@ private[oap] class FilterOptimizer(keySchema: StructType) {
       }
       // union two intervals
       union
-    }
-    else {// base.start is not DUMMY
+    } else { // base.start is not DUMMY
       if (order.compare(extra.start, base.start)==0) {
         base.startInclude = base.startInclude || extra.startInclude
       }
@@ -442,8 +441,7 @@ private[oap] class FilterOptimizer(keySchema: StructType) {
     else {
       if (key2 == IndexScanner.DUMMY_KEY_START) {
         (key1, include1)
-      }
-      else { // both key1 and key2 are not Dummy
+      } else { // both key1 and key2 are not Dummy
         if (order.compare(key1, key2) == 0) {
           return (key1, include1 && include2)
         }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexContext.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexContext.scala
@@ -73,17 +73,22 @@ private[oap] class IndexContext(meta: DataSourceMeta) extends Logging {
               val start = intervalMap(attribute).head.start
               val end = intervalMap(attribute).head.end
               val ordering = unapply(attribute).get.order
-              if(start != IndexScanner.DUMMY_KEY_START &&
+              if (start != IndexScanner.DUMMY_KEY_START &&
                 end != IndexScanner.DUMMY_KEY_END &&
-                ordering.compare(start, end) == 0) {num += 1} else flag = 1
-            }
-            else {
+                ordering.compare(start, end) == 0) {
+                num += 1
+              } else {
+                flag = 1
+              }
+            } else {
               if (!intervalMap.contains(attribute)) flag = 2 else flag = 1
             }
           } // end for
-          if (flag == 1) num += 1
-          if (num>0) {
-            availableIndexes.append( (num-1, meta.indexMetas(idx)) )
+          if (flag == 1) {
+            num += 1
+          }
+          if (num > 0) {
+            availableIndexes.append((num - 1, meta.indexMetas(idx)) )
           }
         case BitMapIndex(entries) =>
           for (entry <- entries) {
@@ -145,7 +150,9 @@ private[oap] class IndexContext(meta: DataSourceMeta) extends Logging {
       if (hasUsedAttrs.intersect(attrs).isEmpty) {
         attrs.foreach(hasUsedAttrs.add)
         true
-      } else false
+      } else {
+        false
+      }
     }
 
     def takeCandidateSet = {
@@ -190,13 +197,15 @@ private[oap] class IndexContext(meta: DataSourceMeta) extends Logging {
     //    intervalArray.sortWith(compare)
     logDebug("Building Index Scanners with IndexMeta and IntervalMap ...")
 
-    if (availableIndexers == null || availableIndexers.isEmpty) return
+    if (availableIndexers == null || availableIndexers.isEmpty) {
+      return
+    }
 
     val availableScanners = availableIndexers.map(availableIndexer =>
       buildScanner(availableIndexer._1, availableIndexer._2, intervalMap, options))
       .filter(_ != null)
 
-    if(availableScanners.nonEmpty) {
+    if (availableScanners.nonEmpty) {
       logDebug("Index Scanner Intervals: "
         + availableScanners.map(_.intervalArray.mkString(", ")).mkString(" | "))
 
@@ -211,7 +220,9 @@ private[oap] class IndexContext(meta: DataSourceMeta) extends Logging {
     mutable.HashMap[String, ArrayBuffer[RangeInterval]],
     options: Map[String, String] = Map.empty): IndexScanner = {
 
-    if (lastIdx == -1 && bestIndexer == null) return null
+    if (lastIdx == -1 && bestIndexer == null) {
+      return null
+    }
     var keySchema: StructType = null
     var scanner: IndexScanner = null
     bestIndexer.indexType match {
@@ -231,14 +242,22 @@ private[oap] class IndexContext(meta: DataSourceMeta) extends Logging {
         scanner.intervalArray = new ArrayBuffer[RangeInterval](intervalMap(attributes.last).length)
 
         for (i <- intervalMap(attributes.last).indices) {
-          val startKeys = attributes.indices.map(attrIdx =>
-            if (attrIdx == attributes.length-1) intervalMap(attributes(attrIdx))(i).start
-            else intervalMap(attributes(attrIdx)).head.start )
+          val startKeys = attributes.indices.map { attrIdx =>
+            if (attrIdx == attributes.length - 1) {
+              intervalMap(attributes(attrIdx))(i).start
+            } else {
+              intervalMap(attributes(attrIdx)).head.start
+            }
+          }
           val compositeStartKey = startKeys.reduce((key1, key2) => new JoinedRow(key1, key2))
 
-          val endKeys = attributes.indices.map(attrIdx =>
-            if (attrIdx == attributes.length-1) intervalMap(attributes(attrIdx))(i).end
-            else intervalMap(attributes(attrIdx)).head.end )
+          val endKeys = attributes.indices.map { attrIdx =>
+            if (attrIdx == attributes.length - 1) {
+              intervalMap(attributes(attrIdx))(i).end
+            } else {
+              intervalMap(attributes(attrIdx)).head.end
+            }
+          }
           val compositeEndKey = endKeys.reduce((key1, key2) => new JoinedRow(key1, key2))
 
           scanner.intervalArray.append(
@@ -309,8 +328,11 @@ private[oap] class FilterOptimizer(keySchema: StructType) {
   // isNullPredicate is assumed to be "smallest"
   def compareRangeInterval(interval1: RangeInterval, interval2: RangeInterval): Boolean = {
     if (interval1.isNullPredicate || interval2.isNullPredicate) {
-      if (interval1.isNullPredicate) return true
-      else return false
+      if (interval1.isNullPredicate) {
+        return true
+      } else {
+        return false
+      }
     }
     if ((interval1.start eq IndexScanner.DUMMY_KEY_START) &&
       (interval2.start ne IndexScanner.DUMMY_KEY_START)) {
@@ -338,16 +360,23 @@ private[oap] class FilterOptimizer(keySchema: StructType) {
     }// end def union
 
     // isNull U isNull => isNull
-    if (base.isNullPredicate && extra.isNullPredicate) return true
+    if (base.isNullPredicate && extra.isNullPredicate) {
+      return true
+    }
     // isNull U otherFilterPredicate => isNull U otherFilterPredicate
-    if (base.isNullPredicate ^ extra.isNullPredicate) return false
+    if (base.isNullPredicate ^ extra.isNullPredicate) {
+      return false
+    }
 
     if (base.start eq IndexScanner.DUMMY_KEY_START) {
       if (base.end eq IndexScanner.DUMMY_KEY_END) {
         // base is isNotNullPredicate
         // isNotNull U isNull => isNotNull U isNull
-        if (extra.isNullPredicate) return false
-        else return true // isNotNull U otherFilterPredicate => isNotNull
+        if (extra.isNullPredicate) {
+          return false
+        } else {
+          return true
+        } // isNotNull U otherFilterPredicate => isNotNull
       }
       if (extra.start ne IndexScanner.DUMMY_KEY_START) {
         val cmp = order.compare(extra.start, base.end)
@@ -420,8 +449,7 @@ private[oap] class FilterOptimizer(keySchema: StructType) {
         }
         if (order.compare(key1, key2) > 0 ^ isEndKey) {
           (key1, include1)
-        }
-        else {
+        } else {
           (key2, include2)
         }
       }
@@ -432,7 +460,7 @@ private[oap] class FilterOptimizer(keySchema: StructType) {
   def validate(interval: RangeInterval): Boolean = {
     if ((interval.start ne IndexScanner.DUMMY_KEY_START)
       && (interval.end ne IndexScanner.DUMMY_KEY_END)) {
-      if (order.compare(interval.start, interval.end)>0) {
+      if (order.compare(interval.start, interval.end) > 0) {
         return false
       }
       if (order.compare(interval.start, interval.end) == 0
@@ -453,8 +481,9 @@ private[oap] class FilterOptimizer(keySchema: StructType) {
       if !(interval1.isNullPredicate ^ interval2.isNullPredicate)
     } yield {
       // isNull & isNull => isNull
-      if (interval1.isNullPredicate && interval2.isNullPredicate) interval1
-      else {
+      if (interval1.isNullPredicate && interval2.isNullPredicate) {
+        interval1
+      } else {
         // this condition contains isNotNull & normalInterval => normalInterval
         val interval = RangeInterval(
           IndexScanner.DUMMY_KEY_START,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -191,15 +191,17 @@ private[oap] object ScannerBuilder extends Logging {
         attribute match {
           case ic (filterOptimizer) => // extract the corresponding scannerBuilder
             // combine all intervals of the same attribute of leftMap and rightMap
-            if (needMerge) leftMap.put(attribute,
-              filterOptimizer.mergeBound(leftMap.getOrElseUpdate (attribute, null), intervals) )
-            // add bound of the same attribute to the left map
-            else leftMap.put(attribute,
-              filterOptimizer.addBound(leftMap.getOrElse (attribute, null), intervals) )
+            if (needMerge) {
+              leftMap.put(attribute,
+                filterOptimizer.mergeBound(leftMap.getOrElseUpdate (attribute, null), intervals))
+            } else {
+              // add bound of the same attribute to the left map
+              leftMap.put(attribute,
+                filterOptimizer.addBound(leftMap.getOrElse (attribute, null), intervals))
+            }
           case _ => // this attribute does not exist, do nothing
         }
-      }
-      else {
+      } else {
         leftMap.put(attribute, intervals)
       }
     }
@@ -297,15 +299,21 @@ private[oap] object ScannerBuilder extends Logging {
       ic: IndexContext,
       scannerOptions: Map[String, String] = Map.empty,
       maxChooseSize: Int = 1): Array[Filter] = {
-    if (filters == null || filters.isEmpty) return filters
+    if (filters == null || filters.isEmpty) {
+      return filters
+    }
     logDebug("Transform filters into Intervals:")
     val intervalMapArray = filters.map(optimizeFilterBound(_, ic))
     // reduce multiple hashMap to one hashMap("AND" operation)
     val intervalMap = intervalMapArray.reduce(
       (leftMap, rightMap) =>
-        if (leftMap == null || leftMap.isEmpty) rightMap
-        else if (rightMap == null || rightMap.isEmpty) leftMap
-        else combineIntervalMaps(leftMap, rightMap, ic, needMerge = true)
+        if (leftMap == null || leftMap.isEmpty) {
+          rightMap
+        } else if (rightMap == null || rightMap.isEmpty) {
+          leftMap
+        } else {
+          combineIntervalMaps(leftMap, rightMap, ic, needMerge = true)
+        }
     )
 
     if (intervalMap.nonEmpty) {
@@ -354,8 +362,11 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
         actualUsedScanners.par.foreach(_.initialize(dataPath, conf))
         actualUsedScanners.map(_.toSet)
           .reduce((left, right) => {
-            if (left.isEmpty || right.isEmpty) Set.empty
-            else left.intersect(right)
+            if (left.isEmpty || right.isEmpty) {
+              Set.empty
+            } else {
+              left.intersect(right)
+            }
           }).iterator
     }
     this

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -126,11 +126,17 @@ private[oap] object IndexUtils {
       assert(s + e >= 0, "too large array size caused overflow")
       m = (s + e) / 2
       val cmp = compare(keys(m), candidate)
-      if (cmp == 0) found = true
-      else if (cmp < 0) s = m + 1
-      else e = m - 1
+      if (cmp == 0) {
+        found = true
+      } else if (cmp < 0) {
+        s = m + 1
+      } else {
+        e = m - 1
+      }
     }
-    if (!found) m = s
+    if (!found) {
+      m = s
+    }
     (m, found)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputFormat.scala
@@ -38,7 +38,9 @@ private[index] class OapIndexOutputFormat extends FileOutputFormat[Void, Interna
       if (isAppend) {
         val target = new Path(FileOutputFormat.getOutputPath(taskAttemptContext), file.getName)
         target.getFileSystem(configuration).exists(target)
-      } else false
+      } else {
+        false
+      }
     }
 
     val extension = "." + configuration.get(OapIndexFileFormat.INDEX_TIME) +

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -101,7 +101,9 @@ case class CreateIndexCommand(
             return Nil
           }
         }
-        if (existsData != null) existsData.foreach(metaBuilder.addFileMeta)
+        if (existsData != null) {
+          existsData.foreach(metaBuilder.addFileMeta)
+        }
         if (existsIndexes != null) {
           existsIndexes.filter(_.name != indexName).foreach(metaBuilder.addIndexMeta)
         }
@@ -184,8 +186,10 @@ case class CreateIndexCommand(
     val retMap = retVal.flatten.groupBy(_.parent)
     bAndP.foreach(bp =>
       retMap.getOrElse(bp._2.toString, Nil).foreach(r =>
-        if (!bp._3) bp._1.addFileMeta(
-          FileMeta(r.fingerprint, r.rowCount, r.dataFile))
+        if (!bp._3) {
+          bp._1.addFileMeta(
+            FileMeta(r.fingerprint, r.rowCount, r.dataFile))
+        }
       ))
     // write updated metas down
     bAndP.foreach(bp => DataSourceMeta.write(
@@ -242,7 +246,9 @@ case class DropIndexCommand(
                 return Nil
               }
             }
-            if (existsData != null) existsData.foreach(metaBuilder.addFileMeta)
+            if (existsData != null) {
+              existsData.foreach(metaBuilder.addFileMeta)
+            }
             if (existsIndexes != null) {
               existsIndexes.filter(_.name != indexName).foreach(metaBuilder.addIndexMeta)
             }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/CodecFactory.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/CodecFactory.scala
@@ -41,8 +41,9 @@ private[oap] class CodecFactory(conf: Configuration) {
       case None =>
         val codecName = CompressionCodecName.valueOf(codecString)
         val codecClass = codecName.getHadoopCompressionCodecClass
-        if (codecClass == null) None
-        else {
+        if (codecClass == null) {
+          None
+        } else {
           val codec = ReflectionUtils.newInstance(codecClass, conf).asInstanceOf[CompressionCodec]
           codecByName.put(codecString, codec)
           Some(codec)
@@ -79,7 +80,9 @@ private[oap] class BytesCompressor(compressionCodec: Option[CompressionCodec]) {
       case Some(codec) =>
         compressedOutBuffer.reset()
         // null compressor for non-native gzip
-        if (compressor != null) compressor.reset()
+        if (compressor != null) {
+          compressor.reset()
+        }
         val cos = codec.createOutputStream(compressedOutBuffer, compressor)
         cos.write(bytes)
         cos.finish()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/EncodedFiberBuilder.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/EncodedFiberBuilder.scala
@@ -115,8 +115,11 @@ private[oap] case class PlainBinaryDictionaryFiberBuilder(
 
   override def buildDictionary: Array[Byte] = {
     val dictionary = valuesWriter.createDictionaryPage()
-    if (dictionary != null) dictionary.getBytes.toByteArray
-    else Array.empty[Byte]
+    if (dictionary != null) {
+      dictionary.getBytes.toByteArray
+    } else {
+      Array.empty[Byte]
+    }
   }
 
   override def getDictionarySize: Int = valuesWriter.getDictionarySize
@@ -166,8 +169,11 @@ private[oap] case class PlainIntegerDictionaryFiberBuilder(
 
   override def buildDictionary: Array[Byte] = {
     val dictionary = valuesWriter.createDictionaryPage()
-    if (dictionary != null) dictionary.getBytes.toByteArray
-    else Array.empty[Byte]
+    if (dictionary != null) {
+      dictionary.getBytes.toByteArray
+    } else {
+      Array.empty[Byte]
+    }
   }
 
   override def getDictionarySize: Int = valuesWriter.getDictionarySize

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -60,7 +60,9 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
         case IntegerType => new PlainIntegerDictionary(dictionaryPage)
         case other => sys.error(s"not support data type: $other")
       }
-    } else dictionaries(fiberId)
+    } else {
+      dictionaries(fiberId)
+    }
   }
 
   def getFiberData(groupId: Int, fiberId: Int): FiberCache = {
@@ -98,8 +100,11 @@ private[oap] case class OapDataFile(path: String, schema: StructType,
       }
 
     val rowCount =
-      if (groupId == meta.groupCount - 1) meta.rowCountInLastGroup
-      else meta.rowCountInEachGroup
+      if (groupId == meta.groupCount - 1) {
+        meta.rowCountInLastGroup
+      } else {
+        meta.rowCountInEachGroup
+      }
 
     // We have to read Array[Byte] from file and decode/decompress it before putToFiberCache
     // TODO: Try to finish this in off-heap memory

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileHandle.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileHandle.scala
@@ -143,8 +143,11 @@ private[oap] object ColumnStatistics {
   }
 
   def apply(stat: ParquetStatistics): ColumnStatistics = {
-    if (!stat.hasNonNullValue) new ColumnStatistics(null, null)
-    else new ColumnStatistics(stat.getMinBytes, stat.getMaxBytes)
+    if (!stat.hasNonNullValue) {
+      new ColumnStatistics(null, null)
+    } else {
+      new ColumnStatistics(stat.getMinBytes, stat.getMaxBytes)
+    }
   }
 
   def apply(in: DataInputStream): ColumnStatistics = {
@@ -154,14 +157,18 @@ private[oap] object ColumnStatistics {
       val bytes = new Array[Byte](minLength)
       in.readFully(bytes)
       bytes
-    } else null
+    } else {
+      null
+    }
 
     val maxLength = in.readInt()
     val max = if (maxLength != 0) {
       val bytes = new Array[Byte](maxLength)
       in.readFully(bytes)
       bytes
-    } else null
+    } else {
+      null
+    }
 
     new ColumnStatistics(min, max)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -97,7 +97,9 @@ private[oap] class OapDataWriter(
     var idx = 0
     while (idx < rowGroup.length) {
       rowGroup(idx).append(row)
-      if (!row.isNullAt(idx)) updateStats(statisticsArray(idx), row, idx, schema(idx).dataType)
+      if (!row.isNullAt(idx)) {
+        updateStats(statisticsArray(idx), row, idx, schema(idx).dataType)
+      }
       idx += 1
     }
     rowCount += 1
@@ -145,7 +147,9 @@ private[oap] class OapDataWriter(
       val encoding = rowGroup(i).getEncoding
       val dictionaryDataLength = dictByteData.length
       val dictionaryIdSize = rowGroup(i).getDictionarySize
-      if (dictionaryDataLength > 0) out.write(dictByteData)
+      if (dictionaryDataLength > 0) {
+        out.write(dictByteData)
+      }
       fiberMeta.appendColumnMeta(new ColumnMeta(encoding, dictionaryDataLength, dictionaryIdSize,
         ColumnStatistics(statisticsArray(i))))
     }
@@ -228,13 +232,21 @@ private[oap] class OapDataReader(
             val sameOrder =
               !((indexScanners.order == Ascending) ^ isAscending)
 
-            if (sameOrder) indexScanners.take(limit).toArray
-            else indexScanners.toArray.reverse.take(limit)
-          } else indexScanners.toArray
+            if (sameOrder) {
+              indexScanners.take(limit).toArray
+            } else {
+              indexScanners.toArray.reverse.take(limit)
+            }
+          } else {
+            indexScanners.toArray
+          }
 
           // Parquet reader does not support backward scan, so rowIds must be sorted.
-          if (meta.dataReaderClassName.contains("ParquetDataFile")) rowIds.sorted
-          else rowIds
+          if (meta.dataReaderClassName.contains("ParquetDataFile")) {
+            rowIds.sorted
+          } else {
+            rowIds
+          }
         }
 
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -86,16 +86,23 @@ private[oap] class BloomFilterStatisticsReader(
       if (schema.length > 1) {
         if (numFields == schema.length && ordering.compare(interval.start, interval.end) == 0) {
           !bfIndex.checkExist(converter(interval.start).getBytes)
-        } else !bfIndex.checkExist(partialConverter(interval.start).getBytes)
+        } else {
+          !bfIndex.checkExist(partialConverter(interval.start).getBytes)
+        }
       } else {
         if (numFields == 1 && ordering.compare(interval.start, interval.end) == 0) {
           !bfIndex.checkExist(converter(interval.start).getBytes)
-        } else false
+        } else {
+          false
+        }
       }
     }
 
-    if (skipIndex) StaticsAnalysisResult.SKIP_INDEX
-    else StaticsAnalysisResult.USE_INDEX
+    if (skipIndex) {
+      StaticsAnalysisResult.SKIP_INDEX
+    } else {
+      StaticsAnalysisResult.USE_INDEX
+    }
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -53,7 +53,9 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
   }
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double = {
-    if (min == null || max == null) return StaticsAnalysisResult.USE_INDEX
+    if (min == null || max == null) {
+      return StaticsAnalysisResult.USE_INDEX
+    }
 
     val start = intervalArray.head
     val end = intervalArray.last
@@ -64,15 +66,22 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
     val startOutOfBound =
       if (start.start.numFields == schema.length && !start.startInclude) {
         startOrdering.gteq(start.start, max)
-      } else startOrdering.gt(start.start, max)
+      } else {
+        startOrdering.gt(start.start, max)
+      }
 
     val endOutOfBound =
       if (end.end.numFields == schema.length && !end.endInclude) {
         endOrdering.lteq(end.end, min)
-      } else endOrdering.lt(end.end, min)
+      } else {
+        endOrdering.lt(end.end, min)
+      }
 
-    if (startOutOfBound || endOutOfBound) StaticsAnalysisResult.SKIP_INDEX
-    else StaticsAnalysisResult.USE_INDEX
+    if (startOutOfBound || endOutOfBound) {
+      StaticsAnalysisResult.SKIP_INDEX
+    } else {
+      StaticsAnalysisResult.USE_INDEX
+    }
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -87,11 +87,17 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
     metas.zipWithIndex.indexWhere {
       case (meta, index) =>
         if (row.numFields == schema.length) {
-          if (include && index < metas.length - 1) ordering.compare(row, meta.row) < 0
-          else ordering.compare(row, meta.row) <= 0
+          if (include && index < metas.length - 1) {
+            ordering.compare(row, meta.row) < 0
+          } else {
+            ordering.compare(row, meta.row) <= 0
+          }
         } else {
-          if (isStart) partialOrdering.compare(row, meta.row) <= 0
-          else partialOrdering.compare(row, meta.row) < 0
+          if (isStart) {
+            partialOrdering.compare(row, meta.row) <= 0
+          } else {
+            partialOrdering.compare(row, meta.row) < 0
+          }
         }
     }
   }
@@ -130,9 +136,13 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
           cover -= 0.5 * (metas(right).accumulatorCnt - metas(right - 1).accumulatorCnt)
         }
 
-        if (cover > wholeCount) StaticsAnalysisResult.FULL_SCAN
-        else if (cover < 0) StaticsAnalysisResult.USE_INDEX
-        else cover / wholeCount
+        if (cover > wholeCount) {
+          StaticsAnalysisResult.FULL_SCAN
+        } else if (cover < 0) {
+          StaticsAnalysisResult.USE_INDEX
+        } else {
+          cover / wholeCount
+        }
       }
     } else {
       StaticsAnalysisResult.USE_INDEX

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -66,7 +66,9 @@ private[oap] class SampleBasedStatisticsReader(
       var hitCnt = 0
       val partialOrder = GenerateOrdering.create(StructType(schema.dropRight(1)))
       for (row <- sampleArray) {
-        if (Statistics.rowInIntervalArray(row, intervalArray, ordering, partialOrder)) hitCnt += 1
+        if (Statistics.rowInIntervalArray(row, intervalArray, ordering, partialOrder)) {
+          hitCnt += 1
+        }
       }
       hitCnt * 1.0 / sampleArray.length
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -126,12 +126,13 @@ object Statistics {
     if (intervalArray == null || intervalArray.isEmpty) {
       false
     } else {
-      intervalArray.exists{interval =>
+      intervalArray.exists { interval =>
         val startOrder =
           if (interval.start.numFields == row.numFields) fullOrder else partialOrder
         val endOrder =
           if (interval.end.numFields == row.numFields) fullOrder else partialOrder
-        rowInSingleInterval(row, interval, startOrder, endOrder)}
+        rowInSingleInterval(row, interval, startOrder, endOrder)
+      }
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -123,13 +123,16 @@ object Statistics {
   def rowInIntervalArray(
       row: InternalRow, intervalArray: ArrayBuffer[RangeInterval],
       fullOrder: BaseOrdering, partialOrder: BaseOrdering): Boolean = {
-    if (intervalArray == null || intervalArray.isEmpty) false
-    else intervalArray.exists{interval =>
-      val startOrder =
-        if (interval.start.numFields == row.numFields) fullOrder else partialOrder
-      val endOrder =
-        if (interval.end.numFields == row.numFields) fullOrder else partialOrder
-      rowInSingleInterval(row, interval, startOrder, endOrder)}
+    if (intervalArray == null || intervalArray.isEmpty) {
+      false
+    } else {
+      intervalArray.exists{interval =>
+        val startOrder =
+          if (interval.start.numFields == row.numFields) fullOrder else partialOrder
+        val endOrder =
+          if (interval.end.numFields == row.numFields) fullOrder else partialOrder
+        rowInSingleInterval(row, interval, startOrder, endOrder)}
+    }
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -68,7 +68,10 @@ class StatisticsWriteManager {
   }
 
   def addOapKey(key: Key): Unit = {
-    if (key.anyNull) return // stats info does not collect null keys
+    if (key.anyNull) {
+      // stats info does not collect null keys
+      return
+    }
     content.append(key)
     stats.foreach(_.addOapKey(key))
   }
@@ -138,8 +141,10 @@ object StatisticsManager {
     var resSum: Double = 0.0
     var resNum: Int = 0
 
-    if (stats.isEmpty) StaticsAnalysisResult.USE_INDEX // use index if no statistics
-    else {
+    if (stats.isEmpty) {
+      // use index if no statistics
+      StaticsAnalysisResult.USE_INDEX
+    } else {
       stats.foreach { stat =>
         val res = stat.analyse(intervalArray)
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
@@ -77,7 +77,9 @@ object OapUtils extends Logging {
         }
         EqualTo(AttributeReference(key, partitionColumnsInfo.get(key).get)(), Literal(v))
       }.toSeq
-    } else Nil
+    } else {
+      Nil
+    }
     fileIndex.listFiles(filters)
   }
 
@@ -125,7 +127,9 @@ object OapUtils extends Logging {
         }
         val pathFragment = PartitioningUtils.getPathFragment(partitionSpec.get, partitionSchema)
         rootPaths.map(rootPath => new Path(rootPath, pathFragment)).filter(fs.exists)
-      } else rootPaths
+      } else {
+        rootPaths
+      }
 
     getPartitionPaths(directoryPaths, fs)
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -754,9 +754,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering null key") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
-      if (i <= 5) Seq(null, s"this is row $i")
-      else Seq(i, s"this is row $i")).map(Row.fromSeq)
+    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+     }.map(Row.fromSeq)
     val schema =
       StructType(
         StructField("a", IntegerType) ::
@@ -787,9 +787,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering null key in Parquet format") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
-      if (i <= 5) Seq(null, s"this is row $i")
-      else Seq(i, s"this is row $i")).map(Row.fromSeq)
+    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
     val schema =
       StructType(
         StructField("a", IntegerType) ::
@@ -820,9 +820,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering non-null key") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 10).map(i =>
-      if (i <= 3) Seq(null, s"this is row $i")
-      else Seq(i, s"this is row $i")).map(Row.fromSeq)
+    val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
+      if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
     val schema =
       StructType(
         StructField("a", IntegerType) ::
@@ -846,9 +846,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering non-null key in Parquet format") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 10).map(i =>
-      if (i <= 3) Seq(null, s"this is row $i")
-      else Seq(i, s"this is row $i")).map(Row.fromSeq)
+    val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
+      if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
     val schema =
       StructType(
         StructField("a", IntegerType) ::
@@ -872,9 +872,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering null key and normal key mixed") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
-      if (i <= 5) Seq(null, s"this is row $i")
-      else Seq(i, s"this is row $i")).map(Row.fromSeq)
+    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
     val schema =
       StructType(
         StructField("a", IntegerType) ::
@@ -895,9 +895,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering null key and normal key mixed in Parquet format") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
-      if (i <= 5) Seq(null, s"this is row $i")
-      else Seq(i, s"this is row $i")).map(Row.fromSeq)
+    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
     val schema =
       StructType(
         StructField("a", IntegerType) ::

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -78,8 +78,7 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
 
   test("check sequence reading if parquet format") {
     val data: Seq[(Int, String)] = (1 to 300).map { i =>
-      if (i == 10) (1, s"this is test $i")
-      else (i, s"this is test $i")
+      if (i == 10) (1, s"this is test $i") else (i, s"this is test $i")
     }
     data.toDF("key", "value").createOrReplaceTempView("t")
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -119,8 +119,12 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
     var oapDataFile: File = null
     var oapMetaFile: File = null
     files.foreach { fileName =>
-      if (fileName.toString.endsWith(OapFileFormat.OAP_DATA_EXTENSION)) oapDataFile = fileName
-      if (fileName.toString.endsWith(OapFileFormat.OAP_META_FILE)) oapMetaFile = fileName
+      if (fileName.toString.endsWith(OapFileFormat.OAP_DATA_EXTENSION)) {
+        oapDataFile = fileName
+      }
+      if (fileName.toString.endsWith(OapFileFormat.OAP_META_FILE)) {
+        oapMetaFile = fileName
+      }
     }
     val df = sqlContext.read.format("oap").load(dir.getAbsolutePath)
     df.createOrReplaceTempView("oap_table")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
@@ -114,8 +114,11 @@ class FiberSuite extends SharedOapContext with Logging {
       assert(meta.rowGroupsMeta.length === rowGroupCounts(i))
       meta.close()
     }
-    if (previousRowGroupSize == null) configuration.unset(OapFileFormat.ROW_GROUP_SIZE)
-    else configuration.set(OapFileFormat.ROW_GROUP_SIZE, previousRowGroupSize)
+    if (previousRowGroupSize == null) {
+      configuration.unset(OapFileFormat.ROW_GROUP_SIZE)
+    } else {
+      configuration.set(OapFileFormat.ROW_GROUP_SIZE, previousRowGroupSize)
+    }
   }
 
   test("test oap row group configuration") {
@@ -137,8 +140,11 @@ class FiberSuite extends SharedOapContext with Logging {
     assert(meta.rowGroupsMeta.length === 1)
     meta.close()
     // set back to default value
-    if (previousRowGroupSize == null) configuration.unset(OapFileFormat.ROW_GROUP_SIZE)
-    else configuration.set(OapFileFormat.ROW_GROUP_SIZE, previousRowGroupSize)
+    if (previousRowGroupSize == null) {
+      configuration.unset(OapFileFormat.ROW_GROUP_SIZE)
+    } else {
+      configuration.set(OapFileFormat.ROW_GROUP_SIZE, previousRowGroupSize)
+    }
   }
 
   // a simple algorithm to check if it's should be null

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapMicroBenchmarkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapMicroBenchmarkSuite.scala
@@ -212,7 +212,9 @@ class BitmapMicroBenchmarkSuite extends QueryTest with SharedOapContext with Bef
     rbFis.close()
     val rbEndTime = System.nanoTime
     val rbTime = (rbEndTime - rbStartTime) / 1000
-    if(!rbRead.equals(rb)) throw new RuntimeException("rb r/w is not equal!")
+    if(!rbRead.equals(rb)) {
+      throw new RuntimeException("rb r/w is not equal!")
+    }
 
     /* The result is below. The unit is us. The configuration is the same as the above.
      * spark r/w time is 57412.

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapUsageSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapUsageSuite.scala
@@ -71,7 +71,9 @@ class BitmapUsageSuite extends QueryTest with SharedOapContext with BeforeAndAft
     int.skip(rb1.serializedSizeInBytes + rb2.serializedSizeInBytes)
     val rbtest3 = new RoaringBitmap()
     rbtest3.deserialize(int)
-    if (!rbtest3.equals(rb3)) throw new RuntimeException("bug!")
+    if (!rbtest3.equals(rb3)) {
+      throw new RuntimeException("bug!")
+    }
   }
 
   test("test to use MutableRoaringBitmap and ImmutableRoarigBitmap " +

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
@@ -77,7 +77,9 @@ class IndexSelectionSuite extends SharedOapContext with BeforeAndAfterEach{
       case _ => null
     }
     assert(lastIdx == targetLastIdx)
-    if (idxMeta != null) assert(idxMeta.name equals targetIdxName)
+    if (idxMeta != null) {
+      assert(idxMeta.name equals targetIdxName)
+    }
   }
 
   test("Non-Index Test") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DeltaByteArrayEncoderSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DeltaByteArrayEncoderSuite.scala
@@ -51,9 +51,13 @@ class DeltaByteArrayEncoderCheck extends Properties("DeltaByteArrayEncoder") {
             new OapDataFileHandle(rowCountInEachGroup = rowCount), StringType)
           !(0 until groupCount).exists { group =>
             // If lastCount > rowCount, assume lastCount = rowCount
-            val count = if (group < groupCount - 1) rowCount
-                        else if (lastCount > rowCount) rowCount
-                        else lastCount
+            val count = if (group < groupCount - 1) {
+              rowCount
+            } else if (lastCount > rowCount) {
+              rowCount
+            } else {
+              lastCount
+            }
             (0 until count).foreach { row =>
               fiberBuilder.append(InternalRow(UTF8String.fromString(values(row % values.length))))
               referenceFiberBuilder

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DictionaryBasedEncoderSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DictionaryBasedEncoderSuite.scala
@@ -51,9 +51,14 @@ class DictionaryBasedEncoderCheck extends Properties("DictionaryBasedEncoder") {
           val fiberBuilder = PlainBinaryDictionaryFiberBuilder(rowCount, 0, StringType)
           !(0 until groupCount).exists { group =>
             // If lastCount > rowCount, assume lastCount = rowCount
-            val count = if (group < groupCount - 1) rowCount
-            else if (lastCount > rowCount) rowCount
-            else lastCount
+            val count =
+              if (group < groupCount - 1) {
+                rowCount
+              } else if (lastCount > rowCount) {
+                rowCount
+              } else {
+                lastCount
+              }
             (0 until count).foreach { row =>
               fiberBuilder.append(InternalRow(UTF8String.fromString(values(row % values.length))))
               referenceFiberBuilder
@@ -76,7 +81,9 @@ class DictionaryBasedEncoderCheck extends Properties("DictionaryBasedEncoder") {
             assert(parsedBytes.length == referenceBytes.length)
             parsedBytes.zip(referenceBytes).exists(byte => byte._1 != byte._2)
           }
-        } else true
+        } else {
+          true
+        }
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileHandleSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileHandleSuite.scala
@@ -114,8 +114,11 @@ class OapDataFileHandleCheck extends Properties("OapDataFileHandle") {
     for { min <- arbitrary[Array[Byte]]
           max <- arbitrary[Array[Byte]]
     } yield {
-        if (min.isEmpty || max.isEmpty) new ColumnStatistics(null, null)
-        else new ColumnStatistics(min, max)
+        if (min.isEmpty || max.isEmpty) {
+          new ColumnStatistics(null, null)
+        } else {
+          new ColumnStatistics(min, max)
+        }
       }
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
@@ -40,8 +40,9 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
 
   private def checkBloomFilter(bf1: BloomFilter, bf2: BloomFilter) = {
     val res =
-      if (bf1.getNumOfHashFunc != bf2.getNumOfHashFunc) false
-      else {
+      if (bf1.getNumOfHashFunc != bf2.getNumOfHashFunc) {
+        false
+      } else {
         val bitLongArray1 = bf1.getBitMapLongArray
         val bitLongArray2 = bf2.getBitMapLongArray
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update the code style of if/else in scala to be consistent to the below Spark style guide.
I've searched the code base and should have fixed most of them.

```
Put curly braces even around one-line if, else or loop statements. The only exception is if you are using if/else as an one-line ternary operator.

// Correct:
if (true) {
  println("Wow!")
}
 
// Correct:
if (true) statement1 else statement2
 
// Wrong:
if (true)
  println("Wow!")
```


## How was this patch tested?
Existing tests.

