### PR TITLE
Add DDL support for indices disabling

### DIFF
--- a/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -157,6 +157,7 @@ statement
     | DISABLE SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
         partitionSpec?                                                 #oapDisableIndex
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
+    | SHOW DISABLED SINDICES                                           #oapShowDisabledIndices
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
     ;
@@ -720,7 +721,7 @@ nonReserved
     | UNBOUNDED | WHEN
     | DATABASE | SELECT | FROM | WHERE | HAVING | TO | TABLE | WITH | NOT | CURRENT_DATE | CURRENT_TIMESTAMP
     | CHECK
-    | DISABLE
+    | DISABLE | DISABLED
     ;
 
 SELECT: 'SELECT';
@@ -831,6 +832,7 @@ COMMIT: 'COMMIT';
 ROLLBACK: 'ROLLBACK';
 MACRO: 'MACRO';
 DISABLE: 'DISABLE';
+DISABLED: 'DISABLED';
 
 IF: 'IF';
 
@@ -951,6 +953,7 @@ CURRENT_TIMESTAMP: 'CURRENT_TIMESTAMP';
 
 CHECK: 'CHECK';
 SINDEX: 'SINDEX' | 'OINDEX';
+SINDICES: 'SINDICES' | 'OINDICES';
 BTREE: 'BTREE';
 BLOOM: 'BLOOM';
 BITMAP: 'BITMAP';

--- a/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -156,6 +156,7 @@ statement
         partitionSpec?                                                 #oapDropIndex
     | DISABLE SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
         partitionSpec?                                                 #oapDisableIndex
+    | ENABLE SINDEX IDENTIFIER                                         #oapEnableIndex
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
     | SHOW DISABLED SINDICES                                           #oapShowDisabledIndices
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
@@ -721,7 +722,7 @@ nonReserved
     | UNBOUNDED | WHEN
     | DATABASE | SELECT | FROM | WHERE | HAVING | TO | TABLE | WITH | NOT | CURRENT_DATE | CURRENT_TIMESTAMP
     | CHECK
-    | DISABLE | DISABLED
+    | DISABLE | DISABLED | ENABLE
     ;
 
 SELECT: 'SELECT';
@@ -833,6 +834,7 @@ ROLLBACK: 'ROLLBACK';
 MACRO: 'MACRO';
 DISABLE: 'DISABLE';
 DISABLED: 'DISABLED';
+ENABLE: 'ENABLE';
 
 IF: 'IF';
 

--- a/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -154,11 +154,9 @@ statement
         partitionSpec?                                                 #oapCreateIndex
     | DROP SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
         partitionSpec?                                                 #oapDropIndex
-    | DISABLE SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
-        partitionSpec?                                                 #oapDisableIndex
+    | DISABLE SINDEX IDENTIFIER                                        #oapDisableIndex
     | ENABLE SINDEX IDENTIFIER                                         #oapEnableIndex
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
-    | SHOW DISABLED SINDICES                                           #oapShowDisabledIndices
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
     ;
@@ -722,7 +720,7 @@ nonReserved
     | UNBOUNDED | WHEN
     | DATABASE | SELECT | FROM | WHERE | HAVING | TO | TABLE | WITH | NOT | CURRENT_DATE | CURRENT_TIMESTAMP
     | CHECK
-    | DISABLE | DISABLED | ENABLE
+    | DISABLE | ENABLE
     ;
 
 SELECT: 'SELECT';
@@ -833,7 +831,6 @@ COMMIT: 'COMMIT';
 ROLLBACK: 'ROLLBACK';
 MACRO: 'MACRO';
 DISABLE: 'DISABLE';
-DISABLED: 'DISABLED';
 ENABLE: 'ENABLE';
 
 IF: 'IF';

--- a/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -154,7 +154,7 @@ statement
         partitionSpec?                                                 #oapCreateIndex
     | DROP SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
         partitionSpec?                                                 #oapDropIndex
-    | DISABLE SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
+    | DISABLE SINDEX (IF EXISTS)? IDENTIFIER_WITH_COMMA ON tableIdentifier
         partitionSpec?                                                 #oapDisableIndex
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
@@ -720,6 +720,7 @@ nonReserved
     | UNBOUNDED | WHEN
     | DATABASE | SELECT | FROM | WHERE | HAVING | TO | TABLE | WITH | NOT | CURRENT_DATE | CURRENT_TIMESTAMP
     | CHECK
+    | DISABLE
     ;
 
 SELECT: 'SELECT';
