### PR TITLE
Fix for endless `RpcEnv already stopped`

### DIFF
--- a/src/test/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSuite.scala
@@ -104,6 +104,8 @@ class OapRpcManagerSuite extends SparkFunSuite with BeforeAndAfterEach with Priv
     Thread.sleep(2000 + 2 * sc.conf.getTimeAsMs(
       OapConf.OAP_HEARTBEAT_INTERVAL.key, OapConf.OAP_HEARTBEAT_INTERVAL.defaultValue.get))
     verify(rpcManagerMasterEndpoint, new AtLeast(1)).invokePrivate(_handleHeartbeat(heartbeat))
+    
+    rpcManagerSlave1.stop()
   }
 
   private def addSpiedRpcManagerSlaveEndpoint(executorId: String): OapRpcManagerSlaveEndpoint = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before this PR, endless `WARN: RpcEnv already stopped` is shown after `OapRpcManagerSuite` is run,
due to my mistake of forgetting to close the manually started threadPool.

We should manually stop it here due to it's manually constructed, so not managed by Spark.

## How was this patch tested?

Current tests.
