### PR TITLE
Follow #605 BitMapScanner clear bmFooterFiber status to enable re-entry

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -134,6 +134,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
       if (bmFooterCache != null) {
         bmFooterCache.release()
         bmFooterCache = null
+        bmFooterFiber = null
       }
       if (bmStatsContentCache != null) {
         bmStatsContentCache.release()


### PR DESCRIPTION
## What changes were proposed in this pull request?
When test the combing-index like `select xx from table where a = xxx and b = xxx` , there's a problem like #605( #604 ), In this sql a use btIndex and b use bmIndex, if sql like  `select xx from table where b = xxx` , there's no problem.The reasons for the above problems are as follows:

1. In our scene, bitmap index alway not trigger skipIndex read Behavior, so it will always invoke scanner.initialize method clear BitMapScanner status even if there more than 1 file in 1 task

2. But when use combing-index, some times btIndex trigger skipIndex read Behavior and bitmapscanner no chance to invoke scanner.initialize method, if there 2 files in 1 task, the 1st file skip index but not clear BitMapScanner bmFooterFiber status, the 2nd file do bitmap analyzeStatistics will use previous bmFooterFiber to wrap bmFooterCache, then there may occur read eof problem.

So only change of this pr is clear BitMapScanner. bmFooterFiber status after do analyzeStatistics to fix  above problems .

## How was this patch tested?
mvn test pass
