### PR TITLE
Add drop oindex after create oindex sql case

### DIFF
--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 import org.apache.spark.util.Utils
 
@@ -140,140 +140,142 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
   }
 
   test("Oap Meta integration test") {
-    val df = sparkContext.parallelize(1 to 100, 3)
-      .map(i => (i, i + 100, s"this is row $i"))
-      .toDF("a", "b", "c")
-    df.write.format("oap").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
-    val oapDf = sqlContext.read.format("oap").load(tmpDir.getAbsolutePath)
-    oapDf.createOrReplaceTempView("oapt1")
+    withIndex(TestIndex("oapt1", "index1"),
+      TestIndex("oapt1", "index3")) {
+      val df = sparkContext.parallelize(1 to 100, 3)
+        .map(i => (i, i + 100, s"this is row $i"))
+        .toDF("a", "b", "c")
+      df.write.format("oap").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
+      val oapDf = sqlContext.read.format("oap").load(tmpDir.getAbsolutePath)
+      oapDf.createOrReplaceTempView("oapt1")
 
-    val path = new Path(
-      new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
-    val oapMeta = DataSourceMeta.initialize(path, new Configuration())
+      val path = new Path(
+        new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
+      val oapMeta = DataSourceMeta.initialize(path, new Configuration())
 
-    val fileHeader = oapMeta.fileHeader
-    assert(fileHeader.recordCount === 100)
-    assert(fileHeader.dataFileCount === 3)
-    assert(fileHeader.indexCount === 0)
+      val fileHeader = oapMeta.fileHeader
+      assert(fileHeader.recordCount === 100)
+      assert(fileHeader.dataFileCount === 3)
+      assert(fileHeader.indexCount === 0)
 
-    val fileMetas = oapMeta.fileMetas
-    assert(fileMetas.length === 3)
-    assert(fileMetas.map(_.recordCount).sum === 100)
-    assert(fileMetas(0).dataFileName.endsWith(OapFileFormat.OAP_DATA_EXTENSION))
+      val fileMetas = oapMeta.fileMetas
+      assert(fileMetas.length === 3)
+      assert(fileMetas.map(_.recordCount).sum === 100)
+      assert(fileMetas(0).dataFileName.endsWith(OapFileFormat.OAP_DATA_EXTENSION))
 
-    assert(oapMeta.schema === df.schema)
+      assert(oapMeta.schema === df.schema)
 
-    sql("create oindex index1 on oapt1 (a)")
-    sql("create oindex index2 on oapt1 (a asc)") // dup as index1, still creating
-    sql("create oindex index3 on oapt1 (a desc)")
-    sql("create oindex if not exists index3 on oapt1 (a desc)") // not creating
-    sql("drop oindex index2 on oapt1") // dropping
-    sql("drop oindex if exists index5 on oapt1") // not dropping
-    sql("drop oindex if exists index2 on oapt1") // not dropping
+      withIndex(TestIndex("oapt1", "index2")) {
+        sql("create oindex index1 on oapt1 (a)")
+        sql("create oindex index2 on oapt1 (a asc)") // dup as index1, still creating
+        sql("create oindex index3 on oapt1 (a desc)")
+        sql("create oindex if not exists index3 on oapt1 (a desc)") // not creating
+      }
+      sql("drop oindex if exists index5 on oapt1") // not dropping
+      sql("drop oindex if exists index2 on oapt1") // not dropping
 
-    val oapMeta2 = DataSourceMeta.initialize(path, new Configuration())
-    val fileHeader2 = oapMeta2.fileHeader
-    assert(fileHeader2.recordCount === 100)
-    assert(fileHeader2.dataFileCount === 3)
-    assert(fileHeader2.indexCount === 2)
-    // other should keep the same
-    val fileMetas2 = oapMeta2.fileMetas
-    assert(fileMetas2.length === 3)
-    assert(fileMetas2.map(_.recordCount).sum === 100)
-    assert(fileMetas2(0).dataFileName.endsWith(OapFileFormat.OAP_DATA_EXTENSION))
-    assert(oapMeta2.schema === oapMeta.schema)
-    assert(oapMeta2.dataReaderClassName === oapMeta.dataReaderClassName)
-    // clean index after case
-    sql("drop oindex index1 on oapt1")
-    sql("drop oindex index3 on oapt1")
+      val oapMeta2 = DataSourceMeta.initialize(path, new Configuration())
+      val fileHeader2 = oapMeta2.fileHeader
+      assert(fileHeader2.recordCount === 100)
+      assert(fileHeader2.dataFileCount === 3)
+      assert(fileHeader2.indexCount === 2)
+      // other should keep the same
+      val fileMetas2 = oapMeta2.fileMetas
+      assert(fileMetas2.length === 3)
+      assert(fileMetas2.map(_.recordCount).sum === 100)
+      assert(fileMetas2(0).dataFileName.endsWith(OapFileFormat.OAP_DATA_EXTENSION))
+      assert(oapMeta2.schema === oapMeta.schema)
+      assert(oapMeta2.dataReaderClassName === oapMeta.dataReaderClassName)
+    }
   }
 
   test("Oap IndexMeta Test") {
-    val df = sparkContext.parallelize(1 to 100, 3)
-      .map(i => (i, i + 100, s"this is row $i"))
-      .toDF("a", "b", "c")
-    df.write.format("oap").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
-    val oapDf = sqlContext.read.format("oap").load(tmpDir.getAbsolutePath)
-    oapDf.createOrReplaceTempView("oapt1")
+    withIndex(TestIndex("oapt1", "mi")) {
+      val df = sparkContext.parallelize(1 to 100, 3)
+        .map(i => (i, i + 100, s"this is row $i"))
+        .toDF("a", "b", "c")
+      df.write.format("oap").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
+      val oapDf = sqlContext.read.format("oap").load(tmpDir.getAbsolutePath)
+      oapDf.createOrReplaceTempView("oapt1")
 
-    val path = new Path(
-      new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
+      val path = new Path(
+        new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
 
-    sql("create oindex mi on oapt1 (a, c desc, b asc)")
+      sql("create oindex mi on oapt1 (a, c desc, b asc)")
 
-    val oapMeta = DataSourceMeta.initialize(path, new Configuration())
-    val fileHeader = oapMeta.fileHeader
-    assert(fileHeader.indexCount === 1)
-    val indexMetas = oapMeta.indexMetas
-    assert(indexMetas.length === 1)
-    val indexMeta = indexMetas.head
-    assert(indexMeta.name === "mi")
-    assert(indexMeta.indexType === BTreeIndex(Seq(
-      BTreeIndexEntry(0, Ascending),
-      BTreeIndexEntry(2, Descending),
-      BTreeIndexEntry(1, Ascending)
-    )))
-    // clean index after case
-    sql("drop oindex mi on oapt1")
+      val oapMeta = DataSourceMeta.initialize(path, new Configuration())
+      val fileHeader = oapMeta.fileHeader
+      assert(fileHeader.indexCount === 1)
+      val indexMetas = oapMeta.indexMetas
+      assert(indexMetas.length === 1)
+      val indexMeta = indexMetas.head
+      assert(indexMeta.name === "mi")
+      assert(indexMeta.indexType === BTreeIndex(Seq(
+        BTreeIndexEntry(0, Ascending),
+        BTreeIndexEntry(2, Descending),
+        BTreeIndexEntry(1, Ascending)
+      )))
+    }
   }
 
   test("Oap Meta integration test for parquet") {
-    val df = sparkContext.parallelize(1 to 100, 3)
-      .map(i => (i, i + 100, s"this is row $i"))
-      .toDF("a", "b", "c")
-    df.write.format("parquet").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
-    val oapDf = sqlContext.read.format("parquet").load(tmpDir.getAbsolutePath)
-    oapDf.createOrReplaceTempView("oapt1")
+    withIndex(TestIndex("oapt1", "index1"),
+      TestIndex("oapt1", "index3")) {
+      val df = sparkContext.parallelize(1 to 100, 3)
+        .map(i => (i, i + 100, s"this is row $i"))
+        .toDF("a", "b", "c")
+      df.write.format("parquet").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
+      val oapDf = sqlContext.read.format("parquet").load(tmpDir.getAbsolutePath)
+      oapDf.createOrReplaceTempView("oapt1")
 
-    val path = new Path(
-      new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
+      val path = new Path(
+        new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
 
-    val fs = path.getFileSystem(new Configuration())
-    assert(!fs.exists(path))
+      val fs = path.getFileSystem(new Configuration())
+      assert(!fs.exists(path))
 
-    sql("create oindex index1 on oapt1 (a)")
-    sql("create oindex index2 on oapt1 (a asc)") // dup as index1, still creating
-    sql("create oindex index3 on oapt1 (a desc)")
-    sql("create oindex if not exists index3 on oapt1 (a desc)") // not creating
-    sql("drop oindex index2 on oapt1") // dropping
-    sql("drop oindex if exists index5 on oapt1") // not dropping
-    sql("drop oindex if exists index2 on oapt1") // not dropping
+      withIndex(TestIndex("oapt1", "index2")) {
+        sql("create oindex index1 on oapt1 (a)")
+        sql("create oindex index2 on oapt1 (a asc)") // dup as index1, still creating
+        sql("create oindex index3 on oapt1 (a desc)")
+        sql("create oindex if not exists index3 on oapt1 (a desc)") // not creating
+      }
+      sql("drop oindex if exists index5 on oapt1") // not dropping
+      sql("drop oindex if exists index2 on oapt1") // not dropping
 
-    val oapMeta2 = DataSourceMeta.initialize(path, new Configuration())
-    val fileHeader2 = oapMeta2.fileHeader
-    assert(fileHeader2.recordCount === 100)
-    assert(fileHeader2.dataFileCount === 3)
-    assert(fileHeader2.indexCount === 2)
-    // clean index after case
-    sql("drop oindex index1 on oapt1")
-    sql("drop oindex index3 on oapt1")
+      val oapMeta2 = DataSourceMeta.initialize(path, new Configuration())
+      val fileHeader2 = oapMeta2.fileHeader
+      assert(fileHeader2.recordCount === 100)
+      assert(fileHeader2.dataFileCount === 3)
+      assert(fileHeader2.indexCount === 2)
+    }
   }
 
   test("FileMeta's data file name test for parquet") {
-    val df = sparkContext.parallelize(1 to 100, 3)
-      .map(i => (i, i + 100, s"this is row $i"))
-      .toDF("a", "b", "c")
-    df.write.format("parquet").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
-    val oapDf = sqlContext.read.format("parquet").load(tmpDir.getAbsolutePath)
-    oapDf.createOrReplaceTempView("t")
+    withIndex(TestIndex("t", "index1")) {
+      val df = sparkContext.parallelize(1 to 100, 3)
+        .map(i => (i, i + 100, s"this is row $i"))
+        .toDF("a", "b", "c")
+      df.write.format("parquet").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
+      val oapDf = sqlContext.read.format("parquet").load(tmpDir.getAbsolutePath)
+      oapDf.createOrReplaceTempView("t")
 
-    val path = new Path(
-      new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
+      val path = new Path(
+        new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
 
-    val fs = path.getFileSystem(new Configuration())
-    assert(!fs.exists(path))
+      val fs = path.getFileSystem(new Configuration())
+      assert(!fs.exists(path))
 
-    sql("create oindex index1 on t (a)") // this will create index files along with meta file
-    assert(fs.exists(path))
+      sql("create oindex index1 on t (a)") // this will create index files along with meta file
+      assert(fs.exists(path))
 
-    val oapMeta = DataSourceMeta.initialize(path, sparkContext.hadoopConfiguration)
-    val fileMetas = oapMeta.fileMetas
-    assert(fileMetas.length === 3)
-    assert(fileMetas.map(_.recordCount).sum === 100)
-    assert(fileMetas(0).dataFileName.endsWith(".parquet"))
-    assert(fileMetas(0).dataFileName.startsWith("part"))
-    // clean index after case
-    sql("drop oindex index1 on t")
+      val oapMeta = DataSourceMeta.initialize(path, sparkContext.hadoopConfiguration)
+      val fileMetas = oapMeta.fileMetas
+      assert(fileMetas.length === 3)
+      assert(fileMetas.map(_.recordCount).sum === 100)
+      assert(fileMetas(0).dataFileName.endsWith(".parquet"))
+      assert(fileMetas(0).dataFileName.startsWith("part"))
+    }
   }
 
   test("Oap meta for partitioned table") {
@@ -377,172 +379,171 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
   }
 
   test("test hasAvailableIndex from Meta") {
-    val df = sparkContext.parallelize(1 to 100, 3)
-      .map(i => (i, i + 100, s"this is row $i"))
-      .toDF("a", "b", "c")
-    df.write.format("parquet").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
-    val oapDf = sqlContext.read.format("parquet").load(tmpDir.getAbsolutePath)
-    oapDf.createOrReplaceTempView("oapt1")
+    withIndex(TestIndex("oapt1", "indexA"),
+      TestIndex("oapt1", "indexC"),
+      TestIndex("oapt1", "indexABC")) {
+      val df = sparkContext.parallelize(1 to 100, 3)
+        .map(i => (i, i + 100, s"this is row $i"))
+        .toDF("a", "b", "c")
+      df.write.format("parquet").mode(SaveMode.Overwrite).save(tmpDir.getAbsolutePath)
+      val oapDf = sqlContext.read.format("parquet").load(tmpDir.getAbsolutePath)
+      oapDf.createOrReplaceTempView("oapt1")
 
-    sql("create oindex indexA on oapt1 (a)")
-    sql("create oindex indexC on oapt1 (c) using bitmap")
-    sql("create oindex indexABC on oapt1 (a,b,c)")
+      sql("create oindex indexA on oapt1 (a)")
+      sql("create oindex indexC on oapt1 (c) using bitmap")
+      sql("create oindex indexABC on oapt1 (a,b,c)")
 
-    val path = new Path(
-      new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
-    val meta = DataSourceMeta.initialize(path, new Configuration())
+      val path = new Path(
+        new File(tmpDir.getAbsolutePath, OapFileFormat.OAP_META_FILE).getAbsolutePath)
+      val meta = DataSourceMeta.initialize(path, new Configuration())
 
-    val bTreeIndexAttrSet = new mutable.HashSet[String]()
-    val bitmapIndexAttrSet = new mutable.HashSet[String]()
-    for (idxMeta <- meta.indexMetas) {
-      idxMeta.indexType match {
-        case BTreeIndex(entries) =>
-          bTreeIndexAttrSet.add(meta.schema(entries.head.ordinal).name)
-        case BitMapIndex(entries) =>
-          entries.map(ordinal => meta.schema(ordinal).name).foreach(bitmapIndexAttrSet.add)
-        case _ => // we don't support other types of index
+      val bTreeIndexAttrSet = new mutable.HashSet[String]()
+      val bitmapIndexAttrSet = new mutable.HashSet[String]()
+      for (idxMeta <- meta.indexMetas) {
+        idxMeta.indexType match {
+          case BTreeIndex(entries) =>
+            bTreeIndexAttrSet.add(meta.schema(entries.head.ordinal).name)
+          case BitMapIndex(entries) =>
+            entries.map(ordinal => meta.schema(ordinal).name).foreach(bitmapIndexAttrSet.add)
+          case _ => // we don't support other types of index
+        }
       }
-    }
-    val hashSetList = new mutable.ListBuffer[mutable.HashSet[String]]()
-    hashSetList.append(bTreeIndexAttrSet)
-    hashSetList.append(bitmapIndexAttrSet)
+      val hashSetList = new mutable.ListBuffer[mutable.HashSet[String]]()
+      hashSetList.append(bTreeIndexAttrSet)
+      hashSetList.append(bitmapIndexAttrSet)
 
-    // Query "select * from t where b == 1" will generate IsNotNull expr which is unsupportted
-    val isNotNull = Seq(IsNotNull(AttributeReference("b", IntegerType)()),
-      IsNotNull(AttributeReference("a", IntegerType)()))
-    val eq = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)))
-    val eq2 = Seq(EqualTo(AttributeReference("b", IntegerType)(), Literal(1)))
-    val eq3 = Seq(EqualTo(Literal(1), AttributeReference("a", IntegerType)()))
-    val lt = Seq(LessThan(AttributeReference("a", IntegerType)(), Literal(1)))
-    val gt = Seq(GreaterThan(AttributeReference("a", IntegerType)(), Literal(1)))
-    val gt2 = Seq(GreaterThan(AttributeReference("c", StringType)(), Literal("A Row")))
-    val lte = Seq(LessThanOrEqual(AttributeReference("a", IntegerType)(), Literal(1)))
-    val gte = Seq(GreaterThanOrEqual(AttributeReference("a", IntegerType)(), Literal(1)))
-    val gte1 = Seq(GreaterThanOrEqual(Literal(1), AttributeReference("a", IntegerType)()))
-    val or1 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
-      EqualTo(AttributeReference("a", IntegerType)(), Literal(1))))
-    val or2 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
-      LessThan(AttributeReference("a", IntegerType)(), Literal(3))))
+      // Query "select * from t where b == 1" will generate IsNotNull expr which is unsupportted
+      val isNotNull = Seq(IsNotNull(AttributeReference("b", IntegerType)()),
+        IsNotNull(AttributeReference("a", IntegerType)()))
+      val eq = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)))
+      val eq2 = Seq(EqualTo(AttributeReference("b", IntegerType)(), Literal(1)))
+      val eq3 = Seq(EqualTo(Literal(1), AttributeReference("a", IntegerType)()))
+      val lt = Seq(LessThan(AttributeReference("a", IntegerType)(), Literal(1)))
+      val gt = Seq(GreaterThan(AttributeReference("a", IntegerType)(), Literal(1)))
+      val gt2 = Seq(GreaterThan(AttributeReference("c", StringType)(), Literal("A Row")))
+      val lte = Seq(LessThanOrEqual(AttributeReference("a", IntegerType)(), Literal(1)))
+      val gte = Seq(GreaterThanOrEqual(AttributeReference("a", IntegerType)(), Literal(1)))
+      val gte1 = Seq(GreaterThanOrEqual(Literal(1), AttributeReference("a", IntegerType)()))
+      val or1 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
+        EqualTo(AttributeReference("a", IntegerType)(), Literal(1))))
+      val or2 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
+        LessThan(AttributeReference("a", IntegerType)(), Literal(3))))
 
-    val or3 = Seq(Or(GreaterThan(AttributeReference("c", StringType)(), Literal("A row")),
-      LessThan(AttributeReference("c", StringType)(), Literal("A row"))))
+      val or3 = Seq(Or(GreaterThan(AttributeReference("c", StringType)(), Literal("A row")),
+        LessThan(AttributeReference("c", StringType)(), Literal("A row"))))
 
-    val or4 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(3)),
-      LessThan(AttributeReference("c", StringType)(), Literal("A row"))))
+      val or4 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(3)),
+        LessThan(AttributeReference("c", StringType)(), Literal("A row"))))
 
-    val complicated_Or = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(50)),
-      And(GreaterThan(AttributeReference("a", IntegerType)(), Literal(3)),
-        LessThan(AttributeReference("a", IntegerType)(), Literal(24)))))
-
-    val moreComplicated_Or =
-      Seq(Or(And(GreaterThan(AttributeReference("a", IntegerType)(), Literal(56)),
-        LessThan(AttributeReference("a", IntegerType)(), Literal(97))),
+      val complicated_Or = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(50)),
         And(GreaterThan(AttributeReference("a", IntegerType)(), Literal(3)),
           LessThan(AttributeReference("a", IntegerType)(), Literal(24)))))
 
-    // ************** Muliti-Column Search Queries**********
-    val multi_column1 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
-      EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
-      LessThan(AttributeReference("c", StringType)(), Literal("A row")))
+      val moreComplicated_Or =
+        Seq(Or(And(GreaterThan(AttributeReference("a", IntegerType)(), Literal(56)),
+          LessThan(AttributeReference("a", IntegerType)(), Literal(97))),
+          And(GreaterThan(AttributeReference("a", IntegerType)(), Literal(3)),
+            LessThan(AttributeReference("a", IntegerType)(), Literal(24)))))
 
-    val multi_column2 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
-      GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)),
-      LessThan(AttributeReference("c", StringType)(), Literal("A row")))
+      // ************** Muliti-Column Search Queries**********
+      val multi_column1 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
+        EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
+        LessThan(AttributeReference("c", StringType)(), Literal("A row")))
 
-    val multi_column3 = Seq(GreaterThan(AttributeReference("a", IntegerType)(), Literal(1)),
-      GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)),
-      LessThan(AttributeReference("c", StringType)(), Literal("A row")))
+      val multi_column2 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
+        GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)),
+        LessThan(AttributeReference("c", StringType)(), Literal("A row")))
 
-    val multi_column4 = Seq(LessThan(AttributeReference("a", IntegerType)(), Literal(1)),
-      GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)),
-      LessThan(AttributeReference("c", StringType)(), Literal("A row")))
+      val multi_column3 = Seq(GreaterThan(AttributeReference("a", IntegerType)(), Literal(1)),
+        GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)),
+        LessThan(AttributeReference("c", StringType)(), Literal("A row")))
 
-    val multi_column5 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
-      LessThan(AttributeReference("c", StringType)(), Literal("A row")))
+      val multi_column4 = Seq(LessThan(AttributeReference("a", IntegerType)(), Literal(1)),
+        GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)),
+        LessThan(AttributeReference("c", StringType)(), Literal("A row")))
 
-    val multi_column6 = Seq(GreaterThan(AttributeReference("a", IntegerType)(), Literal(1)),
-      LessThan(AttributeReference("c", StringType)(), Literal("A row")))
+      val multi_column5 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
+        LessThan(AttributeReference("c", StringType)(), Literal("A row")))
 
-    val multi_column7 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
-      GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)))
+      val multi_column6 = Seq(GreaterThan(AttributeReference("a", IntegerType)(), Literal(1)),
+        LessThan(AttributeReference("c", StringType)(), Literal("A row")))
 
-    val multi_column8 = Seq(LessThan(AttributeReference("a", IntegerType)(), Literal(1)),
-      GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)))
+      val multi_column7 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
+        GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)))
 
-    val multi_column9 = Seq(EqualTo(AttributeReference("b", IntegerType)(), Literal(1)),
-      GreaterThan(AttributeReference("c", StringType)(), Literal("a Row")))
+      val multi_column8 = Seq(LessThan(AttributeReference("a", IntegerType)(), Literal(1)),
+        GreaterThan(AttributeReference("b", IntegerType)(), Literal(56)))
 
-    val multi_column10 = Seq(LessThan(AttributeReference("b", IntegerType)(), Literal(1)),
-      GreaterThan(AttributeReference("c", StringType)(), Literal("a Row")))
+      val multi_column9 = Seq(EqualTo(AttributeReference("b", IntegerType)(), Literal(1)),
+        GreaterThan(AttributeReference("c", StringType)(), Literal("a Row")))
 
-    val multi_column11 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
-      EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
-      EqualTo(AttributeReference("c", StringType)(), Literal("A row")))
+      val multi_column10 = Seq(LessThan(AttributeReference("b", IntegerType)(), Literal(1)),
+        GreaterThan(AttributeReference("c", StringType)(), Literal("a Row")))
 
-    val multi_column12 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
-      EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
-      Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
-        EqualTo(AttributeReference("a", IntegerType)(), Literal(18))))
+      val multi_column11 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
+        EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
+        EqualTo(AttributeReference("c", StringType)(), Literal("A row")))
 
-    val multi_column13 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
-      EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
-      Or(GreaterThan(AttributeReference("c", StringType)(), Literal("a row")),
-        EqualTo(AttributeReference("c", StringType)(), Literal("a row"))))
+      val multi_column12 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
+        EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
+        Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
+          EqualTo(AttributeReference("a", IntegerType)(), Literal(18))))
 
