### PR TITLE
ParquetFileFormat supports data cache.#669

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java
@@ -64,13 +64,13 @@ public class SingleGroupOapRecordReader extends VectorizedOapRecordReader {
       super.initializeInternal();
     }
 
-    public void initBatch(MemoryMode memMode, int maxRows) {
+    public void initBatch(int maxRows) {
       StructType batchSchema = new StructType();
       for (StructField f: sparkSchema.fields()) {
         batchSchema = batchSchema.add(f);
       }
   
-      columnarBatch = ColumnarBatch.allocate(batchSchema, memMode, maxRows);
+      columnarBatch = ColumnarBatch.allocate(batchSchema, DEFAULT_MEMORY_MODE, maxRows);
   
       // Initialize missing columns with nulls.
       for (int i = 0; i < missingColumns.length; i++) {

--- a/src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java
@@ -35,14 +35,17 @@ import org.apache.spark.sql.types.StructType;
 public class SingleGroupOapRecordReader extends VectorizedOapRecordReader {
 
     private int blockId;
+    private int rowGroupCount;
   
     public SingleGroupOapRecordReader(
           Path file,
           Configuration configuration,
           ParquetMetadata footer,
-          int blockId) {
+          int blockId,
+          int rowGroupCount) {
       super(file, configuration, footer);
       this.blockId = blockId;
+      this.rowGroupCount = rowGroupCount;
     }
   
     /**
@@ -64,13 +67,13 @@ public class SingleGroupOapRecordReader extends VectorizedOapRecordReader {
       super.initializeInternal();
     }
 
-    public void initBatch(int maxRows) {
+    public void initBatch() {
       StructType batchSchema = new StructType();
       for (StructField f: sparkSchema.fields()) {
         batchSchema = batchSchema.add(f);
       }
   
-      columnarBatch = ColumnarBatch.allocate(batchSchema, DEFAULT_MEMORY_MODE, maxRows);
+      columnarBatch = ColumnarBatch.allocate(batchSchema, DEFAULT_MEMORY_MODE, rowGroupCount);
   
       // Initialize missing columns with nulls.
       for (int i = 0; i < missingColumns.length; i++) {

--- a/src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
+import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.sql.execution.vectorized.ColumnarBatch;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public class SingleGroupOapRecordReader extends VectorizedOapRecordReader {
+
+    private int blockId;
+  
+    public SingleGroupOapRecordReader(
+          Path file,
+          Configuration configuration,
+          ParquetMetadata footer,
+          int blockId) {
+      super(file, configuration, footer);
+      this.blockId = blockId;
+    }
+  
+    /**
+     * Override initialize method, init footer if need,
+     * then call super.initialize and initializeInternal
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Override
+    public void initialize() throws IOException, InterruptedException {
+      if (this.footer == null) {
+          footer = readFooter(configuration, file, NO_FILTER);
+      }
+      List<BlockMetaData> inputBlockList = Lists.newArrayList();
+      inputBlockList.add(footer.getBlocks().get(blockId));
+      ParquetMetadata meta = new ParquetMetadata(footer.getFileMetaData(), inputBlockList);
+      // need't do filterRowGroups.
+      initialize(meta, configuration, false);
+      super.initializeInternal();
+    }
+
+    public void initBatch(MemoryMode memMode, int maxRows) {
+      StructType batchSchema = new StructType();
+      for (StructField f: sparkSchema.fields()) {
+        batchSchema = batchSchema.add(f);
+      }
+  
+      columnarBatch = ColumnarBatch.allocate(batchSchema, memMode, maxRows);
+  
+      // Initialize missing columns with nulls.
+      for (int i = 0; i < missingColumns.length; i++) {
+        if (missingColumns[i]) {
+          columnarBatch.column(i).putNulls(0, columnarBatch.capacity());
+          columnarBatch.column(i).setIsConstant();
+        }
+      }
+    }
+  }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -148,7 +148,7 @@ object FiberCacheManager extends Logging {
   }
 
   // Used by test suite
-  private[filecache] def clearAllFibers(): Unit = cacheBackend.cleanUp
+  private[oap] def clearAllFibers(): Unit = cacheBackend.cleanUp
 
   // TODO: test case, consider data eviction, try not use DataFileHandle which my be costly
   private[filecache] def status: String = {
@@ -172,6 +172,8 @@ object FiberCacheManager extends Logging {
   def cacheStats: CacheStats = cacheBackend.cacheStats
 
   def cacheSize: Long = cacheBackend.cacheSize
+
+  def cacheCount: Long = cacheBackend.cacheCount
 
   // Used by test suite
   private[filecache] def pendingCount: Int = cacheBackend.pendingFiberCount

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -214,7 +214,7 @@ private[oap] class OapDataReader(
       options: Map[String, String] = Map.empty): OapIterator[InternalRow] = {
     logDebug("Initializing OapDataReader...")
     // TODO how to save the additional FS operation to get the Split size
-    val fileScanner = DataFile(path.toUri.toString, meta.schema, meta.dataReaderClassName, conf)
+    val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf)
     if (meta.dataReaderClassName.contains("ParquetDataFile")) {
       fileScanner.asInstanceOf[ParquetDataFile].setVectorizedContext(context)
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -214,7 +214,7 @@ private[oap] class OapDataReader(
       options: Map[String, String] = Map.empty): OapIterator[InternalRow] = {
     logDebug("Initializing OapDataReader...")
     // TODO how to save the additional FS operation to get the Split size
-    val fileScanner = DataFile(path.toString, meta.schema, meta.dataReaderClassName, conf)
+    val fileScanner = DataFile(path.toUri.toString, meta.schema, meta.dataReaderClassName, conf)
     if (meta.dataReaderClassName.contains("ParquetDataFile")) {
       fileScanner.asInstanceOf[ParquetDataFile].setVectorizedContext(context)
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -47,14 +47,6 @@ private[oap] case class ParquetDataFile(
   private var context: Option[VectorizedContext] = None
   private val meta: ParquetDataFileHandle = DataFileHandleCacheManager(this)
   private val file = new Path(StringUtils.unEscapeString(path))
-  private val memoryMode = {
-    if (configuration.getBoolean(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key,
-      OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED.defaultValue.get))  {
-      MemoryMode.OFF_HEAP
-    } else {
-      MemoryMode.ON_HEAP
-    }
-  }
   private val parquetDataCacheEnable =
     configuration.getBoolean(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key,
       OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.defaultValue.get)
@@ -97,7 +89,7 @@ private[oap] case class ParquetDataFile(
       addRequestSchemaToConf(conf, requiredId)
       reader = new SingleGroupOapRecordReader(file, conf, meta.footer, groupId)
       reader.initialize()
-      reader.initBatch(memoryMode, rowGroupRowCount)
+      reader.initBatch(rowGroupRowCount)
       val data = getFiberByteData(schema(fiberId).dataType, rowGroupRowCount, reader)
       MemoryManager.toDataFiberCache(data)
     } finally {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -184,7 +184,7 @@ private[oap] case class ParquetDataFile(
         // in that sence we should not cache data in memory
         // and rollback to read this rowgroup from file directly.
         if (parquetDataCacheEnable &&
-        !meta.footer.getBlocks.asScala.exists(blockMeta => blockMeta.getRowCount > Int.MaxValue)) {
+          !meta.footer.getBlocks.asScala.exists(_.getRowCount > Int.MaxValue)) {
           buildIterator(configuration, requiredIds, rowIds = None)
         } else {
           initVectorizedReader(c,

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -203,11 +203,4 @@ object OapConf {
       .doc("To indicate if enable parquet data cache, default false")
       .booleanConf
       .createWithDefault(false)
-
-  val COLUMN_VECTOR_OFFHEAP_ENABLED =
-    SQLConfigBuilder("spark.sql.columnVector.offheap.enabled")
-      .internal()
-      .doc("When true, use OffHeapColumnVector in ColumnarBatch.")
-      .booleanConf
-      .createWithDefault(false)
 }

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -196,4 +196,18 @@ object OapConf {
       .doc("The interval of fiber cache metrics update")
       .longConf
       .createWithDefault(10L)
+
+  val OAP_PARQUET_DATA_CACHE_ENABLED =
+    SQLConfigBuilder("spark.sql.oap.parquet.data.cache.enable")
+      .internal()
+      .doc("To indicate if enable parquet data cache, default false")
+      .booleanConf
+      .createWithDefault(false)
+
+  val COLUMN_VECTOR_OFFHEAP_ENABLED =
+    SQLConfigBuilder("spark.sql.columnVector.offheap.enabled")
+      .internal()
+      .doc("When true, use OffHeapColumnVector in ColumnarBatch.")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -946,4 +946,19 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     sql("drop oindex idx1 on parquet_test")
     sql("drop oindex idx2 on parquet_test")
   }
+
+  test("filtering parquet in FiberCache") {
+    withSQLConf("spark.sql.oap.parquet.data.cache.enable" -> "true") {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex index1 on parquet_test (a)")
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
+        Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a class of SingleGroupOapRecordReader which is used to read one group each time.

Add four interfaces in ParquetDataFile:
       1. def getroupIdToRowIds(rowIds: Option[Array[Int]]): Option[Map[Int, Array[Int]]] 
       2. def buildIterator(conf: Configuration, requiredIds: Array[Int],
                                  rowIds: Option[Array[Int]]): OapIterator[InternalRow]
       3. def getFiberByteData (dataType: DataType, rowGroupRowCount: Int,
                                        reader: SingleGroupOapRecordReader): Array[Byte]
       4. def getFiberData(groupId: Int, fiberId: Int): FiberCache 




## How was this patch tested?

All existing tests pass.

Add two new tests:
test("read by columnIds and rowIds in fiberCache") 
test("read by columnIds in fiberCache") {



