### PR TITLE
#694 Change to use UnSplitParquetFileFormat build index

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheManager
 import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, UnSplitParquetFileFormat}
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.rpc.OapMessages.CacheDrop
 import org.apache.spark.sql.types._
@@ -57,20 +57,23 @@ case class CreateIndexCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val qe = sparkSession.sessionState.executePlan(UnresolvedRelation(table))
     qe.assertAnalyzed()
-    val relation = qe.optimizedPlan
+    val opRelation = qe.optimizedPlan
 
-    val (fileCatalog, schema, readerClassName, identifier, fsRelation) = relation match {
+    val (fileCatalog, schema, readerClassName, identifier, relation) = opRelation match {
       case LogicalRelation(
       _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id) =>
-        (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, id, _fsRelation)
+        (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, id, opRelation)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), _, id) =>
+      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id) =>
         if (!sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED)) {
           throw new OapException(s"turn on ${
             OapConf.OAP_PARQUET_ENABLED.key} to allow index building on parquet files")
         }
-        format.forbidSplit
-        (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, id, _fsRelation)
+        val fsRelation = _fsRelation.copy(
+          fileFormat = new UnSplitParquetFileFormat(),
+          options = _fsRelation.options)(_fsRelation.sparkSession)
+        val lRelation = LogicalRelation(fsRelation, attributes, id)
+        (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, id, lRelation)
       case other =>
         throw new OapException(s"We don't support index building for ${other.simpleString}")
     }
@@ -289,16 +292,19 @@ case class RefreshIndexCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val qe = sparkSession.sessionState.executePlan(UnresolvedRelation(table))
     qe.assertAnalyzed()
-    val relation = qe.optimizedPlan
+    val opRelation = qe.optimizedPlan
 
-    val (fileCatalog, schema, readerClassName) = relation match {
+    val (fileCatalog, schema, readerClassName, relation) = opRelation match {
       case LogicalRelation(
           HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, _) =>
-        (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME)
+        (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, opRelation)
       case LogicalRelation(
-          HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), _, _) =>
-        format.forbidSplit
-        (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME)
+      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id) =>
+        val fsRelation = _fsRelation.copy(
+          fileFormat = new UnSplitParquetFileFormat(),
+          options = _fsRelation.options)(_fsRelation.sparkSession)
+        val lRelation = LogicalRelation(fsRelation, attributes, id)
+        (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, lRelation)
       case other =>
         throw new OapException(s"We don't support index refreshing for ${other.simpleString}")
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -44,7 +44,6 @@ import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjectio
 import org.apache.spark.sql.catalyst.parser.LegacyTypeStringParser
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.SerializableConfiguration
@@ -67,10 +66,6 @@ class ParquetFileFormat
   override def hashCode(): Int = getClass.hashCode()
 
   override def equals(other: Any): Boolean = other.isInstanceOf[ParquetFileFormat]
