### PR TITLE
Bitmap utils to directly traverse row IDs in fiber caches

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -160,6 +160,8 @@ private[oap] class BitmapIndexRecordWriter(
       dos.close()
       bos.close()
     })
+    // Add another offset in order to easily get the offset for the last entry.
+    bmOffsetListBuffer.append(bmEntryListOffset + totalBitmapSize)
     bmEntryListTotalSize = totalBitmapSize
 
     // Write entry for null value rows if exists

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtils.scala
@@ -20,7 +20,11 @@ package org.apache.spark.sql.execution.datasources.oap.utils
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.Breaks._
 
-// The chunks are physically consecutive, so it doesn't require to set chunk offset.
+/* The chunks inside of one single fiber cache are physically consecutive,
+ * so it doesn't require to set chunk offset. This class is to directly get
+ * the row ID list recorded in all of the chunks of this single fiber cache
+ * in ascending order.
+ */
 private[oap] case class ChunksInSingleFiberCacheIterator(wfc: OapBitmapWrappedFiberCache)
   extends ChunksIterator {
 
@@ -35,7 +39,10 @@ private[oap] case class ChunksInSingleFiberCacheIterator(wfc: OapBitmapWrappedFi
   }
 }
 
-// The chunks are not physically consecutive, so it requires to set chunk offset.
+/* The chunks inside of different multi fiber cache are not physically consecutive, so it
+ * requires to set chunk offset for different fibers. This class is to directly get the row ID
+ * list recorded in all of the chunks in all of multi fiber caches in ascending order.
+ */
 private[oap] case class ChunksInMultiFiberCachesIterator(
     chunksInFc: ArrayBuffer[OapBitmapChunkInFiberCache])
   extends ChunksIterator {
@@ -53,8 +60,9 @@ private[oap] case class ChunksInMultiFiberCachesIterator(
   }
 }
 
