### PR TITLE
#644 optimize drop index strategy

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -238,7 +238,8 @@ case class DropIndexCommand(
         val partitions = OapUtils.getPartitions(fileCatalog, partitionSpec)
         val targetDirs = partitions.filter(_.files.nonEmpty)
         if(targetDirs.isEmpty) {
-          throw new AnalysisException(s"""No data and Index in $partitions""")
+          logWarning(s"""No data and Index in $partitions, DropIndexCommand do nothing.""")
+          return Nil
         }
         val hadoopConfiguration = sparkSession.sparkContext.hadoopConfiguration
         val fs = FileSystem.get(hadoopConfiguration)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -236,48 +236,61 @@ case class DropIndexCommand(
           if format.isInstanceOf[OapFileFormat] || format.isInstanceOf[ParquetFileFormat] =>
         logInfo(s"Dropping index $indexName")
         val partitions = OapUtils.getPartitions(fileCatalog, partitionSpec)
-        partitions.filter(_.files.nonEmpty).foreach(p => {
+        val targetDirs = partitions.filter(_.files.nonEmpty)
+        if(targetDirs.isEmpty) {
+          throw new AnalysisException(s"""No data and Index in $partitions""")
+        }
+        val hadoopConfiguration = sparkSession.sparkContext.hadoopConfiguration
+        val fs = FileSystem.get(hadoopConfiguration)
+        val dirsCount = targetDirs.map(p => {
           val parent = p.files.head.getPath.getParent
-          // TODO get `fs` outside of foreach() to boost
-          val fs = parent.getFileSystem(sparkSession.sparkContext.hadoopConfiguration)
           if (fs.exists(new Path(parent, OapFileFormat.OAP_META_FILE))) {
             val metaBuilder = new DataSourceMetaBuilder()
-            val m = OapUtils.getMeta(sparkSession.sparkContext.hadoopConfiguration, parent)
+            val m = OapUtils.getMeta(hadoopConfiguration, parent)
             assert(m.nonEmpty)
             val oldMeta = m.get
             val existsIndexes = oldMeta.indexMetas
             val existsData = oldMeta.fileMetas
             if (existsIndexes.forall(_.name != indexName)) {
-              if (!allowNotExists) {
-                throw new AnalysisException(
-                  s"""Index $indexName does not exist on ${identifier.getOrElse(parent)}""")
-              } else {
-                logWarning(s"drop non-exists index $indexName")
-                return Nil
+              logWarning(s"drop non-exists index $indexName")
+              allowNotExists
+            } else {
+              if (existsData != null) {
+                existsData.foreach(metaBuilder.addFileMeta)
               }
+              if (existsIndexes != null) {
+                existsIndexes.filter(_.name != indexName).foreach(metaBuilder.addIndexMeta)
+              }
+              metaBuilder.withNewDataReaderClassName(oldMeta.dataReaderClassName)
+              DataSourceMeta.write(
+                new Path(parent.toString, OapFileFormat.OAP_META_FILE),
+                hadoopConfiguration,
+                metaBuilder.withNewSchema(oldMeta.schema).build())
+              // TODO don't use listFiles Api
+              val allFile = fs.listFiles(parent, false)
+              val filePaths = new Iterator[Path] {
+                override def hasNext: Boolean = allFile.hasNext
+                override def next(): Path = allFile.next().getPath
+              }.toSeq
+              filePaths.filter(_.toString.endsWith(
+                "." + indexName + OapFileFormat.OAP_INDEX_EXTENSION)).foreach(idxPath =>
+                fs.delete(idxPath, true))
+              true
             }
-            if (existsData != null) {
-              existsData.foreach(metaBuilder.addFileMeta)
-            }
-            if (existsIndexes != null) {
-              existsIndexes.filter(_.name != indexName).foreach(metaBuilder.addIndexMeta)
-            }
-            metaBuilder.withNewDataReaderClassName(oldMeta.dataReaderClassName)
-            DataSourceMeta.write(
-              new Path(parent.toString, OapFileFormat.OAP_META_FILE),
-              sparkSession.sparkContext.hadoopConfiguration,
-              metaBuilder.withNewSchema(oldMeta.schema).build(),
-              deleteIfExits = true)
-            val allFile = fs.listFiles(parent, false)
-            val filePaths = new Iterator[Path] {
-              override def hasNext: Boolean = allFile.hasNext
-              override def next(): Path = allFile.next().getPath
-            }.toSeq
-            filePaths.filter(_.toString.endsWith(
-              "." + indexName + OapFileFormat.OAP_INDEX_EXTENSION)).foreach(idxPath =>
-              fs.delete(idxPath, true))
+          } else {
+            false
           }
-        })
+        }).count(_ == true)
+        // No actual drop index action and allowNotExists is false, throw AnalysisException
+        if (dirsCount == 0 && !allowNotExists) {
+          identifier match {
+            case Some(catalogTable) =>
+              throw new AnalysisException(s"""Index $indexName does not exist on $catalogTable""")
+            case None =>
+              val parent = targetDirs.head.files.head.getPath.getParent
+              throw new AnalysisException(s"""Index $indexName does not exist on $parent""")
+          }
+        }
       case other => sys.error(s"We don't support index dropping for ${other.simpleString}")
     }
     Seq.empty

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -281,7 +281,7 @@ case class DropIndexCommand(
             false
           }
         }).count(_ == true)
