### PR TITLE
FiberSensor supports Parquet Cache

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -158,11 +158,11 @@ object FiberCacheManager extends Logging {
 
     val statusRawData = dataFibers.groupBy(_.file).map {
       case (dataFile, fiberSet) =>
-        val fileMeta = DataFileHandleCacheManager(dataFile).asInstanceOf[OapDataFileHandle]
-        val fiberBitSet = new BitSet(fileMeta.groupCount * fileMeta.fieldCount)
+        val fileMeta: DataFileHandle = DataFileHandleCacheManager(dataFile)
+        val fiberBitSet = new BitSet(fileMeta.getGroupCount * fileMeta.getFieldCount)
         fiberSet.foreach(fiber =>
-          fiberBitSet.set(fiber.columnIndex + fileMeta.fieldCount * fiber.rowGroupId))
-        FiberCacheStatus(dataFile.path, fiberBitSet, fileMeta)
+          fiberBitSet.set(fiber.columnIndex + fileMeta.getFieldCount * fiber.rowGroupId))
+        FiberCacheStatus(dataFile.path, fiberBitSet, fileMeta.getGroupCount, fileMeta.getFieldCount)
     }.toSeq
 
     CacheStatusSerDe.serialize(statusRawData)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -156,6 +156,14 @@ object FiberCacheManager extends Logging {
       case fiber: DataFiber => fiber
     }
 