@@ -829,6 +830,7 @@ TRANSACTION: 'TRANSACTION';
 COMMIT: 'COMMIT';
 ROLLBACK: 'ROLLBACK';
 MACRO: 'MACRO';
+DISABLE: 'DISABLE';
 
 IF: 'IF';
 
@@ -995,6 +997,10 @@ BIGDECIMAL_LITERAL
 
 IDENTIFIER
     : (LETTER | DIGIT | '_')+
+    ;
+
+IDENTIFIER_WITH_COMMA
+    : (IDENTIFIER)+ (',' (IDENTIFIER)+)?
     ;
 
 BACKQUOTED_IDENTIFIER

--- a/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -154,6 +154,8 @@ statement
         partitionSpec?                                                 #oapCreateIndex
     | DROP SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
         partitionSpec?                                                 #oapDropIndex
+    | DISABLE SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
+        partitionSpec?                                                 #oapDisableIndex
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand

--- a/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -154,7 +154,7 @@ statement
         partitionSpec?                                                 #oapCreateIndex
     | DROP SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
         partitionSpec?                                                 #oapDropIndex
-    | DISABLE SINDEX (IF EXISTS)? IDENTIFIER_WITH_COMMA ON tableIdentifier
+    | DISABLE SINDEX (IF EXISTS)? IDENTIFIER ON tableIdentifier
         partitionSpec?                                                 #oapDisableIndex
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
@@ -997,10 +997,6 @@ BIGDECIMAL_LITERAL
 
 IDENTIFIER
     : (LETTER | DIGIT | '_')+
-    ;
-
-IDENTIFIER_WITH_COMMA
-    : (IDENTIFIER)+ (',' (IDENTIFIER)+)?
     ;
 
 BACKQUOTED_IDENTIFIER

--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1475,14 +1475,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     }
 
   override def visitOapDisableIndex(ctx: OapDisableIndexContext): LogicalPlan =
-    OapDisableIndexCommand(
-      ctx.IDENTIFIER.getText,
-      visitTableIdentifier(ctx.tableIdentifier),
-      ctx.EXISTS != null,
-      Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
-
-  override def visitOapShowDisabledIndices(ctx: OapShowDisabledIndicesContext): LogicalPlan =
-    OapShowDisableIndicesCommand()
+    OapDisableIndexCommand(ctx.IDENTIFIER.getText)
 
   override def visitOapEnableIndex(ctx: OapEnableIndexContext): LogicalPlan =
     OapEnableIndexCommand(ctx.IDENTIFIER.getText)

--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1476,7 +1476,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
   override def visitOapDisableIndex(ctx: OapDisableIndexContext): LogicalPlan =
     OapDisableIndexCommand(
-      ctx.IDENTIFIER_WITH_COMMA.getText,
+      ctx.IDENTIFIER.getText,
       visitTableIdentifier(ctx.tableIdentifier),
       ctx.EXISTS != null,
       Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))

--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1483,4 +1483,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
 
   override def visitOapShowDisabledIndices(ctx: OapShowDisabledIndicesContext): LogicalPlan =
     OapShowDisableIndicesCommand()
+
+  override def visitOapEnableIndex(ctx: OapEnableIndexContext): LogicalPlan =
+    OapEnableIndexCommand(ctx.IDENTIFIER.getText)
 }

--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1473,4 +1473,11 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
         tableIdentifier.identifier,
         Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
     }
+
+  override def visitOapDisableIndex(ctx: OapDropIndexContext): LogicalPlan =
+    OapDisableIndexCommand(
+      ctx.IDENTIFIER.getText,
+      visitTableIdentifier(ctx.tableIdentifier),
+      ctx.EXISTS != null,
+      Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
 }

--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1480,4 +1480,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
       visitTableIdentifier(ctx.tableIdentifier),
       ctx.EXISTS != null,
       Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
+
+  override def visitOapShowDisabledIndices(ctx: OapShowDisabledIndicesContext): LogicalPlan =
+    OapShowDisableIndicesCommand()
 }

--- a/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1474,9 +1474,9 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
         Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
     }
 
-  override def visitOapDisableIndex(ctx: OapDropIndexContext): LogicalPlan =
+  override def visitOapDisableIndex(ctx: OapDisableIndexContext): LogicalPlan =
     OapDisableIndexCommand(
-      ctx.IDENTIFIER.getText,
+      ctx.IDENTIFIER_WITH_COMMA.getText,
       visitTableIdentifier(ctx.tableIdentifier),
       ctx.EXISTS != null,
       Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -689,14 +689,33 @@ case class OapDisableIndexCommand(
                   s"""Index $notExistsIndicesString does not exist on
                      | ${identifier.getOrElse(parent)}""".stripMargin)
               } else {
-                logWarning(s"drop non-exists index $notExistsIndicesString")
+                logWarning(s"disable non-exists index $notExistsIndicesString")
               }
             }
             sparkSession.conf.set(OapConf.OAP_INDEX_DISABLE_LIST.key, indexNames)
           }
         })
