### PR TITLE
Add OAP manager

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -31,7 +30,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OapMetricsManager$}
+import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OapMetricsManager}
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberSensor
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat => ParquetSource}
 import org.apache.spark.sql.execution.metric.SQLMetrics

--- a/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OapMetrics}
+import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OapMetricsManager$}
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberSensor
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat => ParquetSource}
 import org.apache.spark.sql.execution.metric.SQLMetrics
@@ -284,7 +284,7 @@ case class FileSourceScanExec(
   override lazy val metrics =
     Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
       "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time")) ++
-      OapMetrics.metrics(sparkContext)
+      OapMetricsManager.metrics(sparkContext)
 
   protected override def doExecute(): RDD[InternalRow] = {
     if (supportsBatch) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -50,7 +50,7 @@ private[sql] class OapFileFormat extends FileFormat
   with Logging
   with Serializable {
 
-  val oapMetrics = new OapMetrics
+  val oapMetrics = new OapMetricsManager
 
   override def initialize(
       sparkSession: SparkSession,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsManager.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataReader
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
-private[sql] class OapMetrics extends Serializable {
+private[spark] class OapMetricsManager extends Serializable {
   /**
    * 4 kinds of Tasks and 5 kinds of Rows:
    *   1.skipForStatisticTasks
@@ -49,19 +49,19 @@ private[sql] class OapMetrics extends Serializable {
 
   def initMetrics(metrics: Map[String, SQLMetric]): Unit = {
     // set task-level Accumulator
-    _totalTasks = Some(metrics(OapMetrics.totalTasksName))
-    _skipForStatisticTasks = Some(metrics(OapMetrics.skipForStatisticTasksName))
-    _hitIndexTasks = Some(metrics(OapMetrics.hitIndexTaskName))
-    _ignoreIndexTasks = Some(metrics(OapMetrics.ignoreIndexTasksName))
-    _missIndexTasks = Some(metrics(OapMetrics.missIndexTasksName))
+    _totalTasks = Some(metrics(OapMetricsManager.totalTasksName))
+    _skipForStatisticTasks = Some(metrics(OapMetricsManager.skipForStatisticTasksName))
+    _hitIndexTasks = Some(metrics(OapMetricsManager.hitIndexTaskName))
+    _ignoreIndexTasks = Some(metrics(OapMetricsManager.ignoreIndexTasksName))
+    _missIndexTasks = Some(metrics(OapMetricsManager.missIndexTasksName))
 
     // set row-level Accumulator
-    _totalRows = Some(metrics(OapMetrics.totalRowsName))
-    _rowsSkippedForStatistic = Some(metrics(OapMetrics.rowsSkippedForStatisticName))
-    _rowsReadWhenHitIndex = Some(metrics(OapMetrics.rowsReadWhenHitIndexName))
-    _rowsSkippedWhenHitIndex = Some(metrics(OapMetrics.rowsSkippedWhenHitIndexName))
-    _rowsReadWhenIgnoreIndex = Some(metrics(OapMetrics.rowsReadWhenIgnoreIndexName))
-    _rowsReadWhenMissIndex = Some(metrics(OapMetrics.rowsReadWhenMissIndexName))
+    _totalRows = Some(metrics(OapMetricsManager.totalRowsName))
+    _rowsSkippedForStatistic = Some(metrics(OapMetricsManager.rowsSkippedForStatisticName))
+    _rowsReadWhenHitIndex = Some(metrics(OapMetricsManager.rowsReadWhenHitIndexName))
+    _rowsSkippedWhenHitIndex = Some(metrics(OapMetricsManager.rowsSkippedWhenHitIndexName))
+    _rowsReadWhenIgnoreIndex = Some(metrics(OapMetricsManager.rowsReadWhenIgnoreIndexName))
+    _rowsReadWhenMissIndex = Some(metrics(OapMetricsManager.rowsReadWhenMissIndexName))
   }
 
   def totalTasks: Option[SQLMetric] = _totalTasks
@@ -117,7 +117,7 @@ private[sql] class OapMetrics extends Serializable {
   }
 }
 
-private[sql] object OapMetrics {
+private[sql] object OapMetricsManager {
   val totalTasksName = "totalTasks"
   val skipForStatisticTasksName = "skipForStatisticTasks"
   val hitIndexTaskName = "hitIndexTasks"

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -227,7 +227,7 @@ case class DropIndexCommand(
     val scheduler = sparkSession.sparkContext.schedulerBackend
     scheduler match {
       case scheduler: CoarseGrainedSchedulerBackend =>
-        SparkEnv.get.oapRpcManager.send(CacheDrop(indexName))
+        SparkEnv.get.oapManager.rpcManager.send(CacheDrop(indexName))
       case _: LocalSchedulerBackend => FiberCacheManager.removeIndexCache(indexName)
     }
 

--- a/src/main/scala/org/apache/spark/sql/oap/OapManager.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/OapManager.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap
+
+import org.apache.spark.sql.execution.datasources.oap.OapMetricsManager
+import org.apache.spark.sql.oap.rpc.OapRpcManager
+
+/**
+ * This is to hold OAP-specific xxManagers in SparkEnv, so as to bring more convenience for
+ * developers
+ */
+class OapManager(val rpcManager: OapRpcManager, val metricsManager: OapMetricsManager) {
+  def stop(): Unit = {
+    rpcManager.stop()
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is to resolve #706 . An `OapManager` is created in `SparkEnv`. In this way, multiple `xxManager` in OAP can be merged to one place, making it easy to manage, and get the object's reference.

After changing some current `Object` to `Class` implementations, like `FiberCacheManager` can be migrated to this place. 

## How was this patch tested?

Existing tests.

