### PR TITLE
Refactor - Package movements

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/OapSessionState.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/OapSessionState.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, FileSourc
 import org.apache.spark.sql.execution.datasources.oap.OapStrategies
 import org.apache.spark.sql.hive.client.HiveClient
 import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
+import org.apache.spark.sql.oap.OapSession
 
 class OapSessionState(sparkSession: OapSession) extends HiveSessionState(sparkSession) {
   self =>

--- a/src/main/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
@@ -21,10 +21,11 @@ import java.io.PrintStream
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
-import org.apache.spark.oap.ui.OapTab
-import org.apache.spark.sql.{OapSession, SQLContext}
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.execution.datasources.oap.listener.{FiberInfoListener, OapIndexInfoListener}
 import org.apache.spark.sql.hive.{HiveUtils, OapSessionState}
+import org.apache.spark.sql.oap.OapSession
+import org.apache.spark.sql.oap.ui.OapTab
 import org.apache.spark.util.Utils
 
 private[hive] object OapEnv extends Logging {

--- a/src/main/scala/org/apache/spark/sql/oap/OapSession.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/OapSession.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql
+package org.apache.spark.sql.oap
 
 import java.util.concurrent.atomic.AtomicReference
 
@@ -24,6 +24,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.SQLListener
 import org.apache.spark.sql.internal.SessionState
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION

--- a/src/main/scala/org/apache/spark/sql/oap/ui/FiberCacheManagerPage.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/ui/FiberCacheManagerPage.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.oap.ui
+package org.apache.spark.sql.oap.ui
 
 import javax.servlet.http.HttpServletRequest
 

--- a/src/main/scala/org/apache/spark/sql/oap/ui/OapTab.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/ui/OapTab.scala
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.spark.oap.ui
+package org.apache.spark.sql.oap.ui
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.ui.{SparkUI, SparkUITab}
 
 class OapTab(parent: SparkUI) extends SparkUITab(parent, "OAP") with Logging {
+
   val listener = parent.executorsListener
 
   attachPage(new FiberCacheManagerPage(this))

--- a/src/main/scala/org/apache/spark/status/api/v1/AllFiberCacheManagerListResource.scala
+++ b/src/main/scala/org/apache/spark/status/api/v1/AllFiberCacheManagerListResource.scala
@@ -19,7 +19,7 @@ package org.apache.spark.status.api.v1
 import javax.ws.rs.{GET, Produces}
 import javax.ws.rs.core.MediaType
 
-import org.apache.spark.oap.ui.{FiberCacheManagerPage, FiberCacheManagerSummary}
+import org.apache.spark.sql.oap.ui.{FiberCacheManagerPage, FiberCacheManagerSummary}
 import org.apache.spark.ui.SparkUI
 
 @Produces(Array(MediaType.APPLICATION_JSON))

--- a/src/test/scala/org/apache/spark/sql/TestOap.scala
+++ b/src/test/scala/org/apache/spark/sql/TestOap.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.oap.OapSession
 
 object TestOap extends TestOapContext(
   OapSession.builder.config(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- `org.apache.spark.oap.ui` should be in `org.apache.spark.sql.oap` package
- Move test related to test package

## How was this patch tested?

Current tests.