### PR TITLE
#604 Bitmap scanner should clear status to enable re-entry

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -32,7 +32,6 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
   override def toString(): String = "BPlusTreeScanner"
   @transient protected var currentKeyArray: Array[CurrentKey] = _
 
-  var currentKeyIdx = 0
   var recordReader: BTreeIndexRecordReader = _
 
   def initialize(dataPath: Path, conf: Configuration): IndexScanner = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -52,15 +52,8 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   private var bmUniqueKeyListCount: Int = _
   private var bmEntryListTotalSize: Int = _
   private var bmOffsetListTotalSize: Int = _
-
-  private var bmUniqueKeyListOffset: Int = _
-  private var bmEntryListOffset: Int = _
-
   private var bmNullEntryOffset: Int = _
   private var bmNullEntrySize: Int = _
-
-  private var bmOffsetListOffset: Int = _
-  private var bmFooterOffset: Int = _
 
   private var bmFooterFiber: BitmapFiber = _
   private var bmFooterCache: WrappedFiberCache = _
@@ -78,7 +71,6 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   private var bmEntryListCache: WrappedFiberCache = _
 
   private var fin: FSDataInputStream = _
-  private var idxFileSize: Long = 0L
 
   @transient private var bmRowIdIterator: Iterator[Integer] = _
   private var empty: Boolean = _
@@ -87,7 +79,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
 
   override def next(): Int = bmRowIdIterator.next()
 
-  private def loadBmFooter(fin: FSDataInputStream): FiberCache = {
+  private def loadBmFooter(fin: FSDataInputStream, bmFooterOffset: Int): FiberCache = {
     MemoryManager.putToIndexFiberCache(fin, bmFooterOffset, BITMAP_FOOTER_SIZE)
   }
 
@@ -101,16 +93,12 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     if (fin == null) {
       fin = fs.open(idxPath)
     }
-    if (idxFileSize == 0L) {
-      idxFileSize = fs.getFileStatus(idxPath).getLen
-    }
-    if (bmFooterOffset == 0) {
-      bmFooterOffset = idxFileSize.toInt - BITMAP_FOOTER_SIZE
-    }
+    val idxFileSize = fs.getFileStatus(idxPath).getLen
+    val bmFooterOffset = idxFileSize.toInt - BITMAP_FOOTER_SIZE
 
     if (bmFooterFiber == null) {
       bmFooterFiber = BitmapFiber(
-        () => loadBmFooter(fin), idxPath.toString, BitmapIndexSectionId.footerSection, 0)
+        () => loadBmFooter(fin, bmFooterOffset), idxPath.toString, BitmapIndexSectionId.footerSection, 0)
     }
     if (bmFooterCache == null) {
       bmFooterCache = WrappedFiberCache(FiberCacheManager.get(bmFooterFiber, conf))
@@ -169,7 +157,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     bmNullEntrySize = data.getInt(IndexUtils.INT_SIZE * 6)
   }
 
-  private def loadBmKeyList(fin: FSDataInputStream): FiberCache = {
+  private def loadBmKeyList(fin: FSDataInputStream, bmUniqueKeyListOffset: Int): FiberCache = {
     // TODO: seems not supported yet on my local dev machine(hadoop is 2.7.3).
     // fin.setReadahead(bmUniqueKeyListTotalSize)
     MemoryManager.putToIndexFiberCache(fin, bmUniqueKeyListOffset, bmUniqueKeyListTotalSize)
@@ -185,15 +173,18 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     })
   }
 