-
-  @transient protected var splitable = true
-
-  def forbidSplit: Unit = splitable = false
 
   override def prepareWrite(
       sparkSession: SparkSession,
@@ -276,7 +271,7 @@ class ParquetFileFormat
   override def isSplitable(
       sparkSession: SparkSession,
       options: Map[String, String],
-      path: Path): Boolean = splitable
+      path: Path): Boolean = false
 
   override def buildReaderWithPartitionValues(
       sparkSession: SparkSession,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -271,7 +271,7 @@ class ParquetFileFormat
   override def isSplitable(
       sparkSession: SparkSession,
       options: Map[String, String],
-      path: Path): Boolean = false
+      path: Path): Boolean = true
 
   override def buildReaderWithPartitionValues(
       sparkSession: SparkSession,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/UnSplitParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/UnSplitParquetFileFormat.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+
+class UnSplitParquetFileFormat extends ParquetFileFormat {
+
+  override def isSplitable(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      path: Path): Boolean = false
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -205,6 +205,8 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     withIndex(TestIndex("parquet_test", "index1")) {
       sql("create oindex index1 on parquet_test (a)")
 
+      sql("SELECT * FROM parquet_test WHERE b = '1'")
+
       checkAnswer(sql("SELECT * FROM parquet_test WHERE a = 1"),
         Row(1, "this is test 1") :: Nil)
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -24,11 +24,9 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.scheduler.SparkListenerOapIndexInfoUpdate
 import org.apache.spark.sql._
-import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, ScannerBuilder}
 import org.apache.spark.sql.execution.datasources.oap.io.{OapDataReader, OapIndexInfo, OapIndexInfoStatus}
 import org.apache.spark.sql.execution.datasources.oap.utils.OapIndexInfoStatusSerDe
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.sources._
@@ -76,13 +74,11 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
     val df = sqlContext.read.format("parquet").load(parquetPath.getAbsolutePath)
     df.createOrReplaceTempView("parquet_table")
     val defaultMaxBytes = sqlConf.getConf(SQLConf.FILES_MAX_PARTITION_BYTES)
-    val maxPartitionBytes = 100L
-    sqlConf.setConf(SQLConf.FILES_MAX_PARTITION_BYTES, maxPartitionBytes)
+    sqlConf.setConf(SQLConf.FILES_MAX_PARTITION_BYTES, 100L)
     val numTasks = sql("select * from parquet_table").queryExecution.toRdd.partitions.length
     withIndex(TestIndex("parquet_table", "parquet_idx")) {
       sql("create oindex parquet_idx on parquet_table (a)")
-      assert(numTasks == parquetPath.listFiles().filter(_.getName.endsWith(".parquet"))
-        .map(f => Math.ceil(f.length().toDouble / maxPartitionBytes).toInt).sum)
+      assert(numTasks == parquetPath.listFiles().count(_.getName.endsWith(".index")))
       sqlConf.setConf(SQLConf.FILES_MAX_PARTITION_BYTES, defaultMaxBytes)
     }
   }
@@ -188,28 +184,6 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
     assert(oapIndexInfo.hostName == host)
     assert(oapIndexInfo.executorId == executorId)
     assert(oapIndexInfo.oapIndexInfo == indexInfoStatusSerializeStr)
-  }
-
-  test("forbidSplit method in Parquet File Format") {
-    val df = sqlContext.read.format("parquet").load(parquetPath.getAbsolutePath)
-    df.createOrReplaceTempView("parquet_table")
-    val defaultMaxBytes = sqlConf.getConf(SQLConf.FILES_MAX_PARTITION_BYTES)
-    val maxPartitionBytes = 100L
-    sqlConf.setConf(SQLConf.FILES_MAX_PARTITION_BYTES, maxPartitionBytes)
-    val query = "select * from parquet_table"
-
-    // isSplitable is true and numTasks1 == 36
-    val numTasks1 = sql(query).queryExecution.toRdd.partitions.length
-    assert(numTasks1 == parquetPath.listFiles().filter(_.getName.endsWith(".parquet"))
-      .map(f => Math.ceil(f.length().toDouble / maxPartitionBytes).toInt).sum)
-
-    // Manual call forbidSplit method, isSplitable is false and numTasks2 = 3
-    val qe = sql(query).queryExecution
-    qe.sparkPlan.asInstanceOf[FileSourceScanExec]
-      .relation.fileFormat.asInstanceOf[ParquetFileFormat].forbidSplit
-    val numTasks2 = qe.toRdd.partitions.length
-    assert(numTasks2 == parquetPath.listFiles().count(_.getName.endsWith(".parquet")))
-    sqlConf.setConf(SQLConf.FILES_MAX_PARTITION_BYTES, defaultMaxBytes)
   }
 
   /** Verifies data and schema. */


### PR DESCRIPTION
## What changes were proposed in this pull request?
As #694 said, fileformat instance for one table in one sparksession uses the same instance, so if do forbitSplit once, the `splitable` status will always `false`, this pr to solve this problem in a different way.

1. revert code changes of #583 

2. Add a new ·FileFormat· named  `UnSplitParquetFileFormat` use to create/refresh index, `UnSplitParquetFileFormat` extends `ParquetFileFormat` and override `isSplitable` method always return false.

3. Use  `UnSplitParquetFileFormat` instead of `ParquetFileFormat` when do create/refresh index operation

## How was this patch tested?

mvn test pass.

