### PR TITLE
Oap use VectorizedReader read Parquet

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -400,7 +400,7 @@ case class FileSourceScanExec(
        |  int numRows = $batch.numRows();
        |  while ($idx < numRows) {
        |    int $rowidx = $idx++;
-       |    if($batch.isFiltered($rowidx)) continue;
+       |    if ($batch.isFiltered($rowidx)) continue;
        |    ${consume(ctx, columnsBatchInput).trim}
        |    if (shouldStop()) return;
        |  }

--- a/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -400,6 +400,7 @@ case class FileSourceScanExec(
        |  int numRows = $batch.numRows();
        |  while ($idx < numRows) {
        |    int $rowidx = $idx++;
+       |    if($batch.isFiltered($rowidx)) continue;
        |    ${consume(ctx, columnsBatchInput).trim}
        |    if (shouldStop()) return;
        |  }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.execution.datasources.oap.utils.{FilterHelper, OapUt
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.types.{AtomicType, StructField, StructType}
 import org.apache.spark.util.SerializableConfiguration
 
 private[sql] class OapFileFormat extends FileFormat
@@ -126,8 +126,18 @@ private[sql] class OapFileFormat extends FileFormat
    * Returns whether the reader will return the rows as batch or not.
    */
   override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
-    // TODO we should naturelly support batch
-    false
+    // TODO remove readerClassName after oap support batch return
+    val readerClassName = meta match {
+      case Some(m) =>
+        m.dataReaderClassName
+      case _ => ""
+    }
+    val conf = sparkSession.sessionState.conf
+    // TODO modify conditions after oap support batch return
+    readerClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
+      conf.parquetVectorizedReaderEnabled && conf.wholeStageEnabled &&
+      schema.length <= conf.wholeStageMaxNumFields &&
+      schema.forall(_.dataType.isInstanceOf[AtomicType])
   }
 
   override def isSplitable(
@@ -274,6 +284,16 @@ private[sql] class OapFileFormat extends FileFormat
         val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
         val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
+        // refer to ParquetFileFormat
+        // use resultSchema to decide if
+        // this query support Vectorized Read and returningBatch
+        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+        val enableVectorizedReader: Boolean =
+          m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
+          sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
+          resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
+        val returningBatch = supportBatch(sparkSession, resultSchema)
+
         hadoopConf.setDouble(OapConf.OAP_FULL_SCAN_THRESHOLD.key,
           sparkSession.conf.get(OapConf.OAP_FULL_SCAN_THRESHOLD))
         hadoopConf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key,
@@ -305,17 +325,32 @@ private[sql] class OapFileFormat extends FileFormat
             case _ =>
               OapIndexInfo.partitionOapIndex.put(file.filePath, false)
               FilterHelper.setFilterIfExist(conf, pushed)
+              // if enableVectorizedReader == true, init VectorizedContext
+              // else context is None
+              val context = if (enableVectorizedReader) {
+                Some(VectorizedContext(partitionSchema,
+                  file.partitionValues, returningBatch))
+              } else {
+                None
+              }
               val reader = new OapDataReader(
-                new Path(new URI(file.filePath)), m, filterScanners, requiredIds)
+                new Path(new URI(file.filePath)), m, filterScanners, requiredIds, context)
               val iter = reader.initialize(conf, options)
               Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
               oapMetrics.updateIndexAndRowRead(reader, totalRows)
+              // if enableVectorizedReader == true, return iter directly
+              // else use original branch
+              // partitionValues already filled by VectorizedReader
+              if (enableVectorizedReader) {
+                iter
+              } else {
+                val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
+                val joinedRow = new JoinedRow()
+                val appendPartitionColumns =
+                  GenerateUnsafeProjection.generate(fullSchema, fullSchema)
 
-              val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
-              val joinedRow = new JoinedRow()
-              val appendPartitionColumns = GenerateUnsafeProjection.generate(fullSchema, fullSchema)
-
-              iter.map(d => appendPartitionColumns(joinedRow(d, file.partitionValues)))
+                iter.map(d => appendPartitionColumns(joinedRow(d, file.partitionValues)))
+              }
           }
         }
       case None => (_: PartitionedFile) => {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -135,7 +135,8 @@ private[sql] class OapFileFormat extends FileFormat
     val conf = sparkSession.sessionState.conf
     // TODO modify conditions after oap support batch return
     readerClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
-      conf.parquetVectorizedReaderEnabled && conf.wholeStageEnabled &&
+      conf.parquetVectorizedReaderEnabled &&
+      conf.wholeStageEnabled &&
       schema.length <= conf.wholeStageMaxNumFields &&
       schema.forall(_.dataType.isInstanceOf[AtomicType])
   }
