### PR TITLE
Fix IndexedVectorizedOapRecordReader initialize logic error #615

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -79,7 +79,7 @@ public class IndexedVectorizedOapRecordReader extends VectorizedOapRecordReader 
       this.rowIdsIter = indexedFooter.getRowIdsList().iterator();
 
       // use indexedFooter read data, need't do filterRowGroups.
-      initialize(footer, configuration, false);
+      initialize(indexedFooter, configuration, false);
       super.initializeInternal();
     }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -73,8 +73,8 @@ abstract class ParquetDataFileSuite extends SparkFunSuite
 
   private def prepareData(): Unit = {
     val dictPageSize = 512
-    val blockSize = 128 * 1024 * 1024
-    val pageSize = 1024 * 1024
+    val blockSize = 128 * 1024
+    val pageSize = 1024
     GroupWriteSupport.setSchema(parquetSchema, configuration)
     val writer = ExampleParquetWriter.builder(new Path(fileName))
       .withCompressionCodec(UNCOMPRESSED)
@@ -292,7 +292,7 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
 
   override def data: Seq[Group] = {
     val factory = new SimpleGroupFactory(parquetSchema)
-    (0 until 5000).map(i => factory.newGroup()
+    (0 until 100000).map(i => factory.newGroup()
       .append("int32_field", i)
       .append("int64_field", 64L)
       .append("boolean_field", true)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -324,7 +324,10 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
     reader.setVectorizedContext(context)
     val requiredIds = Array(0, 1)
-    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 23000)
+    // RowGroup0 => page0: [0, 1, 7, 8, 120, 121, 381, 382]
+    // RowGroup0 => page5: [23000]
+    // RowGroup1 => page0: [26000]
+    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 23000, 26000)
     val iterator = reader.iterator(requiredIds, rowIds)
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -324,7 +324,7 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
     reader.setVectorizedContext(context)
     val requiredIds = Array(0, 1)
-    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382)
+    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 23000)
     val iterator = reader.iterator(requiredIds, rowIds)
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -326,8 +326,8 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
     val requiredIds = Array(0, 1)
     // RowGroup0 => page0: [0, 1, 7, 8, 120, 121, 381, 382]
     // RowGroup0 => page5: [23000]
-    // RowGroup1 => page0: [26000]
-    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 23000, 26000)
+    // RowGroup2 => page0: [50752]
+    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 23000, 50752)
     val iterator = reader.iterator(requiredIds, rowIds)
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
In #592 I extract resuable code of `SpecificOapRecordReaderBase.initialize` then the initialize method of  `IndexedVectorizedOapRecordReader` and `VectorizedOapRecordReader` will call it, `IndexedVectorizedOapRecordReader` should pass indexedFooter which only contains rowgroups we need but I now footer which contains all rowgroups, It will make a mistake result if rowgroups length of footer not eq rowgroups lenght of indexedFooter.
 
## How was this patch tested?
change VectorizedDataSuite to reproduction #615 and no error after this pr changed.