### PR TITLE
Internal API Name refactoring

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -234,7 +234,7 @@ private[oap] object MemoryManager extends Logging {
 
   // Used by IndexFile
   // TODO: putToFiberCache(in: Stream, position: Long, length: Int, type: FiberType)
-  def putToIndexFiberCache(in: FSDataInputStream, position: Long, length: Int): IndexFiberCache = {
+  def toIndexFiberCache(in: FSDataInputStream, position: Long, length: Int): IndexFiberCache = {
     val bytes = new Array[Byte](length)
     in.readFully(position, bytes)
     val memoryBlock = allocate(bytes.length)
@@ -249,7 +249,7 @@ private[oap] object MemoryManager extends Logging {
 
   // Used by OapDataFile since we need to parse the raw data in on-heap memory before put it into
   // off-heap memory
-  def putToDataFiberCache(bytes: Array[Byte]): DataFiberCache = {
+  def toDataFiberCache(bytes: Array[Byte]): DataFiberCache = {
     val memoryBlock = allocate(bytes.length)
     Platform.copyMemory(
       bytes,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReaderV1.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReaderV1.scala
@@ -71,7 +71,7 @@ private[oap] case class BTreeIndexFileReaderV1(
   }
 
   def readFooter(): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, footerIndex, footerLength)
+    MemoryManager.toIndexFiberCache(reader, footerIndex, footerLength)
 
   def readRowIdList(partIdx: Int): FiberCache = {
     val partSize = rowIdListSizePerSection.toLong * IndexUtils.INT_SIZE
@@ -81,16 +81,16 @@ private[oap] case class BTreeIndexFileReaderV1(
       partSize
     }
     assert(readLength <= Int.MaxValue, "Size of each row id list partition is too large!")
-    MemoryManager.putToIndexFiberCache(reader, rowIdListIndex + partIdx * partSize,
+    MemoryManager.toIndexFiberCache(reader, rowIdListIndex + partIdx * partSize,
       readLength.toInt)
   }
 
   @deprecated("no need to read the whole row id list", "v0.3")
   def readRowIdList(): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, rowIdListIndex, rowIdListLength.toInt)
+    MemoryManager.toIndexFiberCache(reader, rowIdListIndex, rowIdListLength.toInt)
 
   def readNode(offset: Int, size: Int): FiberCache =
-    MemoryManager.putToIndexFiberCache(reader, nodesIndex + offset, size)
+    MemoryManager.toIndexFiberCache(reader, nodesIndex + offset, size)
 
   def close(): Unit = try {
     reader.close()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -79,11 +79,11 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   override def next(): Int = bmRowIdIterator.next()
 
   private def loadBmFooter(fin: FSDataInputStream, bmFooterOffset: Int): FiberCache = {
-    MemoryManager.putToIndexFiberCache(fin, bmFooterOffset, BITMAP_FOOTER_SIZE)
+    MemoryManager.toIndexFiberCache(fin, bmFooterOffset, BITMAP_FOOTER_SIZE)
   }
 
   private def loadBmStatsContent(fin: FSDataInputStream, offset: Long, size: Long): FiberCache = {
-    MemoryManager.putToIndexFiberCache(fin, offset, size.toInt)
+    MemoryManager.toIndexFiberCache(fin, offset, size.toInt)
   }
 
   private def cacheBitmapFooterSegment(idxPath: Path, conf: Configuration): Unit = {
@@ -156,7 +156,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
   private def loadBmKeyList(fin: FSDataInputStream, bmUniqueKeyListOffset: Int): FiberCache = {
     // TODO: seems not supported yet on my local dev machine(hadoop is 2.7.3).
     // fin.setReadahead(bmUniqueKeyListTotalSize)
-    MemoryManager.putToIndexFiberCache(fin, bmUniqueKeyListOffset, bmUniqueKeyListTotalSize)
+    MemoryManager.toIndexFiberCache(fin, bmUniqueKeyListOffset, bmUniqueKeyListTotalSize)
   }
 
   private def readBmUniqueKeyListFromCache(data: FiberCache): IndexedSeq[InternalRow] = {
@@ -171,19 +171,19 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
 
   private def loadBmEntryList(
       fin: FSDataInputStream, bmEntryListOffset: Int, bmEntryListTotalSize: Int): FiberCache = {
-    MemoryManager.putToIndexFiberCache(fin, bmEntryListOffset, bmEntryListTotalSize)
+    MemoryManager.toIndexFiberCache(fin, bmEntryListOffset, bmEntryListTotalSize)
   }
 
   private def loadBmOffsetList(
       fin: FSDataInputStream,
       bmOffsetListOffset: Int,
       bmOffsetListTotalSize: Int): FiberCache = {
-    MemoryManager.putToIndexFiberCache(fin, bmOffsetListOffset, bmOffsetListTotalSize)
+    MemoryManager.toIndexFiberCache(fin, bmOffsetListOffset, bmOffsetListTotalSize)
   }
 
   private def loadBmNullList(
       fin: FSDataInputStream, bmNullEntryOffset: Int, bmNullEntrySize: Int): FiberCache = {
-    MemoryManager.putToIndexFiberCache(fin, bmNullEntryOffset, bmNullEntrySize)
+    MemoryManager.toIndexFiberCache(fin, bmNullEntryOffset, bmNullEntrySize)
   }
 
   private def checkVersionNum(versionNum: Int, fin: FSDataInputStream): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -110,7 +110,7 @@ private[oap] case class OapDataFile(
     // We have to read Array[Byte] from file and decode/decompress it before putToFiberCache
     // TODO: Try to finish this in off-heap memory
     val data = fiberParser.parse(decompressor.decompress(bytes, uncompressedLen), rowCount)
-    MemoryManager.putToDataFiberCache(data)
+    MemoryManager.toDataFiberCache(data)
   }
 
   private def buildIterator(

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -80,7 +80,7 @@ class MemoryManagerSuite extends SharedOapContext {
       })
       val nnkw = new NonNullKeyWriter(schema)
       nnkw.writeKey(buf, InternalRow.fromSeq(values))
-      MemoryManager.putToDataFiberCache(buf.toByteArray)
+      MemoryManager.toDataFiberCache(buf.toByteArray)
     }
   }
 
@@ -106,14 +106,14 @@ class MemoryManagerSuite extends SharedOapContext {
     val bytes = new Array[Byte](10240)
     random.nextBytes(bytes)
     val is = createInputStreamFromBytes(bytes)
-    val indexFiberCache = MemoryManager.putToIndexFiberCache(is, 0, 10240)
+    val indexFiberCache = MemoryManager.toIndexFiberCache(is, 0, 10240)
     assert(bytes === indexFiberCache.toArray)
   }
 
   test("test data in DataFiberCache") {
     val bytes = new Array[Byte](10240)
     random.nextBytes(bytes)
-    val dataFiberCache = MemoryManager.putToDataFiberCache(bytes)
+    val dataFiberCache = MemoryManager.toDataFiberCache(bytes)
     assert(bytes === dataFiberCache.toArray)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MemoryManager.putToDataFiberCache` => `MemoryManager.toDataFiberCache()`
`MemoryManager.putToIndexFiberCache` => `MemoryManager.toIndexFiberCache()`

#673 

## How was this patch tested?

Existing UTs.


