### PR TITLE
Fix 'No trailing whitespace allowed' of SingleGroupOapRecordReader.java

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java
@@ -35,7 +35,7 @@ public class SingleGroupOapRecordReader extends VectorizedOapRecordReader {
 
     private int blockId;
     private int rowGroupCount;
-  
+
     public SingleGroupOapRecordReader(
         Path file,
         Configuration configuration,
@@ -46,7 +46,7 @@ public class SingleGroupOapRecordReader extends VectorizedOapRecordReader {
       this.blockId = blockId;
       this.rowGroupCount = rowGroupCount;
     }
-  
+
     /**
      * Override initialize method, init footer if need,
      * then call super.initialize and initializeInternal
@@ -71,9 +71,7 @@ public class SingleGroupOapRecordReader extends VectorizedOapRecordReader {
       for (StructField f: sparkSchema.fields()) {
         batchSchema = batchSchema.add(f);
       }
-  
       columnarBatch = ColumnarBatch.allocate(batchSchema, DEFAULT_MEMORY_MODE, rowGroupCount);
-  
       // Initialize missing columns with nulls.
       for (int i = 0; i < missingColumns.length; i++) {
         if (missingColumns[i]) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are 4 error message with checkstyle plugin as follow:
`[ERROR] src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java:[38] (regexp) RegexpSingleline: No trailing whitespace allowed.
[ERROR] src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java:[49] (regexp) RegexpSingleline: No trailing whitespace allowed.
[ERROR] src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java:[74] (regexp) RegexpSingleline: No trailing whitespace allowed.
[ERROR] src/main/java/org/apache/parquet/hadoop/SingleGroupOapRecordReader.java:[76] (regexp) RegexpSingleline: No trailing whitespace allowed.
`

fix it.
## How was this patch tested?
mvn test pass