### PR TITLE
LocalCluster test should require 2 * 1 as Spark do

### DIFF
--- a/src/test/scala/org/apache/spark/sql/test/TestOapSession.scala
+++ b/src/test/scala/org/apache/spark/sql/test/TestOapSession.scala
@@ -43,7 +43,7 @@ private[sql] class TestOapLocalClusterSession(sc: SparkContext) extends TestSpar
   self =>
   def this(sparkConf: SparkConf) {
     this(new SparkContext(
-      s"local-cluster[2, 2, 1024]",
+      s"local-cluster[2, 1, 1024]",
       "test-oap-local-cluster-context",
       sparkConf.set("spark.sql.testkey", "true")
         .set("spark.hadoop.fs.file.impl", classOf[DebugFilesystem].getName)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

From [travis-doc](https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System), only 2 cores are granted. In this condition, it's not necessary to use 2 * 2, `LocalCluster` mode aims to test under multi-executors, the parallelism in each doesn't matter.

## How was this patch tested?

Existing tests.

