### PR TITLE
[Branch-0.3]Make sure use table basedir as temporary path(#636)

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -150,7 +150,7 @@ case class CreateIndexCommand(
       ds = ds.filter(s"$k='$v'")
     }
 
-    val outPutPath = fileCatalog.rootPaths.head
+    val outPutPath = OapUtils.getOutPutPath(fileCatalog, partitionSpec)
     assert(outPutPath != null, "Expected exactly one path to be specified, but no value")
 
     val qualifiedOutputPath = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -370,7 +370,7 @@ case class RefreshIndexCommand(
         ds = ds.filter(s"$k='$v'")
       }
 
-      val outPutPath = fileCatalog.rootPaths.head
+      val outPutPath = OapUtils.getOutPutPath(fileCatalog, partitionSpec)
       assert(outPutPath != null, "Expected exactly one path to be specified, but no value")
 
       val qualifiedOutputPath = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -150,7 +150,7 @@ case class CreateIndexCommand(
       ds = ds.filter(s"$k='$v'")
     }
 
-    val outPutPath = OapUtils.getOutPutPath(fileCatalog, partitionSpec)
+    val outPutPath = OapUtils.getOutPutPath(fileCatalog)
     assert(outPutPath != null, "Expected exactly one path to be specified, but no value")
 
     val qualifiedOutputPath = {
@@ -370,7 +370,7 @@ case class RefreshIndexCommand(
         ds = ds.filter(s"$k='$v'")
       }
 
-      val outPutPath = OapUtils.getOutPutPath(fileCatalog, partitionSpec)
+      val outPutPath = OapUtils.getOutPutPath(fileCatalog)
       assert(outPutPath != null, "Expected exactly one path to be specified, but no value")
 
       val qualifiedOutputPath = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
@@ -201,26 +201,16 @@ object OapUtils extends Logging {
     getPartitions(fileIndex, partitionSpec)
   }
 
-  def getOutPutPath(
-      fileIndex: FileIndex,
-      partitionSpec: Option[TablePartitionSpec] = None): Path = {
+  def getOutPutPath(fileIndex: FileIndex): Path = {
     def getTargetPath(path: Path, times: Int): Path = {
       if (times > 0) getTargetPath(path.getParent, times - 1)
       else path
-    }
-    def getTableBaseDir(
-        path: Path,
-        partitionSpec: Option[TablePartitionSpec] = None): Path = {
-      partitionSpec match {
-        case Some(p) => getTargetPath(path, p.size)
-        case _ => path
-      }
     }
     val paths = fileIndex.rootPaths
     assert(paths.nonEmpty, "Expected at least one path of fileIndex.rootPaths, but no value")
     paths.length match {
       case 1 => paths.head
-      case _ => getTableBaseDir(paths.head, partitionSpec)
+      case _ => getTargetPath(paths.head, fileIndex.partitionSchema.length)
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
@@ -201,16 +201,22 @@ object OapUtils extends Logging {
     getPartitions(fileIndex, partitionSpec)
   }
 
+  /**
+   * If fileIndex.rootPaths has only one item, it will use as job temporary dir,
+   * else get table base dir use as job temporary dir.
+   * @param fileIndex [[FileIndex]] of a relation
+   * @return path use to save job temporary data
+   */
   def getOutPutPath(fileIndex: FileIndex): Path = {
-    def getTargetPath(path: Path, times: Int): Path = {
-      if (times > 0) getTargetPath(path.getParent, times - 1)
+    def getTableBaseDir(path: Path, times: Int): Path = {
+      if (times > 0) getTableBaseDir(path.getParent, times - 1)
       else path
     }
     val paths = fileIndex.rootPaths
     assert(paths.nonEmpty, "Expected at least one path of fileIndex.rootPaths, but no value")
     paths.length match {
       case 1 => paths.head
-      case _ => getTargetPath(paths.head, fileIndex.partitionSchema.length)
+      case _ => getTableBaseDir(paths.head, fileIndex.partitionSchema.length)
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtils.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.parquet.bytes.BytesUtils
 import org.apache.parquet.io.api.Binary
-import org.apache.spark.SparkConf
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtilsSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.utils
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.execution.datasources.InMemoryFileIndex
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+/**
+ * Now We don't have mock utils, so OapUtilsSuite extends SharedOapContext to use SparkSession.
+ */
+class OapUtilsSuite extends SharedOapContext {
+
+  test("test rootPaths empty") {
+    val fileIndex = new InMemoryFileIndex(spark, Seq.empty, Map.empty, None)
+    intercept[AssertionError] {
+      OapUtils.getOutPutPath(fileIndex)
+    }
+  }
+
+  test("test rootPaths eq 1") {
+    val tablePath = new Path("/table")
+    val rootPaths = Seq(tablePath)
+    val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, None)
+    val ret = OapUtils.getOutPutPath(fileIndex)
+    assert(ret.equals(tablePath))
+  }
+
+  test("test rootPaths more than 1") {
+    val part1 = new Path("/table/a=1/b=1")
+    val part2 = new Path("/table/a=1/b=2")
+    val tablePath = new Path("/table")
+    val partitionSchema = new StructType()
+      .add(StructField("a", StringType))
+      .add(StructField("b", StringType))
+    val rootPaths = Seq(part1, part2)
+    val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, Some(partitionSchema))
+    val ret = OapUtils.getOutPutPath(fileIndex)
+    assert(ret.equals(tablePath))
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapUtilsSuite.scala
@@ -35,7 +35,7 @@ class OapUtilsSuite extends SharedOapContext {
     }
   }
 
-  test("test rootPaths eq 1") {
+  test("test rootPaths length eq 1 no partitioned") {
     val tablePath = new Path("/table")
     val rootPaths = Seq(tablePath)
     val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, None)
@@ -43,7 +43,18 @@ class OapUtilsSuite extends SharedOapContext {
     assert(ret.equals(tablePath))
   }
 
-  test("test rootPaths more than 1") {
+  test("test rootPaths length eq 1 partitioned") {
+    val tablePath = new Path("/table")
+    val partitionSchema = new StructType()
+      .add(StructField("a", StringType))
+      .add(StructField("b", StringType))
+    val rootPaths = Seq(tablePath)
+    val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, Some(partitionSchema))
+    val ret = OapUtils.getOutPutPath(fileIndex)
+    assert(ret.equals(tablePath))
+  }
+
+  test("test rootPaths length more than 1") {
     val part1 = new Path("/table/a=1/b=1")
     val part2 = new Path("/table/a=1/b=2")
     val tablePath = new Path("/table")
@@ -54,5 +65,16 @@ class OapUtilsSuite extends SharedOapContext {
     val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, Some(partitionSchema))
     val ret = OapUtils.getOutPutPath(fileIndex)
     assert(ret.equals(tablePath))
+  }
+
+  test("test rootPaths length eq 1 but partitioned") {
+    val part1 = new Path("/table/a=1/b=1")
+    val partitionSchema = new StructType()
+      .add(StructField("a", StringType))
+      .add(StructField("b", StringType))
+    val rootPaths = Seq(part1)
+    val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, Some(partitionSchema))
+    val ret = OapUtils.getOutPutPath(fileIndex)
+    assert(ret.equals(part1))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When fileIndex instance of `PrunedInMemoryFileIndex`, it's `rootPaths` will be `partitionSpec.partitions.map(_.path)`,  and `rootPaths.head` will be `basedir+partitiondir`, it will 
cause a mistake as #636 said,  so make sure to use table basedir as temporary path.

## How was this patch tested?

mvn test pass 