-// This will virtually link all the chunks in multi fiber caches in ascending order of chunk key.
-// It will provide the input for the above ChunksInMultiFiberCachesIterator class.
+/* This method will virtually link all the chunks in multi fiber caches in ascending
+ * order of chunk key. It will provide the input for the above ChunksInMultiFiberCachesIterator.
+ */
 private[oap] object BitmapUtils {
 
   // Just get array of the chunks across multi fiber caches in acending order of key.

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtils.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.utils
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.Breaks._
+
+// The chunks are physically consecutive, so it doesn't require to set chunk offset.
+private[oap] case class ChunksInSingleFiberCacheIterator(wfc: OapBitmapWrappedFiberCache)
+  extends ChunksIterator {
+
+  override def init(): Iterator[Int] = {
+    totalLength = wfc.getTotalChunkLength
+    if (idx < totalLength) {
+      iteratorForChunk = wfc.getIteratorForChunk(idx)
+      val cks = wfc.getChunkKeys
+      highPart = (cks(idx) & 0xFFFF) << 16
+    }
+    return this
+  }
+}
+
+// The chunks are not physically consecutive, so it requires to set chunk offset.
+private[oap] case class ChunksInMultiFiberCachesIterator(
+    chunksInFc: ArrayBuffer[OapBitmapChunkInFiberCache])
+  extends ChunksIterator {
+
+  override def init(): Iterator[Int] = {
+    totalLength = chunksInFc.length
+    if (idx < totalLength) {
+      val wfc = chunksInFc(idx).wfc
+      val chunkIdx = chunksInFc(idx).chunkIdx
+      wfc.setOffset(chunkIdx)
+      iteratorForChunk = wfc.getIteratorForChunk(chunkIdx)
+      highPart = (chunksInFc(idx).getChunkKey & 0xFFFF) << 16
+    }
+    return this
+  }
+}
+
+private[oap] object OapBitmapFastAggregation {
+
+  // Just get array of the chunks across multi fiber caches in acending order of key.
+  def or(wfcSeq: Seq[OapBitmapWrappedFiberCache]): ArrayBuffer[OapBitmapChunkInFiberCache] = {
+    val firstWfc = wfcSeq(0)
+    firstWfc.init
+    val initialChunkLength = firstWfc.getTotalChunkLength
+    val finalChunkArray = new ArrayBuffer[OapBitmapChunkInFiberCache]()
+    var initialIdx = 0
+    var nextIdx = 0
+    (0 until initialChunkLength).map(idx => {
+      finalChunkArray += OapBitmapChunkInFiberCache(firstWfc, idx)
+    })
+    (1 until wfcSeq.length).foreach(idx => {
+      initialIdx = 0
+      var initialKey = finalChunkArray(initialIdx).getChunkKey
+      val nextWfc = wfcSeq(idx)
+      nextWfc.init
+      nextIdx = 0
+      val nextChunkLength = nextWfc.getTotalChunkLength
+      val nextChunkKeys = nextWfc.getChunkKeys
+      var nextKey = nextChunkKeys(nextIdx)
+      breakable {
+        while (true) {
+          val result = initialKey - nextKey
+          result match {
+            case res if res < 0 =>
+              initialIdx += 1
+              if (initialIdx == finalChunkArray.length) break
+              initialKey = finalChunkArray(initialIdx).getChunkKey
+            case res if res == 0 =>
+              // Just link the next chunk to be adjacent for traversing.
+              finalChunkArray.insert(initialIdx, OapBitmapChunkInFiberCache(nextWfc, nextIdx))
+              // Bypass the two adjacent chunks with equal keys.
+              initialIdx += 2
+              nextIdx += 1
+              if (initialIdx == finalChunkArray.length || nextIdx == nextChunkLength) break
+              initialKey = finalChunkArray(initialIdx).getChunkKey
+              nextKey = nextChunkKeys(nextIdx)
+            case res if res > 0 =>
+              // Insert the next chunk with nextIdx from the next fiber cache.
+              finalChunkArray.insert(initialIdx, OapBitmapChunkInFiberCache(nextWfc, nextIdx))
+              initialIdx += 1
+              nextIdx += 1
+              if (nextIdx == nextChunkLength) break
+              nextKey = nextChunkKeys(nextIdx)
+          }
+        }
+      }
+      if (initialIdx == finalChunkArray.length && nextIdx < nextChunkLength) {
+        // Append the remaining chunks from the above next fiber cache.
+        (nextIdx until nextChunkLength).foreach(idx =>
+          finalChunkArray += OapBitmapChunkInFiberCache(nextWfc, idx))
+      }
+    })
+    finalChunkArray
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtils.scala
@@ -60,12 +60,18 @@ private[oap] case class ChunksInMultiFiberCachesIterator(
   }
 }
 
-/* This method will virtually link all the chunks in multi fiber caches in ascending
- * order of chunk key. It will provide the input for the above ChunksInMultiFiberCachesIterator.
- */
 private[oap] object BitmapUtils {
 
-  // Just get array of the chunks across multi fiber caches in acending order of key.
+  // Below constants are used by OapBitmapWrappedFiberCache class.
+  val SERIAL_COOKIE: Int = 12347
+  val SERIAL_COOKIE_NO_RUNCONTAINER: Int = 12346
+  val NO_OFFSET_THRESHOLD: Int = 4
+  val DEFAULT_MAX_SIZE: Int = 4096
+  val BITMAP_MAX_CAPACITY: Int = 1 << 16
+
+  /* Below method will virtually link all the chunks in multi fiber caches in ascending order
+   * of chunk key. It will provide the input for the above ChunksInMultiFiberCachesIterator.
+   */
   def or(wfcSeq: Seq[OapBitmapWrappedFiberCache]): ArrayBuffer[OapBitmapChunkInFiberCache] = {
     val firstWfc = wfcSeq(0)
     firstWfc.init
@@ -108,7 +114,7 @@ private[oap] object BitmapUtils {
               nextIdx += 1
               if (nextIdx == nextChunkLength) break
               nextKey = nextChunkKeys(nextIdx)
-          }
+            }
         }
       }
       if (initialIdx == finalChunkArray.length && nextIdx < nextChunkLength) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCache.scala
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.utils
+
+import scala.util.control.Breaks._
+
+import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, WrappedFiberCache}
+
+// Oap Bitmap Scanner will use below class to directly traverse the row IDs
+// in fiber caches while keeping compatible with Roaring Bitmap format.
+// It doesn't need to create the roaring bitmap object on heap any more.
+// The spec link is https://github.com/RoaringBitmap/RoaringFormatSpec/
+private[oap] class OapBitmapWrappedFiberCache(fc: FiberCache) extends WrappedFiberCache(fc) {
+
+  private val SERIAL_COOKIE: Int = 12347
+  private val SERIAL_COOKIE_NO_RUNCONTAINER: Int = 12346
+  private val NO_OFFSET_THRESHOLD: Int = 4
+  private val DEFAULT_MAX_SIZE: Int = 4096
+  private val BITMAP_MAX_CAPACITY: Int = 1 << 16
+
+  private var chunkLength: Int = 0
+  // It indicates no this section.
+  private var chunkOffsetListOffset: Int = -1
+
+  private var curOffset: Int = 0
+
+  // No run chunks by default.
+  private var hasRun: Boolean = false
+  private var bitmapOfRunChunks: Array[Byte] = _
+
+  private var chunkKeys: Array[Short] = _
+  private var chunkCardinalities: Array[Short] = _
+
+  // The reading byte order is little endian to keep consistent with roaring bitmap writing order.
+  // Read from the specific offset.
+  private def getIntNoMoving(offset: Int): Int = {
+    val curPos = offset
+    ((fc.getByte(curPos + 3) & 0xFF) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFF) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)
+  }
+
+  private def getChunkSize(chunkIdx: Int): Int = {
+    // NO run chunks in this case.
+    chunkIdx match {
+      case idx if (isArrayChunk(idx)) =>
+        (chunkCardinalities(idx) & 0xFFFF) * 2
+      case idx if (isBitmapChunk(idx)) =>
+        BITMAP_MAX_CAPACITY / 8
+      case _ =>
+        throw new OapException("It's illegal to get chunk size.")
+    }
+  }
+
+  private def getBytes(length: Int): Array[Byte] = {
+    val byteBuffer = fc.getBytes(curOffset, length)
+    curOffset += length
+    byteBuffer
+  }
+
+  private def isRunChunk(idx: Int): Boolean = {
+    if (hasRun && (bitmapOfRunChunks(idx / 8) & (1 << (idx % 8))).toInt != 0) true else false
+  }
+
+  private def isArrayChunk(idx: Int): Boolean = {
+    // The logic in getIteratorForChunk excludes the run chunk first.
+    (chunkCardinalities(idx) & 0xFFFF) <= DEFAULT_MAX_SIZE
+  }
+
+  private def isBitmapChunk(idx: Int): Boolean = {
+    // The logic in getIteratorForChunk excludes the run and array chunks first.
+    (chunkCardinalities(idx) & 0xFFFF) > DEFAULT_MAX_SIZE
+  }
+
+  private def getInt(): Int = {
+    val curPos = curOffset
+    curOffset += 4
+    ((fc.getByte(curPos + 3) & 0xFF) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFF) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)
+  }
+
+  def getShort(): Short = {
+    val curPos = curOffset
+    curOffset += 2
+    (((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)).toShort
+  }
+
+  def getLong(): Long = {
+    val curPos = curOffset
+    curOffset += 8
+    ((fc.getByte(curPos + 7) & 0xFFL) << 56) |
+      ((fc.getByte(curPos + 6) & 0xFFL) << 48) |
+      ((fc.getByte(curPos + 5) & 0xFFL) << 40) |
+      ((fc.getByte(curPos + 4) & 0xFFL) << 32) |
+      ((fc.getByte(curPos + 3) & 0xFFL) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFFL) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFFL) << 8) |
+      (fc.getByte(curPos) & 0xFFL)
+  }
+
+  def getTotalChunkLength(): Int = chunkLength
+
+  def getChunkKeys(): Array[Short] = chunkKeys
+
+  def getChunkCardinality(idx: Int): Short = chunkCardinalities(idx)
+
+  def getBitmapCapacity(): Int = BITMAP_MAX_CAPACITY
+
+  // It's used to traverse multi-chunks across multi-fiber caches in bitwise OR case.
+  def setOffset(chunkIdx: Int): Unit = {
+    if (chunkOffsetListOffset < 0) {
+      var accumulOffset = 0
+      (0 until chunkIdx).foreach(idx =>
+        accumulOffset += getChunkSize(idx))
+      curOffset += accumulOffset
+    } else {
+      curOffset = getIntNoMoving(chunkOffsetListOffset + chunkIdx * 4)
+    }
+  }
+
+  def getIteratorForChunk(chunkIdx: Int): Iterator[Int] = {
+    chunkIdx match {
+      case idx if (isRunChunk(idx)) =>
+        return RunChunkIterator(this)
+      case idx if (isArrayChunk(idx)) =>
+        return ArrayChunkIterator(this, idx)
+      case idx if (isBitmapChunk(idx)) =>
+        return BitmapChunkIterator(this)
+      case _ =>
+        throw new OapException("It's illegal chunk in bitmap index fiber caches.\n")
+    }
+  }
+
+  def init(): Unit = {
+    val cookie = getInt
+    cookie match {
+      case ck if ((ck & 0xFFFF) == SERIAL_COOKIE) =>
+        chunkLength = (cookie >>> 16) + 1
+        hasRun = true
+      case ck if (ck == SERIAL_COOKIE_NO_RUNCONTAINER) =>
+        chunkLength = getInt
+      case _ =>
+        throw new OapException("It's invalid roaring bitmap header in OAP bitmap index file.")
+    }
+    if (hasRun) {
+      val size = (chunkLength + 7) / 8
+      bitmapOfRunChunks = getBytes(size)
+    }
+    chunkKeys = new Array[Short](chunkLength)
+    chunkCardinalities = new Array[Short](chunkLength)
+    (0 until chunkLength).foreach(idx => {
+      chunkKeys(idx) = getShort
+      chunkCardinalities(idx) = (1 + (0xFFFF & getShort)).toShort
+    })
+    if (!hasRun || chunkLength >= NO_OFFSET_THRESHOLD) {
+      chunkOffsetListOffset = curOffset
+      curOffset += chunkLength * 4
+    }
+  }
+}
+
+private[oap] case class OapBitmapChunkInFiberCache(wfc: OapBitmapWrappedFiberCache, chunkIdx: Int) {
+  def getChunkKey(): Short = {
+    val cks = wfc.getChunkKeys
+    cks(chunkIdx)
+  }
+}
+
+private[oap] abstract class ChunksIterator extends Iterator[Int] {
+
+  protected var idx: Int = 0
+  protected var totalLength: Int = 0
+  protected var highPart: Int = 0
+  protected var iteratorForChunk: Iterator[Int] = _
+
+  def init(): Iterator[Int]
+
+  override def hasNext: Boolean = idx < totalLength
+
+  override def next(): Int = {
+    val value = iteratorForChunk.next | highPart
+    if (!iteratorForChunk.hasNext) {
+      idx += 1
+      init
+    }
+    value
+  }
+}
+
+private[oap] case class RunChunkIterator(wfc: OapBitmapWrappedFiberCache) extends Iterator[Int] {
+
+  private var totalRuns: Int = wfc.getShort & 0xFFFF
+  private var runBase: Int = wfc.getShort & 0xFFFF
+  private var maxCurRunLength: Int = wfc.getShort & 0xFFFF
+  private var runIdx: Int = 0
+  private var runLength: Int = 0
+
+  override def hasNext: Boolean = runIdx < totalRuns
+
+  override def next(): Int = {
+    val value = runBase + runLength
+    runLength += 1
+    if (runLength > maxCurRunLength) {
+      runLength = 0
+      runIdx += 1
+      if (runIdx < totalRuns) {
+        runBase = wfc.getShort & 0xFFFF
+        maxCurRunLength = wfc.getShort & 0xFFFF
+      }
+    }
+    value
+  }
+}
+
+// Chunk index is used to get the cardinality for array chunk.
+private[oap] case class ArrayChunkIterator(wfc: OapBitmapWrappedFiberCache, chunkIdx: Int)
+  extends Iterator[Int] {
+
+  private val totalCountInChunk: Int = wfc.getChunkCardinality(chunkIdx) & 0xFFFF
+  private var idxInChunk: Int = 0
+
+  override def hasNext: Boolean = idxInChunk < totalCountInChunk
+
+  override def next(): Int = {
+    idxInChunk += 1
+    wfc.getShort & 0xFFFF
+  }
+}
+
+private[oap] case class BitmapChunkIterator(wfc: OapBitmapWrappedFiberCache) extends Iterator[Int] {
+
+  private val wordLength: Int = wfc.getBitmapCapacity / 64
+  private var wordIdx: Int = -1
+  private var curWord: Long = 0L
+  do {
+    curWord = wfc.getLong
+    wordIdx += 1
+  } while (curWord == 0L && wordIdx < wordLength)
+
+  override def hasNext: Boolean = wordIdx < wordLength
+
+  override def next(): Int = {
+    val tmp = curWord & -curWord
+    val value = wordIdx * 64 + java.lang.Long.bitCount(tmp - 1)
+    curWord ^= tmp
+    breakable {
+      while (curWord == 0L) {
+        wordIdx += 1
+        if (wordIdx == wordLength) break
+        curWord = wfc.getLong
+      }
+    }
+    value
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtilsSuite.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.utils
+
+import java.io.File
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FSDataInputStream, Path}
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.execution.datasources.oap.filecache.{BitmapFiber, MemoryManager, FiberCache, FiberCacheManager, WrappedFiberCache}
+import org.apache.spark.sql.execution.datasources.oap.index.{BitmapIndexSectionId, IndexUtils}
+import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
+import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.util.Utils
+
+// Below data are used to test the functionality of directly getting
+// row IDs from fiber caches without roarting bitmap involved.
+class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
+
+  import testImplicits._
+  private val BITMAP_FOOTER_SIZE = 6 * 8
+  private var dir: File = _
+  private val dataForRunChunk: Seq[(Int, String)] =
+    (1 to 20000).map{i => (i / 100, s"this is test $i")}
+  private val dataForArrayChunk: Seq[(Int, String)] =
+    (1 to 20000).map{i => (i, s"this is test $i")}
+  private val dataForBitmapChunk: Seq[(Int, String)] =
+    (1 to 20000).map{i => (i % 2, s"this is test $i")}
+  private val dataCombination =
+    dataForBitmapChunk ++ dataForArrayChunk ++ dataForRunChunk
+  private val dataArray =
+    Array(dataForRunChunk, dataForArrayChunk, dataForBitmapChunk, dataCombination)
+
+  override def beforeEach(): Unit = {
+    dir = Utils.createTempDir()
+    val path = dir.getAbsolutePath
+    sql(s"""CREATE TEMPORARY VIEW oap_test (a INT, b STRING)
+            | USING oap
+            | OPTIONS (path '$path')""".stripMargin)
+  }
+
+  override def afterEach(): Unit = {
+    sqlContext.dropTempTable("oap_test")
+    dir.delete()
+  }
+
+  // Below are just borrowed from BitMapScanner.scala in order to easily load bitmap index files.
+  private def loadBmFooter(
+      fin: FSDataInputStream,
+      bmFooterOffset: Int): FiberCache =
+    MemoryManager.putToIndexFiberCache(fin, bmFooterOffset, BITMAP_FOOTER_SIZE)
+
+  private def loadBmEntry(
+      fin: FSDataInputStream,
+      offset: Int,
+      size: Int): FiberCache =
+    MemoryManager.putToIndexFiberCache(fin, offset, size)
+
+  private def loadBmOffsetList(
+      fin: FSDataInputStream,
+      bmOffsetListOffset: Int,
+      bmOffsetListTotalSize: Int): FiberCache =
+    MemoryManager.putToIndexFiberCache(fin, bmOffsetListOffset, bmOffsetListTotalSize)
+
+  private def getIdxOffset(
+      fiberCache: FiberCache,
+      baseOffset: Long,
+      idx: Int): Int = {
+    val idxOffset = baseOffset + idx * 4
+    fiberCache.getInt(idxOffset)
+  }
+
+  private def getMetaDataAndFiberCaches(
+      fin: FSDataInputStream,
+      idxPath: Path,
+      conf: Configuration): (Int, WrappedFiberCache, WrappedFiberCache) = {
+    val idxFileSize = idxPath.getFileSystem(conf).getFileStatus(idxPath).getLen
+    val bmFooterOffset = idxFileSize.toInt - BITMAP_FOOTER_SIZE
+    val bmFooterFiber = BitmapFiber(
+      () => loadBmFooter(fin, bmFooterOffset),
+      idxPath.toString, BitmapIndexSectionId.footerSection, 0)
+    val bmFooterCache = WrappedFiberCache(FiberCacheManager.get(bmFooterFiber, conf))
+    val bmUniqueKeyListTotalSize = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE)
+    val keyCount = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE * 2)
+    val bmEntryListTotalSize = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE * 3)
+    val bmOffsetListTotalSize = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE * 4)
+    val bmNullEntrySize = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE * 6)
+    val bmUniqueKeyListOffset = IndexFile.VERSION_LENGTH
+    val bmEntryListOffset = bmUniqueKeyListOffset + bmUniqueKeyListTotalSize
+    val bmOffsetListOffset = bmEntryListOffset + bmEntryListTotalSize + bmNullEntrySize
+    val bmOffsetListFiber = BitmapFiber(
+      () => loadBmOffsetList(fin, bmOffsetListOffset, bmOffsetListTotalSize),
+      idxPath.toString, BitmapIndexSectionId.entryOffsetsSection, 0)
+    val bmOffsetListCache = WrappedFiberCache(FiberCacheManager.get(bmOffsetListFiber, conf))
+    (keyCount, bmOffsetListCache, bmFooterCache)
+  }
+
+  test("test the functionality of directly traversing single fiber cache without roaring bitmap") {
+    dataArray.foreach(dataIdx => {
+      dataIdx.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index_bm on oap_test (a) USING BITMAP")
+      dir.listFiles.foreach(fileName => {
+        if (fileName.toString.endsWith(OapFileFormat.OAP_INDEX_EXTENSION)) {
+          val idxPath = new Path(fileName.toString)
+          val conf = new Configuration()
+          val fin = idxPath.getFileSystem(conf).open(idxPath)
+          val (keyCount, bmOffsetListCache, bmFooterCache) =
+            getMetaDataAndFiberCaches(fin, idxPath, conf)
+          var maxRowIdInPartition = 0
+          (0 until keyCount).map( idx => {
+            val curIdxOffset = getIdxOffset(bmOffsetListCache.fc, 0L, idx)
+            val entrySize = getIdxOffset(bmOffsetListCache.fc, 0L, idx + 1) - curIdxOffset
+            val entryFiber = BitmapFiber(
+              () => loadBmEntry(fin, curIdxOffset, entrySize), idxPath.toString,
+            BitmapIndexSectionId.entryListSection, idx)
+            val wfc = new OapBitmapWrappedFiberCache(FiberCacheManager.get(entryFiber, conf))
+            wfc.init
+            val rowIdIterator = ChunksInSingleFiberCacheIterator(wfc).init
+            // The row id is starting from 0.
+            val rowIdSeq = Seq(0 to rowIdIterator.max)
+            rowIdIterator.foreach(rowId => assert(rowIdSeq.contains(rowId) == true))
+            wfc.release
+          })
+          bmFooterCache.release
+          bmOffsetListCache.release
+          fin.close
+        }
+      })
+      sql("drop oindex index_bm on oap_test")
+    })
+  }
+
+  test("test the functionality of directly bitwise OR case for multi fiber caches") {
+    dataArray.foreach(dataIdx => {
+      dataIdx.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index_bm on oap_test (a) USING BITMAP")
+      dir.listFiles.foreach(fileName => {
+        if (fileName.toString.endsWith(OapFileFormat.OAP_INDEX_EXTENSION)) {
+          val idxPath = new Path(fileName.toString)
+          val conf = new Configuration()
+          val fin = idxPath.getFileSystem(conf).open(idxPath)
+          val (keyCount, bmOffsetListCache, bmFooterCache) =
+            getMetaDataAndFiberCaches(fin, idxPath, conf)
+          val wfcSeq = (0 until keyCount).map(idx => {
+            val curIdxOffset = getIdxOffset(bmOffsetListCache.fc, 0L, idx)
+            val entrySize = getIdxOffset(bmOffsetListCache.fc, 0L, idx + 1) - curIdxOffset
+            val entryFiber = BitmapFiber(
+              () => loadBmEntry(fin, curIdxOffset, entrySize), idxPath.toString,
+              BitmapIndexSectionId.entryListSection, idx)
+            new OapBitmapWrappedFiberCache(FiberCacheManager.get(entryFiber, conf))
+          })
+          val chunkList = OapBitmapFastAggregation.or(wfcSeq)
+          var rowIdIterator = ChunksInMultiFiberCachesIterator(chunkList).init
+          // The row id is starting from 0.
+          val rowIdSeq = Seq(0 to rowIdIterator.max)
+          rowIdIterator.foreach(rowId => assert(rowIdSeq.contains(rowId) == true))
+          wfcSeq.foreach(wfc => wfc.release)
+          bmFooterCache.release
+          bmOffsetListCache.release
+          fin.close
+        }
+      })
+      sql("drop oindex index_bm on oap_test")
+    })
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtilsSuite.scala
@@ -32,29 +32,46 @@ import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.util.Utils
 
-// Below data are used to test the functionality of directly getting
-// row IDs from fiber caches without roarting bitmap involved.
 class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
 
   import testImplicits._
   private val BITMAP_FOOTER_SIZE = 6 * 8
   private var dir: File = _
+
+// Below data are used to test the functionality of directly getting
+// row IDs from fiber caches with roarting bitmap bypassed.
   private val dataForRunChunk: Seq[(Int, String)] =
     (1 to 20000).map{i => (i / 100, s"this is test $i")}
   private val dataForArrayChunk: Seq[(Int, String)] =
     (1 to 20000).map{i => (i, s"this is test $i")}
   private val dataForBitmapChunk: Seq[(Int, String)] =
     (1 to 20000).map{i => (i % 2, s"this is test $i")}
-  private val dataCombination =
+  private val expectedRowIdSeq = (0 until 20000).toSeq
+  private val expectedRowIdSeqCombinationTotal = (0 until 60000).toSeq
+  // Below data can be used to further validate the functionality of BitmapUtils class.
+  // Unfortunately, the tasks are killed on github due to more time consumption after
+  // adding the following test cases although all of them passed locally.
+/*
+  private val expectedRowIdSeqCombination = (0 until 40000).toSeq
+  private val dataCombination1 =
+    dataForBitmapChunk ++ dataForArrayChunk
+  private val dataCombination2 =
+    dataForBitmapChunk ++ dataForRunChunk
+  private val dataCombination3 =
+    dataForArrayChunk ++ dataForRunChunk
+  private val dataSourceArray =
+    Array((dataForRunChunk, expectedRowIdSeq), (dataForArrayChunk, expectedRowIdSeq),
+      (dataForBitmapChunk, expectedRowIdSeq), (dataCombination1, expectedRowIdSeqCombination),
+      (dataCombination2, expectedRowIdSeqCombination),
+      (dataCombination3, expectedRowIdSeqCombination),
+      (dataCombinationTotal, expectedRowIdSeqCombinationTotal))
+*/
+  private val dataCombinationTotal =
     dataForBitmapChunk ++ dataForArrayChunk ++ dataForRunChunk
-  private val dataArray =
-    Array(dataForRunChunk, dataForArrayChunk, dataForBitmapChunk, dataCombination)
-
-  private val seqForRunChunk = (1 to 9).toSeq
-  private val seqForArrayChunk = Seq(11, 13, 15, 17, 19)
-  private val seqForBitmapChunk = (20 to 10000).filter(_ % 2 == 1)
-  private val seqCombination =
-    seqForBitmapChunk ++ seqForArrayChunk ++ seqForRunChunk
+  private val dataSourceArray =
+    Array((dataForRunChunk, expectedRowIdSeq), (dataForArrayChunk, expectedRowIdSeq),
+      (dataForBitmapChunk, expectedRowIdSeq),
+      (dataCombinationTotal, expectedRowIdSeqCombinationTotal))
 
   override def beforeEach(): Unit = {
     dir = Utils.createTempDir()
@@ -69,75 +86,8 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
     dir.delete()
   }
 
-  test("test ChunksInSingleFiberCacheIterator to get the expected row IDs") {
-    val seqArray =
-      Array(seqForRunChunk, seqForArrayChunk, seqForBitmapChunk, seqCombination)
-    seqArray.foreach(seqIdx => {
-      val subDir = Utils.createTempDir()
-      val rb = new RoaringBitmap()
-      seqIdx.foreach(rb.add)
-      val rbFile = subDir.getAbsolutePath + "rb.bin"
-      rb.runOptimize()
-      val rbFos = new FileOutputStream(rbFile)
-      val rbBos = new ByteArrayOutputStream()
-      val rbDos = new DataOutputStream(rbBos)
-      rb.serialize(rbDos)
-      rbBos.writeTo(rbFos)
-      rbBos.close()
-      rbDos.close()
-      rbFos.close()
-      val rbPath = new Path(rbFile)
-      val conf = new Configuration()
-      val fin = rbPath.getFileSystem(conf).open(rbPath)
-      val fileSize = rbPath.getFileSystem(conf).getFileStatus(rbPath).getLen
-      val rbFiber = BitmapFiber(() => loadBmSection(fin, 0, fileSize.toInt), rbPath.toString, 0, 0)
-      val wrappedFiberCache = new OapBitmapWrappedFiberCache(FiberCacheManager.get(rbFiber, conf))
-      wrappedFiberCache.init
-      var actualRowIdSeq = Seq.empty[Int]
-      ChunksInSingleFiberCacheIterator(wrappedFiberCache).init.foreach(rowId =>
-        actualRowIdSeq :+= rowId)
-      actualRowIdSeq.foreach(rowId => assert(seqIdx.contains(rowId) == true))
-      seqIdx.foreach(rowId => assert(actualRowIdSeq.contains(rowId) == true))
-      wrappedFiberCache.release
-      fin.close
-      subDir.delete
-    })
-  }
-
-  test("test ChunksInMultiFiberCachesIterator to get the expected row IDs") {
-    val seqArray =
-      Array(seqForRunChunk, seqForArrayChunk, seqForBitmapChunk)
-    val wrapperFiberCacheSeq = seqArray.map(seqIdx => {
-      val rb = new RoaringBitmap()
-      seqIdx.foreach(rb.add)
-      val rbFile = dir.getAbsolutePath + seqIdx.head.toString
-      rb.runOptimize()
-      val rbFos = new FileOutputStream(rbFile)
-      val rbBos = new ByteArrayOutputStream()
-      val rbDos = new DataOutputStream(rbBos)
-      rb.serialize(rbDos)
-      rbBos.writeTo(rbFos)
-      rbBos.close()
-      rbDos.close()
-      rbFos.close()
-      val rbPath = new Path(rbFile)
-      val conf = new Configuration()
-      val fin = rbPath.getFileSystem(conf).open(rbPath)
-      val rbFileSize = rbPath.getFileSystem(conf).getFileStatus(rbPath).getLen
-      val rbFiber = BitmapFiber(() => loadBmSection(fin, 0, rbFileSize.toInt), rbPath.toString, 0, 0)
-      fin.close
-      new OapBitmapWrappedFiberCache(FiberCacheManager.get(rbFiber, conf))
-    })
-    var actualRowIdSeq = Seq.empty[Int]
-    val chunkList = BitmapUtils.or(wrapperFiberCacheSeq)
-    ChunksInMultiFiberCachesIterator(chunkList).init.foreach(rowId => actualRowIdSeq :+= rowId)
-    actualRowIdSeq.foreach(rowId => assert(seqCombination.contains(rowId) == true))
-    seqCombination.foreach(rowId => assert(actualRowIdSeq.contains(rowId) == true))
-    wrapperFiberCacheSeq.foreach(wfc => wfc.release)
-  }
-
-  private def loadBmSection(fin: FSDataInputStream, offset: Int, size: Int): FiberCache =
-    MemoryManager.putToIndexFiberCache(fin, offset, size)
+  private def loadBmSection(fin: FSDataInputStream, offset: Long, size: Int): FiberCache =
+    MemoryManager.toIndexFiberCache(fin, offset, size)
 
   private def getIdxOffset(fiberCache: FiberCache, baseOffset: Long, idx: Int): Int = {
     val idxOffset = baseOffset + idx * 4
@@ -149,7 +99,7 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
       idxPath: Path,
       conf: Configuration): (Int, WrappedFiberCache, WrappedFiberCache) = {
     val idxFileSize = idxPath.getFileSystem(conf).getFileStatus(idxPath).getLen
-    val footerOffset = idxFileSize.toInt - BITMAP_FOOTER_SIZE
+    val footerOffset = idxFileSize - BITMAP_FOOTER_SIZE
     val footerFiber = BitmapFiber(
       () => loadBmSection(fin, footerOffset, BITMAP_FOOTER_SIZE),
       idxPath.toString, BitmapIndexSectionId.footerSection, 0)
@@ -162,20 +112,17 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
     val entryListOffset = IndexFile.VERSION_LENGTH + uniqueKeyListTotalSize
     val offsetListOffset = entryListOffset + entryListTotalSize + nullEntrySize
     val offsetListFiber = BitmapFiber(
-      () => loadBmSection(fin, offsetListOffset, offsetListTotalSize),
+      () => loadBmSection(fin, offsetListOffset.toLong, offsetListTotalSize),
       idxPath.toString, BitmapIndexSectionId.entryOffsetsSection, 0)
     val offsetListCache = WrappedFiberCache(FiberCacheManager.get(offsetListFiber, conf))
     (keyCount, offsetListCache, footerCache)
   }
 
   test("test how to directly get the row ID list from single fiber cache without roaring bitmap") {
-    dataArray.foreach(dataIdx => {
-      dataIdx.toDF("key", "value").createOrReplaceTempView("t")
+    dataSourceArray.foreach(dataSourceElement => {
+      dataSourceElement._1.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table oap_test select * from t")
       sql("create oindex index_bm on oap_test (a) USING BITMAP")
-      // For dataCombination, the total rows is 3 * 20000 = 60000.
-      val expectedRowIdSeq = if (dataIdx != dataCombination) (0 until 20000).toSeq
-        else (0 until 60000).toSeq
       var actualRowIdSeq = Seq.empty[Int]
       var accumulatorRowId = 0
       dir.listFiles.foreach(fileName => {
@@ -190,14 +137,13 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
             val curIdxOffset = getIdxOffset(offsetListCache.fc, 0L, idx)
             val entrySize = getIdxOffset(offsetListCache.fc, 0L, idx + 1) - curIdxOffset
             val entryFiber = BitmapFiber(
-              () => loadBmSection(fin, curIdxOffset, entrySize), idxPath.toString,
+              () => loadBmSection(fin, curIdxOffset.toLong, entrySize), idxPath.toString,
             BitmapIndexSectionId.entryListSection, idx)
             val wrappedFiberCache =
               new OapBitmapWrappedFiberCache(FiberCacheManager.get(entryFiber, conf))
             wrappedFiberCache.init
             ChunksInSingleFiberCacheIterator(wrappedFiberCache).init.foreach(rowId => {
-              val realRowId = rowId + accumulatorRowId
-              actualRowIdSeq :+= realRowId
+              actualRowIdSeq :+= rowId + accumulatorRowId
               if (maxRowIdInPartition < rowId) maxRowIdInPartition = rowId
             })
             wrappedFiberCache.release
@@ -209,22 +155,17 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
           fin.close
         }
       })
-      // It's not appropriate to use Set to just match if they are equal, because it can't avoid
-      // the possibility that the actual row ID seq may contain some repeated same elements.
-      actualRowIdSeq.foreach(rowId => assert(expectedRowIdSeq.contains(rowId) == true))
-      expectedRowIdSeq.foreach(rowId => assert(actualRowIdSeq.contains(rowId) == true))
+      actualRowIdSeq.foreach(rowId => assert(dataSourceElement._2.contains(rowId)))
+      dataSourceElement._2.foreach(rowId => assert(actualRowIdSeq.contains(rowId)))
       sql("drop oindex index_bm on oap_test")
     })
   }
 
   test("test how to directly get the row Id list after bitwise OR among multi fiber caches") {
-    dataArray.foreach(dataIdx => {
-      dataIdx.toDF("key", "value").createOrReplaceTempView("t")
+    dataSourceArray.foreach(dataSourceElement => {
+      dataSourceElement._1.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table oap_test select * from t")
       sql("create oindex index_bm on oap_test (a) USING BITMAP")
-      // For dataCombination, the total rows is 3 * 20000 = 60000.
-      val expectedRowIdSeq = if (dataIdx != dataCombination) (0 until 20000).toSeq
-        else (0 until 60000).toSeq
       var actualRowIdSeq = Seq.empty[Int]
       var accumulatorRowId = 0
       dir.listFiles.foreach(fileName => {
@@ -239,14 +180,13 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
             val curIdxOffset = getIdxOffset(offsetListCache.fc, 0L, idx)
             val entrySize = getIdxOffset(offsetListCache.fc, 0L, idx + 1) - curIdxOffset
             val entryFiber = BitmapFiber(
-              () => loadBmSection(fin, curIdxOffset, entrySize), idxPath.toString,
+              () => loadBmSection(fin, curIdxOffset.toLong, entrySize), idxPath.toString,
               BitmapIndexSectionId.entryListSection, idx)
             new OapBitmapWrappedFiberCache(FiberCacheManager.get(entryFiber, conf))
           })
           val chunkList = BitmapUtils.or(wrappedFiberCacheSeq)
           ChunksInMultiFiberCachesIterator(chunkList).init.foreach(rowId => {
-              val realRowId = rowId + accumulatorRowId
-              actualRowIdSeq :+= realRowId
+              actualRowIdSeq :+= rowId + accumulatorRowId
               if (maxRowIdInPartition < rowId) maxRowIdInPartition = rowId
           })
           accumulatorRowId += maxRowIdInPartition + 1
@@ -256,8 +196,8 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
           fin.close
         }
       })
-      actualRowIdSeq.foreach(rowId => assert(expectedRowIdSeq.contains(rowId) == true))
-      expectedRowIdSeq.foreach(rowId => assert(actualRowIdSeq.contains(rowId) == true))
+      actualRowIdSeq.foreach(rowId => assert(dataSourceElement._2.contains(rowId)))
+      dataSourceElement._2.foreach(rowId => assert(actualRowIdSeq.contains(rowId)))
       sql("drop oindex index_bm on oap_test")
     })
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.utils
+
+import java.io.{ByteArrayOutputStream, DataOutputStream, File, FileOutputStream}
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FSDataInputStream, Path}
+import org.roaringbitmap.RoaringBitmap
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.filecache.{BitmapFiber, MemoryManager, FiberCache, FiberCacheManager}
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.util.Utils
+
+// Below are used to test the functionality of OapBitmapWrappedFiberCache class.
+class OapBitmapWrappedFiberCacheSuite
+  extends QueryTest with SharedOapContext with BeforeAndAfterEach {
+
+  import testImplicits._
+  private var dir: File = _
+  private var path: String = _
+
+  override def beforeEach(): Unit = {
+    dir = Utils.createTempDir()
+    path = dir.getAbsolutePath
+    sql(s"""CREATE TEMPORARY VIEW oap_test (a INT, b STRING)
+            | USING oap
+            | OPTIONS (path '$path')""".stripMargin)
+  }
+
+  override def afterEach(): Unit = {
+    sqlContext.dropTempTable("oap_test")
+    dir.delete()
+  }
+
+  private def loadRbFile(fin: FSDataInputStream, offset: Int, size: Int): FiberCache =
+    MemoryManager.putToIndexFiberCache(fin, offset, size)
+
+  test("test the functionality of OapBitmapWrappedFiberCache") {
+    val CHUNK_SIZE = 1 << 16
+    val dataForRunChunk = (1 to 9).toSeq
+    val dataForArrayChunk = Seq(1, 3, 5, 7, 9)
+    val dataForBitmapChunk = (1 to 10000).filter(_ % 2 == 1)
+    val dataCombination =
+      dataForBitmapChunk ++ dataForArrayChunk ++ dataForRunChunk
+    val dataArray =
+      Array(dataForRunChunk, dataForArrayChunk, dataForBitmapChunk, dataCombination)
+    dataArray.foreach(dataIdx => {
+      val rb = new RoaringBitmap()
+      dataIdx.foreach(rb.add)
+      val rbFile = path + "rb.bin"
+      rb.runOptimize()
+      val rbFos = new FileOutputStream(rbFile)
+      val rbBos = new ByteArrayOutputStream()
+      val rbDos = new DataOutputStream(rbBos)
+      rb.serialize(rbDos)
+      rbBos.writeTo(rbFos)
+      rbBos.close()
+      rbDos.close()
+      rbFos.close()
+      val rbPath = new Path(rbFile.toString)
+      val conf = new Configuration()
+      val fin = rbPath.getFileSystem(conf).open(rbPath)
+      val rbFileSize = rbPath.getFileSystem(conf).getFileStatus(rbPath).getLen
+      val rbFiber = BitmapFiber(() => loadRbFile(fin, 0, rbFileSize.toInt), rbPath.toString, 0, 0)
+      val rbWfc = new OapBitmapWrappedFiberCache(FiberCacheManager.get(rbFiber, conf))
+      rbWfc.init
+      val chunkLength = rbWfc.getTotalChunkLength
+      val length = dataIdx.size / CHUNK_SIZE
+      assert(chunkLength == (length + 1))
+      val chunkKeys = rbWfc.getChunkKeys
+      assert(chunkKeys(0).toInt == 0)
+      rbWfc.setOffset(0)
+      val chunk = rbWfc.getIteratorForChunk(0)
+      chunk match {
+        case RunChunkIterator(rbWfc) => assert(chunk == RunChunkIterator(rbWfc))
+        case ArrayChunkIterator(rbWfc, 0) => assert(chunk == ArrayChunkIterator(rbWfc, 0))
+        case BitmapChunkIterator(rbWfc) => assert(chunk == BitmapChunkIterator(rbWfc))
+        case _ => throw new OapException("unexpected chunk in OapBitmapWrappedFiberCache.")
+      }
+      rbWfc.release
+    })
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
@@ -33,10 +33,10 @@ import org.apache.spark.util.Utils
 class OapBitmapWrappedFiberCacheSuite
   extends QueryTest with SharedOapContext {
 
-  private def loadRbFile(fin: FSDataInputStream, offset: Int, size: Int): FiberCache =
-    MemoryManager.putToIndexFiberCache(fin, offset, size)
+  private def loadRbFile(fin: FSDataInputStream, offset: Long, size: Int): FiberCache =
+    MemoryManager.toIndexFiberCache(fin, offset, size)
 
-  test("test the public methods of OapBitmapWrappedFiberCache class") {
+  test("test the functionality of OapBitmapWrappedFiberCache class") {
     val CHUNK_SIZE = 1 << 16
     val dataForRunChunk = (1 to 9).toSeq
     val dataForArrayChunk = Seq(1, 3, 5, 7, 9)
@@ -63,7 +63,7 @@ class OapBitmapWrappedFiberCacheSuite
       val conf = new Configuration()
       val fin = rbPath.getFileSystem(conf).open(rbPath)
       val rbFileSize = rbPath.getFileSystem(conf).getFileStatus(rbPath).getLen
-      val rbFiber = BitmapFiber(() => loadRbFile(fin, 0, rbFileSize.toInt), rbPath.toString, 0, 0)
+      val rbFiber = BitmapFiber(() => loadRbFile(fin, 0L, rbFileSize.toInt), rbPath.toString, 0, 0)
       val rbWfc = new OapBitmapWrappedFiberCache(FiberCacheManager.get(rbFiber, conf))
       rbWfc.init
       val chunkLength = rbWfc.getTotalChunkLength


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch provides the lightweight functionality to directly
traverse the row IDs in fiber caches which are compatible with
the roaring bitmap format.
It doens't need to create roaring bitmap object on heap.

Meanwhile this patch provides two test cases to test the functionality
of traversing the row IDs in single fiber cache or multi fiber caches
for two typical equal query cases with bitmap index.
One is single equal value case. The other is multi equal value case.

1. select * from t where a = apple
2. select * from t where a in {"apple", "banana", ...}

## How was this patch tested?
mvn clean test package and all tests passed locally