@@ -284,9 +285,8 @@ private[sql] class OapFileFormat extends FileFormat
         val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
         val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
-        // refer to ParquetFileFormat
-        // use resultSchema to decide if
-        // this query support Vectorized Read and returningBatch
+        // refer to ParquetFileFormat, use resultSchema to decide if this query support
+        // Vectorized Read and returningBatch.
         val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
         val enableVectorizedReader: Boolean =
           m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
@@ -325,8 +325,8 @@ private[sql] class OapFileFormat extends FileFormat
             case _ =>
               OapIndexInfo.partitionOapIndex.put(file.filePath, false)
               FilterHelper.setFilterIfExist(conf, pushed)
-              // if enableVectorizedReader == true, init VectorizedContext
-              // else context is None
+              // if enableVectorizedReader == true, init VectorizedContext,
+              // else context is None.
               val context = if (enableVectorizedReader) {
                 Some(VectorizedContext(partitionSchema,
                   file.partitionValues, returningBatch))
@@ -338,9 +338,8 @@ private[sql] class OapFileFormat extends FileFormat
               val iter = reader.initialize(conf, options)
               Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
               oapMetrics.updateIndexAndRowRead(reader, totalRows)
-              // if enableVectorizedReader == true, return iter directly
-              // else use original branch
-              // partitionValues already filled by VectorizedReader
+              // if enableVectorizedReader == true, return iter directly because of partitionValues
+              // already filled by VectorizedReader, else use original branch.
               if (enableVectorizedReader) {
                 iter
               } else {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -35,7 +35,6 @@ abstract class DataFile {
   def path: String
   def schema: StructType
   def configuration: Configuration
-  def context: Option[VectorizedContext]
 
   def createDataFileHandle(): DataFileHandle
   def getFiberData(groupId: Int, fiberId: Int): FiberCache
@@ -51,13 +50,11 @@ private[oap] class OapIterator[T](inner: Iterator[T]) extends Iterator[T] with C
 
 private[oap] object DataFile {
   def apply(path: String, schema: StructType, dataFileClassName: String,
-      configuration: Configuration,
-      context: Option[VectorizedContext] = None): DataFile = {
+      configuration: Configuration): DataFile = {
     Try(Utils.classForName(dataFileClassName).getDeclaredConstructor(
-      classOf[String], classOf[StructType], classOf[Configuration],
-      classOf[Option[VectorizedContext]])).toOption match {
+      classOf[String], classOf[StructType], classOf[Configuration])).toOption match {
       case Some(ctor) =>
-        Try (ctor.newInstance(path, schema, configuration, context).asInstanceOf[DataFile]) match {
+        Try (ctor.newInstance(path, schema, configuration).asInstanceOf[DataFile]) match {
           case Success(e) => e
           case Failure(e) =>
             throw new OapException(s"Cannot instantiate class $dataFileClassName", e)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -32,8 +32,11 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.CompletionIterator
 
 
-private[oap] case class OapDataFile(path: String, schema: StructType,
-                                    configuration: Configuration) extends DataFile {
+private[oap] case class OapDataFile(
+    path: String,
+    schema: StructType,
+    configuration: Configuration,
+    context: Option[VectorizedContext] = None) extends DataFile {
 
   private val dictionaries = new Array[Dictionary](schema.length)
   private val codecFactory = new CodecFactory(configuration)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -35,8 +35,7 @@ import org.apache.spark.util.CompletionIterator
 private[oap] case class OapDataFile(
     path: String,
     schema: StructType,
-    configuration: Configuration,
-    context: Option[VectorizedContext] = None) extends DataFile {
+    configuration: Configuration) extends DataFile {
 
   private val dictionaries = new Array[Dictionary](schema.length)
   private val codecFactory = new CodecFactory(configuration)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -209,7 +209,10 @@ private[oap] class OapDataReader(
       options: Map[String, String] = Map.empty): OapIterator[InternalRow] = {
     logDebug("Initializing OapDataReader...")
     // TODO how to save the additional FS operation to get the Split size
-    val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf, context)
+    val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf)
+    if (meta.dataReaderClassName.contains("ParquetDataFile")) {
+      fileScanner.asInstanceOf[ParquetDataFile].setVectorizedContext(context)
+    }
 
     def fullScan: OapIterator[InternalRow] = {
       val start = if (log.isDebugEnabled) System.currentTimeMillis else 0

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -189,7 +189,8 @@ private[oap] class OapDataReader(
   path: Path,
   meta: DataSourceMeta,
   filterScanners: Option[IndexScanners],
-  requiredIds: Array[Int]) extends Logging {
+  requiredIds: Array[Int],
+  context: Option[VectorizedContext] = None) extends Logging {
 
   import org.apache.spark.sql.execution.datasources.oap.INDEX_STAT._
 
@@ -204,7 +205,7 @@ private[oap] class OapDataReader(
       options: Map[String, String] = Map.empty): OapIterator[InternalRow] = {
     logDebug("Initializing OapDataReader...")
     // TODO how to save the additional FS operation to get the Split size
-    val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf)
+    val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf, context)
 
     def fullScan: OapIterator[InternalRow] = {
       val start = if (log.isDebugEnabled) System.currentTimeMillis else 0

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -22,7 +22,7 @@ import java.io.Closeable
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.util.StringUtils
-import org.apache.parquet.hadoop.{DefaultRecordReader, OapRecordReader}
+import org.apache.parquet.hadoop._
 import org.apache.parquet.hadoop.api.RecordReader
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -35,7 +35,8 @@ import org.apache.spark.sql.types.StructType
 private[oap] case class ParquetDataFile(
     path: String,
     schema: StructType,
-    configuration: Configuration) extends DataFile {
+    configuration: Configuration,
+    context: Option[VectorizedContext] = None) extends DataFile {
 
   def getFiberData(groupId: Int, fiberId: Int): FiberCache = {
     // TODO data cache
@@ -46,10 +47,15 @@ private[oap] case class ParquetDataFile(
     addRequestSchemaToConf(configuration, requiredIds)
     val file = new Path(StringUtils.unEscapeString(path))
     val meta: ParquetDataFileHandle = DataFileHandleCacheManager(this)
-
-    initRecordReader(
-      new DefaultRecordReader[UnsafeRow](new OapReadSupportImpl,
-        file, configuration, meta.footer))
+    context match {
+      case Some(c) =>
+        initVectorizedReader(c,
+          new VectorizedOapRecordReader(file, configuration, meta.footer))
+      case _ =>
+        initRecordReader(
+          new DefaultRecordReader[UnsafeRow](new OapReadSupportImpl,
+            file, configuration, meta.footer))
+    }
   }
 
   def iterator(
@@ -61,10 +67,16 @@ private[oap] case class ParquetDataFile(
       addRequestSchemaToConf(configuration, requiredIds)
       val file = new Path(StringUtils.unEscapeString(path))
       val meta: ParquetDataFileHandle = DataFileHandleCacheManager(this)
-
-      initRecordReader(
-        new OapRecordReader[UnsafeRow](new OapReadSupportImpl,
-          file, configuration, rowIds, meta.footer))
+      context match {
+        case Some(c) =>
+          initVectorizedReader(c,
+            new IndexedVectorizedOapRecordReader(file,
+              configuration, meta.footer, rowIds))
+        case _ =>
+          initRecordReader(
+            new OapRecordReader[UnsafeRow](new OapReadSupportImpl,
+              file, configuration, rowIds, meta.footer))
+      }
     }
   }
 
@@ -72,6 +84,18 @@ private[oap] case class ParquetDataFile(
     reader.initialize()
     val iterator = new FileRecordReaderIterator[UnsafeRow](reader)
     new OapIterator[InternalRow](iterator) {
+      override def close(): Unit = iterator.close()
+    }
+  }
+
+  private def initVectorizedReader(c: VectorizedContext, reader: VectorizedOapRecordReader) = {
+    reader.initialize()
+    reader.initBatch(c.partitionColumns, c.partitionValues)
+    if (c.returningBatch) {
+      reader.enableReturningBatches()
+    }
+    val iterator = new FileRecordReaderIterator(reader)
+    new OapIterator[InternalRow](iterator.asInstanceOf[Iterator[InternalRow]]) {
       override def close(): Unit = iterator.close()
     }
   }
@@ -86,7 +110,6 @@ private[oap] case class ParquetDataFile(
     }
     conf.set(ParquetReadSupportHelper.SPARK_ROW_REQUESTED_SCHEMA, requestSchemaString)
   }
-
 
   private class FileRecordReaderIterator[V](private[this] var rowReader: RecordReader[V])
     extends Iterator[V] with Closeable {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -35,8 +35,9 @@ import org.apache.spark.sql.types.StructType
 private[oap] case class ParquetDataFile(
     path: String,
     schema: StructType,
-    configuration: Configuration,
-    context: Option[VectorizedContext] = None) extends DataFile {
+    configuration: Configuration) extends DataFile {
+
+  private var context: Option[VectorizedContext] = None
 
   def getFiberData(groupId: Int, fiberId: Int): FiberCache = {
     // TODO data cache
@@ -79,6 +80,9 @@ private[oap] case class ParquetDataFile(
       }
     }
   }
+
+  def setVectorizedContext(context: Option[VectorizedContext]): Unit =
+    this.context = context
 
   private def initRecordReader(reader: RecordReader[UnsafeRow]) = {
     reader.initialize()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -302,7 +302,8 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
 
   test("read by columnIds and rowIds disable returningBatch") {
     val context = Some(VectorizedContext(null, null, returningBatch = false))
-    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val reader = ParquetDataFile(fileName, requestSchema, configuration)
+    reader.setVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 1134, 1753, 2222, 3928, 4200, 4734)
     val iterator = reader.iterator(requiredIds, rowIds)
@@ -320,7 +321,8 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
 
   test("read by columnIds and rowIds enable returningBatch") {
     val context = Some(VectorizedContext(null, null, returningBatch = true))
-    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val reader = ParquetDataFile(fileName, requestSchema, configuration)
+    reader.setVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382)
     val iterator = reader.iterator(requiredIds, rowIds)
@@ -342,7 +344,8 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
 
   test("read by columnIds and empty rowIds array disable returningBatch") {
     val context = Some(VectorizedContext(null, null, returningBatch = false))
-    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val reader = ParquetDataFile(fileName, requestSchema, configuration)
+    reader.setVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array.emptyIntArray
     val iterator = reader.iterator(requiredIds, rowIds)
@@ -355,7 +358,8 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
 
   test("read by columnIds and empty rowIds array enable returningBatch") {
     val context = Some(VectorizedContext(null, null, returningBatch = true))
-    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val reader = ParquetDataFile(fileName, requestSchema, configuration)
+    reader.setVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array.emptyIntArray
     val iterator = reader.iterator(requiredIds, rowIds)
@@ -368,7 +372,8 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
 
   test("read by columnIds disable returningBatch") {
     val context = Some(VectorizedContext(null, null, returningBatch = false))
-    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val reader = ParquetDataFile(fileName, requestSchema, configuration)
+    reader.setVectorizedContext(context)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
     val result = ArrayBuffer[ Int ]()
@@ -385,7 +390,8 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
 
   test("read by columnIds enable returningBatch") {
     val context = Some(VectorizedContext(null, null, returningBatch = true))
-    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val reader = ParquetDataFile(fileName, requestSchema, configuration)
+    reader.setVectorizedContext(context)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
     val result = ArrayBuffer[ Int ]()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -404,3 +404,4 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
     }
   }
 }
+

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -23,10 +23,11 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0
+import org.apache.parquet.column.ParquetProperties.WriterVersion
+import org.apache.parquet.column.ParquetProperties.WriterVersion.{PARQUET_1_0, PARQUET_2_0}
+import org.apache.parquet.example.Paper
 import org.apache.parquet.example.data.Group
 import org.apache.parquet.example.data.simple.{SimpleGroup, SimpleGroupFactory}
-import org.apache.parquet.example.Paper
 import org.apache.parquet.hadoop.example.{ExampleParquetWriter, GroupWriteSupport}
 import org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED
 import org.apache.parquet.schema.{MessageType, PrimitiveType}
@@ -36,6 +37,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.vectorized.ColumnarBatch
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -63,6 +65,8 @@ abstract class ParquetDataFileSuite extends SparkFunSuite
 
   protected def parquetSchema: MessageType
 
+  protected def dataVersion: WriterVersion
+
   override def beforeEach(): Unit = prepareData()
 
   override def afterEach(): Unit = cleanDir()
@@ -79,7 +83,7 @@ abstract class ParquetDataFileSuite extends SparkFunSuite
       .withDictionaryPageSize(dictPageSize)
       .withDictionaryEncoding(true)
       .withValidation(false)
-      .withWriterVersion(PARQUET_2_0)
+      .withWriterVersion(dataVersion)
       .withConf(configuration)
       .build()
 
@@ -111,6 +115,8 @@ class SimpleDataSuite extends ParquetDataFileSuite {
     new PrimitiveType(REQUIRED, FLOAT, "float_field"),
     new PrimitiveType(REQUIRED, DOUBLE, "double_field")
   )
+
+  override def dataVersion: WriterVersion = PARQUET_2_0
 
   override def data: Seq[Group] = {
     val factory = new SimpleGroupFactory(parquetSchema)
@@ -199,6 +205,8 @@ class NestedDataSuite extends ParquetDataFileSuite {
 
   override def parquetSchema: MessageType = Paper.schema
 
+  override def dataVersion: WriterVersion = PARQUET_2_0
+
   override def data: Seq[Group] = {
     val r1 = new SimpleGroup(parquetSchema)
       r1.add("DocId", 10L)
@@ -264,3 +272,135 @@ class NestedDataSuite extends ParquetDataFileSuite {
   }
 }
 
+class VectorizedDataSuite extends ParquetDataFileSuite {
+
+  private val requestSchema: StructType = new StructType()
+    .add(StructField("int32_field", IntegerType))
+    .add(StructField("int64_field", LongType))
+    .add(StructField("boolean_field", BooleanType))
+    .add(StructField("float_field", FloatType))
+
+  override def parquetSchema: MessageType = new MessageType("test",
+    new PrimitiveType(REQUIRED, INT32, "int32_field"),
+    new PrimitiveType(REQUIRED, INT64, "int64_field"),
+    new PrimitiveType(REQUIRED, BOOLEAN, "boolean_field"),
+    new PrimitiveType(REQUIRED, FLOAT, "float_field"),
+    new PrimitiveType(REQUIRED, DOUBLE, "double_field")
+  )
+
+  override def dataVersion: WriterVersion = PARQUET_1_0
+
+  override def data: Seq[Group] = {
+    val factory = new SimpleGroupFactory(parquetSchema)
+    (0 until 5000).map(i => factory.newGroup()
+      .append("int32_field", i)
+      .append("int64_field", 64L)
+      .append("boolean_field", true)
+      .append("float_field", 1.0f)
+      .append("double_field", 2.0d))
+  }
+
+  test("read by columnIds and rowIds disable returningBatch") {
+    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val requiredIds = Array(0, 1)
+    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 1134, 1753, 2222, 3928, 4200, 4734)
+    val iterator = reader.iterator(requiredIds, rowIds)
+    val result = ArrayBuffer[Int]()
+    while (iterator.hasNext) {
+      val row = iterator.next()
+      assert(row.numFields == 2)
+      result += row.getInt(0)
+    }
+    assert(rowIds.length == result.length)
+    for (i <- rowIds.indices) {
+      assert(rowIds(i) == result(i))
+    }
+  }
+
+  test("read by columnIds and rowIds enable returningBatch") {
+    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val requiredIds = Array(0, 1)
+    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382)
+    val iterator = reader.iterator(requiredIds, rowIds)
+    val result = ArrayBuffer[Int]()
+    while (iterator.hasNext) {
+      val batch = iterator.next().asInstanceOf[ColumnarBatch]
+      val rowIterator = batch.rowIterator()
+      while (rowIterator.hasNext) {
+        val row = rowIterator.next()
+        assert(row.numFields == 2)
+        result += row.getInt(0)
+      }
+    }
+    assert(rowIds.length == result.length)
+    for (i <- rowIds.indices) {
+      assert(rowIds(i) == result(i))
+    }
+  }
+
+  test("read by columnIds and empty rowIds array disable returningBatch") {
+    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val requiredIds = Array(0, 1)
+    val rowIds = Array.emptyIntArray
+    val iterator = reader.iterator(requiredIds, rowIds)
+    assert(!iterator.hasNext)
+    val e = intercept[java.util.NoSuchElementException] {
+      iterator.next()
+    }.getMessage
+    assert(e.contains("next on empty iterator"))
+  }
+
+  test("read by columnIds and empty rowIds array enable returningBatch") {
+    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val requiredIds = Array(0, 1)
+    val rowIds = Array.emptyIntArray
+    val iterator = reader.iterator(requiredIds, rowIds)
+    assert(!iterator.hasNext)
+    val e = intercept[java.util.NoSuchElementException] {
+      iterator.next()
+    }.getMessage
+    assert(e.contains("next on empty iterator"))
+  }
+
+  test("read by columnIds disable returningBatch") {
+    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val requiredIds = Array(0)
+    val iterator = reader.iterator(requiredIds)
+    val result = ArrayBuffer[ Int ]()
+    while (iterator.hasNext) {
+      val row = iterator.next()
+      result += row.getInt(0)
+    }
+    val length = data.length
+    assert(length == result.length)
+    for (i <- 0 until length) {
+      assert(i == result(i))
+    }
+  }
+
+  test("read by columnIds enable returningBatch") {
+    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val reader = ParquetDataFile(fileName, requestSchema, configuration, context)
+    val requiredIds = Array(0)
+    val iterator = reader.iterator(requiredIds)
+    val result = ArrayBuffer[ Int ]()
+    while (iterator.hasNext) {
+      val batch = iterator.next().asInstanceOf[ColumnarBatch]
+      val batchIter = batch.rowIterator()
+      while (batchIter.hasNext) {
+        val row = batchIter.next
+        result += row.getInt(0)
+      }
+    }
+    val length = data.length
+    assert(length == result.length)
+    for (i <- 0 until length) {
+      assert(i == result(i))
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Task 6 of #536

1. Add `VectorizedContext` encapsulation infomation for Vectorized Read, `partitionColumns` and `partitionValues` use by `VectorizedOapRecordReader#initBatch` method, `returningBatch` use by `VectorizedOapRecordReader#enableReturningBatches` method.

2. Add `Option[VectorizedContext]` to `DataFile` Constructor and transfer it from `OapFileFormat`

3. `OapFileFormat` redefine supportBatch for Parquet File, this method use by `FileSourceScanExec` to init supportsBatch condition and buildReaderWithPartitionValues to know if support read data returningBatches.

4. `OapFileFormat` refer to `ParquetFileFormat`, use resultSchema to decide if this query support Vectorized Read and returningBatch and pass context to `OapDataReader`.

5. `OapFileFormat#buildReaderWithPartitionValues` method return iter directly if `enableVectorizedReader == true` because of partitionValues already filled by VectorizedReader, else use original branch.

6.  `ParquetDataFile` use `VectorizedOapRecordReader` or `IndexedVectorizedOapRecordReader` read Parquet file when `VectorizedContext` is not None.

7. Add `VectorizedDataSuite` to test ParquetDataFile read data full scan or Indexed. 

8. Add `batch.isFiltered($rowidx)` process to `FileSourceScanExec#doProduceVectorized` generate Java code to skip  write row to outbuffer by index data. 

## How was this patch tested?

1. existing sql case

2. VectorizedDataSuite 