### PR TITLE
#430 avoid use on-heap BitSet in ColumnValues

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValues.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValues.scala
@@ -29,7 +29,7 @@ class ColumnValues(defaultSize: Int, dataType: DataType, val buffer: FiberCache)
   require(dataType.isInstanceOf[AtomicType], s"Only atomic type accepted for now, got $dataType.")
 
   // for any FiberData, the first `(defaultSize - 1) >> 6 + 1` longs will be the bitmask
-  // num of bytes needed to hold defaultSize elements is then `((defaultSize - 1) >> 3) + 8`
+  // num of bytes needed to hold defaultSize elements is then `((defaultSize - 1) >> 6 << 3) + 8`
   private val dataOffset = ((defaultSize - 1) >> 6 << 3) + 8
 
   def isNullAt(idx: Int): Boolean = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValues.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValues.scala
@@ -28,14 +28,13 @@ import org.apache.spark.util.collection.BitSet
 class ColumnValues(defaultSize: Int, dataType: DataType, val buffer: FiberCache) {
   require(dataType.isInstanceOf[AtomicType], s"Only atomic type accepted for now, got $dataType.")
 
-  // for any FiberData, the first defaultSize / 8 will be the bitmask
-  // TODO what if defaultSize / 8 is not an integer?
-
-  private val dataOffset = (((defaultSize - 1) >> 6) + 1) * 8
+  // for any FiberData, the first `(defaultSize - 1) >> 6 + 1` longs will be the bitmask
+  // num of bytes needed to hold defaultSize elements is then `((defaultSize - 1) >> 3) + 8`
+  private val dataOffset = ((defaultSize - 1) >> 3) + 8
 
   def isNullAt(idx: Int): Boolean = {
     val bitmask = 1L << (idx & 0x3f)   // mod 64 and shift
-    (buffer.getLong((idx >> 6) * 8) & bitmask) == 0  // div by 64 and mask
+    (buffer.getLong(idx >> 3) & bitmask) == 0  // div by 64 and mask
   }
 
   private def genericGet(idx: Int): Any = dataType match {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValues.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValues.scala
@@ -30,11 +30,11 @@ class ColumnValues(defaultSize: Int, dataType: DataType, val buffer: FiberCache)
 
   // for any FiberData, the first `(defaultSize - 1) >> 6 + 1` longs will be the bitmask
   // num of bytes needed to hold defaultSize elements is then `((defaultSize - 1) >> 3) + 8`
-  private val dataOffset = ((defaultSize - 1) >> 3) + 8
+  private val dataOffset = ((defaultSize - 1) >> 6 << 3) + 8
 
   def isNullAt(idx: Int): Boolean = {
     val bitmask = 1L << (idx & 0x3f)   // mod 64 and shift
-    (buffer.getLong(idx >> 3) & bitmask) == 0  // div by 64 and mask
+    (buffer.getLong(idx >> 6 << 3) & bitmask) == 0  // div by 64 and mask
   }
 
   private def genericGet(idx: Int): Any = dataType match {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValues.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValues.scala
@@ -121,10 +121,7 @@ class ColumnValues(defaultSize: Int, dataType: DataType, val buffer: FiberCache)
     //    value #N
     val length = getIntValue(idx * 2)
     val offset = getIntValue(idx * 2 + 1)
-    val result = new Array[Byte](length)
-    buffer.copyMemoryToBytes(offset, result)
-
-    result
+    buffer.getBytes(offset, length)
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -126,18 +126,10 @@ case class FiberCache(protected val fiberData: MemoryBlock) extends Logging {
     bytes
   }
 
-  /** TODO: may cause copy memory from off-heap to on-heap, used by [[ColumnValues]] */
-  protected def copyMemory(offset: Long, dst: AnyRef, dstOffset: Long, length: Long): Unit =
-    Platform.copyMemory(getBaseObj, getBaseOffset + offset, dst, dstOffset, length)
-
-  def copyMemoryToLongs(offset: Long, dst: Array[Long]): Unit =
-    copyMemory(offset, dst, Platform.LONG_ARRAY_OFFSET, dst.length * 8)
-
-  def copyMemoryToInts(offset: Long, dst: Array[Int]): Unit =
-    copyMemory(offset, dst, Platform.INT_ARRAY_OFFSET, dst.length * 4)
-
-  def copyMemoryToBytes(offset: Long, dst: Array[Byte]): Unit =
-    copyMemory(offset, dst, Platform.BYTE_ARRAY_OFFSET, dst.length)
+  private def copyMemoryToBytes(offset: Long, dst: Array[Byte]): Unit = {
+    Platform.copyMemory(
+      getBaseObj, getBaseOffset + offset, dst, Platform.BYTE_ARRAY_OFFSET, dst.length)
+  }
 
   def size(): Long = fiberData.size()
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use Spark BitSet means copy data to on-heap memory. Lets use off-heap memory directly.
This resolves #430 

## How was this patch tested?

current tests.