-  private def loadBmEntryList(fin: FSDataInputStream): FiberCache = {
+  private def loadBmEntryList(fin: FSDataInputStream, bmEntryListOffset: Int): FiberCache = {
     MemoryManager.putToIndexFiberCache(fin, bmEntryListOffset, bmEntryListTotalSize)
   }
 
-  private def loadBmOffsetList(fin: FSDataInputStream): FiberCache = {
+  private def loadBmOffsetList(
+      fin: FSDataInputStream,
+      bmOffsetListOffset: Int,
+      bmOffsetListTotalSize: Int): FiberCache = {
     MemoryManager.putToIndexFiberCache(fin, bmOffsetListOffset, bmOffsetListTotalSize)
   }
 
-  private def loadBmNullList(fin: FSDataInputStream): FiberCache = {
+  private def loadBmNullList(fin: FSDataInputStream, bmNullEntryOffset: Int, bmNullEntrySize: Int): FiberCache = {
     MemoryManager.putToIndexFiberCache(fin, bmNullEntryOffset, bmNullEntrySize)
   }
 
@@ -219,24 +210,26 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
       readBmFooterFromCache(bmFooterCache.fc)
 
       // Get the offset for the different segments in bitmap index file.
-      bmUniqueKeyListOffset = IndexFile.VERSION_LENGTH
-      bmEntryListOffset = bmUniqueKeyListOffset + bmUniqueKeyListTotalSize
-      bmOffsetListOffset = bmEntryListOffset + bmEntryListTotalSize + bmNullEntrySize
+      val bmUniqueKeyListOffset = IndexFile.VERSION_LENGTH
+      val bmEntryListOffset = bmUniqueKeyListOffset + bmUniqueKeyListTotalSize
+      val bmOffsetListOffset = bmEntryListOffset + bmEntryListTotalSize + bmNullEntrySize
 
       bmUniqueKeyListFiber = BitmapFiber(
-        () => loadBmKeyList(fin), idxPath.toString, BitmapIndexSectionId.keyListSection, 0)
+        () => loadBmKeyList(fin, bmUniqueKeyListOffset), idxPath.toString, BitmapIndexSectionId.keyListSection, 0)
       bmUniqueKeyListCache = WrappedFiberCache(FiberCacheManager.get(bmUniqueKeyListFiber, conf))
 
       bmEntryListFiber = BitmapFiber(
-        () => loadBmEntryList(fin), idxPath.toString, BitmapIndexSectionId.entryListSection, 0)
+        () => loadBmEntryList(fin, bmEntryListOffset), idxPath.toString, BitmapIndexSectionId.entryListSection, 0)
       bmEntryListCache = WrappedFiberCache(FiberCacheManager.get(bmEntryListFiber, conf))
 
       bmOffsetListFiber = BitmapFiber(
-        () => loadBmOffsetList(fin), idxPath.toString, BitmapIndexSectionId.entryOffsetsSection, 0)
+        () => loadBmOffsetList(fin, bmOffsetListOffset, bmOffsetListTotalSize),
+        idxPath.toString,
+        BitmapIndexSectionId.entryOffsetsSection, 0)
       bmOffsetListCache = WrappedFiberCache(FiberCacheManager.get(bmOffsetListFiber, conf))
 
       bmNullListFiber = BitmapFiber(
-        () => loadBmNullList(fin), idxPath.toString, BitmapIndexSectionId.entryNullSection, 0)
+        () => loadBmNullList(fin, bmNullEntryOffset, bmNullEntrySize), idxPath.toString, BitmapIndexSectionId.entryNullSection, 0)
       bmNullListCache = WrappedFiberCache(FiberCacheManager.get(bmNullListFiber, conf))
     } finally {
       try {
@@ -332,7 +325,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
           Seq.empty[RoaringBitmap]
         } else {
           val startIdxOffset = getStartIdxOffset(bmOffsetListCache.fc, 0L, startIdx)
-          val curPosition = startIdxOffset - bmEntryListOffset
+          val curPosition = startIdxOffset - IndexFile.VERSION_LENGTH - bmUniqueKeyListTotalSize
           getDesiredBitmaps(bmEntryListCache.fc, curPosition, startIdx, endIdx + 1)
         }
       case range if range.isNullPredicate =>
@@ -369,28 +362,44 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     try {
       initDesiredRowIdIterator()
     } finally {
-      closeCache()
+      clearCache()
     }
 
     this
   }
 
-  def closeCache(): Unit = {
+  def clearCache(): Unit = {
     if (bmFooterCache != null) {
       bmFooterCache.release()
+      bmFooterCache = null
+      bmFooterFiber = null
     }
     if (bmUniqueKeyListCache != null) {
       bmUniqueKeyListCache.release()
+      bmUniqueKeyListCache = null
+      bmUniqueKeyListFiber = null
     }
     if (bmOffsetListCache != null) {
       bmOffsetListCache.release()
+      bmOffsetListCache = null
+      bmOffsetListFiber = null
     }
     if (bmEntryListCache != null) {
       bmEntryListCache.release()
+      bmEntryListCache = null
+      bmEntryListFiber = null
     }
     if (bmNullListCache != null) {
       bmNullListCache.release()
+      bmNullListCache = null
+      bmNullListFiber = null
     }
+    bmUniqueKeyListTotalSize = 0
+    bmUniqueKeyListCount = 0
+    bmEntryListTotalSize = 0
+    bmOffsetListTotalSize = 0
+    bmNullEntryOffset = 0
+    bmNullEntrySize = 0
   }
 
   override def toString: String = "BitMapScanner"

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -121,12 +121,10 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
 
     sql("insert overwrite table oap_test_1 select * from t")
     sql("create oindex bmidx1 on oap_test_1 (a) using bitmap")
-    sql("create oindex bmidx2 on oap_test_1 (b) using bitmap")
 
     val df1 = sql("SELECT * FROM oap_test_1 WHERE a = 1")
     checkAnswer(df1, Row(1, "this is row 1") :: Row(1, "this is row 21") :: Nil)
 
     sql("drop oindex bmidx1 on oap_test_1")
-    sql("drop oindex bmidx2 on oap_test_1")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there are multiple tasks use the same scanner, it could lead to core dump.

## How was this patch tested?

add a unit test.
