### PR TITLE
Micro benchmarks for two bitmap index equal query cases

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -20,7 +20,8 @@ import java.io.DataInput
 import java.io.EOFException
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.Breaks._
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
@@ -153,7 +154,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
     MemoryManager.putToIndexFiberCache(fin, bmUniqueKeyListOffset, bmUniqueKeyListTotalSize)
   }
 
-  private def readBmUniqueKeyListFromCache(data: FiberCache): IndexedSeq[InternalRow] = {
+  private def readBmUniqueKeyListFromCache(data: FiberCache): Seq[InternalRow] = {
     var curOffset = 0
     (0 until bmUniqueKeyListCount).map( idx => {
       val (value, length) =
@@ -253,7 +254,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   }
 
   private def getBitmapIdx(
-      keySeq: IndexedSeq[InternalRow],
+      keySeq: Seq[InternalRow],
       range: RangeInterval): (Int, Int) = {
     val keyLength = keySeq.length
     val startIdx = if (range.start == IndexScanner.DUMMY_KEY_START) {
@@ -303,7 +304,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
       byteCache: FiberCache,
       position: Int,
       startIdx: Int,
-      endIdx: Int): IndexedSeq[RoaringBitmap] = {
+      endIdx: Int): Seq[RoaringBitmap] = {
     if (byteCache.size() != 0) {
       val bmStream = new BitmapDataInputStream(byteCache)
       bmStream.skipBytes(position)
@@ -314,11 +315,11 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
         bmEntry
       })
     } else {
-      IndexedSeq.empty
+      Seq.empty
     }
   }
 
-  private def getDesiredBitmapArray: mutable.ArrayBuffer[RoaringBitmap] = {
+  private def getDesiredBitmapArray: ArrayBuffer[RoaringBitmap] = {
     val keySeq = readBmUniqueKeyListFromCache(bmUniqueKeyListCache.fc)
     intervalArray.flatMap{
       case range if !range.isNullPredicate =>
@@ -507,4 +508,354 @@ private[oap] class BitmapDataInputStream(bitsStream: FiberCache) extends DataInp
    throw new UnsupportedOperationException("Bitmap doesn't need this." +
      "It' inlegal to use it in bitmap!!!")
  }
+}
+
+private[oap] object OapBitmapFastAggregation {
+
+  // Just get array of the chunks across multi fiber caches in acending order of key.
+  def or(wfcSeq: Seq[OapBitmapWrappedFiberCache]): ArrayBuffer[OapBitmapChunkInFiberCache] = {
+    val firstWfc = wfcSeq(0)
+    firstWfc.init
+    val initialChunkLength = firstWfc.getTotalChunkLength
+    val finalChunkArray = new ArrayBuffer[OapBitmapChunkInFiberCache]()
+    var initialIdx = 0
+    var nextIdx = 0
+    (0 until initialChunkLength).map(idx => {
+      finalChunkArray += OapBitmapChunkInFiberCache(firstWfc, idx)
+    })
+    (1 until wfcSeq.length).foreach(idx => {
+      initialIdx = 0
+      var initialKey = finalChunkArray(initialIdx).getChunkKey
+      val nextWfc = wfcSeq(idx)
+      nextWfc.init
+      nextIdx = 0
+      val nextChunkLength = nextWfc.getTotalChunkLength
+      val nextChunkKeys = nextWfc.getChunkKeys
+      var nextKey = nextChunkKeys(nextIdx)
+      breakable {
+        while (true) {
+          val result = initialKey - nextKey
+          result match {
+            case res if res < 0 =>
+              initialIdx += 1
+              if (initialIdx == finalChunkArray.length) break
+              initialKey = finalChunkArray(initialIdx).getChunkKey
+            case res if res == 0 =>
+              // Just link the next chunk to be adjacent for traversing.
+              finalChunkArray.insert(initialIdx, OapBitmapChunkInFiberCache(nextWfc, nextIdx))
+              // Bypass the two adjacent chunks with equal keys.
+              initialIdx += 2
+              nextIdx += 1
+              if (initialIdx == finalChunkArray.length || nextIdx == nextChunkLength) break
+              initialKey = finalChunkArray(initialIdx).getChunkKey
+              nextKey = nextChunkKeys(nextIdx)
+            case res if res > 0 =>
+              // Insert the next chunk with nextIdx from the next fiber cache.
+              finalChunkArray.insert(initialIdx, OapBitmapChunkInFiberCache(nextWfc, nextIdx))
+              initialIdx += 1
+              nextIdx += 1
+              if (nextIdx == nextChunkLength) break
+              nextKey = nextChunkKeys(nextIdx)
+          }
+        }
+      }
+      if (initialIdx == finalChunkArray.length && nextIdx < nextChunkLength) {
+        // Append the remaining chunks from the above next fiber cache.
+        (nextIdx until nextChunkLength).foreach(idx =>
+          finalChunkArray += OapBitmapChunkInFiberCache(nextWfc, idx))
+      }
+    })
+    finalChunkArray
+  }
+}
+
+private[oap] class OapBitmapWrappedFiberCache(
+    fc: FiberCache) extends WrappedFiberCache(fc) {
+
+  // Below initializaton is compatible with Roaring Bitmap.
+  // The spec link is https://github.com/RoaringBitmap/RoaringFormatSpec/
+  private val SERIAL_COOKIE: Int = 12347
+  private val SERIAL_COOKIE_NO_RUNCONTAINER: Int = 12346
+  private val NO_OFFSET_THRESHOLD: Int = 4
+  private val DEFAULT_MAX_SIZE: Int = 4096
+  private val BITMAP_MAX_CAPACITY: Int = 1 << 16
+
+  private var chunkLength: Int = 0
+  // It indicates no this section.
+  private var chunkOffsetListOffset: Int = -1
+
+  private var curOffset: Int = 0
+
+  // No run chunks by default.
+  private var hasRun: Boolean = false
+  private var bitmapOfRunChunks: Array[Byte] = _
+
+  private var chunkKeys: Array[Short] = _
+  private var chunkCardinalities: Array[Short] = _
+
+  // The reading byte order is little endian to keep consistent with roaring bitmap writing order.
+  def getInt(): Int = {
+    val curPos = curOffset
+    curOffset += 4
+    ((fc.getByte(curPos + 3) & 0xFF) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFF) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)
+  }
+
+  // Read from the specific offset.
+  def getIntNoMoving(offset: Int): Int = {
+    val curPos = offset
+    ((fc.getByte(curPos + 3) & 0xFF) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFF) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)
+  }
+
+  def getShort(): Short = {
+    val curPos = curOffset
+    curOffset += 2
+    (((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)).toShort
+  }
+
+  def getLong(): Long = {
+    val curPos = curOffset
+    curOffset += 8
+    ((fc.getByte(curPos + 7) & 0xFFL) << 56) |
+      ((fc.getByte(curPos + 6) & 0xFFL) << 48) |
+      ((fc.getByte(curPos + 5) & 0xFFL) << 40) |
+      ((fc.getByte(curPos + 4) & 0xFFL) << 32) |
+      ((fc.getByte(curPos + 3) & 0xFFL) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFFL) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFFL) << 8) |
+      (fc.getByte(curPos) & 0xFFL)
+  }
+
+  def getBytes(length: Int): Array[Byte] = {
+    val byteBuffer = fc.getBytes(curOffset, length)
+    curOffset += length
+    byteBuffer
+  }
+
+  def getTotalChunkLength(): Int = chunkLength
+
+  def getChunkKeys(): Array[Short] = chunkKeys
+
+  def getChunkCardinality(idx: Int): Short = chunkCardinalities(idx)
+
+  def getBitmapCapacity(): Int = BITMAP_MAX_CAPACITY
+
+  private def getChunkSize(chunkIdx: Int): Int = {
+    // NO run chunks in this case.
+    chunkIdx match {
+      case idx if (isArrayChunk(idx)) =>
+        (chunkCardinalities(idx) & 0xFFFF) * 2
+      case idx if (isBitmapChunk(idx)) =>
+        BITMAP_MAX_CAPACITY / 8
+      case _ =>
+        throw new OapException("It's illegal to get chunk size.")
+    }
+  }
+
+  // It's used to traverse multi-chunks across multi-fiber caches in bitwise OR case.
+  def setOffset(chunkIdx: Int): Unit = {
+    if (chunkOffsetListOffset < 0) {
+      var accumulOffset = 0
+      (0 until chunkIdx).foreach(idx =>
+        accumulOffset += getChunkSize(idx))
+      curOffset += accumulOffset
+    } else {
+      curOffset = getIntNoMoving(chunkOffsetListOffset + chunkIdx * 4)
+    }
+  }
+
+  def init(): Unit = {
+    val cookie = getInt
+    cookie match {
+      case ck if ((ck & 0xFFFF) == SERIAL_COOKIE) =>
+        chunkLength = (cookie >>> 16) + 1
+        hasRun = true
+      case ck if (ck == SERIAL_COOKIE_NO_RUNCONTAINER) =>
+        chunkLength = getInt
+      case _ =>
+        throw new OapException("It's invalid roaring bitmap header in OAP bitmap index file.")
+    }
+    if (hasRun) {
+      val size = (chunkLength + 7) / 8
+      bitmapOfRunChunks = getBytes(size)
+    }
+    chunkKeys = new Array[Short](chunkLength)
+    chunkCardinalities = new Array[Short](chunkLength)
+    (0 until chunkLength).foreach(idx => {
+      chunkKeys(idx) = getShort
+      chunkCardinalities(idx) = (1 + (0xFFFF & getShort)).toShort
+    })
+    if (!hasRun || chunkLength >= NO_OFFSET_THRESHOLD) {
+      chunkOffsetListOffset = curOffset
+      curOffset += chunkLength * 4
+    }
+  }
+
+  def isRunChunk(idx: Int): Boolean = {
+    if (hasRun && (bitmapOfRunChunks(idx / 8) & (1 << (idx % 8))).toInt != 0) true else false
+  }
+
+  def isArrayChunk(idx: Int): Boolean = {
+    // The logic in getIteratorForChunk excludes the run chunk first.
+    (chunkCardinalities(idx) & 0xFFFF) <= DEFAULT_MAX_SIZE
+  }
+
+  def isBitmapChunk(idx: Int): Boolean = {
+    // The logic in getIteratorForChunk excludes the run and array chunks first.
+    (chunkCardinalities(idx) & 0xFFFF) > DEFAULT_MAX_SIZE
+  }
+
+  def getIteratorForChunk(chunkIdx: Int): Iterator[Int] = {
+    chunkIdx match {
+      case idx if (isRunChunk(idx)) =>
+        return RunChunkIterator(this)
+      case idx if (isArrayChunk(idx)) =>
+        return ArrayChunkIterator(this, idx)
+      case idx if (isBitmapChunk(idx)) =>
+        return BitmapChunkIterator(this)
+      case _ =>
+        throw new OapException("It's illegal chunk in bitmap index fiber caches.\n")
+    }
+  }
+}
+
+private[oap] case class OapBitmapChunkInFiberCache(
+    wfc: OapBitmapWrappedFiberCache, chunkIdx: Int) {
+  def getChunkKey(): Short = {
+    val cks = wfc.getChunkKeys
+    cks(chunkIdx)
+  }
+}
+
+// The chunks are physically consecutive, so it doesn't require to set chunk offset.
+private[oap] case class ChunksInSingleFiberCacheIterator(
+    wfc: OapBitmapWrappedFiberCache)
+  extends ChunksIterator {
+
+  override def init(): Iterator[Int] = {
+    totalLength = wfc.getTotalChunkLength
+    if (idx < totalLength) {
+      iteratorForChunk = wfc.getIteratorForChunk(idx)
+      val cks = wfc.getChunkKeys
+      highPart = (cks(idx) & 0xFFFF) << 16
+    }
+    return this
+  }
+}
+
+// The chunks are not physically consecutive, so it requires to set chunk offset.
+private[oap] case class ChunksInMultiFiberCachesIterator(
+    chunksInFc: ArrayBuffer[OapBitmapChunkInFiberCache])
+  extends ChunksIterator {
+
+  override def init(): Iterator[Int] = {
+    totalLength = chunksInFc.length
+    if (idx < totalLength) {
+      val wfc = chunksInFc(idx).wfc
+      val chunkIdx = chunksInFc(idx).chunkIdx
+      wfc.setOffset(chunkIdx)
+      iteratorForChunk = wfc.getIteratorForChunk(chunkIdx)
+      highPart = (chunksInFc(idx).getChunkKey & 0xFFFF) << 16
+    }
+    return this
+  }
+}
+
+private[oap] abstract class ChunksIterator extends Iterator[Int] {
+
+  protected var idx: Int = 0
+  protected var totalLength: Int = 0
+  protected var highPart: Int = 0
+  protected var iteratorForChunk: Iterator[Int] = _
+
+  def init(): Iterator[Int]
+
+  override def hasNext: Boolean = idx < totalLength
+
+  override def next(): Int = {
+    val value = iteratorForChunk.next | highPart
+    if (!iteratorForChunk.hasNext) {
+      idx += 1
+      init
+    }
+    value
+  }
+}
+
+private[oap] case class RunChunkIterator(
+    wfc: OapBitmapWrappedFiberCache)
+  extends Iterator[Int] {
+
+  private var totalRuns: Int = wfc.getShort & 0xFFFF
+  private var runBase: Int = wfc.getShort & 0xFFFF
+  private var maxCurRunLength: Int = wfc.getShort & 0xFFFF
+  private var runIdx: Int = 0
+  private var runLength: Int = 0
+
+  override def hasNext: Boolean = runIdx < totalRuns
+
+  override def next(): Int = {
+    val value = runBase + runLength
+    runLength += 1
+    if (runLength > maxCurRunLength) {
+      runLength = 0
+      runIdx += 1
+      if (runIdx < totalRuns) {
+        runBase = wfc.getShort & 0xFFFF
+        maxCurRunLength = wfc.getShort & 0xFFFF
+      }
+    }
+    value
+  }
+}
+
+// Chunk index is used to get the cardinality for array chunk.
+private[oap] case class ArrayChunkIterator(
+    wfc: OapBitmapWrappedFiberCache, chunkIdx: Int)
+  extends Iterator[Int] {
+
+  private val totalCountInChunk: Int = wfc.getChunkCardinality(chunkIdx) & 0xFFFF
+  private var idxInChunk: Int = 0
+
+  override def hasNext: Boolean = idxInChunk < totalCountInChunk
+
+  override def next(): Int = {
+    idxInChunk += 1
+    wfc.getShort & 0xFFFF
+  }
+}
+
+private[oap] case class BitmapChunkIterator(
+    wfc: OapBitmapWrappedFiberCache)
+  extends Iterator[Int] {
+
+  private val wordLength: Int = wfc.getBitmapCapacity / 64
+  private var wordIdx: Int = -1
+  private var curWord: Long = 0L
+  do {
+    curWord = wfc.getLong
+    wordIdx += 1
+  } while (curWord == 0L && wordIdx < wordLength)
+
+  override def hasNext: Boolean = wordIdx < wordLength
+
+  override def next(): Int = {
+    val tmp = curWord & -curWord
+    val value = wordIdx * 64 + java.lang.Long.bitCount(tmp - 1)
+    curWord ^= tmp
+    breakable {
+      while (curWord == 0L) {
+        wordIdx += 1
+        if (wordIdx == wordLength) break
+        curWord = wfc.getLong
+      }
+    }
+    value
+  }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -160,6 +160,8 @@ private[oap] class BitmapIndexRecordWriter(
       dos.close()
       bos.close()
     })
+    // Add another offset in order to easily get the offset for the last entry.
+    bmOffsetListBuffer.append(bmEntryListOffset + totalBitmapSize)
     bmEntryListTotalSize = totalBitmapSize
 
     // Write entry for null value rows if exists


### PR DESCRIPTION
## What changes were proposed in this pull request?

This micro benchmarks are to test the functionality and performance
of directly traversing the row IDs in fiber caches of bitmap index file.

The first case is to just traverse the row IDs in one single fiber caches.
The second case is to traverse the row IDs across multi fiber caches

## How was this patch tested?
mvn clean test package and all the test passed.