-    // a contradictory SQL condition
-    val multi_column14 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
-      EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
-      EqualTo(AttributeReference("c", StringType)(), Literal("A row")),
-      GreaterThan(AttributeReference("a", IntegerType)(), Literal(10)))
+      val multi_column13 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
+        EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
+        Or(GreaterThan(AttributeReference("c", StringType)(), Literal("a row")),
+          EqualTo(AttributeReference("c", StringType)(), Literal("a row"))))
 
-    // No requirement
-    assert(!isNotNull.exists(meta.isSupportedByIndex(_, None)))
-    assert(eq.exists(meta.isSupportedByIndex(_, None)))
-    assert(eq3.exists(meta.isSupportedByIndex(_, None)))
-    assert(lt.exists(meta.isSupportedByIndex(_, None)))
-    assert(gt.exists(meta.isSupportedByIndex(_, None)))
-    assert(gt2.exists(meta.isSupportedByIndex(_, None)))
-    assert(lte.exists(meta.isSupportedByIndex(_, None)))
-    assert(gte.exists(meta.isSupportedByIndex(_, None)))
-    assert(gte1.exists(meta.isSupportedByIndex(_, None)))
-    assert(!eq2.exists(meta.isSupportedByIndex(_, None)))
-    assert(or1.exists(meta.isSupportedByIndex(_, None)))
-    assert(or2.exists(meta.isSupportedByIndex(_, None)))
-    assert(or3.exists(meta.isSupportedByIndex(_, None)))
-    assert(!or4.exists(meta.isSupportedByIndex(_, None)))
-    assert(complicated_Or.exists(meta.isSupportedByIndex(_, None)))
-    assert(
-      moreComplicated_Or.exists(meta.isSupportedByIndex(_, None))
-    )
-    assert(multi_column1.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column2.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column3.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column4.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column5.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column6.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column7.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column8.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column9.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column10.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column11.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column12.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column13.exists(meta.isSupportedByIndex(_, None)))
-    assert(multi_column14.exists(meta.isSupportedByIndex(_, None)))
+      // a contradictory SQL condition
+      val multi_column14 = Seq(EqualTo(AttributeReference("a", IntegerType)(), Literal(1)),
+        EqualTo(AttributeReference("b", IntegerType)(), Literal(56)),
+        EqualTo(AttributeReference("c", StringType)(), Literal("A row")),
+        GreaterThan(AttributeReference("a", IntegerType)(), Literal(10)))
 
-    // check requirements.
-    val indexRequirement: IndexType = BTreeIndex()
-    // btree metrics, bitmap index should fail
-    assert(eq.exists(meta.isSupportedByIndex(_, Some(indexRequirement))))
-    assert(!gt2.exists(meta.isSupportedByIndex(_, Some(indexRequirement))))
+      // No requirement
+      assert(!isNotNull.exists(meta.isSupportedByIndex(_, None)))
+      assert(eq.exists(meta.isSupportedByIndex(_, None)))
+      assert(eq3.exists(meta.isSupportedByIndex(_, None)))
+      assert(lt.exists(meta.isSupportedByIndex(_, None)))
+      assert(gt.exists(meta.isSupportedByIndex(_, None)))
+      assert(gt2.exists(meta.isSupportedByIndex(_, None)))
+      assert(lte.exists(meta.isSupportedByIndex(_, None)))
+      assert(gte.exists(meta.isSupportedByIndex(_, None)))
+      assert(gte1.exists(meta.isSupportedByIndex(_, None)))
+      assert(!eq2.exists(meta.isSupportedByIndex(_, None)))
+      assert(or1.exists(meta.isSupportedByIndex(_, None)))
+      assert(or2.exists(meta.isSupportedByIndex(_, None)))
+      assert(or3.exists(meta.isSupportedByIndex(_, None)))
+      assert(!or4.exists(meta.isSupportedByIndex(_, None)))
+      assert(complicated_Or.exists(meta.isSupportedByIndex(_, None)))
+      assert(
+        moreComplicated_Or.exists(meta.isSupportedByIndex(_, None))
+      )
+      assert(multi_column1.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column2.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column3.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column4.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column5.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column6.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column7.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column8.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column9.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column10.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column11.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column12.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column13.exists(meta.isSupportedByIndex(_, None)))
+      assert(multi_column14.exists(meta.isSupportedByIndex(_, None)))
 
-    val multiRequirements: Seq[IndexType] = Seq(BTreeIndex(), BitMapIndex())
-    assert(
-      multi_column6.zip(multiRequirements)
-        .map(x => meta.isSupportedByIndex(x._1, Some(x._2))).reduce(_ && _))
-    // clean index after case
-    sql("drop oindex indexA on oapt1")
-    sql("drop oindex indexC on oapt1")
-    sql("drop oindex indexABC on oapt1")
+      // check requirements.
+      val indexRequirement: IndexType = BTreeIndex()
+      // btree metrics, bitmap index should fail
+      assert(eq.exists(meta.isSupportedByIndex(_, Some(indexRequirement))))
+      assert(!gt2.exists(meta.isSupportedByIndex(_, Some(indexRequirement))))
 
+      val multiRequirements: Seq[IndexType] = Seq(BTreeIndex(), BitMapIndex())
+      assert(
+        multi_column6.zip(multiRequirements)
+          .map(x => meta.isSupportedByIndex(x._1, Some(x._2))).reduce(_ && _))
+    }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -183,6 +183,9 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     assert(fileMetas2(0).dataFileName.endsWith(OapFileFormat.OAP_DATA_EXTENSION))
     assert(oapMeta2.schema === oapMeta.schema)
     assert(oapMeta2.dataReaderClassName === oapMeta.dataReaderClassName)
+    // clean index after case
+    sql("drop oindex index1 on oapt1")
+    sql("drop oindex index3 on oapt1")
   }
 
   test("Oap IndexMeta Test") {
@@ -210,6 +213,8 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
       BTreeIndexEntry(2, Descending),
       BTreeIndexEntry(1, Ascending)
     )))
+    // clean index after case
+    sql("drop oindex mi on oapt1")
   }
 
   test("Oap Meta integration test for parquet") {
@@ -239,6 +244,9 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     assert(fileHeader2.recordCount === 100)
     assert(fileHeader2.dataFileCount === 3)
     assert(fileHeader2.indexCount === 2)
+    // clean index after case
+    sql("drop oindex index1 on oapt1")
+    sql("drop oindex index3 on oapt1")
   }
 
   test("FileMeta's data file name test for parquet") {
@@ -264,6 +272,8 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     assert(fileMetas.map(_.recordCount).sum === 100)
     assert(fileMetas(0).dataFileName.endsWith(".parquet"))
     assert(fileMetas(0).dataFileName.startsWith("part"))
+    // clean index after case
+    sql("drop oindex index1 on t")
   }
 
   test("Oap meta for partitioned table") {
@@ -529,6 +539,10 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     assert(
       multi_column6.zip(multiRequirements)
         .map(x => meta.isSupportedByIndex(x._1, Some(x._2))).reduce(_ && _))
+    // clean index after case
+    sql("drop oindex indexA on oapt1")
+    sql("drop oindex indexC on oapt1")
+    sql("drop oindex indexABC on oapt1")
 
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataTypeSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataTypeSupportSuite.scala
@@ -23,7 +23,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex, TestPartition}
 
 class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
 
