### PR TITLE
#718 Refactor constructor of ParquetDataFileHandle

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -292,9 +292,8 @@ private[oap] case class ParquetDataFile(
     }
   }
 
-  override def createDataFileHandle(): ParquetDataFileHandle = {
-    new ParquetDataFileHandle().read(configuration, new Path(StringUtils.unEscapeString(path)))
-  }
+  override def createDataFileHandle(): ParquetDataFileHandle =
+    new ParquetDataFileHandle(configuration, new Path(StringUtils.unEscapeString(path)))
 
   override def totalRows(): Long = {
     import scala.collection.JavaConverters._

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileHandle.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileHandle.scala
@@ -27,7 +27,7 @@ private[oap] class ParquetDataFileHandle(
   val footer: ParquetMetadata)
   extends DataFileHandle {
 
-  assert(footer != null)
+  require(footer != null, "footer of ParquetDataFileHandle should not be null.")
 
   def this(conf: Configuration, path: Path) {
     this(ParquetFileReader.readFooter(conf, path, NO_FILTER))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileHandle.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileHandle.scala
@@ -24,20 +24,22 @@ import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.metadata.ParquetMetadata
 
 private[oap] class ParquetDataFileHandle(
-  var footer: ParquetMetadata = null)
+  val footer: ParquetMetadata)
   extends DataFileHandle {
+
+  assert(footer != null)
+
+  def this(conf: Configuration, path: Path) {
+    this(ParquetFileReader.readFooter(conf, path, NO_FILTER))
+  }
 
   override def fin: FSDataInputStream = null
 
   override def len: Long = 0
 
-  def read(conf: Configuration, path: Path): ParquetDataFileHandle = {
-    this.footer = ParquetFileReader.readFooter(conf, path, NO_FILTER)
-    this
-  }
-
-  override def getGroupCount: Int = if (footer == null) 0 else footer.getBlocks.size()
+  override def getGroupCount: Int = footer.getBlocks.size()
 
   override def getFieldCount: Int =
-    if (footer == null) 0 else footer.getFileMetaData.getSchema.getColumns.size()
+    footer.getFileMetaData.getSchema.getColumns.size()
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor constructor of ParquetDataFileHandle, init footer in constructor because a ParquetDataFileHandle instance with a null footer is not supposed to exist. 

## How was this patch tested?
mvn test pass
