### PR TITLE
Change ParquetDataFile.meta to lazy

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -45,7 +45,7 @@ private[oap] case class ParquetDataFile(
     configuration: Configuration) extends DataFile {
 
   private var context: Option[VectorizedContext] = None
-  private val meta: ParquetDataFileHandle = DataFileHandleCacheManager(this)
+  private lazy val meta: ParquetDataFileHandle = DataFileHandleCacheManager(this)
   private val file = new Path(StringUtils.unEscapeString(path))
   private val parquetDataCacheEnable =
     configuration.getBoolean(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change ParquetDataFile.meta to lazy,  else it will read parquet footer before analysis index.

## How was this patch tested?

mvn test pass