@@ -110,148 +110,157 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
   }
 
   test("create index on table partitioned by string type") {
-    val data: Seq[(Int, String)] = (1 to 10).map { i => (i, (i%2).toString)}
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_string select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_string (a) partition(b='1')")
-    checkAnswer(sql("select * from oap_partitioned_by_string where a = 1"),
-      Row(1, "1"):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_string partition(b='1')")
+    withIndex(TestIndex("parquet_partitioned_by_string", "idx1")) {
+      val data: Seq[(Int, String)] = (1 to 10).map { i => (i, (i%2).toString)}
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_partitioned_by_string select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_string (a) partition(b='1')")
+      checkAnswer(sql("select * from oap_partitioned_by_string where a = 1"),
+        Row(1, "1"):: Nil)
+      sql("drop oindex idx1 on oap_partitioned_by_string partition(b='1')")
 
-    sql("insert overwrite table parquet_partitioned_by_string select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_string (a) partition(b='1')")
-    checkAnswer(sql("select * from parquet_partitioned_by_string where a = 1"),
-      Row(1, "1"):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_string partition(b='1')")
-
+      sql("insert overwrite table parquet_partitioned_by_string select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_string (a) partition(b='1')")
+      checkAnswer(sql("select * from parquet_partitioned_by_string where a = 1"),
+        Row(1, "1"):: Nil)
+    }
   }
 
   test("create index on table partitioned by int type") {
     val data: Seq[(Int, Int)] = (1 to 10).map { i => (i, i%2)}
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_int select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_int (a) partition(b=1)")
-    checkAnswer(sql("select * from oap_partitioned_by_int where a = 1"),
-      Row(1, 1):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_int partition(b=1)")
+    withIndex(TestIndex("oap_partitioned_by_int", "idx1", TestPartition("b", "1"))) {
+      sql("insert overwrite table oap_partitioned_by_int select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_int (a) partition(b=1)")
+      checkAnswer(sql("select * from oap_partitioned_by_int where a = 1"),
+        Row(1, 1):: Nil)
+    }
+    withIndex(TestIndex("parquet_partitioned_by_int", "idx1", TestPartition("b", "1"))) {
+      sql("insert overwrite table parquet_partitioned_by_int select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_int (a) partition(b=1)")
+      checkAnswer(sql("select * from parquet_partitioned_by_int where a = 1"),
+        Row(1, 1):: Nil)
+    }
 
-    sql("insert overwrite table parquet_partitioned_by_int select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_int (a) partition(b=1)")
-    checkAnswer(sql("select * from parquet_partitioned_by_int where a = 1"),
-      Row(1, 1):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_int partition(b=1)")
   }
 
   test("create index on table partitioned by long type") {
     val data: Seq[(Int, Long)] = (1 to 10).map { i => (i, (i%2).toLong)}
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_long select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_long (a) partition(b=1)")
-    checkAnswer(sql("select * from oap_partitioned_by_long where a = 1"),
-      Row(1, 1L):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_long partition(b=1)")
-
-    sql("insert overwrite table parquet_partitioned_by_long select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_long (a) partition(b=1)")
-    checkAnswer(sql("select * from parquet_partitioned_by_long where a = 1"),
-      Row(1, 1L):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_long partition(b=1)")
+    withIndex(TestIndex("oap_partitioned_by_long", "idx1", TestPartition("b", "1"))) {
+      sql("insert overwrite table oap_partitioned_by_long select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_long (a) partition(b=1)")
+      checkAnswer(sql("select * from oap_partitioned_by_long where a = 1"),
+        Row(1, 1L):: Nil)
+    }
+    withIndex(TestIndex("parquet_partitioned_by_long", "idx1", TestPartition("b", "1"))) {
+      sql("insert overwrite table parquet_partitioned_by_long select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_long (a) partition(b=1)")
+      checkAnswer(sql("select * from parquet_partitioned_by_long where a = 1"),
+        Row(1, 1L):: Nil)
+    }
   }
 
   test("create index on table partitioned by boolean type") {
     val data: Seq[(Int, Boolean)] = (1 to 10).map { i => (i, i%2==0)}
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_boolean select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_boolean (a) partition(b=false)")
-    checkAnswer(sql("select * from oap_partitioned_by_boolean where a = 1"),
-      Row(1, false):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_boolean partition(b=false)")
-
-    sql("insert overwrite table parquet_partitioned_by_boolean select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_boolean (a) partition(b=false)")
-    checkAnswer(sql("select * from parquet_partitioned_by_boolean where a = 1"),
-      Row(1, false):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_boolean partition(b=false)")
+    withIndex(TestIndex("oap_partitioned_by_boolean", "idx1", TestPartition("b", "false"))) {
+      sql("insert overwrite table oap_partitioned_by_boolean select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_boolean (a) partition(b=false)")
+      checkAnswer(sql("select * from oap_partitioned_by_boolean where a = 1"),
+        Row(1, false):: Nil)
+    }
+    withIndex(TestIndex("parquet_partitioned_by_boolean", "idx1", TestPartition("b", "false"))) {
+      sql("insert overwrite table parquet_partitioned_by_boolean select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_boolean (a) partition(b=false)")
+      checkAnswer(sql("select * from parquet_partitioned_by_boolean where a = 1"),
+        Row(1, false):: Nil)
+    }
   }
 
   test("create index on table partitioned by date type") {
     val data: Seq[(Int, Date)] = (1 to 10).map { i => (i, DateTimeUtils.toJavaDate(i%2))}
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_date select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_date (a) partition(b='1970-01-01')")
-    checkAnswer(sql("select * from oap_partitioned_by_date where a = 1"),
-      Row(1, DateTimeUtils.toJavaDate(1)):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_date partition(b='1970-01-01')")
-
-    sql("insert overwrite table parquet_partitioned_by_date select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_date (a) partition(b='1970-01-01')")
-    checkAnswer(sql("select * from parquet_partitioned_by_date where a = 1"),
-      Row(1, DateTimeUtils.toJavaDate(1)):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_date partition(b='1970-01-01')")
+    withIndex(TestIndex("oap_partitioned_by_date", "idx1", TestPartition("b", "1970-01-01"))) {
+      sql("insert overwrite table oap_partitioned_by_date select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_date (a) partition(b='1970-01-01')")
+      checkAnswer(sql("select * from oap_partitioned_by_date where a = 1"),
+        Row(1, DateTimeUtils.toJavaDate(1)):: Nil)
+    }
+    withIndex(TestIndex("parquet_partitioned_by_date", "idx1", TestPartition("b", "1970-01-01"))) {
+      sql("insert overwrite table parquet_partitioned_by_date select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_date (a) partition(b='1970-01-01')")
+      checkAnswer(sql("select * from parquet_partitioned_by_date where a = 1"),
+        Row(1, DateTimeUtils.toJavaDate(1)):: Nil)
+    }
   }
 
   test("create index on table partitioned by double type") {
     val data: Seq[(Int, Double)] = (1 to 10).map { i => (i, (i%2).toDouble)}
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_double select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_double (a) partition(b=1.0)")
-    checkAnswer(sql("select * from oap_partitioned_by_double where a = 1"),
-      Row(1, 1.0):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_double partition(b=1.0)")
-
-    sql("insert overwrite table parquet_partitioned_by_double select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_double (a) partition(b=1.0)")
-    checkAnswer(sql("select * from parquet_partitioned_by_double where a = 1"),
-      Row(1, 1.0):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_double partition(b=1.0)")
+    withIndex(TestIndex("oap_partitioned_by_double", "idx1", TestPartition("b", "1.0"))) {
+      sql("insert overwrite table oap_partitioned_by_double select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_double (a) partition(b=1.0)")
+      checkAnswer(sql("select * from oap_partitioned_by_double where a = 1"),
+        Row(1, 1.0):: Nil)
+    }
+    withIndex(TestIndex("parquet_partitioned_by_double", "idx1", TestPartition("b", "1.0"))) {
+      sql("insert overwrite table parquet_partitioned_by_double select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_double (a) partition(b=1.0)")
+      checkAnswer(sql("select * from parquet_partitioned_by_double where a = 1"),
+        Row(1, 1.0):: Nil)
+    }
   }
 
   test("create index on table partitioned by float type") {
     val data: Seq[(Int, Float)] = (1 to 10).map { i => (i, (i%2).toFloat)}
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_float select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_float (a) partition(b=1.0)")
-    checkAnswer(sql("select * from oap_partitioned_by_float where a = 1"),
-      Row(1, 1.0f):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_float partition(b=1.0)")
-
-    sql("insert overwrite table parquet_partitioned_by_float select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_float (a) partition(b=1.0)")
-    checkAnswer(sql("select * from parquet_partitioned_by_float where a = 1"),
-      Row(1, 1.0f):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_float partition(b=1.0)")
+    withIndex(TestIndex("oap_partitioned_by_float", "idx1", TestPartition("b", "1.0"))) {
+      sql("insert overwrite table oap_partitioned_by_float select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_float (a) partition(b=1.0)")
+      checkAnswer(sql("select * from oap_partitioned_by_float where a = 1"),
+        Row(1, 1.0f):: Nil)
+    }
+    withIndex(TestIndex("parquet_partitioned_by_float", "idx1", TestPartition("b", "1.0"))) {
+      sql("insert overwrite table parquet_partitioned_by_float select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_float (a) partition(b=1.0)")
+      checkAnswer(sql("select * from parquet_partitioned_by_float where a = 1"),
+        Row(1, 1.0f):: Nil)
+    }
   }
 
   test("create index on table partitioned by byte type") {
     val data: Seq[(Int, Byte)] = (1 to 10).map { i => (i, (i%2).toByte)}
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_byte select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_byte (a) partition(b=1)")
-    checkAnswer(sql("select * from oap_partitioned_by_byte where a = 1"),
-      Row(1, 1.toByte):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_byte partition(b=1)")
-
-    sql("insert overwrite table parquet_partitioned_by_byte select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_byte (a) partition(b=1)")
-    checkAnswer(sql("select * from parquet_partitioned_by_byte where a = 1"),
-      Row(1, 1.toByte):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_byte partition(b=1)")
+    withIndex(TestIndex("oap_partitioned_by_byte", "idx1", TestPartition("b", "1"))) {
+      sql("insert overwrite table oap_partitioned_by_byte select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_byte (a) partition(b=1)")
+      checkAnswer(sql("select * from oap_partitioned_by_byte where a = 1"),
+        Row(1, 1.toByte):: Nil)
+    }
+    withIndex(TestIndex("parquet_partitioned_by_byte", "idx1", TestPartition("b", "1"))) {
+      sql("insert overwrite table parquet_partitioned_by_byte select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_byte (a) partition(b=1)")
+      checkAnswer(sql("select * from parquet_partitioned_by_byte where a = 1"),
+        Row(1, 1.toByte):: Nil)
+    }
   }
 
   test("create index on table partitioned by short type") {
     val data: Seq[(Int, Short)] = (1 to 10).map { i => (i, (i%2).toShort)}
     data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_partitioned_by_short select * from t")
-    sql("create oindex idx1 on oap_partitioned_by_short (a) partition(b=1)")
-    checkAnswer(sql("select * from oap_partitioned_by_short where a = 1"),
-      Row(1, 1.toShort):: Nil)
-    sql("drop oindex idx1 on oap_partitioned_by_short partition(b=1)")
-
-    sql("insert overwrite table parquet_partitioned_by_short select * from t")
-    sql("create oindex idx1 on parquet_partitioned_by_short (a) partition(b=1)")
-    checkAnswer(sql("select * from parquet_partitioned_by_short where a = 1"),
-      Row(1, 1.toShort):: Nil)
-    sql("drop oindex idx1 on parquet_partitioned_by_short partition(b=1)")
+    withIndex(TestIndex("oap_partitioned_by_short", "idx1", TestPartition("b", "1"))) {
+      sql("insert overwrite table oap_partitioned_by_short select * from t")
+      sql("create oindex idx1 on oap_partitioned_by_short (a) partition(b=1)")
+      checkAnswer(sql("select * from oap_partitioned_by_short where a = 1"),
+        Row(1, 1.toShort):: Nil)
+    }
+    withIndex(TestIndex("parquet_partitioned_by_short", "idx1", TestPartition("b", "1"))) {
+      sql("insert overwrite table parquet_partitioned_by_short select * from t")
+      sql("create oindex idx1 on parquet_partitioned_by_short (a) partition(b=1)")
+      checkAnswer(sql("select * from parquet_partitioned_by_short where a = 1"),
+        Row(1, 1.toShort):: Nil)
+    }
   }
 }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataTypeSupportSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataTypeSupportSuite.scala
@@ -116,11 +116,14 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_string (a) partition(b='1')")
     checkAnswer(sql("select * from oap_partitioned_by_string where a = 1"),
       Row(1, "1"):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_string partition(b='1')")
 
     sql("insert overwrite table parquet_partitioned_by_string select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_string (a) partition(b='1')")
     checkAnswer(sql("select * from parquet_partitioned_by_string where a = 1"),
       Row(1, "1"):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_string partition(b='1')")
+
   }
 
   test("create index on table partitioned by int type") {
@@ -130,11 +133,13 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_int (a) partition(b=1)")
     checkAnswer(sql("select * from oap_partitioned_by_int where a = 1"),
       Row(1, 1):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_int partition(b=1)")
 
     sql("insert overwrite table parquet_partitioned_by_int select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_int (a) partition(b=1)")
     checkAnswer(sql("select * from parquet_partitioned_by_int where a = 1"),
       Row(1, 1):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_int partition(b=1)")
   }
 
   test("create index on table partitioned by long type") {
@@ -144,11 +149,13 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_long (a) partition(b=1)")
     checkAnswer(sql("select * from oap_partitioned_by_long where a = 1"),
       Row(1, 1L):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_long partition(b=1)")
 
     sql("insert overwrite table parquet_partitioned_by_long select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_long (a) partition(b=1)")
     checkAnswer(sql("select * from parquet_partitioned_by_long where a = 1"),
       Row(1, 1L):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_long partition(b=1)")
   }
 
   test("create index on table partitioned by boolean type") {
@@ -158,11 +165,13 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_boolean (a) partition(b=false)")
     checkAnswer(sql("select * from oap_partitioned_by_boolean where a = 1"),
       Row(1, false):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_boolean partition(b=false)")
 
     sql("insert overwrite table parquet_partitioned_by_boolean select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_boolean (a) partition(b=false)")
     checkAnswer(sql("select * from parquet_partitioned_by_boolean where a = 1"),
       Row(1, false):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_boolean partition(b=false)")
   }
 
   test("create index on table partitioned by date type") {
@@ -172,11 +181,13 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_date (a) partition(b='1970-01-01')")
     checkAnswer(sql("select * from oap_partitioned_by_date where a = 1"),
       Row(1, DateTimeUtils.toJavaDate(1)):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_date partition(b='1970-01-01')")
 
     sql("insert overwrite table parquet_partitioned_by_date select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_date (a) partition(b='1970-01-01')")
     checkAnswer(sql("select * from parquet_partitioned_by_date where a = 1"),
       Row(1, DateTimeUtils.toJavaDate(1)):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_date partition(b='1970-01-01')")
   }
 
   test("create index on table partitioned by double type") {
@@ -186,11 +197,13 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_double (a) partition(b=1.0)")
     checkAnswer(sql("select * from oap_partitioned_by_double where a = 1"),
       Row(1, 1.0):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_double partition(b=1.0)")
 
     sql("insert overwrite table parquet_partitioned_by_double select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_double (a) partition(b=1.0)")
     checkAnswer(sql("select * from parquet_partitioned_by_double where a = 1"),
       Row(1, 1.0):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_double partition(b=1.0)")
   }
 
   test("create index on table partitioned by float type") {
@@ -200,11 +213,13 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_float (a) partition(b=1.0)")
     checkAnswer(sql("select * from oap_partitioned_by_float where a = 1"),
       Row(1, 1.0f):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_float partition(b=1.0)")
 
     sql("insert overwrite table parquet_partitioned_by_float select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_float (a) partition(b=1.0)")
     checkAnswer(sql("select * from parquet_partitioned_by_float where a = 1"),
       Row(1, 1.0f):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_float partition(b=1.0)")
   }
 
   test("create index on table partitioned by byte type") {
@@ -214,11 +229,13 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_byte (a) partition(b=1)")
     checkAnswer(sql("select * from oap_partitioned_by_byte where a = 1"),
       Row(1, 1.toByte):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_byte partition(b=1)")
 
     sql("insert overwrite table parquet_partitioned_by_byte select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_byte (a) partition(b=1)")
     checkAnswer(sql("select * from parquet_partitioned_by_byte where a = 1"),
       Row(1, 1.toByte):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_byte partition(b=1)")
   }
 
   test("create index on table partitioned by short type") {
@@ -228,11 +245,13 @@ class DataTypeSupportSuite extends QueryTest with SharedOapContext with BeforeAn
     sql("create oindex idx1 on oap_partitioned_by_short (a) partition(b=1)")
     checkAnswer(sql("select * from oap_partitioned_by_short where a = 1"),
       Row(1, 1.toShort):: Nil)
+    sql("drop oindex idx1 on oap_partitioned_by_short partition(b=1)")
 
     sql("insert overwrite table parquet_partitioned_by_short select * from t")
     sql("create oindex idx1 on parquet_partitioned_by_short (a) partition(b=1)")
     checkAnswer(sql("select * from parquet_partitioned_by_short where a = 1"),
       Row(1, 1.toShort):: Nil)
+    sql("drop oindex idx1 on parquet_partitioned_by_short partition(b=1)")
   }
 }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -212,6 +212,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND b = 'this is test 2'"),
       Row(2, "this is test 2") :: Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("filtering parquet2") {
@@ -234,6 +235,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
       Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("test refresh in parquet format on same partition") {
@@ -263,6 +265,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("select * from t_refresh_parquet"),
       Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 1) :: Nil)
+    sql("drop oindex index1 on t_refresh_parquet")
   }
 
   test("test refresh in parquet format on different partition") {
@@ -299,6 +302,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("select * from t_refresh_parquet"),
       Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(5, 1) :: Row(4, 2) :: Nil)
+    sql("drop oindex index1 on t_refresh_parquet")
   }
 
   test("test refresh in parquet format on a partition") {
@@ -349,6 +353,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("select * from t_refresh_parquet"),
       Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Row(3, 2) :: Row(4, 3) :: Nil)
+
+    sql("drop oindex index1 on t_refresh_parquet partition (b=1)")
+    sql("drop oindex index1 on t_refresh_parquet partition (b=2)")
   }
 
   test("test refresh in oap format on same partition") {
@@ -378,6 +385,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("select * from t_refresh"),
       Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 1) :: Nil)
+    sql("drop oindex index1 on t_refresh")
   }
 
   test("test refresh in oap format on different partition") {
@@ -414,6 +422,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("select * from t_refresh"),
       Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 2) :: Row(5, 1) :: Nil)
+    sql("drop oindex index1 on t_refresh")
   }
 
   test("test refresh in oap format on a partition") {
@@ -464,6 +473,8 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("select * from t_refresh"),
       Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Row(3, 2) :: Row(4, 3) :: Nil)
+    sql("drop oindex index1 on t_refresh partition (b=1)")
+    sql("drop oindex index1 on t_refresh partition (b=2)")
   }
 
   test("refresh table of oap format without partition") {
@@ -485,6 +496,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
       Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+    sql("drop oindex index1 on oap_test")
   }
 
   test("refresh table of parquet format without partition") {
@@ -501,6 +513,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
       Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("filtering by string") {
@@ -517,6 +530,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
       Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+    sql("drop oindex index1 on oap_test")
   }
 
   test("support data append without refresh") {
@@ -529,6 +543,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     sql("insert into table oap_test select * from t where key = 100")
     checkAnswer(sql("SELECT * FROM oap_test WHERE a = 100"),
       Row(100, "this is test 100") :: Nil)
+    sql("drop oindex index1 on oap_test")
 
     sql("insert overwrite table parquet_test select * from t where key > 100")
     sql("create oindex index1 on parquet_test (a)")
@@ -536,6 +551,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     sql("insert into table parquet_test select * from t where key = 100")
     checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 100"),
       Row(100, "this is test 100") :: Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("filtering by string with duplicate refresh") {
@@ -562,6 +578,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
     checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
       Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+    sql("drop oindex index1 on oap_test")
   }
 
   test("filtering with string type index") {
@@ -589,6 +606,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
       "b in('this is test 1','this is test 2','this is test 4')"),
       Row(1, "this is test 1") :: Row(2, "this is test 2")
         :: Row(4, "this is test 4") :: Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("test parquet use in StringFieldNotCastDouble") {
@@ -602,6 +620,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
       "b in(1,2,4)"),
       Row(1, "1") :: Row(2, "2")
         :: Row(4, "4") :: Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("test parquet use in IntFieldNotCastDouble") {
@@ -613,6 +632,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     // will use a in (20,30,40), value cast to int
     checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
       "a=10 AND a in (20,30,40)"), Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("test parquet query include in") {
@@ -651,6 +671,8 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
       "b='10' or b in (10,20,30)"),
       Row(10, "10") :: Row(20, "20")
         :: Row(30, "30")  :: Nil)
+    sql("drop oindex index1 on parquet_test")
+    sql("drop oindex index2 on parquet_test")
   }
 
 
@@ -666,6 +688,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
       "a BETWEEN 10 AND 12"),
       Row(10, "10") :: Row(11, "11")
         :: Row(12, "12") :: Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("test oap use in") {
@@ -687,7 +710,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     checkAnswer(sql("SELECT * FROM oap_test WHERE " +
       "b in('this is test 1','this is test 2','this is test 1')"),
       Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
-
+    sql("drop oindex index1 on oap_test")
   }
 
 
@@ -700,6 +723,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     // will use a in (20,30,40), value cast to int
     checkAnswer(sql("SELECT * FROM oap_test WHERE " +
       "a=10 AND a in (20,30,40)"), Nil)
+    sql("drop oindex index1 on oap_test")
   }
 
   test("test oap query include in") {
@@ -738,6 +762,8 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     checkAnswer(sql("SELECT * FROM oap_test WHERE " +
       "b='10' or (b = '20' and a in (10,20,30))"),
       Row(10, "10") :: Row(20, "20") :: Nil)
+    sql("drop oindex index1 on oap_test")
+    sql("drop oindex index2 on oap_test")
   }
 
   test("test parquet inner join") {
@@ -751,6 +777,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
       "inner join parquet_test t2 on t1.a = t2.a " +
       "group by t2.a"),
       Row(3, 3450.0) :: Nil)
+    sql("drop oindex index1 on parquet_test")
   }
 
   test("filtering null key") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -50,6 +50,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   override def beforeEach(): Unit = {
+
     val path = Utils.createTempDir().getAbsolutePath
     currentPath = path
     sql(s"""CREATE TEMPORARY VIEW oap_test (a INT, b STRING)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -26,7 +26,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.oap.OapConf
-import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex, TestPartition}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.util.Utils
 
@@ -133,849 +133,73 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (a)")
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (a)")
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Nil)
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 1 AND a <= 3"),
-      Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 1 AND a <= 3"),
+        Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a <= 2"),
-      Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a <= 2"),
+        Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a >= 300"),
-      Row(300, "this is test 300") :: Nil)
-
-    sql("drop oindex index1 on oap_test")
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a >= 300"),
+        Row(300, "this is test 300") :: Nil)
+    }
   }
 
   test("filtering2") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t where key = 1")
-    sql("insert into table oap_test select * from t where key = 2")
-    sql("insert into table oap_test select * from t where key = 3")
-    sql("insert into table oap_test select * from t where key = 4")
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t where key = 1")
+      sql("insert into table oap_test select * from t where key = 2")
+      sql("insert into table oap_test select * from t where key = 3")
+      sql("insert into table oap_test select * from t where key = 4")
 
-    sql("create oindex index1 on oap_test (a)")
+      sql("create oindex index1 on oap_test (a)")
 
-    val checkPath = new Path(currentPath)
-    val fs = checkPath.getFileSystem(new Configuration())
-    val indexFiles = fs.globStatus(new Path(checkPath, "*.index"))
-    assert(indexFiles.length == 4)
+      val checkPath = new Path(currentPath)
+      val fs = checkPath.getFileSystem(new Configuration())
+      val indexFiles = fs.globStatus(new Path(checkPath, "*.index"))
+      assert(indexFiles.length == 4)
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Nil)
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 1 AND a <= 3"),
-      Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
-
-    sql("drop oindex index1 on oap_test")
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 1 AND a <= 3"),
+        Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+    }
   }
 
   test("filtering multi index") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (a, b)")
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (a, b)")
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b < 'this is test 3'"),
-      Row(150, "this is test 150") :: Nil)
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b < 'this is test 3'"),
+        Row(150, "this is test 150") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b >= 'this is test 1'"),
-      Row(150, "this is test 150") :: Nil)
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b >= 'this is test 1'"),
+        Row(150, "this is test 150") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b = 'this is test 150'"),
-      Row(150, "this is test 150") :: Nil)
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b = 'this is test 150'"),
+        Row(150, "this is test 150") :: Nil)
 
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 299 and b < 'this is test 9'"),
-      Row(300, "this is test 300") :: Nil)
-
-    sql("drop oindex index1 on oap_test")
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 299 and b < 'this is test 9'"),
+        Row(300, "this is test 300") :: Nil)
+    }
   }
 
   test("filtering parquet") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex index1 on parquet_test (a)")
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
-      Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND b = 'this is test 2'"),
-      Row(2, "this is test 2") :: Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("filtering parquet2") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t where key = 1")
-    sql("insert into table parquet_test select * from t where key = 2")
-    sql("insert into table parquet_test select * from t where key = 3")
-    sql("insert into table parquet_test select * from t where key = 4")
-
-    sql("create oindex index1 on parquet_test (a)")
-
-    val checkPath = new Path(currentPath)
-    val fs = checkPath.getFileSystem(new Configuration())
-    val indexFiles = fs.globStatus(new Path(checkPath, "*.index"))
-    assert(indexFiles.length == 4)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
-      Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("test refresh in parquet format on same partition") {
-    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-
-    sql(
-      """
-        |INSERT OVERWRITE TABLE t_refresh_parquet
-        |partition (b=1)
-        |SELECT key from t where value < 4
-      """.stripMargin)
-
-    sql("create oindex index1 on t_refresh_parquet (a)")
-
-    checkAnswer(sql("select * from t_refresh_parquet"),
-      Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Nil)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh_parquet
-        |partition (b=1)
-        |SELECT key from t where value == 4
-      """.stripMargin)
-
-    sql("refresh oindex on t_refresh_parquet")
-
-    checkAnswer(sql("select * from t_refresh_parquet"),
-      Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 1) :: Nil)
-    sql("drop oindex index1 on t_refresh_parquet")
-  }
-
-  test("test refresh in parquet format on different partition") {
-    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-
-    sql(
-      """
-        |INSERT OVERWRITE TABLE t_refresh_parquet
-        |partition (b=1)
-        |SELECT key from t where value < 4
-      """.stripMargin)
-
-    sql("create oindex index1 on t_refresh_parquet (a)")
-
-    checkAnswer(sql("select * from t_refresh_parquet"),
-      Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Nil)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh_parquet
-        |partition (b=2)
-        |SELECT key from t where value == 4
-      """.stripMargin)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh_parquet
-        |partition (b=1)
-        |SELECT key from t where value == 5
-      """.stripMargin)
-
-    sql("refresh oindex on t_refresh_parquet")
-
-    checkAnswer(sql("select * from t_refresh_parquet"),
-      Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(5, 1) :: Row(4, 2) :: Nil)
-    sql("drop oindex index1 on t_refresh_parquet")
-  }
-
-  test("test refresh in parquet format on a partition") {
-    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-
-    sql(
-      """
-        |INSERT OVERWRITE TABLE t_refresh_parquet
-        |partition (b=1)
-        |SELECT key from t where value < 3
-      """.stripMargin)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh_parquet
-        |partition (b=2)
-        |SELECT key from t where value == 2
-      """.stripMargin)
-
-
-    sql("create oindex index1 on t_refresh_parquet (a)")
-
-    checkAnswer(sql("select * from t_refresh_parquet"),
-      Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Nil)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh_parquet
-        |partition (b=2)
-        |SELECT key from t where value == 3
-      """.stripMargin)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh_parquet
-        |partition (b=3)
-        |SELECT key from t where value == 4
-      """.stripMargin)
-
-    sql("refresh oindex on t_refresh_parquet partition (b=2)")
-
-    val fs = new Path(currentPath).getFileSystem(new Configuration())
-    val tablePath = sqlConf.warehousePath + "/t_refresh_parquet/"
-    assert(fs.globStatus(new Path(tablePath + "b=1/*.index")).length == 1)
-    assert(fs.globStatus(new Path(tablePath + "b=2/*.index")).length == 2)
-    assert(fs.globStatus(new Path(tablePath + "b=3/*.index")).length == 0)
-
-    checkAnswer(sql("select * from t_refresh_parquet"),
-      Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Row(3, 2) :: Row(4, 3) :: Nil)
-
-    sql("drop oindex index1 on t_refresh_parquet partition (b=1)")
-    sql("drop oindex index1 on t_refresh_parquet partition (b=2)")
-  }
-
-  test("test refresh in oap format on same partition") {
-    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-
-    sql(
-      """
-        |INSERT OVERWRITE TABLE t_refresh
-        |partition (b=1)
-        |SELECT key from t where value < 4
-      """.stripMargin)
-
-    sql("create oindex index1 on t_refresh (a)")
-
-    checkAnswer(sql("select * from t_refresh"),
-      Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Nil)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh
-        |partition (b=1)
-        |SELECT key from t where value == 4
-      """.stripMargin)
-
-    sql("refresh oindex on t_refresh")
-
-    checkAnswer(sql("select * from t_refresh"),
-      Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 1) :: Nil)
-    sql("drop oindex index1 on t_refresh")
-  }
-
-  test("test refresh in oap format on different partition") {
-    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-
-    sql(
-      """
-        |INSERT OVERWRITE TABLE t_refresh
-        |partition (b=1)
-        |SELECT key from t where value < 4
-      """.stripMargin)
-
-    sql("create oindex index1 on t_refresh (a)")
-
-    checkAnswer(sql("select * from t_refresh"),
-      Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Nil)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh
-        |partition (b=2)
-        |SELECT key from t where value == 4
-      """.stripMargin)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh
-        |partition (b=1)
-        |SELECT key from t where value == 5
-      """.stripMargin)
-
-    sql("refresh oindex on t_refresh")
-
-    checkAnswer(sql("select * from t_refresh"),
-      Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 2) :: Row(5, 1) :: Nil)
-    sql("drop oindex index1 on t_refresh")
-  }
-
-  test("test refresh in oap format on a partition") {
-    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-
-    sql(
-      """
-        |INSERT OVERWRITE TABLE t_refresh
-        |partition (b=1)
-        |SELECT key from t where value < 3
-      """.stripMargin)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh
-        |partition (b=2)
-        |SELECT key from t where value == 2
-      """.stripMargin)
-
-
-    sql("create oindex index1 on t_refresh (a)")
-
-    checkAnswer(sql("select * from t_refresh"),
-      Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Nil)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh
-        |partition (b=2)
-        |SELECT key from t where value == 3
-      """.stripMargin)
-
-    sql(
-      """
-        |INSERT INTO TABLE t_refresh
-        |partition (b=3)
-        |SELECT key from t where value == 4
-      """.stripMargin)
-
-    sql("refresh oindex on t_refresh partition (b=2)")
-
-    val fs = new Path(currentPath).getFileSystem(new Configuration())
-    val tablePath = sqlConf.warehousePath + "/t_refresh/"
-    assert(fs.globStatus(new Path(tablePath + "b=1/*.index")).length == 1)
-    assert(fs.globStatus(new Path(tablePath + "b=2/*.index")).length == 2)
-    assert(fs.globStatus(new Path(tablePath + "b=3/*.index")).length == 0)
-
-    checkAnswer(sql("select * from t_refresh"),
-      Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Row(3, 2) :: Row(4, 3) :: Nil)
-    sql("drop oindex index1 on t_refresh partition (b=1)")
-    sql("drop oindex index1 on t_refresh partition (b=2)")
-  }
-
-  test("refresh table of oap format without partition") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (a)")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Nil)
-
-    sql("insert into table oap_test select * from t")
-    val checkPath = new Path(currentPath)
-    val fs = checkPath.getFileSystem(new Configuration())
-    assert(fs.globStatus(new Path(checkPath, "*.index")).length == 2)
-
-    sql("refresh oindex on oap_test")
-    assert(fs.globStatus(new Path(checkPath, "*.index")).length == 4)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
-    sql("drop oindex index1 on oap_test")
-  }
-
-  test("refresh table of parquet format without partition") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex index1 on parquet_test (a)")
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Nil)
-
-    sql("insert into table parquet_test select * from t")
-    sql("refresh oindex on parquet_test")
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("filtering by string") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (a) using btree")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Nil)
-
-    sql("insert into table oap_test select * from t")
-    sql("refresh oindex on oap_test")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
-    sql("drop oindex index1 on oap_test")
-  }
-
-  test("support data append without refresh") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-
-    sql("insert overwrite table oap_test select * from t where key > 100")
-    sql("create oindex index1 on oap_test (a)")
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 100"), Nil)
-    sql("insert into table oap_test select * from t where key = 100")
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 100"),
-      Row(100, "this is test 100") :: Nil)
-    sql("drop oindex index1 on oap_test")
-
-    sql("insert overwrite table parquet_test select * from t where key > 100")
-    sql("create oindex index1 on parquet_test (a)")
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 100"), Nil)
-    sql("insert into table parquet_test select * from t where key = 100")
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 100"),
-      Row(100, "this is test 100") :: Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("filtering by string with duplicate refresh") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (a) using btree")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Nil)
-
-    sql("insert into table oap_test select * from t")
-    val check_path = new Path(currentPath)
-    assert(check_path.getFileSystem(
-      new Configuration()).globStatus(new Path(check_path, "*.index")).length == 2)
-    sql("refresh oindex on oap_test")
-    assert(check_path.getFileSystem(
-      new Configuration()).globStatus(new Path(check_path, "*.index")).length == 4)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
-
-    sql("refresh oindex on oap_test")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
-      Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
-    sql("drop oindex index1 on oap_test")
-  }
-
-  test("filtering with string type index") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (b)")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE b = 'this is test 1'"),
-      Row(1, "this is test 1") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 1 AND a <= 3"),
-      Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
-    sql("drop oindex index1 on oap_test")
-  }
-
-  test("test paruet use in") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex index1 on parquet_test (b)")
-
-    // will use b in (....)
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "b in('this is test 1','this is test 2','this is test 4')"),
-      Row(1, "this is test 1") :: Row(2, "this is test 2")
-        :: Row(4, "this is test 4") :: Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("test parquet use in StringFieldNotCastDouble") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex index1 on parquet_test (b)")
-
-    // will use b in(1,2,4), values cast to string
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "b in(1,2,4)"),
-      Row(1, "1") :: Row(2, "2")
-        :: Row(4, "4") :: Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("test parquet use in IntFieldNotCastDouble") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex index1 on parquet_test (a)")
-
-    // will use a in (20,30,40), value cast to int
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "a=10 AND a in (20,30,40)"), Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("test parquet query include in") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex index1 on parquet_test (a)")
-    sql("create oindex index2 on parquet_test (b)")
-
-    // ((cast(a#12 as double) = 10.0) || a#12 IN (20,30)),
-    // not support cast(a#12 as double) = 10.0
-    // can not use index
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "a=10 or a in (20,30)"),
-      Row(10, "10") :: Row(20, "20")
-        :: Row(30, "30") :: Nil)
-
-    // not support by index
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "b='10' or a in (20,30)"),
-      Row(10, "10") :: Row(20, "20")
-        :: Row(30, "30") :: Nil)
-
-    // not support by index
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "b='10' or (b = '20' and a in (10,20,30))"),
-      Row(10, "10") :: Row(20, "20") :: Nil)
-
-    // use index
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "b='10' and b in (10,20,30)"),
-      Row(10, "10") :: Nil)
-
-    // use index
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "b='10' or b in (10,20,30)"),
-      Row(10, "10") :: Row(20, "20")
-        :: Row(30, "30")  :: Nil)
-    sql("drop oindex index1 on parquet_test")
-    sql("drop oindex index2 on parquet_test")
-  }
-
-
-  test("test parquet use between") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex index1 on parquet_test (a)")
-
-    // (a#12 >= 10) && (a#12 <= 30)
-    // use index
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
-      "a BETWEEN 10 AND 12"),
-      Row(10, "10") :: Row(11, "11")
-        :: Row(12, "12") :: Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("test oap use in") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (b)")
-
-    // will use b in (....)
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "b in('this is test 1','this is test 2','this is test 4')"),
-      Row(1, "this is test 1") :: Row(2, "this is test 2")
-        :: Row(4, "this is test 4") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "b in('this is test 2','this is test 1','this is test 2')"),
-      Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "b in('this is test 1','this is test 2','this is test 1')"),
-      Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
-    sql("drop oindex index1 on oap_test")
-  }
-
-
-  test("test oap use in IntFieldNotCastDouble") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (a)")
-
-    // will use a in (20,30,40), value cast to int
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "a=10 AND a in (20,30,40)"), Nil)
-    sql("drop oindex index1 on oap_test")
-  }
-
-  test("test oap query include in") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (a)")
-    sql("create oindex index2 on oap_test (b)")
-
-    // ((cast(a#12 as double) = 10.0) || a#12 IN (20,30)),
-    // not support cast(a#12 as double) = 10.0
-    // can not use index
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "a=10 or a in (20,30)"),
-      Row(10, "10") :: Row(20, "20")
-        :: Row(30, "30") :: Nil)
-
-    // use index
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "b='10' and b in (10,20,30)"),
-      Row(10, "10") :: Nil)
-
-    // use index
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "b='10' or b in (10,20,30)"),
-      Row(10, "10") :: Row(20, "20")
-        :: Row(30, "30")  :: Nil)
-
-    // not support by index
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "b='10' or a in (20,30)"),
-      Row(10, "10") :: Row(20, "20")
-        :: Row(30, "30") :: Nil)
-
-    // not support by index
-    checkAnswer(sql("SELECT * FROM oap_test WHERE " +
-      "b='10' or (b = '20' and a in (10,20,30))"),
-      Row(10, "10") :: Row(20, "20") :: Nil)
-    sql("drop oindex index1 on oap_test")
-    sql("drop oindex index2 on oap_test")
-  }
-
-  test("test parquet inner join") {
-    val data: Seq[(Int, String)] = (1 to 300).map { i => (i / 10, s"$i") }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex index1 on parquet_test (a)")
-
-    checkAnswer(sql("select t2.a, sum(t2.b) " +
-      "from (select a from parquet_test where a = 3 ) t1 " +
-      "inner join parquet_test t2 on t1.a = t2.a " +
-      "group by t2.a"),
-      Row(3, 3450.0) :: Nil)
-    sql("drop oindex index1 on parquet_test")
-  }
-
-  test("filtering null key") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
-      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-     }.map(Row.fromSeq)
-    val schema =
-      StructType(
-        StructField("a", IntegerType) ::
-          StructField("c", StringType) :: Nil)
-    val df = spark.createDataFrame(rowRDD, schema)
-    df.createOrReplaceTempView("t")
-    val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
-
-    sql("insert overwrite table oap_test select * from t")
-
-    sql("create oindex idx1 on oap_test (a)")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a is null"), nullKeyRows)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 11 AND a <= 13"),
-      Row(12, "this is row 12") :: Row(13, "this is row 13") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a <= 2"), Nil)
-
-    sql("insert into table oap_test values(null, 'this is row 400')")
-    sql("insert into table oap_test values(null, 'this is row 500')")
-    sql("refresh oindex on oap_test")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a is null"),
-      nullKeyRows :+ Row(null, "this is row 400") :+ Row(null, "this is row 500"))
-
-    sql("drop oindex idx1 on oap_test")
-  }
-
-  test("filtering null key in Parquet format") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
-      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-    }.map(Row.fromSeq)
-    val schema =
-      StructType(
-        StructField("a", IntegerType) ::
-          StructField("c", StringType) :: Nil)
-    val df = spark.createDataFrame(rowRDD, schema)
-    df.createOrReplaceTempView("t")
-    val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
-
-    sql("insert overwrite table parquet_test select * from t")
-
-    sql("create oindex idx1 on parquet_test (a)")
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a is null"), nullKeyRows)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 11 AND a <= 13"),
-      Row(12, "this is row 12") :: Row(13, "this is row 13") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a <= 2"), Nil)
-
-    sql("insert into table parquet_test values(null, 'this is row 400')")
-    sql("insert into table parquet_test values(null, 'this is row 500')")
-    sql("refresh oindex on parquet_test")
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a is null"),
-      nullKeyRows :+ Row(null, "this is row 400") :+ Row(null, "this is row 500"))
-
-    sql("drop oindex idx1 on parquet_test")
-  }
-
-  test("filtering non-null key") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
-      if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-    }.map(Row.fromSeq)
-    val schema =
-      StructType(
-        StructField("a", IntegerType) ::
-          StructField("c", StringType) :: Nil)
-    val df = spark.createDataFrame(rowRDD, schema)
-    df.createOrReplaceTempView("t")
-    val nonNullKeyRows = (4 to 10).map(i => Row(i, s"this is row $i"))
-
-    sql("insert overwrite table oap_test select * from t")
-
-    sql("create oindex idx1 on oap_test (a)")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a is not null"), nonNullKeyRows)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 7 AND a <= 9"),
-      Row(8, "this is row 8") :: Row(9, "this is row 9") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a <= 2"), Nil)
-
-    sql("drop oindex idx1 on oap_test")
-  }
-
-  test("filtering non-null key in Parquet format") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
-      if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-    }.map(Row.fromSeq)
-    val schema =
-      StructType(
-        StructField("a", IntegerType) ::
-          StructField("c", StringType) :: Nil)
-    val df = spark.createDataFrame(rowRDD, schema)
-    df.createOrReplaceTempView("t")
-    val nonNullKeyRows = (4 to 10).map(i => Row(i, s"this is row $i"))
-
-    sql("insert overwrite table parquet_test select * from t")
-
-    sql("create oindex idx1 on parquet_test (a)")
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a is not null"), nonNullKeyRows)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 7 AND a <= 9"),
-      Row(8, "this is row 8") :: Row(9, "this is row 9") :: Nil)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a <= 2"), Nil)
-
-    sql("drop oindex idx1 on parquet_test")
-  }
-
-  test("filtering null key and normal key mixed") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
-      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-    }.map(Row.fromSeq)
-    val schema =
-      StructType(
-        StructField("a", IntegerType) ::
-          StructField("c", StringType) :: Nil)
-    val df = spark.createDataFrame(rowRDD, schema)
-    df.createOrReplaceTempView("t")
-    val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
-
-    sql("insert overwrite table oap_test select * from t")
-    sql("create oindex idx1 on oap_test (a)")
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 11 AND a <= 13 or a is null"),
-      Row(12, "this is row 12") :: Row(13, "this is row 13") :: Nil ++ nullKeyRows)
-
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 23 and a is null"), Nil)
-
-    sql("drop oindex idx1 on oap_test")
-  }
-
-  test("filtering null key and normal key mixed in Parquet format") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
-      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-    }.map(Row.fromSeq)
-    val schema =
-      StructType(
-        StructField("a", IntegerType) ::
-          StructField("c", StringType) :: Nil)
-    val df = spark.createDataFrame(rowRDD, schema)
-    df.createOrReplaceTempView("t")
-    val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
-
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex idx1 on parquet_test (a)")
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 11 AND a <= 13 or a is null"),
-      Row(12, "this is row 12") :: Row(13, "this is row 13") :: Nil ++ nullKeyRows)
-
-    checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 23 and a is null"), Nil)
-
-    sql("drop oindex idx1 on parquet_test")
-  }
-
-  test("get columns hit index") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
-      Seq(i, s"this is row $i")).map(Row.fromSeq)
-    val schema =
-      StructType(
-        StructField("a", IntegerType) ::
-          StructField("c", StringType) :: Nil)
-    val df = spark.createDataFrame(rowRDD, schema)
-    df.createOrReplaceTempView("t")
-
-    sql("insert overwrite table parquet_test select * from t")
-    sql("create oindex idx1 on parquet_test (a)")
-    sql("create oindex idx2 on parquet_test (a, b)")
-
-    val df1 = sql("SELECT * FROM parquet_test WHERE a = 1")
-    checkAnswer(df1, Row(1, "this is row 1") :: Nil)
-    val ret1 = getColumnsHitIndex(df1.queryExecution.sparkPlan)
-    assert(ret1.keySet.size == 1 && ret1.keySet.head == "a")
-    assert(ret1.values.head.toString == BTreeIndex(BTreeIndexEntry(0)::Nil).toString)
-
-    val df2 = sql("SELECT * FROM parquet_test WHERE a = 1 AND b = 'this is row 1'")
-    checkAnswer(df2, Row(1, "this is row 1") :: Nil)
-    val ret2 = getColumnsHitIndex(df2.queryExecution.sparkPlan)
-    assert(ret2.keySet.size == 2 && ret2.contains("a") && ret2.contains("b"))
-    assert(ret2("a") == ret2("b") && ret2("a").toString
-      == BTreeIndex(BTreeIndexEntry(0)::BTreeIndexEntry(1)::Nil).toString)
-    sql("drop oindex idx1 on parquet_test")
-    sql("drop oindex idx2 on parquet_test")
-  }
-
-  test("filtering parquet in FiberCache") {
-    withSQLConf("spark.sql.oap.parquet.data.cache.enable" -> "true") {
+    withIndex(TestIndex("parquet_test", "index1")) {
       val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
       data.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table parquet_test select * from t")
@@ -986,6 +210,807 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
       checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
         Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND b = 'this is test 2'"),
+        Row(2, "this is test 2") :: Nil)
+    }
+  }
+
+  test("filtering parquet2") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t where key = 1")
+      sql("insert into table parquet_test select * from t where key = 2")
+      sql("insert into table parquet_test select * from t where key = 3")
+      sql("insert into table parquet_test select * from t where key = 4")
+
+      sql("create oindex index1 on parquet_test (a)")
+
+      val checkPath = new Path(currentPath)
+      val fs = checkPath.getFileSystem(new Configuration())
+      val indexFiles = fs.globStatus(new Path(checkPath, "*.index"))
+      assert(indexFiles.length == 4)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
+        Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+    }
+  }
+
+  test("test refresh in parquet format on same partition") {
+    withIndex(TestIndex("t_refresh_parquet", "index1")) {
+      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+
+      sql(
+        """
+          |INSERT OVERWRITE TABLE t_refresh_parquet
+          |partition (b=1)
+          |SELECT key from t where value < 4
+        """.stripMargin)
+
+      sql("create oindex index1 on t_refresh_parquet (a)")
+
+      checkAnswer(sql("select * from t_refresh_parquet"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Nil)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh_parquet
+          |partition (b=1)
+          |SELECT key from t where value == 4
+        """.stripMargin)
+
+      sql("refresh oindex on t_refresh_parquet")
+
+      checkAnswer(sql("select * from t_refresh_parquet"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 1) :: Nil)
+    }
+  }
+
+  test("test refresh in parquet format on different partition") {
+    withIndex(TestIndex("t_refresh_parquet", "index1")) {
+      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+
+      sql(
+        """
+          |INSERT OVERWRITE TABLE t_refresh_parquet
+          |partition (b=1)
+          |SELECT key from t where value < 4
+        """.stripMargin)
+
+      sql("create oindex index1 on t_refresh_parquet (a)")
+
+      checkAnswer(sql("select * from t_refresh_parquet"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Nil)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh_parquet
+          |partition (b=2)
+          |SELECT key from t where value == 4
+        """.stripMargin)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh_parquet
+          |partition (b=1)
+          |SELECT key from t where value == 5
+        """.stripMargin)
+
+      sql("refresh oindex on t_refresh_parquet")
+
+      checkAnswer(sql("select * from t_refresh_parquet"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(5, 1) :: Row(4, 2) :: Nil)
+    }
+  }
+
+  test("test refresh in parquet format on a partition") {
+    withIndex(TestIndex("t_refresh_parquet", "index1", TestPartition("b", "1")),
+      TestIndex("t_refresh_parquet", "index1", TestPartition("b", "2"))) {
+      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+
+      sql(
+        """
+          |INSERT OVERWRITE TABLE t_refresh_parquet
+          |partition (b=1)
+          |SELECT key from t where value < 3
+        """.stripMargin)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh_parquet
+          |partition (b=2)
+          |SELECT key from t where value == 2
+        """.stripMargin)
+
+
+      sql("create oindex index1 on t_refresh_parquet (a)")
+
+      checkAnswer(sql("select * from t_refresh_parquet"),
+        Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Nil)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh_parquet
+          |partition (b=2)
+          |SELECT key from t where value == 3
+        """.stripMargin)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh_parquet
+          |partition (b=3)
+          |SELECT key from t where value == 4
+        """.stripMargin)
+
+      sql("refresh oindex on t_refresh_parquet partition (b=2)")
+
+      val fs = new Path(currentPath).getFileSystem(new Configuration())
+      val tablePath = sqlConf.warehousePath + "/t_refresh_parquet/"
+      assert(fs.globStatus(new Path(tablePath + "b=1/*.index")).length == 1)
+      assert(fs.globStatus(new Path(tablePath + "b=2/*.index")).length == 2)
+      assert(fs.globStatus(new Path(tablePath + "b=3/*.index")).length == 0)
+
+      checkAnswer(sql("select * from t_refresh_parquet"),
+        Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Row(3, 2) :: Row(4, 3) :: Nil)
+    }
+  }
+
+  test("test refresh in oap format on same partition") {
+    withIndex(TestIndex("t_refresh", "index1")) {
+      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+
+      sql(
+        """
+          |INSERT OVERWRITE TABLE t_refresh
+          |partition (b=1)
+          |SELECT key from t where value < 4
+        """.stripMargin)
+
+      sql("create oindex index1 on t_refresh (a)")
+
+      checkAnswer(sql("select * from t_refresh"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Nil)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh
+          |partition (b=1)
+          |SELECT key from t where value == 4
+        """.stripMargin)
+
+      sql("refresh oindex on t_refresh")
+
+      checkAnswer(sql("select * from t_refresh"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 1) :: Nil)
+    }
+  }
+
+  test("test refresh in oap format on different partition") {
+    withIndex(TestIndex("t_refresh", "index1")) {
+      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+
+      sql(
+        """
+          |INSERT OVERWRITE TABLE t_refresh
+          |partition (b=1)
+          |SELECT key from t where value < 4
+        """.stripMargin)
+
+      sql("create oindex index1 on t_refresh (a)")
+
+      checkAnswer(sql("select * from t_refresh"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Nil)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh
+          |partition (b=2)
+          |SELECT key from t where value == 4
+        """.stripMargin)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh
+          |partition (b=1)
+          |SELECT key from t where value == 5
+        """.stripMargin)
+
+      sql("refresh oindex on t_refresh")
+
+      checkAnswer(sql("select * from t_refresh"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 1) :: Row(4, 2) :: Row(5, 1) :: Nil)
+    }
+  }
+
+  test("test refresh in oap format on a partition") {
+    withIndex(TestIndex("t_refresh", "index1", TestPartition("b", "1")),
+      TestIndex("t_refresh", "index1", TestPartition("b", "2"))) {
+      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+
+      sql(
+        """
+          |INSERT OVERWRITE TABLE t_refresh
+          |partition (b=1)
+          |SELECT key from t where value < 3
+        """.stripMargin)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh
+          |partition (b=2)
+          |SELECT key from t where value == 2
+        """.stripMargin)
+
+
+      sql("create oindex index1 on t_refresh (a)")
+
+      checkAnswer(sql("select * from t_refresh"),
+        Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Nil)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh
+          |partition (b=2)
+          |SELECT key from t where value == 3
+        """.stripMargin)
+
+      sql(
+        """
+          |INSERT INTO TABLE t_refresh
+          |partition (b=3)
+          |SELECT key from t where value == 4
+        """.stripMargin)
+
+      sql("refresh oindex on t_refresh partition (b=2)")
+
+      val fs = new Path(currentPath).getFileSystem(new Configuration())
+      val tablePath = sqlConf.warehousePath + "/t_refresh/"
+      assert(fs.globStatus(new Path(tablePath + "b=1/*.index")).length == 1)
+      assert(fs.globStatus(new Path(tablePath + "b=2/*.index")).length == 2)
+      assert(fs.globStatus(new Path(tablePath + "b=3/*.index")).length == 0)
+
+      checkAnswer(sql("select * from t_refresh"),
+        Row(1, 1) :: Row(2, 1) :: Row(2, 2) :: Row(3, 2) :: Row(4, 3) :: Nil)
+    }
+  }
+
+  test("refresh table of oap format without partition") {
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (a)")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Nil)
+
+      sql("insert into table oap_test select * from t")
+      val checkPath = new Path(currentPath)
+      val fs = checkPath.getFileSystem(new Configuration())
+      assert(fs.globStatus(new Path(checkPath, "*.index")).length == 2)
+
+      sql("refresh oindex on oap_test")
+      assert(fs.globStatus(new Path(checkPath, "*.index")).length == 4)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+    }
+  }
+
+  test("refresh table of parquet format without partition") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex index1 on parquet_test (a)")
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Nil)
+
+      sql("insert into table parquet_test select * from t")
+      sql("refresh oindex on parquet_test")
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+    }
+  }
+
+  test("filtering by string") {
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (a) using btree")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Nil)
+
+      sql("insert into table oap_test select * from t")
+      sql("refresh oindex on oap_test")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+    }
+  }
+
+  test("support data append without refresh") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+
+      sql("insert overwrite table oap_test select * from t where key > 100")
+      sql("create oindex index1 on oap_test (a)")
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 100"), Nil)
+      sql("insert into table oap_test select * from t where key = 100")
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 100"),
+        Row(100, "this is test 100") :: Nil)
+      sql("drop oindex index1 on oap_test")
+
+      sql("insert overwrite table parquet_test select * from t where key > 100")
+      sql("create oindex index1 on parquet_test (a)")
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 100"), Nil)
+      sql("insert into table parquet_test select * from t where key = 100")
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 100"),
+        Row(100, "this is test 100") :: Nil)
+    }
+  }
+
+  test("filtering by string with duplicate refresh") {
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (a) using btree")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Nil)
+
+      sql("insert into table oap_test select * from t")
+      val check_path = new Path(currentPath)
+      assert(check_path.getFileSystem(
+        new Configuration()).globStatus(new Path(check_path, "*.index")).length == 2)
+      sql("refresh oindex on oap_test")
+      assert(check_path.getFileSystem(
+        new Configuration()).globStatus(new Path(check_path, "*.index")).length == 4)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+
+      sql("refresh oindex on oap_test")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
+        Row(1, "this is test 1") :: Row(1, "this is test 1") :: Nil)
+    }
+  }
+
+  test("filtering with string type index") {
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (b)")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE b = 'this is test 1'"),
+        Row(1, "this is test 1") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 1 AND a <= 3"),
+        Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+    }
+  }
+
+  test("test paruet use in") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex index1 on parquet_test (b)")
+
+      // will use b in (....)
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "b in('this is test 1','this is test 2','this is test 4')"),
+        Row(1, "this is test 1") :: Row(2, "this is test 2")
+          :: Row(4, "this is test 4") :: Nil)
+    }
+  }
+
+  test("test parquet use in StringFieldNotCastDouble") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex index1 on parquet_test (b)")
+
+      // will use b in(1,2,4), values cast to string
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "b in(1,2,4)"),
+        Row(1, "1") :: Row(2, "2")
+          :: Row(4, "4") :: Nil)
+    }
+  }
+
+  test("test parquet use in IntFieldNotCastDouble") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex index1 on parquet_test (a)")
+
+      // will use a in (20,30,40), value cast to int
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "a=10 AND a in (20,30,40)"), Nil)
+    }
+  }
+
+  test("test parquet query include in") {
+    withIndex(TestIndex("parquet_test", "index1"),
+      TestIndex("parquet_test", "index2")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex index1 on parquet_test (a)")
+      sql("create oindex index2 on parquet_test (b)")
+
+      // ((cast(a#12 as double) = 10.0) || a#12 IN (20,30)),
+      // not support cast(a#12 as double) = 10.0
+      // can not use index
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "a=10 or a in (20,30)"),
+        Row(10, "10") :: Row(20, "20")
+          :: Row(30, "30") :: Nil)
+
+      // not support by index
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "b='10' or a in (20,30)"),
+        Row(10, "10") :: Row(20, "20")
+          :: Row(30, "30") :: Nil)
+
+      // not support by index
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "b='10' or (b = '20' and a in (10,20,30))"),
+        Row(10, "10") :: Row(20, "20") :: Nil)
+
+      // use index
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "b='10' and b in (10,20,30)"),
+        Row(10, "10") :: Nil)
+
+      // use index
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "b='10' or b in (10,20,30)"),
+        Row(10, "10") :: Row(20, "20")
+          :: Row(30, "30")  :: Nil)
+    }
+  }
+
+
+  test("test parquet use between") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex index1 on parquet_test (a)")
+
+      // (a#12 >= 10) && (a#12 <= 30)
+      // use index
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE " +
+        "a BETWEEN 10 AND 12"),
+        Row(10, "10") :: Row(11, "11")
+          :: Row(12, "12") :: Nil)
+    }
+  }
+
+  test("test oap use in") {
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (b)")
+
+      // will use b in (....)
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "b in('this is test 1','this is test 2','this is test 4')"),
+        Row(1, "this is test 1") :: Row(2, "this is test 2")
+          :: Row(4, "this is test 4") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "b in('this is test 2','this is test 1','this is test 2')"),
+        Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "b in('this is test 1','this is test 2','this is test 1')"),
+        Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
+    }
+  }
+
+
+  test("test oap use in IntFieldNotCastDouble") {
+    withIndex(TestIndex("oap_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (a)")
+
+      // will use a in (20,30,40), value cast to int
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "a=10 AND a in (20,30,40)"), Nil)
+    }
+  }
+
+  test("test oap query include in") {
+    withIndex(TestIndex("oap_test", "index1"),
+      TestIndex("oap_test", "index2")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex index1 on oap_test (a)")
+      sql("create oindex index2 on oap_test (b)")
+
+      // ((cast(a#12 as double) = 10.0) || a#12 IN (20,30)),
+      // not support cast(a#12 as double) = 10.0
+      // can not use index
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "a=10 or a in (20,30)"),
+        Row(10, "10") :: Row(20, "20")
+          :: Row(30, "30") :: Nil)
+
+      // use index
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "b='10' and b in (10,20,30)"),
+        Row(10, "10") :: Nil)
+
+      // use index
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "b='10' or b in (10,20,30)"),
+        Row(10, "10") :: Row(20, "20")
+          :: Row(30, "30")  :: Nil)
+
+      // not support by index
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "b='10' or a in (20,30)"),
+        Row(10, "10") :: Row(20, "20")
+          :: Row(30, "30") :: Nil)
+
+      // not support by index
+      checkAnswer(sql("SELECT * FROM oap_test WHERE " +
+        "b='10' or (b = '20' and a in (10,20,30))"),
+        Row(10, "10") :: Row(20, "20") :: Nil)
+    }
+  }
+
+  test("test parquet inner join") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i / 10, s"$i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex index1 on parquet_test (a)")
+
+      checkAnswer(sql("select t2.a, sum(t2.b) " +
+        "from (select a from parquet_test where a = 3 ) t1 " +
+        "inner join parquet_test t2 on t1.a = t2.a " +
+        "group by t2.a"),
+        Row(3, 3450.0) :: Nil)
+    }
+  }
+
+  test("filtering null key") {
+    withIndex(TestIndex("oap_test", "idx1")) {
+      val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+        if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+      }.map(Row.fromSeq)
+      val schema =
+        StructType(
+          StructField("a", IntegerType) ::
+            StructField("c", StringType) :: Nil)
+      val df = spark.createDataFrame(rowRDD, schema)
+      df.createOrReplaceTempView("t")
+      val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
+
+      sql("insert overwrite table oap_test select * from t")
+
+      sql("create oindex idx1 on oap_test (a)")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a is null"), nullKeyRows)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 11 AND a <= 13"),
+        Row(12, "this is row 12") :: Row(13, "this is row 13") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a <= 2"), Nil)
+
+      sql("insert into table oap_test values(null, 'this is row 400')")
+      sql("insert into table oap_test values(null, 'this is row 500')")
+      sql("refresh oindex on oap_test")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a is null"),
+        nullKeyRows :+ Row(null, "this is row 400") :+ Row(null, "this is row 500"))
+    }
+  }
+
+  test("filtering null key in Parquet format") {
+    withIndex(TestIndex("parquet_test", "idx1")) {
+      val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+        if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+      }.map(Row.fromSeq)
+      val schema =
+        StructType(
+          StructField("a", IntegerType) ::
+            StructField("c", StringType) :: Nil)
+      val df = spark.createDataFrame(rowRDD, schema)
+      df.createOrReplaceTempView("t")
+      val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
+
+      sql("insert overwrite table parquet_test select * from t")
+
+      sql("create oindex idx1 on parquet_test (a)")
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a is null"), nullKeyRows)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 11 AND a <= 13"),
+        Row(12, "this is row 12") :: Row(13, "this is row 13") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a <= 2"), Nil)
+
+      sql("insert into table parquet_test values(null, 'this is row 400')")
+      sql("insert into table parquet_test values(null, 'this is row 500')")
+      sql("refresh oindex on parquet_test")
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a is null"),
+        nullKeyRows :+ Row(null, "this is row 400") :+ Row(null, "this is row 500"))
+    }
+  }
+
+  test("filtering non-null key") {
+    withIndex(TestIndex("oap_test", "idx1")) {
+      val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
+        if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+      }.map(Row.fromSeq)
+      val schema =
+        StructType(
+          StructField("a", IntegerType) ::
+            StructField("c", StringType) :: Nil)
+      val df = spark.createDataFrame(rowRDD, schema)
+      df.createOrReplaceTempView("t")
+      val nonNullKeyRows = (4 to 10).map(i => Row(i, s"this is row $i"))
+
+      sql("insert overwrite table oap_test select * from t")
+
+      sql("create oindex idx1 on oap_test (a)")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a is not null"), nonNullKeyRows)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 7 AND a <= 9"),
+        Row(8, "this is row 8") :: Row(9, "this is row 9") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a <= 2"), Nil)
+    }
+  }
+
+  test("filtering non-null key in Parquet format") {
+    withIndex(TestIndex("parquet_test", "idx1")) {
+      val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
+        if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+      }.map(Row.fromSeq)
+      val schema =
+        StructType(
+          StructField("a", IntegerType) ::
+            StructField("c", StringType) :: Nil)
+      val df = spark.createDataFrame(rowRDD, schema)
+      df.createOrReplaceTempView("t")
+      val nonNullKeyRows = (4 to 10).map(i => Row(i, s"this is row $i"))
+
+      sql("insert overwrite table parquet_test select * from t")
+
+      sql("create oindex idx1 on parquet_test (a)")
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a is not null"), nonNullKeyRows)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 7 AND a <= 9"),
+        Row(8, "this is row 8") :: Row(9, "this is row 9") :: Nil)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a <= 2"), Nil)
+    }
+  }
+
+  test("filtering null key and normal key mixed") {
+    withIndex(TestIndex("oap_test", "idx1")) {
+      val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+        if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+      }.map(Row.fromSeq)
+      val schema =
+        StructType(
+          StructField("a", IntegerType) ::
+            StructField("c", StringType) :: Nil)
+      val df = spark.createDataFrame(rowRDD, schema)
+      df.createOrReplaceTempView("t")
+      val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
+
+      sql("insert overwrite table oap_test select * from t")
+      sql("create oindex idx1 on oap_test (a)")
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 11 AND a <= 13 or a is null"),
+        Row(12, "this is row 12") :: Row(13, "this is row 13") :: Nil ++ nullKeyRows)
+
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 23 and a is null"), Nil)
+    }
+  }
+
+  test("filtering null key and normal key mixed in Parquet format") {
+    withIndex(TestIndex("parquet_test", "idx1")) {
+      val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+        if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+      }.map(Row.fromSeq)
+      val schema =
+        StructType(
+          StructField("a", IntegerType) ::
+            StructField("c", StringType) :: Nil)
+      val df = spark.createDataFrame(rowRDD, schema)
+      df.createOrReplaceTempView("t")
+      val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
+
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex idx1 on parquet_test (a)")
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 11 AND a <= 13 or a is null"),
+        Row(12, "this is row 12") :: Row(13, "this is row 13") :: Nil ++ nullKeyRows)
+
+      checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 23 and a is null"), Nil)
+    }
+  }
+
+  test("get columns hit index") {
+    withIndex(TestIndex("parquet_test", "idx1"),
+      TestIndex("parquet_test", "idx2")) {
+      val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
+        Seq(i, s"this is row $i")).map(Row.fromSeq)
+      val schema =
+        StructType(
+          StructField("a", IntegerType) ::
+            StructField("c", StringType) :: Nil)
+      val df = spark.createDataFrame(rowRDD, schema)
+      df.createOrReplaceTempView("t")
+
+      sql("insert overwrite table parquet_test select * from t")
+      sql("create oindex idx1 on parquet_test (a)")
+      sql("create oindex idx2 on parquet_test (a, b)")
+
+      val df1 = sql("SELECT * FROM parquet_test WHERE a = 1")
+      checkAnswer(df1, Row(1, "this is row 1") :: Nil)
+      val ret1 = getColumnsHitIndex(df1.queryExecution.sparkPlan)
+      assert(ret1.keySet.size == 1 && ret1.keySet.head == "a")
+      assert(ret1.values.head.toString == BTreeIndex(BTreeIndexEntry(0)::Nil).toString)
+
+      val df2 = sql("SELECT * FROM parquet_test WHERE a = 1 AND b = 'this is row 1'")
+      checkAnswer(df2, Row(1, "this is row 1") :: Nil)
+      val ret2 = getColumnsHitIndex(df2.queryExecution.sparkPlan)
+      assert(ret2.keySet.size == 2 && ret2.contains("a") && ret2.contains("b"))
+      assert(ret2("a") == ret2("b") && ret2("a").toString
+        == BTreeIndex(BTreeIndexEntry(0)::BTreeIndexEntry(1)::Nil).toString)
+    }
+  }
+
+  test("filtering parquet in FiberCache") {
+    withIndex(TestIndex("parquet_test", "index1")) {
+      withSQLConf("spark.sql.oap.parquet.data.cache.enable" -> "true") {
+        val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+        data.toDF("key", "value").createOrReplaceTempView("t")
+        sql("insert overwrite table parquet_test select * from t")
+        sql("create oindex index1 on parquet_test (a)")
+
+        checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
+          Row(1, "this is test 1") :: Nil)
+
+        checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
+          Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+      }
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -133,10 +133,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (a)")
 
       checkAnswer(sql("SELECT * FROM oap_test WHERE a = 1"),
@@ -154,14 +154,13 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering2") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t where key = 1")
+    sql("insert into table oap_test select * from t where key = 2")
+    sql("insert into table oap_test select * from t where key = 3")
+    sql("insert into table oap_test select * from t where key = 4")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table oap_test select * from t where key = 1")
-      sql("insert into table oap_test select * from t where key = 2")
-      sql("insert into table oap_test select * from t where key = 3")
-      sql("insert into table oap_test select * from t where key = 4")
-
       sql("create oindex index1 on oap_test (a)")
 
       val checkPath = new Path(currentPath)
@@ -178,10 +177,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering multi index") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (a, b)")
 
       checkAnswer(sql("SELECT * FROM oap_test WHERE a = 150 and b < 'this is test 3'"),
@@ -199,10 +198,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering parquet") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table parquet_test select * from t")
       sql("create oindex index1 on parquet_test (a)")
 
       checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
@@ -217,14 +216,13 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering parquet2") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t where key = 1")
+    sql("insert into table parquet_test select * from t where key = 2")
+    sql("insert into table parquet_test select * from t where key = 3")
+    sql("insert into table parquet_test select * from t where key = 4")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table parquet_test select * from t where key = 1")
-      sql("insert into table parquet_test select * from t where key = 2")
-      sql("insert into table parquet_test select * from t where key = 3")
-      sql("insert into table parquet_test select * from t where key = 4")
-
       sql("create oindex index1 on parquet_test (a)")
 
       val checkPath = new Path(currentPath)
@@ -241,10 +239,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test refresh in parquet format on same partition") {
+    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("t_refresh_parquet", "index1")) {
-      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-
       sql(
         """
           |INSERT OVERWRITE TABLE t_refresh_parquet
@@ -272,10 +269,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test refresh in parquet format on different partition") {
+    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("t_refresh_parquet", "index1")) {
-      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-
       sql(
         """
           |INSERT OVERWRITE TABLE t_refresh_parquet
@@ -310,11 +306,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test refresh in parquet format on a partition") {
+    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("t_refresh_parquet", "index1", TestPartition("b", "1")),
       TestIndex("t_refresh_parquet", "index1", TestPartition("b", "2"))) {
-      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-
       sql(
         """
           |INSERT OVERWRITE TABLE t_refresh_parquet
@@ -363,10 +358,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test refresh in oap format on same partition") {
+    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("t_refresh", "index1")) {
-      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-
       sql(
         """
           |INSERT OVERWRITE TABLE t_refresh
@@ -394,10 +388,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test refresh in oap format on different partition") {
+    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("t_refresh", "index1")) {
-      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-
       sql(
         """
           |INSERT OVERWRITE TABLE t_refresh
@@ -432,11 +425,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test refresh in oap format on a partition") {
+    val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("t_refresh", "index1", TestPartition("b", "1")),
       TestIndex("t_refresh", "index1", TestPartition("b", "2"))) {
-      val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-
       sql(
         """
           |INSERT OVERWRITE TABLE t_refresh
@@ -485,9 +477,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("refresh table of oap format without partition") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (a)")
 
@@ -508,9 +500,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("refresh table of parquet format without partition") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table parquet_test select * from t")
       sql("create oindex index1 on parquet_test (a)")
 
@@ -526,9 +518,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering by string") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (a) using btree")
 
@@ -544,10 +536,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("support data append without refresh") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-
       sql("insert overwrite table oap_test select * from t where key > 100")
       sql("create oindex index1 on oap_test (a)")
       checkAnswer(sql("SELECT * FROM oap_test WHERE a = 100"), Nil)
@@ -566,9 +557,9 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering by string with duplicate refresh") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (a) using btree")
 
@@ -594,10 +585,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering with string type index") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (b)")
 
       checkAnswer(sql("SELECT * FROM oap_test WHERE b = 'this is test 1'"),
@@ -609,10 +600,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test paruet use in") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table parquet_test select * from t")
       sql("create oindex index1 on parquet_test (b)")
 
       // will use b in (....)
@@ -624,10 +615,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test parquet use in StringFieldNotCastDouble") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table parquet_test select * from t")
       sql("create oindex index1 on parquet_test (b)")
 
       // will use b in(1,2,4), values cast to string
@@ -639,10 +630,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test parquet use in IntFieldNotCastDouble") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table parquet_test select * from t")
       sql("create oindex index1 on parquet_test (a)")
 
       // will use a in (20,30,40), value cast to int
@@ -652,11 +643,11 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test parquet query include in") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "index1"),
       TestIndex("parquet_test", "index2")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table parquet_test select * from t")
       sql("create oindex index1 on parquet_test (a)")
       sql("create oindex index2 on parquet_test (b)")
 
@@ -694,10 +685,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
 
   test("test parquet use between") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table parquet_test select * from t")
       sql("create oindex index1 on parquet_test (a)")
 
       // (a#12 >= 10) && (a#12 <= 30)
@@ -710,10 +701,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test oap use in") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (b)")
 
       // will use b in (....)
@@ -734,10 +725,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
 
   test("test oap use in IntFieldNotCastDouble") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
     withIndex(TestIndex("oap_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (a)")
 
       // will use a in (20,30,40), value cast to int
@@ -747,11 +738,11 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test oap query include in") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
     withIndex(TestIndex("oap_test", "index1"),
       TestIndex("oap_test", "index2")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"$i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table oap_test select * from t")
       sql("create oindex index1 on oap_test (a)")
       sql("create oindex index2 on oap_test (b)")
 
@@ -788,10 +779,10 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("test parquet inner join") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i / 10, s"$i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "index1")) {
-      val data: Seq[(Int, String)] = (1 to 300).map { i => (i / 10, s"$i") }
-      data.toDF("key", "value").createOrReplaceTempView("t")
-      sql("insert overwrite table parquet_test select * from t")
       sql("create oindex index1 on parquet_test (a)")
 
       checkAnswer(sql("select t2.a, sum(t2.b) " +
@@ -869,20 +860,19 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering non-null key") {
+    val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
+      if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
+    val schema =
+      StructType(
+        StructField("a", IntegerType) ::
+          StructField("c", StringType) :: Nil)
+    val df = spark.createDataFrame(rowRDD, schema)
+    df.createOrReplaceTempView("t")
+    val nonNullKeyRows = (4 to 10).map(i => Row(i, s"this is row $i"))
+
+    sql("insert overwrite table oap_test select * from t")
     withIndex(TestIndex("oap_test", "idx1")) {
-      val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
-        if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-      }.map(Row.fromSeq)
-      val schema =
-        StructType(
-          StructField("a", IntegerType) ::
-            StructField("c", StringType) :: Nil)
-      val df = spark.createDataFrame(rowRDD, schema)
-      df.createOrReplaceTempView("t")
-      val nonNullKeyRows = (4 to 10).map(i => Row(i, s"this is row $i"))
-
-      sql("insert overwrite table oap_test select * from t")
-
       sql("create oindex idx1 on oap_test (a)")
 
       checkAnswer(sql("SELECT * FROM oap_test WHERE a is not null"), nonNullKeyRows)
@@ -895,20 +885,19 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering non-null key in Parquet format") {
+    val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
+      if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
+    val schema =
+      StructType(
+        StructField("a", IntegerType) ::
+          StructField("c", StringType) :: Nil)
+    val df = spark.createDataFrame(rowRDD, schema)
+    df.createOrReplaceTempView("t")
+    val nonNullKeyRows = (4 to 10).map(i => Row(i, s"this is row $i"))
+
+    sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "idx1")) {
-      val rowRDD = spark.sparkContext.parallelize(1 to 10).map { i =>
-        if (i <= 3) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-      }.map(Row.fromSeq)
-      val schema =
-        StructType(
-          StructField("a", IntegerType) ::
-            StructField("c", StringType) :: Nil)
-      val df = spark.createDataFrame(rowRDD, schema)
-      df.createOrReplaceTempView("t")
-      val nonNullKeyRows = (4 to 10).map(i => Row(i, s"this is row $i"))
-
-      sql("insert overwrite table parquet_test select * from t")
-
       sql("create oindex idx1 on parquet_test (a)")
 
       checkAnswer(sql("SELECT * FROM parquet_test WHERE a is not null"), nonNullKeyRows)
@@ -921,19 +910,19 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering null key and normal key mixed") {
-    withIndex(TestIndex("oap_test", "idx1")) {
-      val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
-        if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-      }.map(Row.fromSeq)
-      val schema =
-        StructType(
-          StructField("a", IntegerType) ::
-            StructField("c", StringType) :: Nil)
-      val df = spark.createDataFrame(rowRDD, schema)
-      df.createOrReplaceTempView("t")
-      val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
+    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
+    val schema =
+      StructType(
+        StructField("a", IntegerType) ::
+          StructField("c", StringType) :: Nil)
+    val df = spark.createDataFrame(rowRDD, schema)
+    df.createOrReplaceTempView("t")
+    val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
 
-      sql("insert overwrite table oap_test select * from t")
+    sql("insert overwrite table oap_test select * from t")
+    withIndex(TestIndex("oap_test", "idx1")) {
       sql("create oindex idx1 on oap_test (a)")
 
       checkAnswer(sql("SELECT * FROM oap_test WHERE a > 11 AND a <= 13 or a is null"),
@@ -944,19 +933,19 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering null key and normal key mixed in Parquet format") {
-    withIndex(TestIndex("parquet_test", "idx1")) {
-      val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
-        if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
-      }.map(Row.fromSeq)
-      val schema =
-        StructType(
-          StructField("a", IntegerType) ::
-            StructField("c", StringType) :: Nil)
-      val df = spark.createDataFrame(rowRDD, schema)
-      df.createOrReplaceTempView("t")
-      val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
+    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map { i =>
+      if (i <= 5) Seq(null, s"this is row $i") else Seq(i, s"this is row $i")
+    }.map(Row.fromSeq)
+    val schema =
+      StructType(
+        StructField("a", IntegerType) ::
+          StructField("c", StringType) :: Nil)
+    val df = spark.createDataFrame(rowRDD, schema)
+    df.createOrReplaceTempView("t")
+    val nullKeyRows = (1 to 5).map(i => Row(null, s"this is row $i"))
 
-      sql("insert overwrite table parquet_test select * from t")
+    sql("insert overwrite table parquet_test select * from t")
+    withIndex(TestIndex("parquet_test", "idx1")) {
       sql("create oindex idx1 on parquet_test (a)")
 
       checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 11 AND a <= 13 or a is null"),
@@ -967,18 +956,19 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("get columns hit index") {
-    withIndex(TestIndex("parquet_test", "idx1"),
-      TestIndex("parquet_test", "idx2")) {
-      val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
-        Seq(i, s"this is row $i")).map(Row.fromSeq)
-      val schema =
-        StructType(
-          StructField("a", IntegerType) ::
-            StructField("c", StringType) :: Nil)
-      val df = spark.createDataFrame(rowRDD, schema)
-      df.createOrReplaceTempView("t")
+    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
+      Seq(i, s"this is row $i")).map(Row.fromSeq)
+    val schema =
+      StructType(
+        StructField("a", IntegerType) ::
+          StructField("c", StringType) :: Nil)
+    val df = spark.createDataFrame(rowRDD, schema)
+    df.createOrReplaceTempView("t")
 
-      sql("insert overwrite table parquet_test select * from t")
+    sql("insert overwrite table parquet_test select * from t")
+    withIndex(
+      TestIndex("parquet_test", "idx1"),
+      TestIndex("parquet_test", "idx2")) {
       sql("create oindex idx1 on parquet_test (a)")
       sql("create oindex idx2 on parquet_test (a, b)")
 
@@ -998,18 +988,16 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering parquet in FiberCache") {
-    withIndex(TestIndex("parquet_test", "index1")) {
       withSQLConf("spark.sql.oap.parquet.data.cache.enable" -> "true") {
         val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
         data.toDF("key", "value").createOrReplaceTempView("t")
         sql("insert overwrite table parquet_test select * from t")
-        sql("create oindex index1 on parquet_test (a)")
-
-        checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
-          Row(1, "this is test 1") :: Nil)
-
-        checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
-          Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
+        withIndex(TestIndex("parquet_test", "index1")) {
+          sql("create oindex index1 on parquet_test (a)")
+          checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
+            Row(1, "this is test 1") :: Nil)
+          checkAnswer(sql("SELECT * FROM parquet_test WHERE a > 1 AND a <= 3"),
+            Row(2, "this is test 2") :: Row(3, "this is test 3") :: Nil)
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapCheckIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapCheckIndexSuite.scala
@@ -106,6 +106,7 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
 
     checkAnswer(sql("check oindex on oap_partition_table"),
       Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
+    sql("drop oindex idx1 on oap_partition_table")
   }
 
   test("check index on table") {
@@ -117,6 +118,7 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
 
     sql("create oindex index1 on oap_test_2 (a)")
     checkAnswer(sql("check oindex on oap_test_2"), Nil)
+    sql("drop oindex index1 on oap_test_2")
   }
 
   test("check index on table: Missing data file") {
@@ -172,6 +174,7 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
           |indexColumn(s): key, indexType: BTree
           |for Data File: $path/$dataFileName
           |of table: t""".stripMargin))
+    sql("drop oindex idx1 on t")
   }
 
   test("check index on partitioned table") {
@@ -202,6 +205,7 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
     sql("create oindex idx1 on oap_partition_table(a)")
 
     checkAnswer(sql("check oindex on oap_partition_table"), Nil)
+    sql("drop oindex idx1 on oap_partition_table")
   }
 
   test("check index on partitioned table: Missing data file") {
@@ -237,6 +241,7 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
     // Check again
     checkAnswer(sql("check oindex on oap_partition_table"),
       Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!")))
+    sql("drop oindex idx1 on oap_partition_table")
   }
 
   test("check index on partitioned table: Missing index file") {
@@ -283,6 +288,7 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
           |indexColumn(s): a, indexType: BTree
           |for Data File: ${partitionPath.toUri.getPath}/$dataFileName
           |of table: oap_partition_table""".stripMargin))
+    sql("drop oindex idx1 on oap_partition_table")
   }
 
   test("check multiple partition directories for ambiguous indices") {
@@ -324,6 +330,8 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
     assert(exception.message.startsWith(
       "\nAmbiguous Index(different indices have the same name):\nindex name:idx1"))
 
+    sql("drop oindex idx1 on oap_partition_table partition(b=1, c='c1')")
+    sql("drop oindex idx1 on oap_partition_table partition(b=2, c='c2')")
   }
 
   test("check index on partitioned table for a specified partition: Missing meta file") {
@@ -359,6 +367,8 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
     checkAnswer(
       sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
       Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
+
+    sql("drop oindex idx1 on oap_partition_table partition(b=2, c='c2')")
   }
 
   test("check index on partitioned table for a specified partition: Missing data file") {
@@ -397,6 +407,7 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
     checkAnswer(sql("check oindex on oap_partition_table partition(b=1, c='c1')"), Nil)
     checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
       Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!")))
+    sql("drop oindex idx1 on oap_partition_table")
   }
 
   test("check index on partitioned table for a specified partition: Missing index file") {
@@ -443,5 +454,6 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
           |indexColumn(s): a, indexType: BTree
           |for Data File: ${partitionPath.toUri.getPath}/$dataFileName
           |of table: oap_partition_table""".stripMargin))
+    sql("drop oindex idx1 on oap_partition_table")
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapCheckIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapCheckIndexSuite.scala
@@ -25,7 +25,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.execution.datasources.oap.index.IndexUtils
 import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
-import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex, TestPartition}
 import org.apache.spark.util.Utils
 
 class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
