### PR TITLE
Fix issue #615.

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -106,13 +106,14 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
       // rowsReturned = totalCountLoadedSoFar to skip remaining data
       if (idsMap.isEmpty()) {
         rowsReturned = totalCountLoadedSoFar;
+        skipfollowingBatch = !rowIdsIter.hasNext();
       }
       return super.nextBatch() && filterRowsWithIndex();
     }
 
     @Override
     protected void checkEndOfRowGroup() throws IOException {
-      if (rowsReturned != totalCountLoadedSoFar) {
+      if (rowsReturned != totalCountLoadedSoFar || skipfollowingBatch) {
         return;
       }
       // if rowsReturned == totalCountLoadedSoFar

--- a/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
@@ -115,6 +115,12 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
     protected ParquetMetadata footer;
 
     /**
+     * Indicate if all following batches should be skipped, which happens
+     * the current batch finishes all index reading.
+     */
+    protected boolean skipfollowingBatch = false;
+
+    /**
      * VectorizedOapRecordReader Contructor
      * new method
      * @param file
@@ -298,7 +304,7 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
       columnarBatch.setNumRows(num);
       numBatched = num;
       batchIdx = 0;
-      return true;
+      return !skipfollowingBatch;
     }
 
     /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When batches can be skipped, extra checkEndOfRowGroup call can be also skipped.

Signed-off-by: Wang, Yue A <yue.a.wang@intel.com>

## How was this patch tested?
mvn passed.
