### PR TITLE
Bitmap index micro benchmarks for equal query cases

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -160,6 +160,8 @@ private[oap] class BitmapIndexRecordWriter(
       dos.close()
       bos.close()
     })
+    // Add another offset in order to easily get the offset for the last entry.
+    bmOffsetListBuffer.append(bmEntryListOffset + totalBitmapSize)
     bmEntryListTotalSize = totalBitmapSize
 
     // Write entry for null value rows if exists

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapBitmapWrappedFiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/OapBitmapWrappedFiberCache.scala
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.index
+
+import scala.util.control.Breaks._
+
+import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, WrappedFiberCache}
+
+// Oap Bitmap Scanner will use below class to directly traverse the row IDs
+// in fiber caches while keeping compatible with Roaring Bitmap format.
+// It doesn't need to create the roaring bitmap object on heap any more.
+// The spec link is https://github.com/RoaringBitmap/RoaringFormatSpec/
+private[oap] class OapBitmapWrappedFiberCache(
+    fc: FiberCache) extends WrappedFiberCache(fc) {
+
+  private val SERIAL_COOKIE: Int = 12347
+  private val SERIAL_COOKIE_NO_RUNCONTAINER: Int = 12346
+  private val NO_OFFSET_THRESHOLD: Int = 4
+  private val DEFAULT_MAX_SIZE: Int = 4096
+  private val BITMAP_MAX_CAPACITY: Int = 1 << 16
+
+  private var chunkLength: Int = 0
+  // It indicates no this section.
+  private var chunkOffsetListOffset: Int = -1
+
+  private var curOffset: Int = 0
+
+  // No run chunks by default.
+  private var hasRun: Boolean = false
+  private var bitmapOfRunChunks: Array[Byte] = _
+
+  private var chunkKeys: Array[Short] = _
+  private var chunkCardinalities: Array[Short] = _
+
+  // The reading byte order is little endian to keep consistent with roaring bitmap writing order.
+  // Read from the specific offset.
+  private def getIntNoMoving(offset: Int): Int = {
+    val curPos = offset
+    ((fc.getByte(curPos + 3) & 0xFF) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFF) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)
+  }
+
+  private def getChunkSize(chunkIdx: Int): Int = {
+    // NO run chunks in this case.
+    chunkIdx match {
+      case idx if (isArrayChunk(idx)) =>
+        (chunkCardinalities(idx) & 0xFFFF) * 2
+      case idx if (isBitmapChunk(idx)) =>
+        BITMAP_MAX_CAPACITY / 8
+      case _ =>
+        throw new OapException("It's illegal to get chunk size.")
+    }
+  }
+
+  private def getBytes(length: Int): Array[Byte] = {
+    val byteBuffer = fc.getBytes(curOffset, length)
+    curOffset += length
+    byteBuffer
+  }
+
+  private def isRunChunk(idx: Int): Boolean = {
+    if (hasRun && (bitmapOfRunChunks(idx / 8) & (1 << (idx % 8))).toInt != 0) true else false
+  }
+
+  private def isArrayChunk(idx: Int): Boolean = {
+    // The logic in getIteratorForChunk excludes the run chunk first.
+    (chunkCardinalities(idx) & 0xFFFF) <= DEFAULT_MAX_SIZE
+  }
+
+  private def isBitmapChunk(idx: Int): Boolean = {
+    // The logic in getIteratorForChunk excludes the run and array chunks first.
+    (chunkCardinalities(idx) & 0xFFFF) > DEFAULT_MAX_SIZE
+  }
+
+  private def getInt(): Int = {
+    val curPos = curOffset
+    curOffset += 4
+    ((fc.getByte(curPos + 3) & 0xFF) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFF) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)
+  }
+
+  def getShort(): Short = {
+    val curPos = curOffset
+    curOffset += 2
+    (((fc.getByte(curPos + 1) & 0xFF) << 8) |
+      (fc.getByte(curPos) & 0xFF)).toShort
+  }
+
+  def getLong(): Long = {
+    val curPos = curOffset
+    curOffset += 8
+    ((fc.getByte(curPos + 7) & 0xFFL) << 56) |
+      ((fc.getByte(curPos + 6) & 0xFFL) << 48) |
+      ((fc.getByte(curPos + 5) & 0xFFL) << 40) |
+      ((fc.getByte(curPos + 4) & 0xFFL) << 32) |
+      ((fc.getByte(curPos + 3) & 0xFFL) << 24) |
+      ((fc.getByte(curPos + 2) & 0xFFL) << 16) |
+      ((fc.getByte(curPos + 1) & 0xFFL) << 8) |
+      (fc.getByte(curPos) & 0xFFL)
+  }
+
+  def getTotalChunkLength(): Int = chunkLength
+
+  def getChunkKeys(): Array[Short] = chunkKeys
+
+  def getChunkCardinality(idx: Int): Short = chunkCardinalities(idx)
+
+  def getBitmapCapacity(): Int = BITMAP_MAX_CAPACITY
+
+  // It's used to traverse multi-chunks across multi-fiber caches in bitwise OR case.
+  def setOffset(chunkIdx: Int): Unit = {
+    if (chunkOffsetListOffset < 0) {
+      var accumulOffset = 0
+      (0 until chunkIdx).foreach(idx =>
+        accumulOffset += getChunkSize(idx))
+      curOffset += accumulOffset
+    } else {
+      curOffset = getIntNoMoving(chunkOffsetListOffset + chunkIdx * 4)
+    }
+  }
+
+  def getIteratorForChunk(chunkIdx: Int): Iterator[Int] = {
+    chunkIdx match {
+      case idx if (isRunChunk(idx)) =>
+        return RunChunkIterator(this)
+      case idx if (isArrayChunk(idx)) =>
+        return ArrayChunkIterator(this, idx)
+      case idx if (isBitmapChunk(idx)) =>
+        return BitmapChunkIterator(this)
+      case _ =>
+        throw new OapException("It's illegal chunk in bitmap index fiber caches.\n")
+    }
+  }
+
+  def init(): Unit = {
+    val cookie = getInt
+    cookie match {
+      case ck if ((ck & 0xFFFF) == SERIAL_COOKIE) =>
+        chunkLength = (cookie >>> 16) + 1
+        hasRun = true
+      case ck if (ck == SERIAL_COOKIE_NO_RUNCONTAINER) =>
+        chunkLength = getInt
+      case _ =>
+        throw new OapException("It's invalid roaring bitmap header in OAP bitmap index file.")
+    }
+    if (hasRun) {
+      val size = (chunkLength + 7) / 8
+      bitmapOfRunChunks = getBytes(size)
+    }
+    chunkKeys = new Array[Short](chunkLength)
+    chunkCardinalities = new Array[Short](chunkLength)
+    (0 until chunkLength).foreach(idx => {
+      chunkKeys(idx) = getShort
+      chunkCardinalities(idx) = (1 + (0xFFFF & getShort)).toShort
+    })
+    if (!hasRun || chunkLength >= NO_OFFSET_THRESHOLD) {
+      chunkOffsetListOffset = curOffset
+      curOffset += chunkLength * 4
+    }
+  }
+}
+
+private[oap] case class OapBitmapChunkInFiberCache(
+    wfc: OapBitmapWrappedFiberCache, chunkIdx: Int) {
+  def getChunkKey(): Short = {
+    val cks = wfc.getChunkKeys
+    cks(chunkIdx)
+  }
+}
+
+private[oap] abstract class ChunksIterator extends Iterator[Int] {
+
+  protected var idx: Int = 0
+  protected var totalLength: Int = 0
+  protected var highPart: Int = 0
+  protected var iteratorForChunk: Iterator[Int] = _
+
+  def init(): Iterator[Int]
+
+  override def hasNext: Boolean = idx < totalLength
+
+  override def next(): Int = {
+    val value = iteratorForChunk.next | highPart
+    if (!iteratorForChunk.hasNext) {
+      idx += 1
+      init
+    }
+    value
+  }
+}
+
+private[oap] case class RunChunkIterator(
+    wfc: OapBitmapWrappedFiberCache)
+  extends Iterator[Int] {
+
+  private var totalRuns: Int = wfc.getShort & 0xFFFF
+  private var runBase: Int = wfc.getShort & 0xFFFF
+  private var maxCurRunLength: Int = wfc.getShort & 0xFFFF
+  private var runIdx: Int = 0
+  private var runLength: Int = 0
+
+  override def hasNext: Boolean = runIdx < totalRuns
+
+  override def next(): Int = {
+    val value = runBase + runLength
+    runLength += 1
+    if (runLength > maxCurRunLength) {
+      runLength = 0
+      runIdx += 1
+      if (runIdx < totalRuns) {
+        runBase = wfc.getShort & 0xFFFF
+        maxCurRunLength = wfc.getShort & 0xFFFF
+      }
+    }
+    value
+  }
+}
+
+// Chunk index is used to get the cardinality for array chunk.
+private[oap] case class ArrayChunkIterator(
+    wfc: OapBitmapWrappedFiberCache, chunkIdx: Int)
+  extends Iterator[Int] {
+
+  private val totalCountInChunk: Int = wfc.getChunkCardinality(chunkIdx) & 0xFFFF
+  private var idxInChunk: Int = 0
+
+  override def hasNext: Boolean = idxInChunk < totalCountInChunk
+
+  override def next(): Int = {
+    idxInChunk += 1
+    wfc.getShort & 0xFFFF
+  }
+}
+
+private[oap] case class BitmapChunkIterator(
+    wfc: OapBitmapWrappedFiberCache)
+  extends Iterator[Int] {
+
+  private val wordLength: Int = wfc.getBitmapCapacity / 64
+  private var wordIdx: Int = -1
+  private var curWord: Long = 0L
+  do {
+    curWord = wfc.getLong
+    wordIdx += 1
+  } while (curWord == 0L && wordIdx < wordLength)
+
+  override def hasNext: Boolean = wordIdx < wordLength
+
+  override def next(): Int = {
+    val tmp = curWord & -curWord
+    val value = wordIdx * 64 + java.lang.Long.bitCount(tmp - 1)
+    curWord ^= tmp
+    breakable {
+      while (curWord == 0L) {
+        wordIdx += 1
+        if (wordIdx == wordLength) break
+        curWord = wfc.getLong
+      }
+    }
+    value
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapMicroBenchmarkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapMicroBenchmarkSuite.scala
@@ -20,12 +20,18 @@ package org.apache.spark.sql.execution.datasources.oap.index
 import java.io._
 import java.util
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FSDataInputStream, Path}
+import org.roaringbitmap.FastAggregation
 import org.roaringbitmap.RoaringBitmap
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.datasources.oap.filecache._
+import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.util.{collection, Utils}
@@ -43,6 +49,20 @@ class BitmapMicroBenchmarkSuite extends QueryTest with SharedOapContext with Bef
   private val scalaBs = new mutable.BitSet()
   private val javaBs = new util.BitSet()
   private val rb = new RoaringBitmap()
+
+  // Below data are used to test the functionality and performance of directly getting
+  // row IDs from fiber caches without roarting bitmap involved.
+  private val BITMAP_FOOTER_SIZE = 4 + 5 * 8
+  private val dataForRunChunk: Seq[(Int, String)] =
+    (1 to 20000).map{i => (i / 100, s"this is test $i")}
+  private val dataForArrayChunk: Seq[(Int, String)] =
+    (1 to 20000).map{i => (i, s"this is test $i")}
+  private val dataForBitmapChunk: Seq[(Int, String)] =
+    (1 to 20000).map{i => (i % 2, s"this is test $i")}
+  private val dataCombination =
+    dataForBitmapChunk ++ dataForArrayChunk ++ dataForRunChunk
+  private val dataArray =
+    Array(dataForRunChunk, dataForArrayChunk, dataForBitmapChunk, dataCombination)
 
   override def beforeEach(): Unit = {
     dir = Utils.createTempDir()
@@ -267,4 +287,128 @@ class BitmapMicroBenchmarkSuite extends QueryTest with SharedOapContext with Bef
      */
   }
 
+  // Below are just borrowed from BitMapScanner.scala in order to easily load bitmap index files.
+  private def loadBmFooter(
+      fin: FSDataInputStream,
+      bmFooterOffset: Int): FiberCache =
+    MemoryManager.putToIndexFiberCache(fin, bmFooterOffset, BITMAP_FOOTER_SIZE)
+
+  private def loadBmEntry(
+      fin: FSDataInputStream,
+      offset: Int,
+      size: Int): FiberCache =
+    MemoryManager.putToIndexFiberCache(fin, offset, size)
+
+  private def loadBmOffsetList(
+      fin: FSDataInputStream,
+      bmOffsetListOffset: Int,
+      bmOffsetListTotalSize: Int): FiberCache =
+    MemoryManager.putToIndexFiberCache(fin, bmOffsetListOffset, bmOffsetListTotalSize)
+
+  private def getIdxOffset(
+      fiberCache: FiberCache,
+      baseOffset: Long,
+      idx: Int): Int = {
+    val idxOffset = baseOffset + idx * 4
+    fiberCache.getInt(idxOffset)
+  }
+
+  private def getMetaDataAndFiberCaches(
+      fin: FSDataInputStream,
+      idxPath: Path,
+      conf: Configuration): (Int, WrappedFiberCache, WrappedFiberCache) = {
+    val idxFileSize = idxPath.getFileSystem(conf).getFileStatus(idxPath).getLen
+    val bmFooterOffset = idxFileSize.toInt - BITMAP_FOOTER_SIZE
+    val bmFooterFiber = BitmapFiber(
+      () => loadBmFooter(fin, bmFooterOffset),
+      idxPath.toString, BitmapIndexSectionId.footerSection, 0)
+    val bmFooterCache = WrappedFiberCache(FiberCacheManager.get(bmFooterFiber, conf))
+    val bmUniqueKeyListTotalSize = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE)
+    val keyCount = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE * 2)
+    val bmEntryListTotalSize = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE * 3)
+    val bmOffsetListTotalSize = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE * 4)
+    val bmNullEntrySize = bmFooterCache.fc.getInt(IndexUtils.INT_SIZE * 6)
+    val bmUniqueKeyListOffset = IndexFile.VERSION_LENGTH
+    val bmEntryListOffset = bmUniqueKeyListOffset + bmUniqueKeyListTotalSize
+    val bmOffsetListOffset = bmEntryListOffset + bmEntryListTotalSize + bmNullEntrySize
+    val bmOffsetListFiber = BitmapFiber(
+      () => loadBmOffsetList(fin, bmOffsetListOffset, bmOffsetListTotalSize),
+      idxPath.toString, BitmapIndexSectionId.entryOffsetsSection, 0)
+    val bmOffsetListCache = WrappedFiberCache(FiberCacheManager.get(bmOffsetListFiber, conf))
+    (keyCount, bmOffsetListCache, bmFooterCache)
+  }
+
+  test("test the functionality of directly traversing single fiber cache without roaring bitmap") {
+    dataArray.foreach(dataIdx => {
+      dataIdx.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index_bm on oap_test (a) USING BITMAP")
+      var maxRowId = 0
+      dir.listFiles.foreach(fileName => {
+        if (fileName.toString.endsWith(OapFileFormat.OAP_INDEX_EXTENSION)) {
+          val idxPath = new Path(fileName.toString)
+          val conf = new Configuration()
+          val fin = idxPath.getFileSystem(conf).open(idxPath)
+          val (keyCount, bmOffsetListCache, bmFooterCache) =
+            getMetaDataAndFiberCaches(fin, idxPath, conf)
+          var maxRowIdInPartition = 0
+          (0 until keyCount).map( idx => {
+            val curIdxOffset = getIdxOffset(bmOffsetListCache.fc, 0L, idx)
+            val entrySize = getIdxOffset(bmOffsetListCache.fc, 0L, idx + 1) - curIdxOffset
+            val entryFiber = BitmapFiber(
+              () => loadBmEntry(fin, curIdxOffset, entrySize), idxPath.toString,
+            BitmapIndexSectionId.entryListSection, idx)
+            val wfc = new OapBitmapWrappedFiberCache(FiberCacheManager.get(entryFiber, conf))
+            wfc.init()
+            val max = ChunksInSingleFiberCacheIterator(wfc).init.max
+            if (maxRowIdInPartition < max) maxRowIdInPartition = max
+            wfc.release
+          })
+          // The row id is starting from 0.
+          maxRowId += maxRowIdInPartition + 1
+          bmFooterCache.release
+          bmOffsetListCache.release
+          fin.close
+        }
+      })
+      assert(sql("select * from t").count == maxRowId)
+      sql("drop oindex index_bm on oap_test")
+    })
+  }
+
+  test("test the functionality of directly bitwise OR case for multi fiber caches") {
+    dataArray.foreach(dataIdx => {
+      dataIdx.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index_bm on oap_test (a) USING BITMAP")
+      var maxRowId = 0
+      dir.listFiles.foreach(fileName => {
+        if (fileName.toString.endsWith(OapFileFormat.OAP_INDEX_EXTENSION)) {
+          val idxPath = new Path(fileName.toString)
+          val conf = new Configuration()
+          val fin = idxPath.getFileSystem(conf).open(idxPath)
+          val (keyCount, bmOffsetListCache, bmFooterCache) =
+            getMetaDataAndFiberCaches(fin, idxPath, conf)
+          val wfcSeq = (0 until keyCount).map(idx => {
+            val curIdxOffset = getIdxOffset(bmOffsetListCache.fc, 0L, idx)
+            val entrySize = getIdxOffset(bmOffsetListCache.fc, 0L, idx + 1) - curIdxOffset
+            val entryFiber = BitmapFiber(
+              () => loadBmEntry(fin, curIdxOffset, entrySize), idxPath.toString,
+              BitmapIndexSectionId.entryListSection, idx)
+            new OapBitmapWrappedFiberCache(FiberCacheManager.get(entryFiber, conf))
+          })
+          val chunkList = OapBitmapFastAggregation.or(wfcSeq)
+          var maxRowIdInPartition = ChunksInMultiFiberCachesIterator(chunkList).init.max
+          // The row id is starting from 0.
+          maxRowId += maxRowIdInPartition + 1
+          wfcSeq.foreach(wfc => wfc.release)
+          bmFooterCache.release
+          bmOffsetListCache.release
+          fin.close
+        }
+      })
+      assert(sql("select * from t").count == maxRowId)
+      sql("drop oindex index_bm on oap_test")
+    })
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch provides two micro performance test cases to test
the performance comparison w/ and w/o roaring bitmap for below
two bitmap index equal query cases.

1. select * from t where a = apple
2. select * from t where a in {"apple", "banana", ...}

## How was this patch tested?

mvn clean test package and all of unit tests passed