@@ -96,17 +96,19 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
         |partition (b=2, c='c2')
         |SELECT key from t where value == 4
       """.stripMargin)
-    sql("create oindex idx1 on oap_partition_table(a)")
 
-    checkAnswer(sql("check oindex on oap_partition_table"), Nil)
+    withIndex(TestIndex("oap_partition_table", "idx1")) {
+      sql("create oindex idx1 on oap_partition_table(a)")
 
-    val partitionPath =
-      new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
-    Utils.deleteRecursively(new File(partitionPath.toUri.getPath, OapFileFormat.OAP_META_FILE))
+      checkAnswer(sql("check oindex on oap_partition_table"), Nil)
 
-    checkAnswer(sql("check oindex on oap_partition_table"),
-      Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
-    sql("drop oindex idx1 on oap_partition_table")
+      val partitionPath =
+        new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
+      Utils.deleteRecursively(new File(partitionPath.toUri.getPath, OapFileFormat.OAP_META_FILE))
+
+      checkAnswer(sql("check oindex on oap_partition_table"),
+        Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
+    }
   }
 
   test("check index on table") {
@@ -116,9 +118,10 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
 
     checkAnswer(sql("check oindex on oap_test_2"), Nil)
 
-    sql("create oindex index1 on oap_test_2 (a)")
-    checkAnswer(sql("check oindex on oap_test_2"), Nil)
-    sql("drop oindex index1 on oap_test_2")
+    withIndex(TestIndex("oap_test_2", "index1")) {
+      sql("create oindex index1 on oap_test_2 (a)")
+      checkAnswer(sql("check oindex on oap_test_2"), Nil)
+    }
   }
 
   test("check index on table: Missing data file") {
@@ -151,30 +154,31 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
     oapDf.createOrReplaceTempView("t")
     checkAnswer(sql("check oindex on t"), Nil)
 
-    // Create a B+ tree index on Column("key")
-    sql("create oindex idx1 on t(key)")
-    checkAnswer(sql("check oindex on t"), Nil)
+    withIndex(TestIndex("t", "idx1")) {
+      // Create a B+ tree index on Column("key")
+      sql("create oindex idx1 on t(key)")
+      checkAnswer(sql("check oindex on t"), Nil)
 
-    // Delete an index file
-    val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(path))
-    assert(metaOpt.nonEmpty)
-    assert(metaOpt.get.fileMetas.nonEmpty)
-    assert(metaOpt.get.indexMetas.nonEmpty)
-    val indexMeta = metaOpt.get.indexMetas.head
-    val dataFileName = metaOpt.get.fileMetas.head.dataFileName
-    val indexFileName =
-      IndexUtils.indexFileFromDataFile(new Path(path, dataFileName),
-        indexMeta.name, indexMeta.time).toUri.getPath
-    Utils.deleteRecursively(new File(indexFileName))
+      // Delete an index file
+      val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(path))
+      assert(metaOpt.nonEmpty)
+      assert(metaOpt.get.fileMetas.nonEmpty)
+      assert(metaOpt.get.indexMetas.nonEmpty)
+      val indexMeta = metaOpt.get.indexMetas.head
+      val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+      val indexFileName =
+        IndexUtils.indexFileFromDataFile(new Path(path, dataFileName),
+          indexMeta.name, indexMeta.time).toUri.getPath
+      Utils.deleteRecursively(new File(indexFileName))
 
-    // Check again
-    checkAnswer(sql("check oindex on t"),
-      Row(
-        s"""Missing index:idx1,
-          |indexColumn(s): key, indexType: BTree
-          |for Data File: $path/$dataFileName
-          |of table: t""".stripMargin))
-    sql("drop oindex idx1 on t")
+      // Check again
+      checkAnswer(sql("check oindex on t"),
+        Row(
+          s"""Missing index:idx1,
+             |indexColumn(s): key, indexType: BTree
+             |for Data File: $path/$dataFileName
+             |of table: t""".stripMargin))
+    }
   }
 
   test("check index on partitioned table") {
@@ -202,10 +206,10 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
       Seq(Row(s"Meta file not found in partition: ${path1.toUri.getPath}"),
         Row(s"Meta file not found in partition: ${path2.toUri.getPath}")))
 
-    sql("create oindex idx1 on oap_partition_table(a)")
-
-    checkAnswer(sql("check oindex on oap_partition_table"), Nil)
-    sql("drop oindex idx1 on oap_partition_table")
+    withIndex(TestIndex("oap_partition_table", "idx1")) {
+      sql("create oindex idx1 on oap_partition_table(a)")
+      checkAnswer(sql("check oindex on oap_partition_table"), Nil)
+    }
   }
 
   test("check index on partitioned table: Missing data file") {
@@ -226,22 +230,23 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
         |SELECT key from t where value = 104
       """.stripMargin)
 