-      case other => sys.error(s"We don't support index dropping for ${other.simpleString}")
+      case other => sys.error(s"We don't support index disabling for ${other.simpleString}")
     }
     Seq.empty
+  }
+}
+
+/**
+ * Show disabled indices
+ */
+case class OapShowDisableIndicesCommand() extends RunnableCommand {
+
+  override val output: Seq[Attribute] = {
+    AttributeReference("index_name", StringType, nullable = false)() :: Nil
+  }
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val disableList = sparkSession.conf.get(OapConf.OAP_INDEX_DISABLE_LIST)
+    if(disableList == "") {
+      Seq.empty
+    } else {
+      disableList.split(",").map(_.trim).map(Row(_)).toSeq
+    }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -651,7 +651,7 @@ case class OapCheckIndexCommand(
 }
 
 /**
- * Disable specific indices
+ * Disable specific index
  */
 case class OapDisableIndexCommand(
     indexNames: String,
@@ -717,5 +717,21 @@ case class OapShowDisableIndicesCommand() extends RunnableCommand {
     } else {
       disableList.split(",").map(_.trim).map(Row(_)).toSeq
     }
+  }
+}
+
+/**
+ * Enable disabled index
+ */
+case class OapEnableIndexCommand(indexName: String) extends RunnableCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val disableList = sparkSession.conf.get(OapConf.OAP_INDEX_DISABLE_LIST).split(",").map(_.trim)
+    val refreshedDisableList = disableList.filterNot(_ == indexName)
+    if (disableList.length == refreshedDisableList.length) {
+      logWarning(s"Index $indexName hasn't been disabled")
+    }
+    sparkSession.conf.set(OapConf.OAP_INDEX_DISABLE_LIST.key, refreshedDisableList.mkString(", "))
+    Seq.empty
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -21,8 +21,8 @@ import scala.collection.mutable
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.scheduler.local.LocalSchedulerBackend
 import org.apache.spark.sql._

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -76,17 +76,17 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     sql("create oindex index1 on oap_test_2 (a desc, b desc)")
 
     checkAnswer(sql("show oindex from oap_test_1"),
-      Row("oap_test_1", "index1", 0, "a", "A", "BTREE") ::
-        Row("oap_test_1", "index2", 0, "b", "D", "BTREE") ::
-        Row("oap_test_1", "index3", 0, "b", "A", "BTREE") ::
-        Row("oap_test_1", "index3", 1, "a", "D", "BTREE") :: Nil)
+      Row("oap_test_1", "index1", 0, "a", "A", "BTREE", true) ::
+        Row("oap_test_1", "index2", 0, "b", "D", "BTREE", true) ::
+        Row("oap_test_1", "index3", 0, "b", "A", "BTREE", true) ::
+        Row("oap_test_1", "index3", 1, "a", "D", "BTREE", true) :: Nil)
 
     checkAnswer(sql("show oindex in oap_test_2"),
-      Row("oap_test_2", "index4", 0, "a", "A", "BTREE") ::
-        Row("oap_test_2", "index5", 0, "b", "D", "BTREE") ::
-        Row("oap_test_2", "index6", 0, "a", "A", "BITMAP") ::
-        Row("oap_test_2", "index1", 0, "a", "D", "BTREE") ::
-        Row("oap_test_2", "index1", 1, "b", "D", "BTREE") :: Nil)
+      Row("oap_test_2", "index4", 0, "a", "A", "BTREE", true) ::
+        Row("oap_test_2", "index5", 0, "b", "D", "BTREE", true) ::
+        Row("oap_test_2", "index6", 0, "a", "A", "BITMAP", true) ::
+        Row("oap_test_2", "index1", 0, "a", "D", "BTREE", true) ::
+        Row("oap_test_2", "index1", 1, "b", "D", "BTREE", true) :: Nil)
   }
 
   test("create and drop index with partition specify") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -309,7 +309,7 @@ class OapPlannerSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
       }
@@ -337,7 +337,8 @@ class OapPlannerSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
         sql(s"drop oindex idxa on $tabName")
         checkAnswer(sql(s"show oindex from $tabName"), Nil)
