### PR TITLE
Remove derpecated code and tests

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReaderV1.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexFileReaderV1.scala
@@ -85,10 +85,6 @@ private[oap] case class BTreeIndexFileReaderV1(
       readLength.toInt)
   }
 
-  @deprecated("no need to read the whole row id list", "v0.3")
-  def readRowIdList(): FiberCache =
-    MemoryManager.toIndexFiberCache(reader, rowIdListIndex, rowIdListLength.toInt)
-
   def readNode(offset: Int, size: Int): FiberCache =
     MemoryManager.toIndexFiberCache(reader, nodesIndex + offset, size)
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeFileReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeFileReaderWriterSuite.scala
@@ -44,12 +44,10 @@ class BTreeFileReaderWriterSuite extends SharedOapContext {
     // Read content from File
     val reader = BTreeIndexFileReader(configuration, path).asInstanceOf[BTreeIndexFileReaderV1]
     val footerRead = reader.readFooter().toArray
-    val rowIdListRead = reader.readRowIdList().toArray
     val nodesRead = (0 until 5).map(i =>
       reader.readNode(nodes.slice(0, i).map(_.length).sum, nodes(i).length).toArray)
     // Check result
     assert(footer === footerRead)
-    assert(rowIdList === rowIdListRead)
     nodes.zip(nodesRead).foreach {
       case (node, nodeRead) => assert(node === nodeRead)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove deprecated code, this will cause
```
Warning:(47, 32) method readRowIdList in class BTreeIndexFileReaderV1 is deprecated: no need to read the whole row id list
    val rowIdListRead = reader.readRowIdList().toArray
```

## How was this patch tested?

Existing tests.