-    sql("create oindex idx1 on oap_partition_table(a)")
+    withIndex(TestIndex("oap_partition_table", "idx1")) {
+      sql("create oindex idx1 on oap_partition_table(a)")
 
-    checkAnswer(sql("check oindex on oap_partition_table"), Nil)
+      checkAnswer(sql("check oindex on oap_partition_table"), Nil)
 
-    // Delete a data file
-    val partitionPath = new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
-    val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
-    assert(metaOpt.nonEmpty)
-    assert(metaOpt.get.fileMetas.nonEmpty)
-    val dataFileName = metaOpt.get.fileMetas.head.dataFileName
-    Utils.deleteRecursively(new File(new Path(partitionPath, dataFileName).toUri.getPath))
+      // Delete a data file
+      val partitionPath = new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
+      val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
+      assert(metaOpt.nonEmpty)
+      assert(metaOpt.get.fileMetas.nonEmpty)
+      val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+      Utils.deleteRecursively(new File(new Path(partitionPath, dataFileName).toUri.getPath))
 
-    // Check again
-    checkAnswer(sql("check oindex on oap_partition_table"),
-      Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!")))
-    sql("drop oindex idx1 on oap_partition_table")
+      // Check again
+      checkAnswer(sql("check oindex on oap_partition_table"),
+        Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!")))
+    }
   }
 
   test("check index on partitioned table: Missing index file") {
@@ -262,33 +267,34 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
         |SELECT key from t where value == 104
       """.stripMargin)
 
-    // Create a B+ tree index on Column("a")
-    sql("create oindex idx1 on oap_partition_table(a)")
+    withIndex(TestIndex("oap_partition_table", "idx1")) {
+      // Create a B+ tree index on Column("a")
+      sql("create oindex idx1 on oap_partition_table(a)")
 
-    checkAnswer(sql("check oindex on oap_partition_table"), Nil)
+      checkAnswer(sql("check oindex on oap_partition_table"), Nil)
 
-    // Delete an index file
-    val partitionPath = new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
-    val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
-    assert(metaOpt.nonEmpty)
-    assert(metaOpt.get.fileMetas.nonEmpty)
-    assert(metaOpt.get.indexMetas.nonEmpty)
-    val indexMeta = metaOpt.get.indexMetas.head
+      // Delete an index file
+      val partitionPath = new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
+      val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
+      assert(metaOpt.nonEmpty)
+      assert(metaOpt.get.fileMetas.nonEmpty)
+      assert(metaOpt.get.indexMetas.nonEmpty)
+      val indexMeta = metaOpt.get.indexMetas.head
 
-    val dataFileName = metaOpt.get.fileMetas.head.dataFileName
-    val indexFileName =
-      IndexUtils.indexFileFromDataFile(
-        new Path(partitionPath, dataFileName), indexMeta.name, indexMeta.time).toUri.getPath
-    Utils.deleteRecursively(new File(indexFileName))
+      val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+      val indexFileName =
+        IndexUtils.indexFileFromDataFile(
+          new Path(partitionPath, dataFileName), indexMeta.name, indexMeta.time).toUri.getPath
+      Utils.deleteRecursively(new File(indexFileName))
 
-    // Check again
-    checkAnswer(sql("check oindex on oap_partition_table"),
-      Row(
-        s"""Missing index:idx1,
-          |indexColumn(s): a, indexType: BTree
-          |for Data File: ${partitionPath.toUri.getPath}/$dataFileName
-          |of table: oap_partition_table""".stripMargin))
-    sql("drop oindex idx1 on oap_partition_table")
+      // Check again
+      checkAnswer(sql("check oindex on oap_partition_table"),
+        Row(
+          s"""Missing index:idx1,
+             |indexColumn(s): a, indexType: BTree
+             |for Data File: ${partitionPath.toUri.getPath}/$dataFileName
+             |of table: oap_partition_table""".stripMargin))
+    }
   }
 
   test("check multiple partition directories for ambiguous indices") {
@@ -316,22 +322,23 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
       Seq(Row(s"Meta file not found in partition: ${path1.toUri.getPath}"),
         Row(s"Meta file not found in partition: ${path2.toUri.getPath}")))
 
-    // Create a B+ tree index on Column("a")
-    sql("create oindex idx1 on oap_partition_table(a) partition(b=1, c='c1')")
+    withIndex(
+      TestIndex("oap_partition_table", "idx1", TestPartition("b", "1"), TestPartition("c", "c1")),
+      TestIndex("oap_partition_table", "idx1", TestPartition("b", "2"), TestPartition("c", "c2"))) {
+      // Create a B+ tree index on Column("a")
+      sql("create oindex idx1 on oap_partition_table(a) partition(b=1, c='c1')")
 
-    checkAnswer(sql("check oindex on oap_partition_table"),
-      Row(s"Meta file not found in partition: ${path2.toUri.getPath}"))
+      checkAnswer(sql("check oindex on oap_partition_table"),
+        Row(s"Meta file not found in partition: ${path2.toUri.getPath}"))
 
-    sql("create oindex idx1 on oap_partition_table(a) using bitmap partition(b=2, c='c2')")
+      sql("create oindex idx1 on oap_partition_table(a) using bitmap partition(b=2, c='c2')")
 
-    val exception = intercept[AnalysisException]{
-      sql("check oindex on oap_partition_table")
+      val exception = intercept[AnalysisException]{
+        sql("check oindex on oap_partition_table")
+      }
+      assert(exception.message.startsWith(
+        "\nAmbiguous Index(different indices have the same name):\nindex name:idx1"))
     }
-    assert(exception.message.startsWith(
-      "\nAmbiguous Index(different indices have the same name):\nindex name:idx1"))
-
-    sql("drop oindex idx1 on oap_partition_table partition(b=1, c='c1')")
-    sql("drop oindex idx1 on oap_partition_table partition(b=2, c='c2')")
   }
 
   test("check index on partitioned table for a specified partition: Missing meta file") {
@@ -357,18 +364,18 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
     checkAnswer(
       sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
       Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
+    withIndex(
+      TestIndex("oap_partition_table", "idx1", TestPartition("b", "2"), TestPartition("c", "c2"))) {
+      sql("create oindex idx1 on oap_partition_table(a) partition(b=2, c='c2')")
 
-    sql("create oindex idx1 on oap_partition_table(a) partition(b=2, c='c2')")
+      checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"), Nil)
 
-    checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"), Nil)
+      Utils.deleteRecursively(new File(partitionPath.toUri.getPath, OapFileFormat.OAP_META_FILE))
 
-    Utils.deleteRecursively(new File(partitionPath.toUri.getPath, OapFileFormat.OAP_META_FILE))
-
-    checkAnswer(
-      sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
-      Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
-
-    sql("drop oindex idx1 on oap_partition_table partition(b=2, c='c2')")
+      checkAnswer(
+        sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
+        Row(s"Meta file not found in partition: ${partitionPath.toUri.getPath}"))
+    }
   }
 
   test("check index on partitioned table for a specified partition: Missing data file") {
@@ -389,25 +396,26 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
         |SELECT key from t where value >= 104
       """.stripMargin)
 
-    sql("create oindex idx1 on oap_partition_table(a)")
+    withIndex(TestIndex("oap_partition_table", "idx1")) {
+      sql("create oindex idx1 on oap_partition_table(a)")
 
-    checkAnswer(sql("check oindex on oap_partition_table partition(b=1, c='c1')"), Nil)
-    checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"), Nil)
+      checkAnswer(sql("check oindex on oap_partition_table partition(b=1, c='c1')"), Nil)
+      checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"), Nil)
 
-    val partitionPath =
-      new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
-    // Delete a data file
-    val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
-    assert(metaOpt.nonEmpty)
-    assert(metaOpt.get.fileMetas.nonEmpty)
-    val dataFileName = metaOpt.get.fileMetas.head.dataFileName
-    Utils.deleteRecursively(new File(new Path(partitionPath, dataFileName).toUri.getPath))
+      val partitionPath =
+        new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
+      // Delete a data file
+      val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
+      assert(metaOpt.nonEmpty)
+      assert(metaOpt.get.fileMetas.nonEmpty)
+      val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+      Utils.deleteRecursively(new File(new Path(partitionPath, dataFileName).toUri.getPath))
 
-    // Check again
-    checkAnswer(sql("check oindex on oap_partition_table partition(b=1, c='c1')"), Nil)
-    checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
-      Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!")))
-    sql("drop oindex idx1 on oap_partition_table")
+      // Check again
+      checkAnswer(sql("check oindex on oap_partition_table partition(b=1, c='c1')"), Nil)
+      checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
+        Seq(Row(s"Data file: ${partitionPath.toUri.getPath}/$dataFileName not found!")))
+    }
   }
 
   test("check index on partitioned table for a specified partition: Missing index file") {
@@ -428,32 +436,33 @@ class OapCheckIndexSuite extends QueryTest with SharedOapContext with BeforeAndA
         |SELECT key from t where value == 104
       """.stripMargin)
 
-    // Create a B+ tree index on Column("a")
-    sql("create oindex idx1 on oap_partition_table(a)")
+    withIndex(TestIndex("oap_partition_table", "idx1")) {
+      // Create a B+ tree index on Column("a")
+      sql("create oindex idx1 on oap_partition_table(a)")
 
-    checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"), Nil)
+      checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"), Nil)
 
-    // Delete an index file
-    val partitionPath = new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
-    val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
-    assert(metaOpt.nonEmpty)
-    assert(metaOpt.get.fileMetas.nonEmpty)
-    assert(metaOpt.get.indexMetas.nonEmpty)
-    val indexMeta = metaOpt.get.indexMetas.head
+      // Delete an index file
+      val partitionPath = new Path(sqlConf.warehousePath + "/oap_partition_table/b=2/c=c2")
+      val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, partitionPath)
+      assert(metaOpt.nonEmpty)
+      assert(metaOpt.get.fileMetas.nonEmpty)
+      assert(metaOpt.get.indexMetas.nonEmpty)
+      val indexMeta = metaOpt.get.indexMetas.head
 
-    val dataFileName = metaOpt.get.fileMetas.head.dataFileName
-    val indexFileName =
-      IndexUtils.indexFileFromDataFile(
-        new Path(partitionPath, dataFileName), indexMeta.name, indexMeta.time).toUri.getPath
-    Utils.deleteRecursively(new File(indexFileName))
+      val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+      val indexFileName =
+        IndexUtils.indexFileFromDataFile(
+          new Path(partitionPath, dataFileName), indexMeta.name, indexMeta.time).toUri.getPath
+      Utils.deleteRecursively(new File(indexFileName))
 
-    // Check again
-    checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
-      Row(
-        s"""Missing index:idx1,
-          |indexColumn(s): a, indexType: BTree
-          |for Data File: ${partitionPath.toUri.getPath}/$dataFileName
-          |of table: oap_partition_table""".stripMargin))
-    sql("drop oindex idx1 on oap_partition_table")
+      // Check again
+      checkAnswer(sql("check oindex on oap_partition_table partition(b=2, c='c2')"),
+        Row(
+          s"""Missing index:idx1,
+             |indexColumn(s): a, indexType: BTree
+             |for Data File: ${partitionPath.toUri.getPath}/$dataFileName
+             |of table: oap_partition_table""".stripMargin))
+    }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -57,6 +57,7 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     val oapDf = spark.read.format("oap").load(path)
     oapDf.createOrReplaceTempView("t")
     sql("create oindex index1 on t (key)")
+    sql("drop oindex index1 on t")
   }
 
   test("show index") {
@@ -86,6 +87,14 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
         Row("oap_test_2", "index6", 0, "a", "A", "BITMAP", true) ::
         Row("oap_test_2", "index1", 0, "a", "D", "BTREE", true) ::
         Row("oap_test_2", "index1", 1, "b", "D", "BTREE", true) :: Nil)
+
+    sql("drop oindex index1 on oap_test_1")
+    sql("drop oindex index2 on oap_test_1")
+    sql("drop oindex index3 on oap_test_1")
+    sql("drop oindex index4 on oap_test_2")
+    sql("drop oindex index5 on oap_test_2")
+    sql("drop oindex index6 on oap_test_2")
+    sql("drop oindex index1 on oap_test_2")
   }
 
   test("create and drop index with partition specify") {
@@ -131,6 +140,7 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     assert(path.getFileSystem(
       configuration).globStatus(new Path(path,
       "oap_partition_table/b=2/c=c2/*.index")).length != 0)
+    sql("drop oindex index1 on oap_partition_table partition (b=2, c='c2')")
   }
 
   test("create duplicated name index") {
@@ -154,5 +164,6 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
       fileStatus.getPath.getName
     }
     assert(indexFiles1 === indexFiles2)
+    sql("drop oindex idxa on t")
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row, SaveMode}
-import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex, TestPartition}
 import org.apache.spark.util.Utils
 
 class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
@@ -56,8 +56,9 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     df.write.format("oap").mode(SaveMode.Overwrite).save(path)
     val oapDf = spark.read.format("oap").load(path)
     oapDf.createOrReplaceTempView("t")
-    sql("create oindex index1 on t (key)")
-    sql("drop oindex index1 on t")
+    withIndex(TestIndex("t", "index1")) {
+      sql("create oindex index1 on t (key)")
+    }
   }
 
   test("show index") {
@@ -68,33 +69,34 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     sql("insert overwrite table oap_test_2 select * from t")
     sql("create oindex index1 on oap_test_1 (a)")
     checkAnswer(sql("show oindex from oap_test_2"), Nil)
-    sql("create oindex index2 on oap_test_1 (b desc)")
-    sql("create oindex index3 on oap_test_1 (b asc, a desc)")
-    sql("create oindex index4 on oap_test_2 (a) using btree")
-    sql("create oindex index5 on oap_test_2 (b desc)")
-    sql("create oindex index6 on oap_test_2 (a) using bitmap")
-    sql("create oindex index1 on oap_test_2 (a desc, b desc)")
+    withIndex(
+      TestIndex("oap_test_1", "index1"),
+      TestIndex("oap_test_1", "index2"),
+      TestIndex("oap_test_1", "index3"),
+      TestIndex("oap_test_2", "index4"),
+      TestIndex("oap_test_2", "index5"),
+      TestIndex("oap_test_2", "index6"),
+      TestIndex("oap_test_2", "index1")) {
+      sql("create oindex index2 on oap_test_1 (b desc)")
+      sql("create oindex index3 on oap_test_1 (b asc, a desc)")
+      sql("create oindex index4 on oap_test_2 (a) using btree")
+      sql("create oindex index5 on oap_test_2 (b desc)")
+      sql("create oindex index6 on oap_test_2 (a) using bitmap")
+      sql("create oindex index1 on oap_test_2 (a desc, b desc)")
 
-    checkAnswer(sql("show oindex from oap_test_1"),
-      Row("oap_test_1", "index1", 0, "a", "A", "BTREE", true) ::
-        Row("oap_test_1", "index2", 0, "b", "D", "BTREE", true) ::
-        Row("oap_test_1", "index3", 0, "b", "A", "BTREE", true) ::
-        Row("oap_test_1", "index3", 1, "a", "D", "BTREE", true) :: Nil)
+      checkAnswer(sql("show oindex from oap_test_1"),
+        Row("oap_test_1", "index1", 0, "a", "A", "BTREE", true) ::
+          Row("oap_test_1", "index2", 0, "b", "D", "BTREE", true) ::
+          Row("oap_test_1", "index3", 0, "b", "A", "BTREE", true) ::
+          Row("oap_test_1", "index3", 1, "a", "D", "BTREE", true) :: Nil)
 
-    checkAnswer(sql("show oindex in oap_test_2"),
-      Row("oap_test_2", "index4", 0, "a", "A", "BTREE", true) ::
-        Row("oap_test_2", "index5", 0, "b", "D", "BTREE", true) ::
-        Row("oap_test_2", "index6", 0, "a", "A", "BITMAP", true) ::
-        Row("oap_test_2", "index1", 0, "a", "D", "BTREE", true) ::
-        Row("oap_test_2", "index1", 1, "b", "D", "BTREE", true) :: Nil)
-
-    sql("drop oindex index1 on oap_test_1")
-    sql("drop oindex index2 on oap_test_1")
-    sql("drop oindex index3 on oap_test_1")
-    sql("drop oindex index4 on oap_test_2")
-    sql("drop oindex index5 on oap_test_2")
-    sql("drop oindex index6 on oap_test_2")
-    sql("drop oindex index1 on oap_test_2")
+      checkAnswer(sql("show oindex in oap_test_2"),
+        Row("oap_test_2", "index4", 0, "a", "A", "BTREE", true) ::
+          Row("oap_test_2", "index5", 0, "b", "D", "BTREE", true) ::
+          Row("oap_test_2", "index6", 0, "a", "A", "BITMAP", true) ::
+          Row("oap_test_2", "index1", 0, "a", "D", "BTREE", true) ::
+          Row("oap_test_2", "index1", 1, "b", "D", "BTREE", true) :: Nil)
+    }
   }
 
   test("create and drop index with partition specify") {
@@ -117,30 +119,36 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
         |SELECT key from t where value == 4
       """.stripMargin)
 