@@ -368,14 +369,16 @@ class OapPlannerSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
         // test refresh oap index
         (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
           .createOrReplaceTempView("t2")
         sql(s"insert into table $tabName select * from t2")
         sql(s"refresh oindex on $tabName")
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
         checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
@@ -404,7 +407,8 @@ class OapPlannerSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
         // test check oap index
         checkAnswer(sql(s"check oindex on $tabName"), Nil)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
@@ -284,6 +284,7 @@ class IndexSelectionSuite extends QueryTest with SharedOapContext with BeforeAnd
     assert(spark.conf.get(OapConf.OAP_INDEX_DISABLE_LIST.key) == "idxa")
     ScannerBuilder.build(filters, ic, Map.empty, 1, "idxa")
     assert(ic.getScanners.get.scanners.length == 1)
+    spark.conf.unset(OapConf.OAP_INDEX_DISABLE_LIST.key)
   }
 
   test("Show disabled indices") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
@@ -277,10 +277,11 @@ class IndexSelectionSuite extends SharedOapContext with BeforeAndAfterEach{
     assert(ic.getScanners.get.scanners.length == 2)
     ic.clear()
 
-    // There shouldn't be whitespaces between index names while using DDL
-    sql("disable oindex idxa,idxb on oap_test")
-    assert(spark.conf.get(OapConf.OAP_INDEX_DISABLE_LIST.key) == "idxa,idxb")
-    ScannerBuilder.build(filters, ic, Map.empty, 1, "idxa,idxb")
-    assert(ic.getScanners.isEmpty)
+    // Can only disable 1 index at a time while using DDL
+    sql("disable oindex idxa on oap_test")
+    assert(spark.conf.get(OapConf.OAP_INDEX_DISABLE_LIST.key) == "idxa")
+    ScannerBuilder.build(filters, ic, Map.empty, 1, "idxa")
+    assert(ic.getScanners.get.scanners.length == 1)
+
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexSelectionSuite.scala
@@ -268,7 +268,7 @@ class IndexSelectionSuite extends QueryTest with SharedOapContext with BeforeAnd
     assert(ic.getScanners.isEmpty)
   }
 
-  test("Allow to disable specific indices by DDL") {
+  test("Allow to disable specific index by DDL") {
     sql("create oindex idxa on oap_test(a)")
     sql("create oindex idxb on oap_test(b)")
 
@@ -295,4 +295,13 @@ class IndexSelectionSuite extends QueryTest with SharedOapContext with BeforeAnd
     checkAnswer(sql("show disabled oindices"), Seq(Row("idxa")))
   }
 
+  test("Enable disabled index") {
+    sql("create oindex idxa on oap_test(a)")
+    sql("create oindex idxb on oap_test(b)")
+
+    sql("disable oindex idxa on oap_test")
+    checkAnswer(sql("show disabled oindices"), Seq(Row("idxa")))
+    sql("enable oindex idxa")
+    assert(sql("show disabled oindices").collect().isEmpty)
+  }
 }

--- a/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import org.apache.hadoop.fs.Path
 import org.scalatest.{BeforeAndAfterEach, Ignore}
+
 import org.apache.spark.sql.{QueryTest, Row, SparkSession, TestOap}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
@@ -75,7 +76,8 @@ class HiveOapIndexDDLSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
       }
@@ -103,7 +105,8 @@ class HiveOapIndexDDLSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
         sql(s"drop oindex idxa on $tabName")
         checkAnswer(sql(s"show oindex from $tabName"), Nil)
@@ -134,14 +137,16 @@ class HiveOapIndexDDLSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
         // test refresh oap index
         (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
           .createOrReplaceTempView("t2")
         sql(s"insert into table $tabName select * from t2")
         sql(s"refresh oindex on $tabName")
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
         checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
@@ -170,7 +175,7 @@ class HiveOapIndexDDLSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE"))
+        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
         // test check oap index
         checkAnswer(sql(s"check oindex on $tabName"), Nil)


### PR DESCRIPTION
## What changes were proposed in this pull request?

To enable disabling indices using DDL.

Note that only 1 index can be disabled at a time. For example, to disable `indexA`, `indexB`:
Two statements: `Disable oindex indexA on table` & `Disable oindex indexB on table` are needed.
Due to supporting of multiple indices disabling at a time will cause other queries' parse error.

## How was this patch tested?

Test case in `IndexSelectionSuite`.

Out of date: <del>Test is currently not added, due to this actually depend on PR#596.</del>

