### PR TITLE
fix multiple scala version warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,7 @@
           </executions>
           <configuration>
             <scalaVersion>${scala.version}</scalaVersion>
+            <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
             <recompileMode>incremental</recompileMode>
             <useZincServer>true</useZincServer>
             <args>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #587 by using `scalaCompatVersion`.
https://groups.google.com/forum/#!topic/maven-and-scala/XSkXrSS8WuU

## How was this patch tested?

manual test.

cc @LuciferYang 