### PR TITLE
[TEST] rename cluster.FilterSuite to cluster.ClusteredFilterSuite

### DIFF
--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/cluster/ClusteredFilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/cluster/ClusteredFilterSuite.scala
@@ -17,20 +17,14 @@
 
 package org.apache.spark.sql.execution.datasources.oap.cluster
 
-import java.sql.Date
-
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.oap.SharedOapLocalClusterContext
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.util.Utils
 
-class FilterSuite extends QueryTest with SharedOapLocalClusterContext with BeforeAndAfterEach {
+class ClusteredFilterSuite
+  extends QueryTest with SharedOapLocalClusterContext with BeforeAndAfterEach {
 
   import testImplicits._
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename cluster.FilterSuite to cluster.ClusteredFilterSuite, to avoid confusion with another `FilterSuite`.
This pr also removes some unused imports in this test suite.

## How was this patch tested?

unit test

