### PR TITLE
Fix oap aggregation strategy performance issue.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/aggregate/OapAggregationIterator.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/aggregate/OapAggregationIterator.scala
@@ -172,6 +172,7 @@ class OapAggregationIterator(
         result.copy()
       }
 
+      numOutputRows += 1
       // If this is the last record, update the task's peak memory usage.
       // So far it has no map/sorter/spill memory.
       if (!hasNext) {
@@ -183,7 +184,6 @@ class OapAggregationIterator(
         spillSize += 0L
         metrics.incPeakExecutionMemory(maxMemory)
       }
-      numOutputRows += 1
       res
     } else {
       // no more result

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
@@ -290,15 +290,12 @@ trait OapStrategies extends Logging {
       oapOption: Map[String, String],
       indexHint: Seq[Expression],
       indexRequirements: Seq[IndexType]): Option[SparkPlan] = {
-    // If executor index selection (EIS) is enabled, oapStrategies are disabled.
     val conf = SparkSession.getActiveSession.get.sessionState.conf
-    if (!conf.getConf(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES)) {
+    if (!conf.getConf(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES) ||
+        conf.getConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)) {
+      // If executor index selection (spark.sql.oap.oindex.eis.enabled) is enabled,
+      // oapStrategies does not work because exeutor may skip the index scan.
       return None
-    } else {
-      if (conf.getConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)) {
-        logWarning("Please disable OAP_ENABLE_EXECUTOR_INDEX_SELECTION to make oapStrategies work.")
-        return None
-      }
     }
 
     // Filters on this relation fall into four categories based

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
@@ -41,10 +41,11 @@ trait OapStrategies extends Logging {
   def oapStrategies: Seq[Strategy] = {
     // BtreeIndex applicable strategies.
     OapSortLimitStrategy ::
+    OapGroupAggregateStrategy ::
     // BitMapIndex applicable strategies.
     OapSemiJoinStrategy ::
     // No requirement.
-    OapGroupAggregateStrategy :: Nil
+    Nil
   }
 
   /**
@@ -250,13 +251,21 @@ trait OapStrategies extends Logging {
           file @ HadoopFsRelation(_, _, _, _, _ : OapFileFormat, _), _, table)) =>
         val filterAttributes = AttributeSet(ExpressionSet(filters))
         val groupingAttributes = AttributeSet(groupExpressions.map(_.toAttribute))
+        val indexRequirement = filters.map(_ => BTreeIndex())
 
         if (groupingAttributes.size == 1 && filterAttributes == groupingAttributes) {
           val oapOption = new CaseInsensitiveMap(file.options +
             (OapFileFormat.OAP_INDEX_GROUP_BY_OPTION_KEY -> "true"))
 
           createOapFileScanPlan(
-            projectList, filters, relation, file, table, oapOption, filters, Nil) match {
+            projectList,
+            filters,
+            relation,
+            file,
+            table,
+            oapOption,
+            filters,
+            indexRequirement) match {
             case Some(fastScan) => OapAggregationFileScanExec(aggExpressions, projectList, fastScan)
             case _ => PlanLater(child)
           }
@@ -283,8 +292,13 @@ trait OapStrategies extends Logging {
       indexRequirements: Seq[IndexType]): Option[SparkPlan] = {
     // If executor index selection (EIS) is enabled, oapStrategies are disabled.
     val conf = SparkSession.getActiveSession.get.sessionState.conf
-    if (conf.getConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)) {
+    if (!conf.getConf(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES)) {
       return None
+    } else {
+      if (conf.getConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)) {
+        logWarning("Please disable OAP_ENABLE_EXECUTOR_INDEX_SELECTION to make oapStrategies work.")
+        return None
+      }
     }
 
     // Filters on this relation fall into four categories based

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -147,6 +147,13 @@ object OapConf {
       .booleanConf
       .createWithDefault(true)
 
+  val OAP_ENABLE_OPTIMIZATION_STRATEGIES =
+    SQLConfigBuilder("spark.sql.oap.strategies.enabled")
+      .internal()
+      .doc("To indicate if enable/disable oap strategies")
+      .booleanConf
+      .createWithDefault(false)
+
   val OAP_INDEX_FILE_SIZE_MAX_RATIO =
     SQLConfigBuilder("spark.sql.oap.oindex.size.ratio")
       .internal()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -88,7 +88,8 @@ class OapPlannerSuite
   }
 
   override def afterAll(): Unit = {
-    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key, false)
+    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key,
+      OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.defaultValue.get)
     spark.stop()
     super.afterAll()
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -82,7 +82,13 @@ class OapPlannerSuite
     spark.sqlContext.dropTempTable("oap_fix_length_schema_table")
   }
 
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key, "true")
+  }
+
   override def afterAll(): Unit = {
+    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key, "false")
     spark.stop()
     super.afterAll()
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -88,7 +88,8 @@ class OapPlannerSuite
   }
 
   override def afterAll(): Unit = {
-    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key,
+    spark.conf.set(
+      OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key,
       OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.defaultValue.get)
     spark.stop()
     super.afterAll()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -84,11 +84,11 @@ class OapPlannerSuite
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key, "true")
+    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key, true)
   }
 
   override def afterAll(): Unit = {
-    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key, "false")
+    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key, false)
     spark.stop()
     super.afterAll()
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The aggregation optimization in oapStrategies requires
group-ed items, bitmap index does not meet such requirement.
Now, it makes oap aggregation use btree index only.
Also, it uses another dedicated flag to control oap strategy.

Signed-off-by: Wang, Yue A <yue.a.wang@intel.com>

## How was this patch tested?
mvn passed.