-    sql("create oindex index1 on oap_partition_table (a) partition (b=1, c='c1')")
+    withIndex(
+      TestIndex("oap_partition_table", "index1",
+        TestPartition("b", "1"), TestPartition("c", "c1"))) {
+      sql("create oindex index1 on oap_partition_table (a) partition (b=1, c='c1')")
 
-    checkAnswer(sql("select * from oap_partition_table where a < 4"),
-      Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Nil)
+      checkAnswer(sql("select * from oap_partition_table where a < 4"),
+        Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Nil)
 
-    assert(path.getFileSystem(
-      configuration).globStatus(new Path(path,
+      assert(path.getFileSystem(
+        configuration).globStatus(new Path(path,
         "oap_partition_table/b=1/c=c1/*.index")).length != 0)
-    assert(path.getFileSystem(
-      configuration).globStatus(new Path(path,
+      assert(path.getFileSystem(
+        configuration).globStatus(new Path(path,
         "oap_partition_table/b=2/c=c2/*.index")).length == 0)
+    }
 
-    sql("create oindex index1 on oap_partition_table (a) partition (b=2, c='c2')")
-    sql("drop oindex index1 on oap_partition_table partition (b=1, c='c1')")
+    withIndex(
+      TestIndex("oap_partition_table", "index1",
+        TestPartition("b", "2"), TestPartition("c", "c2"))) {
+      sql("create oindex index1 on oap_partition_table (a) partition (b=2, c='c2')")
 
-    checkAnswer(sql("select * from oap_partition_table"),
-      Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Row(4, 2, "c2") :: Nil)
-    assert(path.getFileSystem(
-      configuration).globStatus(new Path(path,
-      "oap_partition_table/b=1/c=c1/*.index")).length == 0)
-    assert(path.getFileSystem(
-      configuration).globStatus(new Path(path,
-      "oap_partition_table/b=2/c=c2/*.index")).length != 0)
-    sql("drop oindex index1 on oap_partition_table partition (b=2, c='c2')")
+      checkAnswer(sql("select * from oap_partition_table"),
+        Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Row(4, 2, "c2") :: Nil)
+      assert(path.getFileSystem(
+        configuration).globStatus(new Path(path,
+        "oap_partition_table/b=1/c=c1/*.index")).length == 0)
+      assert(path.getFileSystem(
+        configuration).globStatus(new Path(path,
+        "oap_partition_table/b=2/c=c2/*.index")).length != 0)
+    }
   }
 
   test("create duplicated name index") {
@@ -150,20 +158,22 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     df.write.format("oap").mode(SaveMode.Overwrite).save(pathDir)
     val oapDf = spark.read.format("oap").load(pathDir)
     oapDf.createOrReplaceTempView("t")
-    sql("create oindex idxa on t (a)")
-    val path = new Path(pathDir)
-    val fs = path.getFileSystem(sparkContext.hadoopConfiguration)
-    val indexFiles1 = fs.listStatus(path).collect { case fileStatus if fileStatus.isFile &&
-      fileStatus.getPath.getName.endsWith(OapFileFormat.OAP_INDEX_EXTENSION) =>
-        fileStatus.getPath.getName
-    }
 
-    sql("create oindex if not exists idxa on t (a)")
-    val indexFiles2 = fs.listStatus(path).collect { case fileStatus if fileStatus.isFile &&
-      fileStatus.getPath.getName.endsWith(OapFileFormat.OAP_INDEX_EXTENSION) =>
-      fileStatus.getPath.getName
+    withIndex(TestIndex("t", "idxa")) {
+      sql("create oindex idxa on t (a)")
+      val path = new Path(pathDir)
+      val fs = path.getFileSystem(sparkContext.hadoopConfiguration)
+      val indexFiles1 = fs.listStatus(path).collect { case fileStatus if fileStatus.isFile &&
+        fileStatus.getPath.getName.endsWith(OapFileFormat.OAP_INDEX_EXTENSION) =>
+        fileStatus.getPath.getName
+      }
+
+      sql("create oindex if not exists idxa on t (a)")
+      val indexFiles2 = fs.listStatus(path).collect { case fileStatus if fileStatus.isFile &&
+        fileStatus.getPath.getName.endsWith(OapFileFormat.OAP_INDEX_EXTENSION) =>
+        fileStatus.getPath.getName
+      }
+      assert(indexFiles1 === indexFiles2)
     }
-    assert(indexFiles1 === indexFiles2)
-    sql("drop oindex idxa on t")
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -21,7 +21,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.internal.oap.OapConf
-import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -52,14 +52,14 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       scala.util.Random.shuffle(1 to 300).map{ i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_test_1 select * from t")
-    sql("create oindex index1 on oap_test_1 (a) using bitmap")
-
-    val dfwithIdx = sql("SELECT * FROM oap_test_1 WHERE a > 8 and a <= 200")
-    sql("drop oindex index1 on oap_test_1")
-    val dfWithoutIdx = sql("SELECT * FROM oap_test_1 WHERE a > 8 and a <= 200")
-    val dfOriginal = sql("SELECT * FROM t WHERE key > 8 and key <= 200")
-    assert(dfWithoutIdx.count == dfwithIdx.count)
-    assert(dfWithoutIdx.count == dfOriginal.count)
+    withIndex(TestIndex("oap_test_1", "index1")) {
+      val dfWithoutIdx = sql("SELECT * FROM oap_test_1 WHERE a > 8 and a <= 200")
+      val dfOriginal = sql("SELECT * FROM t WHERE key > 8 and key <= 200")
+      sql("create oindex index1 on oap_test_1 (a) using bitmap")
+      val dfwithIdx = sql("SELECT * FROM oap_test_1 WHERE a > 8 and a <= 200")
+      assert(dfWithoutIdx.count == dfwithIdx.count)
+      assert(dfWithoutIdx.count == dfOriginal.count)
+    }
   }
 
   test("index row boundary") {
@@ -70,12 +70,13 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
                                     .map { i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_test_1 select * from t")
-    sql("create oindex index1 on oap_test_1 (a)")
 
-    checkAnswer(sql(s"SELECT * FROM oap_test_1 WHERE a = $testRowId"),
-      Row(testRowId, s"this is test $testRowId") :: Nil)
+    withIndex(TestIndex("oap_test_1", "index1")) {
+      sql("create oindex index1 on oap_test_1 (a)")
 
-    sql("drop oindex index1 on oap_test_1")
+      checkAnswer(sql(s"SELECT * FROM oap_test_1 WHERE a = $testRowId"),
+        Row(testRowId, s"this is test $testRowId") :: Nil)
+    }
   }
 
   test("check sequence reading if parquet format") {
@@ -84,28 +85,29 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     }
     data.toDF("key", "value").createOrReplaceTempView("t")
 
-    sql("insert overwrite table oap_parquet_test_1 select * from t")
-    sql("create oindex index1 on oap_parquet_test_1 (a)")
+    withIndex(TestIndex("oap_parquet_test_1", "index1")) {
+      sql("insert overwrite table oap_parquet_test_1 select * from t")
+      sql("create oindex index1 on oap_parquet_test_1 (a)")
 
-    // While a in (0, 3), rowIds = (1, 10, 2)
-    // sort to ensure the sequence reading on parquet. so results are (1, 2, 10)
-    val parquetRslt = sql("select * from oap_parquet_test_1 where a > 0 and a < 3")
-    checkAnswer(parquetRslt, Row(1, "this is test 1") ::
-      Row(2, "this is test 2") ::
-      Row(1, "this is test 10") :: Nil)
+      // While a in (0, 3), rowIds = (1, 10, 2)
+      // sort to ensure the sequence reading on parquet. so results are (1, 2, 10)
+      val parquetRslt = sql("select * from oap_parquet_test_1 where a > 0 and a < 3")
+      checkAnswer(parquetRslt, Row(1, "this is test 1") ::
+        Row(2, "this is test 2") ::
+        Row(1, "this is test 10") :: Nil)
+    }
 
-    sql("insert overwrite table oap_test_1 select * from t")
-    sql("create oindex index1 on oap_test_1 (a)")
+    withIndex(TestIndex("oap_test_1", "index1")) {
+      sql("insert overwrite table oap_test_1 select * from t")
+      sql("create oindex index1 on oap_test_1 (a)")
 
-    // Sort is unnecessary for oap format, so rowIds should be (1, 10, 2)
-    val oapResult = sql("select * from oap_test_1 where a > 0 and a < 3")
-    checkAnswer(oapResult,
-      Row(1, "this is test 1") ::
-      Row(1, "this is test 10") ::
-      Row(2, "this is test 2") :: Nil)
-
-    sql("drop oindex index1 on oap_parquet_test_1")
-    sql("drop oindex index1 on oap_test_1")
+      // Sort is unnecessary for oap format, so rowIds should be (1, 10, 2)
+      val oapResult = sql("select * from oap_test_1 where a > 0 and a < 3")
+      checkAnswer(oapResult,
+        Row(1, "this is test 1") ::
+          Row(1, "this is test 10") ::
+          Row(2, "this is test 2") :: Nil)
+    }
   }
 
   test("#604 bitmap index core dump error") {
@@ -119,12 +121,13 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     df.createOrReplaceTempView("t")
 
     sql("insert overwrite table oap_test_1 select * from t")
-    sql("create oindex bmidx1 on oap_test_1 (a) using bitmap")
 
-    val df1 = sql("SELECT * FROM oap_test_1 WHERE a = 1")
-    checkAnswer(df1, Row(1, "this is row 1") :: Row(1, "this is row 21") :: Nil)
+    withIndex(TestIndex("oap_test_1", "bmidx1")) {
+      sql("create oindex bmidx1 on oap_test_1 (a) using bitmap")
 
-    sql("drop oindex bmidx1 on oap_test_1")
+      val df1 = sql("SELECT * FROM oap_test_1 WHERE a = 1")
+      checkAnswer(df1, Row(1, "this is row 1") :: Row(1, "this is row 21") :: Nil)
+    }
   }
 
   test("startswith using index") {
@@ -133,11 +136,12 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       scala.util.Random.shuffle(1 to 30).map(i => (i, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_test_1 select * from t")
-    sql("create oindex index1 on oap_test_1 (b) using btree")
-    checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
-      Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
+    withIndex(TestIndex("oap_test_1", "index1")) {
+      sql("create oindex index1 on oap_test_1 (b) using btree")
+      checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
+        Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
+    }
     sqlConf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
-    sql("drop oindex index1 on oap_test_1")
   }
 
   test("startswith using multi-dimension index") {
@@ -146,11 +150,12 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       scala.util.Random.shuffle(1 to 30).map(i => (i, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_test_1 select * from t")
-    sql("create oindex index1 on oap_test_1 (b, a) using btree")
-    checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
-      Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
+    withIndex(TestIndex("oap_test_1", "index1")) {
+      sql("create oindex index1 on oap_test_1 (b, a) using btree")
+      checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
+        Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
+    }
     sqlConf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
-    sql("drop oindex index1 on oap_test_1")
   }
 
   test("startswith using multi-dimension index - multi-filters") {
@@ -159,11 +164,12 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       scala.util.Random.shuffle(1 to 30).map(i => (i % 7, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_test_1 select * from t")
-    sql("create oindex index1 on oap_test_1 (a, b) using btree")
-    checkAnswer(sql("SELECT * FROM oap_test_1 WHERE a = 3 and b like 'this3%'"),
-      Row(3, "this3 is test") :: Nil)
+    withIndex(TestIndex("oap_test_1", "index1")) {
+      sql("create oindex index1 on oap_test_1 (a, b) using btree")
+      checkAnswer(sql("SELECT * FROM oap_test_1 WHERE a = 3 and b like 'this3%'"),
+        Row(3, "this3 is test") :: Nil)
+    }
     sqlConf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
-    sql("drop oindex index1 on oap_test_1")
   }
 
   test("startswith using multi-dimension index 2") {
@@ -173,10 +179,11 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       13, 23, 7, 24, 3, 8, 5, 9).map(i => (i, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_test_1 select * from t")
-    sql("create oindex index1 on oap_test_1 (b) using btree")
-    checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
-      Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
+    withIndex(TestIndex("oap_test_1", "index1")) {
+      sql("create oindex index1 on oap_test_1 (b) using btree")
+      checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
+        Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
+    }
     sqlConf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
-    sql("drop oindex index1 on oap_test_1")
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -137,6 +137,7 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
       Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     sqlConf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
+    sql("drop oindex index1 on oap_test_1")
   }
 
   test("startswith using multi-dimension index") {
@@ -149,6 +150,7 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
       Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     sqlConf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
+    sql("drop oindex index1 on oap_test_1")
   }
 
   test("startswith using multi-dimension index - multi-filters") {
@@ -161,6 +163,7 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     checkAnswer(sql("SELECT * FROM oap_test_1 WHERE a = 3 and b like 'this3%'"),
       Row(3, "this3 is test") :: Nil)
     sqlConf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
+    sql("drop oindex index1 on oap_test_1")
   }
 
   test("startswith using multi-dimension index 2") {
@@ -174,5 +177,6 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
       Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     sqlConf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
+    sql("drop oindex index1 on oap_test_1")
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -377,19 +377,15 @@ class OapPlannerSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        try {
-          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-          checkAnswer(
-            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-          sql(s"drop oindex idxa on $tabName")
-          checkAnswer(sql(s"show oindex from $tabName"), Nil)
-          sql(s"DROP TABLE $tabName")
-          assert(tmpDir.listFiles.nonEmpty)
-        } finally {
-          sql(s"drop oindex if exists idxa on $tabName")
-        }
+        sql(s"drop oindex idxa on $tabName")
+        checkAnswer(sql(s"show oindex from $tabName"), Nil)
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
       }
     }
   }
@@ -413,25 +409,21 @@ class OapPlannerSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        try {
-          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
-          checkAnswer(
-            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-          // test refresh oap index
-          (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
-            .createOrReplaceTempView("t2")
-          sql(s"insert into table $tabName select * from t2")
-          sql(s"refresh oindex on $tabName")
-          checkAnswer(
-            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
-          checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
-          sql(s"drop oindex idxa on $tabName")
-          sql(s"DROP TABLE $tabName")
-          assert(tmpDir.listFiles.nonEmpty)
-        } finally {
-          sql(s"drop oindex if exists idxa on $tabName")
-        }
+        // test refresh oap index
+        (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
+          .createOrReplaceTempView("t2")
+        sql(s"insert into table $tabName select * from t2")
+        sql(s"refresh oindex on $tabName")
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+        checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
+        sql(s"drop oindex idxa on $tabName")
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
       }
     }
   }
@@ -455,34 +447,30 @@ class OapPlannerSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        try {
-          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-          checkAnswer(
-            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+        checkAnswer(
+          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-          // test check oap index
-          checkAnswer(sql(s"check oindex on $tabName"), Nil)
-          val dirPath = tmpDir.getAbsolutePath
-          val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(dirPath))
-          assert(metaOpt.nonEmpty)
-          assert(metaOpt.get.fileMetas.nonEmpty)
-          assert(metaOpt.get.indexMetas.nonEmpty)
-          val dataFileName = metaOpt.get.fileMetas.head.dataFileName
-          // delete a data file
-          Utils.deleteRecursively(new File(dirPath, dataFileName))
+        // test check oap index
+        checkAnswer(sql(s"check oindex on $tabName"), Nil)
+        val dirPath = tmpDir.getAbsolutePath
+        val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(dirPath))
+        assert(metaOpt.nonEmpty)
+        assert(metaOpt.get.fileMetas.nonEmpty)
+        assert(metaOpt.get.indexMetas.nonEmpty)
+        val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+        // delete a data file
+        Utils.deleteRecursively(new File(dirPath, dataFileName))
 
-          // Check again
-          checkAnswer(
-            sql(s"check oindex on $tabName"),
-            Row(s"Data file: $dirPath/$dataFileName not found!"))
+        // Check again
+        checkAnswer(
+          sql(s"check oindex on $tabName"),
+          Row(s"Data file: $dirPath/$dataFileName not found!"))
 
-          sql(s"drop oindex idxa on $tabName")
-          sql(s"DROP TABLE $tabName")
-          assert(tmpDir.listFiles.nonEmpty)
-        } finally {
-          sql(s"drop oindex if exists idxa on $tabName")
-        }
+        sql(s"drop oindex idxa on $tabName")
+        sql(s"DROP TABLE $tabName")
+        assert(tmpDir.listFiles.nonEmpty)
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -336,7 +336,8 @@ class OapPlannerSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+        checkAnswer(sql(s"show oindex from $tabName"),
+          Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
       }
@@ -407,6 +408,7 @@ class OapPlannerSuite
         checkAnswer(
           sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
         checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
+        sql(s"drop oindex idxa on $tabName")
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
       }
@@ -453,6 +455,7 @@ class OapPlannerSuite
           sql(s"check oindex on $tabName"),
           Row(s"Data file: $dirPath/$dataFileName not found!"))
 
+        sql(s"drop oindex idxa on $tabName")
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
       }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -102,27 +102,29 @@ class OapPlannerSuite
 
     dataRDD.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_sort_opt_table select * from t")
-    sql("create oindex index1 on oap_sort_opt_table (a)")
-    sql("create oindex index2 on oap_sort_opt_table (b)")
+    try {
+      sql("create oindex index1 on oap_sort_opt_table (a)")
+      sql("create oindex index2 on oap_sort_opt_table (b)")
 
-    // check strategy is applied.
-    checkKeywordsExist(
-      sql("explain SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7"),
-      "OapOrderLimitFileScanExec")
+      // check strategy is applied.
+      checkKeywordsExist(
+        sql("explain SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7"),
+        "OapOrderLimitFileScanExec")
 
-    // ASC
-    checkAnswer(
-      sql("SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7"),
-                Row(0) :: Row(0) :: Row(1) :: Row(1) :: Row(1) :: Row(2) :: Row(2) :: Nil)
+      // ASC
+      checkAnswer(
+        sql("SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7"),
+        Row(0) :: Row(0) :: Row(1) :: Row(1) :: Row(1) :: Row(2) :: Row(2) :: Nil)
 
-    // DESC
-    checkAnswer(
-      sql("SELECT a FROM oap_sort_opt_table WHERE a >= 90 AND a <= 101 ORDER BY a DESC LIMIT 14"),
-          Row(101) :: Row(101) :: Row(100) :: Row(100) :: Row(99) :: Row(99) :: Row(98) ::
+      // DESC
+      checkAnswer(
+        sql("SELECT a FROM oap_sort_opt_table WHERE a >= 90 AND a <= 101 ORDER BY a DESC LIMIT 14"),
+        Row(101) :: Row(101) :: Row(100) :: Row(100) :: Row(99) :: Row(99) :: Row(98) ::
           Row( 98) :: Row( 97) :: Row( 97) :: Row( 96) :: Row(96) :: Row(96) :: Row(95) :: Nil)
-
-    sql("drop oindex index1 on oap_sort_opt_table")
-    sql("drop oindex index2 on oap_sort_opt_table")
+    } finally {
+      sql("drop oindex index1 on oap_sort_opt_table")
+      sql("drop oindex index2 on oap_sort_opt_table")
+    }
   }
 
   test("SortPushDown Test with Different Project") {
@@ -131,18 +133,20 @@ class OapPlannerSuite
 
     dataRDD.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_sort_opt_table select * from t")
-    sql("create oindex index1 on oap_sort_opt_table (a)")
-    sql("create oindex index2 on oap_sort_opt_table (b)")
+    try {
+      sql("create oindex index1 on oap_sort_opt_table (a)")
+      sql("create oindex index2 on oap_sort_opt_table (b)")
 
-    checkAnswer(
-      sql("SELECT b FROM oap_sort_opt_table WHERE a >= 1 AND a <= 10 ORDER BY a LIMIT 4"),
+      checkAnswer(
+        sql("SELECT b FROM oap_sort_opt_table WHERE a >= 1 AND a <= 10 ORDER BY a LIMIT 4"),
         Row("this is test 1") ::
-        Row("this is test 2") ::
-        Row("this is test 3") ::
-        Row("this is test 4") :: Nil)
-
-    sql("drop oindex index1 on oap_sort_opt_table")
-    sql("drop oindex index2 on oap_sort_opt_table")
+          Row("this is test 2") ::
+          Row("this is test 3") ::
+          Row("this is test 4") :: Nil)
+    } finally {
+      sql("drop oindex index1 on oap_sort_opt_table")
+      sql("drop oindex index2 on oap_sort_opt_table")
+    }
   }
 
   test("SortPushDown should consider deserialized plan") {
@@ -151,19 +155,21 @@ class OapPlannerSuite
 
     dataRDD.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_sort_opt_table select * from t")
-    sql("create oindex index1 on oap_sort_opt_table (a)")
+    try {
+      sql("create oindex index1 on oap_sort_opt_table (a)")
 
-    val sqlText = "SELECT b FROM oap_sort_opt_table WHERE a >= 1 AND a <= 10 ORDER BY a LIMIT 4"
-    val logicPlan = spark.sessionState.sqlParser.parsePlan(sqlText)
-    val qe = new QueryExecution(spark, logicPlan)
-    assert(qe.sparkPlan.toString().contains("OapOrderLimitFileScanExec"))
+      val sqlText = "SELECT b FROM oap_sort_opt_table WHERE a >= 1 AND a <= 10 ORDER BY a LIMIT 4"
+      val logicPlan = spark.sessionState.sqlParser.parsePlan(sqlText)
+      val qe = new QueryExecution(spark, logicPlan)
+      assert(qe.sparkPlan.toString().contains("OapOrderLimitFileScanExec"))
 
-    implicit val exprEnc: ExpressionEncoder[Row] = encoderFor(RowEncoder(qe.analyzed.schema))
-    val deserializedPlan = CatalystSerde.deserialize[Row](logicPlan)
-    val qe1 = new QueryExecution(spark, deserializedPlan)
-    assert(qe1.sparkPlan.toString().contains("OapOrderLimitFileScanExec"))
-
-    sql("drop oindex index1 on oap_sort_opt_table")
+      implicit val exprEnc: ExpressionEncoder[Row] = encoderFor(RowEncoder(qe.analyzed.schema))
+      val deserializedPlan = CatalystSerde.deserialize[Row](logicPlan)
+      val qe1 = new QueryExecution(spark, deserializedPlan)
+      assert(qe1.sparkPlan.toString().contains("OapOrderLimitFileScanExec"))
+    } finally {
+      sql("drop oindex index1 on oap_sort_opt_table")
+    }
   }
 
   test("Distinct index scan if SemiJoin Test") {
@@ -181,47 +187,49 @@ class OapPlannerSuite
 
     dataRDD1.toDF("key", "value").createOrReplaceTempView("t1")
     sql("insert overwrite table oap_distinct_opt_table select * from t1")
-    sql("create oindex index1 on oap_distinct_opt_table (a) using bitmap")
+    try {
+      sql("create oindex index1 on oap_distinct_opt_table (a) using bitmap")
 
-    checkKeywordsExist(
-      sql("explain SELECT * " +
-      "FROM oap_sort_opt_table t1 " +
-      "WHERE EXISTS " +
-      "(SELECT 1 FROM oap_distinct_opt_table t2 " +
-      "WHERE t1.a = t2.a AND t2.a IN (1, 2, 3, 4)) " +
-      "ORDER BY a"), "OapDistinctFileScanExec")
+      checkKeywordsExist(
+        sql("explain SELECT * " +
+          "FROM oap_sort_opt_table t1 " +
+          "WHERE EXISTS " +
+          "(SELECT 1 FROM oap_distinct_opt_table t2 " +
+          "WHERE t1.a = t2.a AND t2.a IN (1, 2, 3, 4)) " +
+          "ORDER BY a"), "OapDistinctFileScanExec")
 
-    checkKeywordsNotExist(
-      sql("explain SELECT * " +
-        "FROM oap_sort_opt_table t1 " +
-        "WHERE EXISTS " +
-        "(SELECT 1 FROM oap_distinct_opt_table t2 " +
-        "WHERE t1.a = t2.a AND t1.a IN (1, 2, 3, 4)) " +
-        "ORDER BY a"), "OapDistinctFileScanExec")
+      checkKeywordsNotExist(
+        sql("explain SELECT * " +
+          "FROM oap_sort_opt_table t1 " +
+          "WHERE EXISTS " +
+          "(SELECT 1 FROM oap_distinct_opt_table t2 " +
+          "WHERE t1.a = t2.a AND t1.a IN (1, 2, 3, 4)) " +
+          "ORDER BY a"), "OapDistinctFileScanExec")
 
-    // TODO: SemiJoin should enable this kind of query.
-    checkKeywordsNotExist(
-      sql("explain SELECT * " +
-        "FROM oap_sort_opt_table t1 " +
-        "WHERE EXISTS " +
-        "(SELECT 1 FROM oap_distinct_opt_table t2 " +
-        "WHERE t1.a = t2.a)"), "OapDistinctFileScanExec")
+      // TODO: SemiJoin should enable this kind of query.
+      checkKeywordsNotExist(
+        sql("explain SELECT * " +
+          "FROM oap_sort_opt_table t1 " +
+          "WHERE EXISTS " +
+          "(SELECT 1 FROM oap_distinct_opt_table t2 " +
+          "WHERE t1.a = t2.a)"), "OapDistinctFileScanExec")
 
-    checkAnswer(
-      sql("SELECT * " +
-      "FROM oap_sort_opt_table t1 " +
-      "WHERE EXISTS " +
-      "(SELECT 1 FROM oap_distinct_opt_table t2 " +
-      "WHERE t1.a = t2.a AND t2.a >= 1 AND t1.a < 5) " +
-      "ORDER BY a"),
-      Seq(
-        Row(1, "this is test 1"),
-        Row(2, "this is test 2"),
-        Row(3, "this is test 3"),
-        Row(4, "this is test 4")))
-
-    sql("drop oindex index1 on oap_sort_opt_table")
-    sql("drop oindex index1 on oap_distinct_opt_table")
+      checkAnswer(
+        sql("SELECT * " +
+          "FROM oap_sort_opt_table t1 " +
+          "WHERE EXISTS " +
+          "(SELECT 1 FROM oap_distinct_opt_table t2 " +
+          "WHERE t1.a = t2.a AND t2.a >= 1 AND t1.a < 5) " +
+          "ORDER BY a"),
+        Seq(
+          Row(1, "this is test 1"),
+          Row(2, "this is test 2"),
+          Row(3, "this is test 3"),
+          Row(4, "this is test 4")))
+    } finally {
+      sql("drop oindex index1 on oap_sort_opt_table")
+      sql("drop oindex index1 on oap_distinct_opt_table")
+    }
   }
 
   test("OapFileScan WholeStageCodeGen Check") {
@@ -231,23 +239,25 @@ class OapPlannerSuite
 
     dataRDD.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_sort_opt_table select * from t")
-    sql("create oindex index1 on oap_sort_opt_table (a)")
+    try {
+      sql("create oindex index1 on oap_sort_opt_table (a)")
 
-    spark.sqlContext.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "false")
-    val sqlString =
-      "explain SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7"
+      spark.sqlContext.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "false")
+      val sqlString =
+        "explain SELECT a FROM oap_sort_opt_table WHERE a >= 0 AND a <= 10 ORDER BY a LIMIT 7"
 
-    // OapOrderLimitFileScanExec is applied.
-    checkKeywordsExist(sql(sqlString), "OapOrderLimitFileScanExec")
-    // OapOrderLimitFileScanExec WholeStageCodeGen is disabled.
-    checkKeywordsNotExist(sql(sqlString), "*OapOrderLimitFileScanExec")
+      // OapOrderLimitFileScanExec is applied.
+      checkKeywordsExist(sql(sqlString), "OapOrderLimitFileScanExec")
+      // OapOrderLimitFileScanExec WholeStageCodeGen is disabled.
+      checkKeywordsNotExist(sql(sqlString), "*OapOrderLimitFileScanExec")
 
-    spark.sqlContext.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true")
+      spark.sqlContext.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true")
 
-    // OapOrderLimitFileScanExec WholeStageCodeGen is enabled.
-    checkKeywordsExist(sql(sqlString), "*OapOrderLimitFileScanExec")
-
-    sql("drop oindex index1 on oap_sort_opt_table")
+      // OapOrderLimitFileScanExec WholeStageCodeGen is enabled.
+      checkKeywordsExist(sql(sqlString), "*OapOrderLimitFileScanExec")
+    } finally {
+      sql("drop oindex index1 on oap_sort_opt_table")
+    }
   }
 
   test("aggregations with group by test") {
@@ -257,24 +267,26 @@ class OapPlannerSuite
 
     dataRDD.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_fix_length_schema_table select * from t")
-    sql("create oindex index1 on oap_fix_length_schema_table (a)")
+    try {
+      sql("create oindex index1 on oap_fix_length_schema_table (a)")
 
-    val sqlString =
-      "SELECT a, min(b), max(b), std(b), avg(b), first(b), last(b) " +
-        "FROM oap_fix_length_schema_table " +
-        "where a < 30 " +
-        "group by a"
+      val sqlString =
+        "SELECT a, min(b), max(b), std(b), avg(b), first(b), last(b) " +
+          "FROM oap_fix_length_schema_table " +
+          "where a < 30 " +
+          "group by a"
 
-    checkKeywordsExist(sql("explain " + sqlString), "*OapAggregationFileScanExec")
-    val oapDF = sql(sqlString).collect()
+      checkKeywordsExist(sql("explain " + sqlString), "*OapAggregationFileScanExec")
+      val oapDF = sql(sqlString).collect()
 
-    spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "true")
-    checkKeywordsNotExist(sql("explain " + sqlString), "OapAggregationFileScanExec")
-    val baseDF = sql(sqlString)
-
-    checkAnswer(baseDF, oapDF)
-    spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "false")
-    sql("drop oindex index1 on oap_fix_length_schema_table")
+      spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "true")
+      checkKeywordsNotExist(sql("explain " + sqlString), "OapAggregationFileScanExec")
+      val baseDF = sql(sqlString)
+      checkAnswer(baseDF, oapDF)
+    } finally {
+      spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "false")
+      sql("drop oindex index1 on oap_fix_length_schema_table")
+    }
   }
 
   test("oapStrategies does not support empty filter") {
@@ -284,15 +296,17 @@ class OapPlannerSuite
 
     dataRDD.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_fix_length_schema_table select * from t")
-    sql("create oindex index1 on oap_fix_length_schema_table (a)")
+    try {
+      sql("create oindex index1 on oap_fix_length_schema_table (a)")
 
-    val aggQuery = "SELECT a, min(b) FROM oap_fix_length_schema_table group by a"
-    checkKeywordsNotExist(sql("explain " + aggQuery), "*OapAggregationFileScanExec")
+      val aggQuery = "SELECT a, min(b) FROM oap_fix_length_schema_table group by a"
+      checkKeywordsNotExist(sql("explain " + aggQuery), "*OapAggregationFileScanExec")
 
-    val orderByLimitQuery = "SELECT a FROM oap_sort_opt_table ORDER BY a LIMIT 7"
-    checkKeywordsNotExist(sql("explain " + orderByLimitQuery), "*OapOrderLimitFileScanExec")
-
-    sql("drop oindex index1 on oap_fix_length_schema_table")
+      val orderByLimitQuery = "SELECT a FROM oap_sort_opt_table ORDER BY a LIMIT 7"
+      checkKeywordsNotExist(sql("explain " + orderByLimitQuery), "*OapOrderLimitFileScanExec")
+    } finally {
+      sql("drop oindex index1 on oap_fix_length_schema_table")
+    }
   }
 
   test("aggregations with multi filters") {
@@ -363,15 +377,19 @@ class OapPlannerSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        try {
+          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(
-          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+          checkAnswer(
+            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-        sql(s"drop oindex idxa on $tabName")
-        checkAnswer(sql(s"show oindex from $tabName"), Nil)
-        sql(s"DROP TABLE $tabName")
-        assert(tmpDir.listFiles.nonEmpty)
+          sql(s"drop oindex idxa on $tabName")
+          checkAnswer(sql(s"show oindex from $tabName"), Nil)
+          sql(s"DROP TABLE $tabName")
+          assert(tmpDir.listFiles.nonEmpty)
+        } finally {
+          sql(s"drop oindex if exists idxa on $tabName")
+        }
       }
     }
   }
@@ -395,22 +413,25 @@ class OapPlannerSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        try {
+          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+          checkAnswer(
+            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-        checkAnswer(
-          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
-
-        // test refresh oap index
-        (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
-          .createOrReplaceTempView("t2")
-        sql(s"insert into table $tabName select * from t2")
-        sql(s"refresh oindex on $tabName")
-        checkAnswer(
-          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
-        checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
-        sql(s"drop oindex idxa on $tabName")
-        sql(s"DROP TABLE $tabName")
-        assert(tmpDir.listFiles.nonEmpty)
+          // test refresh oap index
+          (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
+            .createOrReplaceTempView("t2")
+          sql(s"insert into table $tabName select * from t2")
+          sql(s"refresh oindex on $tabName")
+          checkAnswer(
+            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+          checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
+          sql(s"drop oindex idxa on $tabName")
+          sql(s"DROP TABLE $tabName")
+          assert(tmpDir.listFiles.nonEmpty)
+        } finally {
+          sql(s"drop oindex if exists idxa on $tabName")
+        }
       }
     }
   }
@@ -434,30 +455,34 @@ class OapPlannerSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        try {
+          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(
-          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+          checkAnswer(
+            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-        // test check oap index
-        checkAnswer(sql(s"check oindex on $tabName"), Nil)
-        val dirPath = tmpDir.getAbsolutePath
-        val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(dirPath))
-        assert(metaOpt.nonEmpty)
-        assert(metaOpt.get.fileMetas.nonEmpty)
-        assert(metaOpt.get.indexMetas.nonEmpty)
-        val dataFileName = metaOpt.get.fileMetas.head.dataFileName
-        // delete a data file
-        Utils.deleteRecursively(new File(dirPath, dataFileName))
+          // test check oap index
+          checkAnswer(sql(s"check oindex on $tabName"), Nil)
+          val dirPath = tmpDir.getAbsolutePath
+          val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(dirPath))
+          assert(metaOpt.nonEmpty)
+          assert(metaOpt.get.fileMetas.nonEmpty)
+          assert(metaOpt.get.indexMetas.nonEmpty)
+          val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+          // delete a data file
+          Utils.deleteRecursively(new File(dirPath, dataFileName))
 
-        // Check again
-        checkAnswer(
-          sql(s"check oindex on $tabName"),
-          Row(s"Data file: $dirPath/$dataFileName not found!"))
+          // Check again
+          checkAnswer(
+            sql(s"check oindex on $tabName"),
+            Row(s"Data file: $dirPath/$dataFileName not found!"))
 
-        sql(s"drop oindex idxa on $tabName")
-        sql(s"DROP TABLE $tabName")
-        assert(tmpDir.listFiles.nonEmpty)
+          sql(s"drop oindex idxa on $tabName")
+          sql(s"DROP TABLE $tabName")
+          assert(tmpDir.listFiles.nonEmpty)
+        } finally {
+          sql(s"drop oindex if exists idxa on $tabName")
+        }
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -156,6 +156,7 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
     val itSetUseIndex = readerIndex.initialize(conf)
     assert(itSetUseIndex.size == 4)
     dir.delete()
+    sql("drop oindex oap_idx on oap_table")
   }
 
   test("OapIndexInfo status and update") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 import org.apache.spark.util.Utils
 
@@ -79,13 +79,11 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
     val maxPartitionBytes = 100L
     sqlConf.setConf(SQLConf.FILES_MAX_PARTITION_BYTES, maxPartitionBytes)
     val numTasks = sql("select * from parquet_table").queryExecution.toRdd.partitions.length
-    try {
+    withIndex(TestIndex("parquet_table", "parquet_idx")) {
       sql("create oindex parquet_idx on parquet_table (a)")
       assert(numTasks == parquetPath.listFiles().filter(_.getName.endsWith(".parquet"))
         .map(f => Math.ceil(f.length().toDouble / maxPartitionBytes).toInt).sum)
       sqlConf.setConf(SQLConf.FILES_MAX_PARTITION_BYTES, defaultMaxBytes)
-    } finally {
-      sql("drop oindex parquet_idx on parquet_table")
     }
   }
 
@@ -140,32 +138,33 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
     }
     val df = sqlContext.read.format("oap").load(dir.getAbsolutePath)
     df.createOrReplaceTempView("oap_table")
-    sql("create oindex oap_idx on oap_table (a)")
-    val conf = configuration
-    val filePath = new Path(oapDataFile.toString)
-    val metaPath = new Path(oapMetaFile.toString)
-    val dataSourceMeta = DataSourceMeta.initialize(metaPath, conf)
-    val requiredIds = Array(0, 1)
-    // No index scanner is used.
-    val readerNoIndex = new OapDataReader(filePath, dataSourceMeta, None, requiredIds)
-    val itNoIndex = readerNoIndex.initialize(conf)
-    assert(itNoIndex.size == 100)
-    val ic = new IndexContext(dataSourceMeta)
-    val filters: Array[Filter] = Array(
-      And(GreaterThan("a", 9), LessThan("a", 14)))
-    ScannerBuilder.build(filters, ic)
-    val filterScanners = ic.getScanners
-    val readerIndex = new OapDataReader(filePath, dataSourceMeta, filterScanners, requiredIds)
-    val itIndex = readerIndex.initialize(conf)
-    assert(itIndex.size == 4)
-    conf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key, false)
-    val itSetIgnoreIndex = readerIndex.initialize(conf)
-    assert(itSetIgnoreIndex.size == 100)
-    conf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key, true)
-    val itSetUseIndex = readerIndex.initialize(conf)
-    assert(itSetUseIndex.size == 4)
-    dir.delete()
-    sql("drop oindex oap_idx on oap_table")
+    withIndex(TestIndex("oap_table", "oap_idx")) {
+      sql("create oindex oap_idx on oap_table (a)")
+      val conf = configuration
+      val filePath = new Path(oapDataFile.toString)
+      val metaPath = new Path(oapMetaFile.toString)
+      val dataSourceMeta = DataSourceMeta.initialize(metaPath, conf)
+      val requiredIds = Array(0, 1)
+      // No index scanner is used.
+      val readerNoIndex = new OapDataReader(filePath, dataSourceMeta, None, requiredIds)
+      val itNoIndex = readerNoIndex.initialize(conf)
+      assert(itNoIndex.size == 100)
+      val ic = new IndexContext(dataSourceMeta)
+      val filters: Array[Filter] = Array(
+        And(GreaterThan("a", 9), LessThan("a", 14)))
+      ScannerBuilder.build(filters, ic)
+      val filterScanners = ic.getScanners
+      val readerIndex = new OapDataReader(filePath, dataSourceMeta, filterScanners, requiredIds)
+      val itIndex = readerIndex.initialize(conf)
+      assert(itIndex.size == 4)
+      conf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key, false)
+      val itSetIgnoreIndex = readerIndex.initialize(conf)
+      assert(itSetIgnoreIndex.size == 100)
+      conf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key, true)
+      val itSetUseIndex = readerIndex.initialize(conf)
+      assert(itSetUseIndex.size == 4)
+      dir.delete()
+    }
   }
 
   test("OapIndexInfo status and update") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileHandle
 import org.apache.spark.sql.execution.datasources.oap.listener.FiberInfoListener
 import org.apache.spark.sql.execution.datasources.oap.utils.CacheStatusSerDe
 import org.apache.spark.sql.internal.oap.OapConf
-import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
 import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.BitSet
 
@@ -71,48 +71,49 @@ class FiberSensorSuite extends QueryTest with SharedOapContext
     data.toDF("key", "value").createOrReplaceTempView("t")
     checkAnswer(sql("SELECT * FROM oap_test"), Seq.empty[Row])
     sql("insert overwrite table oap_test select * from t")
-    sql("create oindex index1 on oap_test (a) using btree")
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 500 AND a < 2500"),
-      data.filter(r => r._1 > 500 && r._1 < 2500).map(r => Row(r._1, r._2)))
-    CacheStats.reset
+    withIndex(TestIndex("oap_test", "index1")) {
+      sql("create oindex index1 on oap_test (a) using btree")
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 500 AND a < 2500"),
+        data.filter(r => r._1 > 500 && r._1 < 2500).map(r => Row(r._1, r._2)))
+      CacheStats.reset
 
-    // Data/Index file statistic
-    val files = FileSystem.get(new Configuration()).listStatus(new Path(currentPath))
-    var indexFileCount = 0L
-    var dataFileCount = 0L
-    for (file <- files) {
-      if (file.getPath.getName.endsWith(".index")) {
-        indexFileCount += 1L
-      } else if (file.getPath.getName.endsWith(".data")) {
-        dataFileCount += 1L
+      // Data/Index file statistic
+      val files = FileSystem.get(new Configuration()).listStatus(new Path(currentPath))
+      var indexFileCount = 0L
+      var dataFileCount = 0L
+      for (file <- files) {
+        if (file.getPath.getName.endsWith(".index")) {
+          indexFileCount += 1L
+        } else if (file.getPath.getName.endsWith(".data")) {
+          dataFileCount += 1L
+        }
       }
+
+      // Only one executor in local-mode, each data file has 4 dataFiber(2 cols * 2 rgs/col)
+      // wait for a heartbeat
+      Thread.sleep(20 * 1000)
+      val summary = FiberCacheManagerSensor.summary()
+      logWarning(s"Summary1: ${summary.toDebugString}")
+      assertResult(1)(FiberCacheManagerSensor.executorToCacheManager.size())
+      assertResult(dataFileCount * 4)(summary.dataFiberCount)
+
+      // all data are cached when run another sql.
+      // Expect: 1.hitCount increase; 2.missCount equal
+      // wait for a heartbeat period
+      checkAnswer(sql("SELECT * FROM oap_test WHERE a > 200 AND a < 2400"),
+        data.filter(r => r._1 > 200 && r._1 < 2400).map(r => Row(r._1, r._2)))
+      CacheStats.reset
+      Thread.sleep(15 * 1000)
+      val summary2 = FiberCacheManagerSensor.summary()
+      logWarning(s"Summary2: ${summary2.toDebugString}")
+      assertResult(1)(FiberCacheManagerSensor.executorToCacheManager.size())
+      assert(summary.hitCount < summary2.hitCount)
+      assertResult(summary.missCount)(summary2.missCount)
+      assertResult(summary.dataFiberCount)(summary2.dataFiberCount)
+      assertResult(summary.dataFiberSize)(summary2.dataFiberSize)
+      assertResult(summary.indexFiberCount)(summary2.indexFiberCount)
+      assertResult(summary.indexFiberSize)(summary2.indexFiberSize)
     }
-
-    // Only one executor in local-mode, each data file has 4 dataFiber(2 cols * 2 rgs/col)
-    // wait for a heartbeat
-    Thread.sleep(20 * 1000)
-    val summary = FiberCacheManagerSensor.summary()
-    logWarning(s"Summary1: ${summary.toDebugString}")
-    assertResult(1)(FiberCacheManagerSensor.executorToCacheManager.size())
-    assertResult(dataFileCount * 4)(summary.dataFiberCount)
-
-    // all data are cached when run another sql.
-    // Expect: 1.hitCount increase; 2.missCount equal
-    // wait for a heartbeat period
-    checkAnswer(sql("SELECT * FROM oap_test WHERE a > 200 AND a < 2400"),
-      data.filter(r => r._1 > 200 && r._1 < 2400).map(r => Row(r._1, r._2)))
-    CacheStats.reset
-    Thread.sleep(15 * 1000)
-    val summary2 = FiberCacheManagerSensor.summary()
-    logWarning(s"Summary2: ${summary2.toDebugString}")
-    assertResult(1)(FiberCacheManagerSensor.executorToCacheManager.size())
-    assert(summary.hitCount < summary2.hitCount)
-    assertResult(summary.missCount)(summary2.missCount)
-    assertResult(summary.dataFiberCount)(summary2.dataFiberCount)
-    assertResult(summary.dataFiberSize)(summary2.dataFiberSize)
-    assertResult(summary.indexFiberCount)(summary2.indexFiberCount)
-    assertResult(summary.indexFiberSize)(summary2.indexFiberSize)
-    sql("drop oindex index1 on oap_test")
   }
 
   test("test FiberCacheManagerSensor onCustomInfoUpdate FiberCacheManagerMessager") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
-import org.scalatest.BeforeAndAfterEach
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
+import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate
@@ -113,6 +112,7 @@ class FiberSensorSuite extends QueryTest with SharedOapContext
     assertResult(summary.dataFiberSize)(summary2.dataFiberSize)
     assertResult(summary.indexFiberCount)(summary2.indexFiberCount)
     assertResult(summary.indexFiberSize)(summary2.indexFiberSize)
+    sql("drop oindex index1 on oap_test")
   }
 
   test("test FiberCacheManagerSensor onCustomInfoUpdate FiberCacheManagerMessager") {

--- a/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
@@ -78,6 +78,7 @@ class HiveOapIndexDDLSuite
 
         checkAnswer(
           sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+        sql(s"drop oindex idxa on $tabName")
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
       }
@@ -148,6 +149,7 @@ class HiveOapIndexDDLSuite
         checkAnswer(
           sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
         checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
+        sql(s"drop oindex idxa on $tabName")
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
       }
@@ -175,7 +177,8 @@ class HiveOapIndexDDLSuite
         assert(tmpDir.listFiles.nonEmpty)
         checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+        checkAnswer(sql(s"show oindex from $tabName"),
+          Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
         // test check oap index
         checkAnswer(sql(s"check oindex on $tabName"), Nil)
@@ -193,6 +196,7 @@ class HiveOapIndexDDLSuite
           sql(s"check oindex on $tabName"),
           Row(s"Data file: $dirPath/$dataFileName not found!"))
 
+        sql(s"drop oindex idxa on $tabName")
         sql(s"DROP TABLE $tabName")
         assert(tmpDir.listFiles.nonEmpty)
       }