-        // No actual drop index action and allowNotExists is false, throw AnalysisException
+        // No actually drop index action and allowNotExists is false, throw AnalysisException
         if (dirsCount == 0 && !allowNotExists) {
           identifier match {
             case Some(catalogTable) =>

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/DropIndexCommandSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/DropIndexCommandSuite.scala
@@ -17,15 +17,11 @@
 
 package org.apache.spark.sql.execution.datasources.oap.index
 
-import java.io.File
-
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, Path, PathFilter}
+import org.apache.hadoop.fs.{Path, PathFilter}
 import org.scalatest.BeforeAndAfterEach
-import org.apache.spark.DebugFilesystem
 
+import org.apache.spark.DebugFilesystem
 import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
-import org.apache.spark.util.Utils
 
 class DropIndexCommandSuite extends SharedOapContext with BeforeAndAfterEach {
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/DropIndexCommandSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/DropIndexCommandSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.index
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
+
+class DropIndexCommandSuite extends SharedOapContext with BeforeAndAfterEach {
+
+  test("drop index on empty table") {
+    Seq("oap", "parquet").foreach(format =>
+      withTable("empty_table") {
+        sql(
+          s"""CREATE TABLE empty_table (a int, b int)
+             | USING $format""".stripMargin)
+        sql(s"""DROP OINDEX index_a ON empty_table""")
+      }
+    )
+  }
+
+  test("drop index on empty table after create index") {
+    Seq("oap", "parquet").foreach(format =>
+      withTable("empty_table") {
+        sql(
+          s"""CREATE TABLE empty_table (a int, b int)
+             | USING $format""".stripMargin)
+        withIndex(TestIndex("empty_table", "a_index")) {
+          sql("CREATE OINDEX a_index ON empty_table(a)")
+        }
+      }
+    )
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.test.oap
 import scala.collection.mutable
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
 
 import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.oap.{IndexType, OapFileFormat}
@@ -105,6 +106,18 @@ trait SharedOapContextBase extends SharedSQLContext {
             .mkString(" partition (", ",", ")")
           spark.sql(s"$baseSql $partitionPart")
         }
+      }
+    }
+  }
+
+  protected def withFileSystem(f: FileSystem => Unit): Unit = {
+    var fs: FileSystem = null
+    try {
+      fs = FileSystem.get(configuration)
+      f(fs)
+    } finally {
+      if (fs != null) {
+        fs.close()
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -110,6 +110,9 @@ trait SharedOapContextBase extends SharedSQLContext {
     }
   }
 
+  /**
+   * Creates a FileSystem , which is then passed to `f` and will be closed after `f` returns.
+   */
   protected def withFileSystem(f: FileSystem => Unit): Unit = {
     var fs: FileSystem = null
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Try to slove #644, If we have a `table` with data partitions b=1, b=2, b=3, then create `index1` at partition b=1 and b =2, if we run  `drop oindex index1 on  table`, before this pr will tell user Index index1 does not exist on CatalogTable, and use this pr will drop `index1` at partition b=1 and b =2, ignore partition b=3，I think this strategy more friendly.

## How was this patch tested?

mvn test pass
