### PR TITLE
Use a class instead of double to represent the statistics analysis result

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache._
 import org.apache.spark.sql.execution.datasources.oap.index.BTreeIndexRecordReader.BTreeFooter
-import org.apache.spark.sql.execution.datasources.oap.statistics.{StaticsAnalysisResult, StatisticsManager}
+import org.apache.spark.sql.execution.datasources.oap.statistics.{StatisticsManager, StatsAnalysisResult}
 
 // we scan the index from the smallest to the largest,
 // this will scan the B+ Tree (index) leaf node.
@@ -48,7 +48,7 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
 
   override protected def analyzeStatistics(
       indexPath: Path,
-      conf: Configuration): StaticsAnalysisResult = {
+      conf: Configuration): StatsAnalysisResult = {
     var reader: BTreeIndexFileReader = null
     var footerCache: FiberCache = null
     try {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -46,7 +46,9 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
     this
   }
 
-  override protected def analyzeStatistics(indexPath: Path, conf: Configuration): Double = {
+  override protected def analyzeStatistics(
+      indexPath: Path,
+      conf: Configuration): StaticsAnalysisResult = {
     var reader: BTreeIndexFileReader = null
     var footerCache: FiberCache = null
     try {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache._
 import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
-import org.apache.spark.sql.execution.datasources.oap.statistics.StatisticsManager
+import org.apache.spark.sql.execution.datasources.oap.statistics.{StaticsAnalysisResult, StatisticsManager}
 import org.apache.spark.sql.execution.datasources.oap.utils.NonNullKeyReader
 import org.apache.spark.util.ShutdownHookManager
 
@@ -102,7 +102,9 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     }
   }
 
-  override protected def analyzeStatistics(indexPath: Path, conf: Configuration): Double = {
+  override protected def analyzeStatistics(
+      indexPath: Path,
+      conf: Configuration): StaticsAnalysisResult = {
     var bmStatsContentCache: WrappedFiberCache = null
     try {
       val fs = indexPath.getFileSystem(conf)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache._
 import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
-import org.apache.spark.sql.execution.datasources.oap.statistics.{StaticsAnalysisResult, StatisticsManager}
+import org.apache.spark.sql.execution.datasources.oap.statistics.{StatisticsManager, StatsAnalysisResult}
 import org.apache.spark.sql.execution.datasources.oap.utils.NonNullKeyReader
 import org.apache.spark.util.ShutdownHookManager
 
@@ -104,7 +104,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
 
   override protected def analyzeStatistics(
       indexPath: Path,
-      conf: Configuration): StaticsAnalysisResult = {
+      conf: Configuration): StatsAnalysisResult = {
     var bmStatsContentCache: WrappedFiberCache = null
     try {
       val fs = indexPath.getFileSystem(conf)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SortDirection, UnsafeRow}
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.io.OapIndexInfo
-import org.apache.spark.sql.execution.datasources.oap.statistics.StaticsAnalysisResult
+import org.apache.spark.sql.execution.datasources.oap.statistics.StatsAnalysisResult
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
@@ -69,19 +69,19 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
 
   def getSchema: StructType = keySchema
 
-  def readBehavior(dataPath: Path, conf: Configuration): StaticsAnalysisResult = {
+  def readBehavior(dataPath: Path, conf: Configuration): StatsAnalysisResult = {
     val indexPath = IndexUtils.indexFileFromDataFile(dataPath, meta.name, meta.time)
     if (!indexPath.getFileSystem(conf).exists(indexPath)) {
       logDebug("No index file exist for data file: " + dataPath)
-      StaticsAnalysisResult.FULL_SCAN
+      StatsAnalysisResult.FULL_SCAN
     } else {
       val start = System.currentTimeMillis()
       val enableOIndex = conf.getBoolean(OapConf.OAP_ENABLE_OINDEX.key,
         OapConf.OAP_ENABLE_OINDEX.defaultValue.get)
-      var behavior: StaticsAnalysisResult = StaticsAnalysisResult.FULL_SCAN
+      var behavior: StatsAnalysisResult = StatsAnalysisResult.FULL_SCAN
       val useIndex = enableOIndex && {
         behavior = readBehavior(indexPath, dataPath, conf)
-        behavior != StaticsAnalysisResult.FULL_SCAN
+        behavior != StatsAnalysisResult.FULL_SCAN
       }
       val end = System.currentTimeMillis()
       logDebug("Index Selection Time (Executor): " + (end - start) + "ms")
@@ -111,7 +111,7 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
   private def readBehavior(
       indexPath: Path,
       dataPath: Path,
-      conf: Configuration): StaticsAnalysisResult = {
+      conf: Configuration): StatsAnalysisResult = {
     if (conf.getBoolean(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key,
       OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.defaultValue.get)) {
       // Index selection is enabled, executor chooses index according to policy.
@@ -126,7 +126,7 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
         conf.getBoolean(OapConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.key,
         OapConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.defaultValue.get)
       if (filePolicyEnable && indexFileSize > dataFileSize * ratio) {
-        return StaticsAnalysisResult.FULL_SCAN
+        return StatsAnalysisResult.FULL_SCAN
       }
 
       val statsPolicyEnable =
@@ -137,12 +137,12 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
       if (statsPolicyEnable) {
         tryAnalyzeStatistics(indexPath, conf)
       } else {
-        StaticsAnalysisResult.USE_INDEX
+        StatsAnalysisResult.USE_INDEX
       }
       // More Policies
     } else {
       // Index selection is disabled, executor always uses index.
-      StaticsAnalysisResult.USE_INDEX
+      StatsAnalysisResult.USE_INDEX
     }
   }
 
@@ -152,18 +152,18 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
    * return -1 means bypass, close to 1 means full scan and close to 0 means by index.
    * called before invoking [[initialize]].
    */
-  private def tryAnalyzeStatistics(indexPath: Path, conf: Configuration): StaticsAnalysisResult = {
+  private def tryAnalyzeStatistics(indexPath: Path, conf: Configuration): StatsAnalysisResult = {
     if (!canBeOptimizedByStatistics) {
-      StaticsAnalysisResult.USE_INDEX
+      StatsAnalysisResult.USE_INDEX
     } else if (intervalArray.isEmpty) {
-      StaticsAnalysisResult.SKIP_INDEX
+      StatsAnalysisResult.SKIP_INDEX
     } else {
       analyzeStatistics(indexPath, conf)
     }
   }
 
-  protected def analyzeStatistics(indexPath: Path, conf: Configuration): StaticsAnalysisResult = {
-    StaticsAnalysisResult.USE_INDEX
+  protected def analyzeStatistics(indexPath: Path, conf: Configuration): StatsAnalysisResult = {
+    StatsAnalysisResult.USE_INDEX
   }
 
   def withKeySchema(schema: StructType): IndexScanner = {
@@ -355,10 +355,10 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
     val scannersAndStatics = scanners
       .map(scanner => (scanner, scanner.readBehavior(dataPath, conf)))
       // _ is (scanner, StaticsAnalysisResult)
-      .filter(_._2 != StaticsAnalysisResult.FULL_SCAN)
+      .filter(_._2 != StatsAnalysisResult.FULL_SCAN)
     scannersAndStatics.length match {
       case 0 => false
-      case _ if scannersAndStatics.exists(_._2 == StaticsAnalysisResult.SKIP_INDEX) =>
+      case _ if scannersAndStatics.exists(_._2 == StatsAnalysisResult.SKIP_INDEX) =>
         actualUsedScanners = Seq.empty
         true
       case _ => actualUsedScanners = scannersAndStatics.map(_._1)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -66,7 +66,7 @@ private[oap] class BloomFilterStatisticsReader(
     readOffset - offset
   }
 
-  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult = {
+  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
 
     val partialSchema = StructType(schema.dropRight(1))
     val partialConverter = UnsafeProjection.create(partialSchema)
@@ -98,9 +98,9 @@ private[oap] class BloomFilterStatisticsReader(
     }
 
     if (skipIndex) {
-      StaticsAnalysisResult.SKIP_INDEX
+      StatsAnalysisResult.SKIP_INDEX
     } else {
-      StaticsAnalysisResult.USE_INDEX
+      StatsAnalysisResult.USE_INDEX
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -66,7 +66,7 @@ private[oap] class BloomFilterStatisticsReader(
     readOffset - offset
   }
 
-  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double = {
+  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult = {
 
     val partialSchema = StructType(schema.dropRight(1))
     val partialConverter = UnsafeProjection.create(partialSchema)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -51,7 +51,7 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
     readOffset - offset
   }
 
-  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double = {
+  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult = {
     if (min == null || max == null) {
       return StaticsAnalysisResult.USE_INDEX
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -51,9 +51,9 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
     readOffset - offset
   }
 
-  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult = {
+  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
     if (min == null || max == null) {
-      return StaticsAnalysisResult.USE_INDEX
+      return StatsAnalysisResult.USE_INDEX
     }
 
     val start = intervalArray.head
@@ -77,9 +77,9 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
       }
 
     if (startOutOfBound || endOutOfBound) {
-      StaticsAnalysisResult.SKIP_INDEX
+      StatsAnalysisResult.SKIP_INDEX
     } else {
-      StaticsAnalysisResult.USE_INDEX
+      StatsAnalysisResult.USE_INDEX
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -108,7 +108,7 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
     getIntervalIdx(end, include, isStart = false)
   }
 
-  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult = {
+  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
     if (metas.nonEmpty) {
       val wholeCount = metas.last.accumulatorCnt
 
@@ -120,7 +120,7 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
 
       if (left == -1 || right == 0) {
         // interval.min > partition.max || interval.max < partition.min
-        StaticsAnalysisResult.SKIP_INDEX
+        StatsAnalysisResult.SKIP_INDEX
       } else {
         var cover: Double =
           if (right != -1) metas(right).accumulatorCnt else metas.last.accumulatorCnt
@@ -135,15 +135,15 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
         }
 
         if (cover > wholeCount) {
-          StaticsAnalysisResult.FULL_SCAN
+          StatsAnalysisResult.FULL_SCAN
         } else if (cover < 0) {
-          StaticsAnalysisResult.USE_INDEX
+          StatsAnalysisResult.USE_INDEX
         } else {
-          StaticsAnalysisResult(cover / wholeCount)
+          StatsAnalysisResult(cover / wholeCount)
         }
       }
     } else {
-      StaticsAnalysisResult.USE_INDEX
+      StatsAnalysisResult.USE_INDEX
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -108,7 +108,7 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
     getIntervalIdx(end, include, isStart = false)
   }
 
-  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double = {
+  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult = {
     if (metas.nonEmpty) {
       val wholeCount = metas.last.accumulatorCnt
 
@@ -139,7 +139,7 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
         } else if (cover < 0) {
           StaticsAnalysisResult.USE_INDEX
         } else {
-          cover / wholeCount
+          StaticsAnalysisResult(cover / wholeCount)
         }
       }
     } else {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -58,9 +58,9 @@ private[oap] class SampleBasedStatisticsReader(
     readOffset - offset
   }
 
-  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult = {
+  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
     if (sampleArray == null || sampleArray.isEmpty) {
-      StaticsAnalysisResult.USE_INDEX
+      StatsAnalysisResult.USE_INDEX
     } else {
       var hitCnt = 0
       val partialOrder = GenerateOrdering.create(StructType(schema.dropRight(1)))
@@ -69,7 +69,7 @@ private[oap] class SampleBasedStatisticsReader(
           hitCnt += 1
         }
       }
-      StaticsAnalysisResult(hitCnt * 1.0 / sampleArray.length)
+      StatsAnalysisResult(hitCnt * 1.0 / sampleArray.length)
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -58,7 +58,7 @@ private[oap] class SampleBasedStatisticsReader(
     readOffset - offset
   }
 
-  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double = {
+  override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult = {
     if (sampleArray == null || sampleArray.isEmpty) {
       StaticsAnalysisResult.USE_INDEX
     } else {
@@ -69,7 +69,7 @@ private[oap] class SampleBasedStatisticsReader(
           hitCnt += 1
         }
       }
-      hitCnt * 1.0 / sampleArray.length
+      StaticsAnalysisResult(hitCnt * 1.0 / sampleArray.length)
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -55,7 +55,7 @@ abstract class StatisticsReader(schema: StructType) {
    * @param intervalArray query intervals from `IndexContext`
    * @return the `StaticsAnalysisResult`
    */
-  def analyse(intervalArray: ArrayBuffer[RangeInterval]): Double =
+  def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult =
     StaticsAnalysisResult.USE_INDEX
 }
 
@@ -141,7 +141,9 @@ object Statistics {
  * coverage form this content.
  */
 object StaticsAnalysisResult {
-  val FULL_SCAN = 1
-  val SKIP_INDEX = -1
-  val USE_INDEX = 0
+  val FULL_SCAN = new StaticsAnalysisResult(1)
+  val SKIP_INDEX = new StaticsAnalysisResult(-1)
+  val USE_INDEX = new StaticsAnalysisResult(0)
 }
+
+case class StaticsAnalysisResult(coverage: Double)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -55,8 +55,8 @@ abstract class StatisticsReader(schema: StructType) {
    * @param intervalArray query intervals from `IndexContext`
    * @return the `StaticsAnalysisResult`
    */
-  def analyse(intervalArray: ArrayBuffer[RangeInterval]): StaticsAnalysisResult =
-    StaticsAnalysisResult.USE_INDEX
+  def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult =
+    StatsAnalysisResult.USE_INDEX
 }
 
 abstract class StatisticsWriter(schema: StructType, conf: Configuration) {
@@ -136,14 +136,14 @@ object Statistics {
 }
 
 /**
- * StaticsAnalysisResult should be one of these following values,
+ * StatsAnalysisResult should be one of these following values,
  * or a double value between 0 and 1, standing for the estimated
  * coverage form this content.
  */
-object StaticsAnalysisResult {
-  val FULL_SCAN = new StaticsAnalysisResult(1)
-  val SKIP_INDEX = new StaticsAnalysisResult(-1)
-  val USE_INDEX = new StaticsAnalysisResult(0)
+object StatsAnalysisResult {
+  val FULL_SCAN = new StatsAnalysisResult(1)
+  val SKIP_INDEX = new StatsAnalysisResult(-1)
+  val USE_INDEX = new StatsAnalysisResult(0)
 }
 
-case class StaticsAnalysisResult(coverage: Double)
+case class StatsAnalysisResult(coverage: Double)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -141,9 +141,9 @@ object Statistics {
  * coverage form this content.
  */
 object StatsAnalysisResult {
-  val FULL_SCAN = new StatsAnalysisResult(1)
-  val SKIP_INDEX = new StatsAnalysisResult(-1)
-  val USE_INDEX = new StatsAnalysisResult(0)
+  val FULL_SCAN = StatsAnalysisResult(1)
+  val SKIP_INDEX = StatsAnalysisResult(-1)
+  val USE_INDEX = StatsAnalysisResult(0)
 }
 
 case class StatsAnalysisResult(coverage: Double)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -136,18 +136,18 @@ object StatisticsManager {
   def analyse(
       stats: Array[StatisticsReader],
       intervalArray: ArrayBuffer[RangeInterval],
-      conf: Configuration): StaticsAnalysisResult = {
+      conf: Configuration): StatsAnalysisResult = {
     val fullScanThreshold = conf.getDouble(
       OapConf.OAP_FULL_SCAN_THRESHOLD.key, OapConf.OAP_FULL_SCAN_THRESHOLD.defaultValue.get)
     val analysisResults = stats.map(_.analyse(intervalArray))
 
-    if (analysisResults.exists(_ == StaticsAnalysisResult.SKIP_INDEX)) {
-      StaticsAnalysisResult.SKIP_INDEX
+    if (analysisResults.exists(_ == StatsAnalysisResult.SKIP_INDEX)) {
+      StatsAnalysisResult.SKIP_INDEX
     } else if (analysisResults.isEmpty ||
       analysisResults.map(_.coverage).sum / analysisResults.length <= fullScanThreshold) {
-      StaticsAnalysisResult.USE_INDEX
+      StatsAnalysisResult.USE_INDEX
     } else {
-      StaticsAnalysisResult.FULL_SCAN
+      StatsAnalysisResult.FULL_SCAN
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -136,34 +136,18 @@ object StatisticsManager {
   def analyse(
       stats: Array[StatisticsReader],
       intervalArray: ArrayBuffer[RangeInterval],
-      conf: Configuration): Double = {
-    var resSum: Double = 0.0
-    var resNum: Int = 0
+      conf: Configuration): StaticsAnalysisResult = {
+    val fullScanThreshold = conf.getDouble(
+      OapConf.OAP_FULL_SCAN_THRESHOLD.key, OapConf.OAP_FULL_SCAN_THRESHOLD.defaultValue.get)
+    val analysisResults = stats.map(_.analyse(intervalArray))
 
-    if (stats.isEmpty) {
-      // use index if no statistics
+    if (analysisResults.exists(_ == StaticsAnalysisResult.SKIP_INDEX)) {
+      StaticsAnalysisResult.SKIP_INDEX
+    } else if (analysisResults.isEmpty ||
+      analysisResults.map(_.coverage).sum / analysisResults.length <= fullScanThreshold) {
       StaticsAnalysisResult.USE_INDEX
     } else {
-      stats.foreach { stat =>
-        val res = stat.analyse(intervalArray)
-
-        if (res == StaticsAnalysisResult.SKIP_INDEX) {
-          resSum = StaticsAnalysisResult.SKIP_INDEX
-        } else {
-          resSum += res
-          resNum += 1
-        }
-      }
-
-      val fullScanConf = OapConf.OAP_FULL_SCAN_THRESHOLD
-      if (resSum == StaticsAnalysisResult.SKIP_INDEX) {
-        StaticsAnalysisResult.SKIP_INDEX
-      } else if (resNum == 0 || resSum / resNum <= conf.getDouble(
-        fullScanConf.key, fullScanConf.defaultValue.get)) {
-        StaticsAnalysisResult.USE_INDEX
-      } else {
-        StaticsAnalysisResult.FULL_SCAN
-      }
+      StaticsAnalysisResult.FULL_SCAN
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
@@ -180,10 +180,10 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
 
     for (i <- 1 until 300) {
       generateInterval(rowGen(i), rowGen(i), true, true)
-      assert(bloomFilterRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+      assert(bloomFilterRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
     }
 
     generateInterval(rowGen(10), rowGen(20), true, true)
-    assert(bloomFilterRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(bloomFilterRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatisticsSuite.scala
@@ -134,54 +134,54 @@ class MinMaxStatisticsSuite extends StatisticsTest {
     minmaxRead.read(fiber, 0)
 
     generateInterval(rowGen(-10), rowGen(-1), startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.SKIP_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.SKIP_INDEX)
 
     generateInterval(rowGen(301), rowGen(400), startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.SKIP_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.SKIP_INDEX)
 
     generateInterval(rowGen(300), rowGen(400), startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(30), rowGen(40), startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(-10), rowGen(1), startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(IndexScanner.DUMMY_KEY_START, IndexScanner.DUMMY_KEY_END,
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(IndexScanner.DUMMY_KEY_START, rowGen(1),
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(IndexScanner.DUMMY_KEY_START, rowGen(0),
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.SKIP_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.SKIP_INDEX)
 
     generateInterval(IndexScanner.DUMMY_KEY_START, rowGen(300),
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(0), IndexScanner.DUMMY_KEY_END,
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(1), IndexScanner.DUMMY_KEY_END,
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(150), IndexScanner.DUMMY_KEY_END,
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(300), IndexScanner.DUMMY_KEY_END,
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(301), IndexScanner.DUMMY_KEY_END,
       startInclude = true, endInclude = true)
-    assert(minmaxRead.analyse(intervalArray) == StaticsAnalysisResult.SKIP_INDEX)
+    assert(minmaxRead.analyse(intervalArray) == StatsAnalysisResult.SKIP_INDEX)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
@@ -151,19 +151,19 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     partByValueRead.read(fiber, 0)
 
     generateInterval(dummyStart, dummyEnd, true, true)
-    assert(partByValueRead.analyse(intervalArray) == 1.0)
+    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
 
     generateInterval(rowGen(1), rowGen(301), true, true)
-    assert(partByValueRead.analyse(intervalArray) == 1.0)
+    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
 
     generateInterval(rowGen(10), rowGen(70), true, true)
-    assert(partByValueRead.analyse(intervalArray) == 0.4)
+    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult(0.4))
 
     generateInterval(rowGen(10), rowGen(190), true, true)
-    assert(partByValueRead.analyse(intervalArray) == 0.8)
+    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult(0.8))
 
     generateInterval(rowGen(-10), rowGen(10), true, true)
-    assert(partByValueRead.analyse(intervalArray) == 31.0 / 300)
+    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult(31.0 / 300))
 
     generateInterval(rowGen(-10), rowGen(0), true, true)
     assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult.SKIP_INDEX)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
@@ -151,27 +151,27 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     partByValueRead.read(fiber, 0)
 
     generateInterval(dummyStart, dummyEnd, true, true)
-    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
+    assert(partByValueRead.analyse(intervalArray) == StatsAnalysisResult.FULL_SCAN)
 
     generateInterval(rowGen(1), rowGen(301), true, true)
-    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
+    assert(partByValueRead.analyse(intervalArray) == StatsAnalysisResult.FULL_SCAN)
 
     generateInterval(rowGen(10), rowGen(70), true, true)
-    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult(0.4))
+    assert(partByValueRead.analyse(intervalArray) == StatsAnalysisResult(0.4))
 
     generateInterval(rowGen(10), rowGen(190), true, true)
-    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult(0.8))
+    assert(partByValueRead.analyse(intervalArray) == StatsAnalysisResult(0.8))
 
     generateInterval(rowGen(-10), rowGen(10), true, true)
-    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult(31.0 / 300))
+    assert(partByValueRead.analyse(intervalArray) == StatsAnalysisResult(31.0 / 300))
 
     generateInterval(rowGen(-10), rowGen(0), true, true)
-    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult.SKIP_INDEX)
+    assert(partByValueRead.analyse(intervalArray) == StatsAnalysisResult.SKIP_INDEX)
 
     generateInterval(rowGen(310), rowGen(400), true, true)
-    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult.SKIP_INDEX)
+    assert(partByValueRead.analyse(intervalArray) == StatsAnalysisResult.SKIP_INDEX)
 
     generateInterval(rowGen(-10), rowGen(0), true, true)
-    assert(partByValueRead.analyse(intervalArray) == StaticsAnalysisResult.SKIP_INDEX)
+    assert(partByValueRead.analyse(intervalArray) == StatsAnalysisResult.SKIP_INDEX)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatisticsSuite.scala
@@ -123,37 +123,37 @@ class SampleBasedStatisticsSuite extends StatisticsTest {
     sampleRead.read(fiber, 0)
 
     generateInterval(rowGen(-10), rowGen(-1), startInclude = true, endInclude = true)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(301), rowGen(400), startInclude = true, endInclude = true)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(dummyStart, dummyEnd,
       startInclude = true, endInclude = true)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.FULL_SCAN)
 
     generateInterval(dummyStart, rowGen(0),
       startInclude = true, endInclude = false)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(dummyStart, rowGen(300),
       startInclude = true, endInclude = true)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.FULL_SCAN)
 
     generateInterval(rowGen(0), dummyEnd,
       startInclude = true, endInclude = true)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.FULL_SCAN)
 
     generateInterval(rowGen(1), dummyEnd,
       startInclude = true, endInclude = true)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.FULL_SCAN)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.FULL_SCAN)
 
     generateInterval(rowGen(300), dummyEnd,
       startInclude = false, endInclude = true)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
 
     generateInterval(rowGen(301), dummyEnd,
       startInclude = true, endInclude = true)
-    assert(sampleRead.analyse(intervalArray) == StaticsAnalysisResult.USE_INDEX)
+    assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsSuite.scala
@@ -76,7 +76,7 @@ class StatisticsSuite extends StatisticsTest with BeforeAndAfterAll {
     assert(readBytes == 4)
 
     val analyzeResult = test.analyse(new ArrayBuffer[RangeInterval]())
-    assert(analyzeResult == StaticsAnalysisResult.USE_INDEX)
+    assert(analyzeResult == StatsAnalysisResult.USE_INDEX)
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Wrap the double value in case class StatsAnalysisResult
2. When analyzing the statistics result, if any result is SKIP_INDEX, we return SKIP_INDEX.
3. Rename StaticsAnalysisResult to StatsAnalysisResult because statics has another meaning, we may either use statistics or stats.


## How was this patch tested?
Existing tests.