### PR TITLE
Use different version for bitmap and btree

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReaderV1.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReaderV1.scala
@@ -65,7 +65,7 @@ private[oap] case class BTreeIndexFileReaderV1(
     Platform.getInt(buffer, Platform.BYTE_ARRAY_OFFSET + offset)
 
   def checkVersionNum(versionNum: Int): Unit = {
-    if (IndexFile.VERSION_NUM != versionNum) {
+    if (IndexFile.BTREE_VERSION_NUM != versionNum) {
       throw new OapException("Btree Index File version is not compatible!")
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileWriter.scala
@@ -45,7 +45,7 @@ private case class BTreeIndexFileWriter(
   private var footerSize = 0
 
   def start(): Unit = {
-    IndexUtils.writeHead(writer, IndexFile.VERSION_NUM)
+    IndexUtils.writeHead(writer, IndexFile.BTREE_VERSION_NUM)
   }
 
   def writeNode(buf: Array[Byte]): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -235,7 +235,7 @@ private[index] case class BTreeIndexRecordWriter(
     val statsBuffer = new ByteArrayOutputStream()
 
     // Index File Version Number
-    IndexUtils.writeInt(buffer, IndexFile.VERSION_NUM)
+    IndexUtils.writeInt(buffer, IndexFile.BTREE_VERSION_NUM)
     // Record Count(all with non-null key) of all nodes in B+ tree
     IndexUtils.writeInt(buffer, nodes.map(_.rowCount).sum)
     // Count of Record(s) that have null key

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -181,7 +181,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   }
 
   private def checkVersionNum(versionNum: Int, fin: FSDataInputStream): Unit = {
-    if (IndexFile.VERSION_NUM != versionNum) {
+    if (IndexFile.BITMAP_VERSION_NUM != versionNum) {
       throw new OapException("Bitmap Index File version is not compatible!")
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -190,7 +190,7 @@ private[oap] class BitmapIndexRecordWriter(
     bmIndexEnd = bmEntryListOffset + bmEntryListTotalSize + bmNullEntrySize + bmOffsetListTotalSize
     // The index end is also the starting position of statistics part.
     val statSize = statisticsWriteManager.write(writer)
-    IndexUtils.writeInt(writer, IndexFile.VERSION_NUM)
+    IndexUtils.writeInt(writer, IndexFile.BITMAP_VERSION_NUM)
     IndexUtils.writeInt(writer, bmUniqueKeyListTotalSize)
     IndexUtils.writeInt(writer, bmUniqueKeyListCount)
     IndexUtils.writeInt(writer, bmEntryListTotalSize)
@@ -202,7 +202,7 @@ private[oap] class BitmapIndexRecordWriter(
   }
 
   private def flushToFile(): Unit = {
-    IndexUtils.writeHead(writer, IndexFile.VERSION_NUM)
+    IndexUtils.writeHead(writer, IndexFile.BITMAP_VERSION_NUM)
     writeUniqueKeyList()
     writeBmEntryList()
     writeBmOffsetList()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -47,7 +47,7 @@ private[oap] object IndexUtils {
   def readHead(reader: FSDataInputStream, offset: Int): Int = {
     val magic = new Array[Byte](IndexFile.VERSION_LENGTH)
     reader.readFully(offset, magic)
-    (1 to IndexFile.VERSION_NUM)
+    (1 to math.max(IndexFile.BTREE_VERSION_NUM, IndexFile.BITMAP_VERSION_NUM))
       .find(version => magic sameElements serializeVersion(version))
       .getOrElse(IndexFile.UNKNOWN_VERSION)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexFile.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.oap.io
 private[oap] object IndexFile {
   val VERSION_LENGTH = 8
   val VERSION_PREFIX = "OAPIDX"
-  val VERSION_NUM = 1
+  val BITMAP_VERSION_NUM = 1
+  val BTREE_VERSION_NUM = 1
   val UNKNOWN_VERSION = -1
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
@@ -87,14 +87,15 @@ class IndexUtilsSuite extends SparkFunSuite with Logging {
   }
 
   test("writeHead to write common and consistent index version to all the index file headers") {
-    val buf = new ByteArrayOutputStream(8)
-    val out = new DataOutputStream(buf)
-    IndexUtils.writeHead(out, IndexFile.VERSION_NUM)
-    val bytes = buf.toByteArray
-    assert(Platform.getByte(bytes, Platform.BYTE_ARRAY_OFFSET + 6) ==
-      (IndexFile.VERSION_NUM >> 8).toByte)
-    assert(Platform.getByte(bytes, Platform.BYTE_ARRAY_OFFSET + 7) ==
-      (IndexFile.VERSION_NUM & 0xFF).toByte)
+    val maxVersion = math.max(IndexFile.BITMAP_VERSION_NUM, IndexFile.BTREE_VERSION_NUM)
+    (1 to maxVersion).foreach { v =>
+      val buf = new ByteArrayOutputStream(8)
+      val out = new DataOutputStream(buf)
+      IndexUtils.writeHead(out, v)
+      val bytes = buf.toByteArray
+      assert(Platform.getByte(bytes, Platform.BYTE_ARRAY_OFFSET + 6) == (v >> 8).toByte)
+      assert(Platform.getByte(bytes, Platform.BYTE_ARRAY_OFFSET + 7) == (v & 0xFF).toByte)
+    }
   }
 
   test("binary search") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since bitmap and btree index may be changed separately. So use different version number.


## How was this patch tested?

Current test pass