--- a/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/HiveOapIndexDDLSuite.scala
@@ -74,13 +74,16 @@ class HiveOapIndexDDLSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
-
-        checkAnswer(
-          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
-        sql(s"drop oindex idxa on $tabName")
-        sql(s"DROP TABLE $tabName")
-        assert(tmpDir.listFiles.nonEmpty)
+        try {
+          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+          checkAnswer(
+            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+          sql(s"drop oindex idxa on $tabName")
+          sql(s"DROP TABLE $tabName")
+          assert(tmpDir.listFiles.nonEmpty)
+        } finally {
+          sql(s"drop oindex if exists idxa on $tabName")
+        }
       }
     }
   }
@@ -104,15 +107,18 @@ class HiveOapIndexDDLSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        try {
+          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+          checkAnswer(
+            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-        checkAnswer(
-          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
-
-        sql(s"drop oindex idxa on $tabName")
-        checkAnswer(sql(s"show oindex from $tabName"), Nil)
-        sql(s"DROP TABLE $tabName")
-        assert(tmpDir.listFiles.nonEmpty)
+          sql(s"drop oindex idxa on $tabName")
+          checkAnswer(sql(s"show oindex from $tabName"), Nil)
+          sql(s"DROP TABLE $tabName")
+          assert(tmpDir.listFiles.nonEmpty)
+        } finally {
+          sql(s"drop oindex if exists idxa on $tabName")
+        }
       }
     }
   }