+    // Use a bit set to represent current cache status of one file.
+    // Say, there is a file has 3 row groups and 3 columns. Then bit set size is 3 * 3 = 9
+    // Say, cache status is below:
+    //            field#0    field#1     field#2
+    // group#0       -        cached        -          // BitSet(1 + 0 * 3) = 1
+    // group#1       -        cached        -          // BitSet(1 + 1 * 3) = 1
+    // group#2       -          -         cached       // BitSet(2 + 2 * 3) = 1
+    // The final bit set is: 010010001
     val statusRawData = dataFibers.groupBy(_.file).map {
       case (dataFile, fiberSet) =>
         val fileMeta: DataFileHandle = DataFileHandleCacheManager(dataFile)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -26,14 +26,14 @@ import com.google.common.base.Throwables
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SparkListenerCustomInfoUpdate
 import org.apache.spark.sql.execution.datasources.oap.IndexMeta
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileHandle
 import org.apache.spark.sql.execution.datasources.oap.utils.CacheStatusSerDe
 import org.apache.spark.util.collection.BitSet
 
 private[oap] case class FiberCacheStatus(
     file: String,
     bitmask: BitSet,
-    meta: OapDataFileHandle) {
+    groupCount: Int,
+    fieldCount: Int) {
 
   val cachedFiberCount = bitmask.cardinality()
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -100,6 +100,9 @@ abstract class DataFileHandle {
   def fin: FSDataInputStream
   def len: Long
 
+  def getGroupCount: Int
+  def getFieldCount: Int
+
   def close(): Unit = {
     if (fin != null) {
       fin.close()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileHandle.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileHandle.scala
@@ -334,4 +334,8 @@ private[oap] class OapDataFileHandle(
     validateConsistency()
     this
   }
+
+  override def getGroupCount: Int = groupCount
+
+  override def getFieldCount: Int = fieldCount
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileHandle.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileHandle.scala
@@ -35,4 +35,9 @@ private[oap] class ParquetDataFileHandle(
     this.footer = ParquetFileReader.readFooter(conf, path, NO_FILTER)
     this
   }
+
+  override def getGroupCount: Int = if (footer == null) 0 else footer.getBlocks.size()
+
+  override def getFieldCount: Int =
+    if (footer == null) 0 else footer.getFileMetaData.getSchema.getColumns.size()
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDe.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDe.scala
@@ -94,13 +94,15 @@ private[oap] object CacheStatusSerDe extends SerDe[String, Seq[FiberCacheStatus]
   private[oap] def statusRawDataToJson(statusRawData: FiberCacheStatus): JValue = {
     ("fiberFilePath" -> statusRawData.file) ~
       ("bitSetJValue" -> bitSetToJson(statusRawData.bitmask)) ~
-      ("dataFileMetaJValue" -> dataFileMetaToJson(statusRawData.meta))
+      ("groupCount" -> statusRawData.groupCount) ~
+      ("fieldCount" -> statusRawData.fieldCount)
   }
 
   private[oap] def statusRawDataFromJson(json: JValue): FiberCacheStatus = {
     val path = (json \ "fiberFilePath").extract[String]
     val bitSet = bitSetFromJson(json \ "bitSetJValue")
-    val dataFileMeta = dataFileMetaFromJson(json \ "dataFileMetaJValue")
-    FiberCacheStatus(path, bitSet, dataFileMeta)
+    val groupCount = (json \ "groupCount").extract[Int]
+    val fieldCount = (json \ "fieldCount").extract[Int]
+    FiberCacheStatus(path, bitSet, groupCount, fieldCount)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -144,8 +144,8 @@ class FiberSensorSuite extends QueryTest with SharedOapContext
 
   test("test get hosts from FiberSensor") {
     val filePath = "file1"
-    val dataFileMeta = new OapDataFileHandle(
-      rowCountInEachGroup = 10, rowCountInLastGroup = 2, groupCount = 30, fieldCount = 3)
+    val groupCount = 30
+    val fieldCount = 3
 
     // executor1 update
     val host1 = "host1"
@@ -153,7 +153,7 @@ class FiberSensorSuite extends QueryTest with SharedOapContext
     val bitSet1 = new BitSet(90)
     bitSet1.set(1)
     bitSet1.set(2)
-    val fcs = Seq(FiberCacheStatus(filePath, bitSet1, dataFileMeta))
+    val fcs = Seq(FiberCacheStatus(filePath, bitSet1, groupCount, fieldCount))
     val fiberInfo = SparkListenerCustomInfoUpdate(host1, execId1,
       "OapFiberCacheHeartBeatMessager", CacheStatusSerDe.serialize(fcs))
     this.update(fiberInfo)
@@ -173,7 +173,7 @@ class FiberSensorSuite extends QueryTest with SharedOapContext
 
     val fiberInfo2 = SparkListenerCustomInfoUpdate(host2, execId2,
       "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
-        .serialize(Seq(FiberCacheStatus(filePath, bitSet2, dataFileMeta))))
+        .serialize(Seq(FiberCacheStatus(filePath, bitSet2, groupCount, fieldCount))))
     this.update(fiberInfo2)
     assert(this.getHosts(filePath) contains  (FiberSensor.OAP_CACHE_HOST_PREFIX + host2 +
       FiberSensor.OAP_CACHE_EXECUTOR_PREFIX + execId2))
@@ -188,7 +188,7 @@ class FiberSensorSuite extends QueryTest with SharedOapContext
     bitSet3.set(10)
     val fiberInfo3 = SparkListenerCustomInfoUpdate(host3, execId3,
       "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
-        .serialize(Seq(FiberCacheStatus(filePath, bitSet3, dataFileMeta))))
+        .serialize(Seq(FiberCacheStatus(filePath, bitSet3, groupCount, fieldCount))))
     this.update(fiberInfo3)
     assert(this.getHosts(filePath) === Some(FiberSensor.OAP_CACHE_HOST_PREFIX + host2 +
       FiberSensor.OAP_CACHE_EXECUTOR_PREFIX + execId2))

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDeSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDeSuite.scala
@@ -56,9 +56,9 @@ class CacheStatusSerDeSuite extends SparkFunSuite {
     val bitSet = new BitSet(90)
     bitSet.set(3)
     bitSet.set(8)
-    val dataFileMeta = new OapDataFileHandle(
-      rowCountInEachGroup = 3, rowCountInLastGroup = 2, groupCount = 30, fieldCount = 3)
-    val rawData = FiberCacheStatus(path, bitSet, dataFileMeta)
+    val groupCount = 30
+    val fieldCount = 3
+    val rawData = FiberCacheStatus(path, bitSet, groupCount, fieldCount)
     val newRawData =
       CacheStatusSerDe.statusRawDataFromJson(CacheStatusSerDe.statusRawDataToJson(rawData))
     assertStatusRawDataEquals(rawData, newRawData)
@@ -74,12 +74,12 @@ class CacheStatusSerDeSuite extends SparkFunSuite {
     bitSet1.set(8)
     bitSet2.set(5)
     bitSet2.set(6)
-    val dataFileMeta1 = new OapDataFileHandle(
-      rowCountInEachGroup = 3, rowCountInLastGroup = 2, groupCount = 30, fieldCount = 3)
-    val dataFileMeta2 = new OapDataFileHandle(
-      rowCountInEachGroup = 3, rowCountInLastGroup = 1, groupCount = 50, fieldCount = 3)
-    rawDataArray += FiberCacheStatus(path1, bitSet1, dataFileMeta1)
-    rawDataArray += FiberCacheStatus(path2, bitSet2, dataFileMeta2)
+    val groupCount1 = 30
+    val groupCount2 = 50
+    val fieldCount1 = 3
+    val fieldCount2 = 3
+    rawDataArray += FiberCacheStatus(path1, bitSet1, groupCount1, fieldCount1)
+    rawDataArray += FiberCacheStatus(path2, bitSet2, groupCount2, fieldCount2)
     val statusRawDataArrayStr = CacheStatusSerDe.serialize(rawDataArray)
     assertStringEquals(statusRawDataArrayStr, CacheStatusSerDeTestStrs.statusRawDataArrayString)
     val deserRawDataArr = CacheStatusSerDe.deserialize(statusRawDataArrayStr)
@@ -117,7 +117,8 @@ class CacheStatusSerDeSuite extends SparkFunSuite {
   private def assertStatusRawDataEquals(data1: FiberCacheStatus, data2: FiberCacheStatus): Unit = {
     assert(data1.file === data2.file)
     assertBitSetEquals(data1.bitmask, data2.bitmask)
-    assertDataFileMetaEquals(data1.meta, data2.meta)
+    assert(data1.groupCount === data2.groupCount)
+    assert(data1.fieldCount === data2.fieldCount)
   }
 
 }
@@ -153,12 +154,8 @@ private[oap] object CacheStatusSerDeTestStrs {
        |          }
        |        ]
        |      },
-       |      "dataFileMetaJValue" : {
-       |        "rowCountInEachGroup" : 3,
-       |        "rowCountInLastGroup" : 2,
-       |        "groupCount" : 30,
-       |        "fieldCount" : 3
-       |      }
+       |      "groupCount" : 30,
+       |      "fieldCount" : 3
        |    },
        |    {
        |      "fiberFilePath" : "file2",
@@ -175,12 +172,8 @@ private[oap] object CacheStatusSerDeTestStrs {
        |          }
        |        ]
        |      },
-       |      "dataFileMetaJValue" : {
-       |        "rowCountInEachGroup" : 3,
-       |        "rowCountInLastGroup" : 1,
-       |        "groupCount" : 50,
-       |        "fieldCount" : 3
-       |      }
+       |      "groupCount" : 50,
+       |      "fieldCount" : 3
        |    }
        |  ]
        |}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix #702 
This PR enables ParquetDataFileHandle support in FiberCacheStatus.

## How was this patch tested?

Current UT