@@ -136,22 +142,26 @@ class HiveOapIndexDDLSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        try {
+          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(
-          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+          checkAnswer(
+            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-        // test refresh oap index
-        (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
-          .createOrReplaceTempView("t2")
-        sql(s"insert into table $tabName select * from t2")
-        sql(s"refresh oindex on $tabName")
-        checkAnswer(
-          sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
-        checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
-        sql(s"drop oindex idxa on $tabName")
-        sql(s"DROP TABLE $tabName")
-        assert(tmpDir.listFiles.nonEmpty)
+          // test refresh oap index
+          (500 to 600).map { i => (i, s"this is test $i") }.toDF("a", "b")
+            .createOrReplaceTempView("t2")
+          sql(s"insert into table $tabName select * from t2")
+          sql(s"refresh oindex on $tabName")
+          checkAnswer(
+            sql(s"show oindex from $tabName"), Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+          checkAnswer(sql(s"select a from $tabName where a=555"), Row(555))
+          sql(s"drop oindex idxa on $tabName")
+          sql(s"DROP TABLE $tabName")
+          assert(tmpDir.listFiles.nonEmpty)
+        } finally {
+          sql(s"drop oindex if exists idxa on $tabName")
+        }
       }
     }
   }
@@ -175,30 +185,34 @@ class HiveOapIndexDDLSuite
         assert(hiveTable.tableType == CatalogTableType.EXTERNAL)
 
         assert(tmpDir.listFiles.nonEmpty)
-        checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
+        try {
+          checkAnswer(sql(s"create oindex idxa on $tabName(a)"), Nil)
 
-        checkAnswer(sql(s"show oindex from $tabName"),
-          Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
+          checkAnswer(sql(s"show oindex from $tabName"),
+            Row(tabName, "idxa", 0, "a", "A", "BTREE", true))
 
-        // test check oap index
-        checkAnswer(sql(s"check oindex on $tabName"), Nil)
-        val dirPath = tmpDir.getAbsolutePath
-        val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(dirPath))
-        assert(metaOpt.nonEmpty)
-        assert(metaOpt.get.fileMetas.nonEmpty)
-        assert(metaOpt.get.indexMetas.nonEmpty)
-        val dataFileName = metaOpt.get.fileMetas.head.dataFileName
-        // delete a data file
-        Utils.deleteRecursively(new File(dirPath, dataFileName))
+          // test check oap index
+          checkAnswer(sql(s"check oindex on $tabName"), Nil)
+          val dirPath = tmpDir.getAbsolutePath
+          val metaOpt = OapUtils.getMeta(sparkContext.hadoopConfiguration, new Path(dirPath))
+          assert(metaOpt.nonEmpty)
+          assert(metaOpt.get.fileMetas.nonEmpty)
+          assert(metaOpt.get.indexMetas.nonEmpty)
+          val dataFileName = metaOpt.get.fileMetas.head.dataFileName
+          // delete a data file
+          Utils.deleteRecursively(new File(dirPath, dataFileName))
 
-        // Check again
-        checkAnswer(
-          sql(s"check oindex on $tabName"),
-          Row(s"Data file: $dirPath/$dataFileName not found!"))
+          // Check again
+          checkAnswer(
+            sql(s"check oindex on $tabName"),
+            Row(s"Data file: $dirPath/$dataFileName not found!"))
 
-        sql(s"drop oindex idxa on $tabName")
-        sql(s"DROP TABLE $tabName")
-        assert(tmpDir.listFiles.nonEmpty)
+          sql(s"drop oindex idxa on $tabName")
+          sql(s"DROP TABLE $tabName")
+          assert(tmpDir.listFiles.nonEmpty)
+        } finally {
+          sql(s"drop oindex if exists idxa on $tabName")
+        }
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/hive/execution/OapQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/OapQuerySuite.scala
@@ -66,21 +66,26 @@ class OapQuerySuite extends HiveComparisonTest with BeforeAndAfter  {
   }
 
   test("create hive table in parquet format") {
-    sql("create table p_table (key int, val string) stored as parquet")
-    sql("insert overwrite table p_table select * from src")
-    sql("create oindex if not exists p_index on p_table(key)")
-
-    assert(sql("select val from p_table where key = 238").collect().head.getString(0) == "val_238")
-    sql("drop oindex p_index on p_table")
-    sql("drop table p_table")
+    try {
+      sql("create table p_table (key int, val string) stored as parquet")
+      sql("insert overwrite table p_table select * from src")
+      sql("create oindex if not exists p_index on p_table(key)")
+      assert(sql("select val from p_table where key = 238")
+        .collect().head.getString(0) == "val_238")
+    } finally {
+      sql("drop oindex p_index on p_table")
+      sql("drop table p_table")
+    }
   }
 
   test("create duplicate hive table in parquet format") {
-    sql("create table p_table1 (key int, val string) stored as parquet")
-    sql("insert overwrite table p_table1 select * from src")
-
-    sql("create oindex p_index on p_table1(key)")
-    assertDupIndex { sql("create oindex p_index on p_table1(key)") }
-    sql("drop oindex p_index on p_table1")
+    try {
+      sql("create table p_table1 (key int, val string) stored as parquet")
+      sql("insert overwrite table p_table1 select * from src")
+      sql("create oindex p_index on p_table1(key)")
+      assertDupIndex { sql("create oindex p_index on p_table1(key)") }
+    } finally {
+      sql("drop oindex p_index on p_table1")
+    }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/hive/execution/OapQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/hive/execution/OapQuerySuite.scala
@@ -71,6 +71,7 @@ class OapQuerySuite extends HiveComparisonTest with BeforeAndAfter  {
     sql("create oindex if not exists p_index on p_table(key)")
 
     assert(sql("select val from p_table where key = 238").collect().head.getString(0) == "val_238")
+    sql("drop oindex p_index on p_table")
     sql("drop table p_table")
   }
 
@@ -80,5 +81,6 @@ class OapQuerySuite extends HiveComparisonTest with BeforeAndAfter  {
 
     sql("create oindex p_index on p_table1(key)")
     assertDupIndex { sql("create oindex p_index on p_table1(key)") }
+    sql("drop oindex p_index on p_table1")
   }
 }

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -98,12 +98,12 @@ trait SharedOapContextBase extends SharedSQLContext {
     try f finally {
       indices.foreach { index =>
         val baseSql = s"DROP OINDEX ${index.indexName} on ${index.tableName}"
-        index.partitions.length match {
-          case 0 => spark.sql(baseSql)
-          case _ =>
-            val partitionPart = index.partitions.map(p => s"${p.key} = '${p.value}'")
-              .mkString(" partition (", ",", ")")
-            spark.sql(s"$baseSql $partitionPart")
+        if (index.partitions.isEmpty) {
+          spark.sql(baseSql)
+        } else {
+          val partitionPart = index.partitions.map(p => s"${p.key} = '${p.value}'")
+            .mkString(" partition (", ",", ")")
+          spark.sql(s"$baseSql $partitionPart")
         }
       }
     }

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -96,7 +96,7 @@ trait SharedOapContextBase extends SharedSQLContext {
         index.partitions.length match {
           case 0 => spark.sql(baseSql)
           case _ =>
-            val partitionPart = index.partitions.map(p => s"${p.key} = ${p.value}").mkString(",")
+            val partitionPart = index.partitions.map(p => s"${p.key} = '${p.value}'").mkString(",")
             spark.sql(s"$baseSql partition ($partitionPart)")
         }
       }

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -89,6 +89,11 @@ trait SharedOapContextBase extends SharedSQLContext {
       }
   }
 
+  /**
+   * Drop oindex by `TestIndex` after calling `f`, `TestIndex` use to
+   * specify the `tableName`, `indexName` and `partitions`.
+   * `partitions` is not necessary unless create index also specify `partitions`.
+   */
   protected def withIndex(indices: TestIndex*)(f: => Unit): Unit = {
     try f finally {
       indices.foreach { index =>
@@ -96,8 +101,9 @@ trait SharedOapContextBase extends SharedSQLContext {
         index.partitions.length match {
           case 0 => spark.sql(baseSql)
           case _ =>
-            val partitionPart = index.partitions.map(p => s"${p.key} = '${p.value}'").mkString(",")
-            spark.sql(s"$baseSql partition ($partitionPart)")
+            val partitionPart = index.partitions.map(p => s"${p.key} = '${p.value}'")
+              .mkString(" partition (", ",", ")")
+            spark.sql(s"$baseSql $partitionPart")
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add `drop oindex` sql after `create oindex` sql test case to keep the isolation between case.

## How was this patch tested?
mvn test pass