### PR TITLE
Do not get or create SparkContext in OapRpcManagerMasterEndpoint

### DIFF
--- a/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -376,7 +376,7 @@ object SparkEnv extends Logging {
       new OutputCommitCoordinatorEndpoint(rpcEnv, outputCommitCoordinator))
     outputCommitCoordinator.coordinatorRef = Some(outputCommitCoordinatorRef)
 
-    val oapRpcManagerMasterEndpoint = new OapRpcManagerMasterEndpoint(rpcEnv)
+    val oapRpcManagerMasterEndpoint = new OapRpcManagerMasterEndpoint(rpcEnv, listenerBus)
     val oapRpcDriverEndpoint = registerOrLookupEndpoint(
       OapRpcManagerMaster.DRIVER_ENDPOINT_NAME, oapRpcManagerMasterEndpoint)
 

--- a/src/test/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSuite.scala
@@ -58,7 +58,7 @@ class OapRpcManagerSuite extends SparkFunSuite with BeforeAndAfterEach with Priv
 
     sc = new SparkContext(conf)
     rpcEnv = sc.env.rpcEnv
-    rpcManagerMasterEndpoint = spy(new OapRpcManagerMasterEndpoint(rpcEnv))
+    rpcManagerMasterEndpoint = spy(new OapRpcManagerMasterEndpoint(rpcEnv, sc.listenerBus))
     rpcManagerMaster = new OapRpcManagerMaster(rpcManagerMasterEndpoint)
     rpcDriverEndpoint = rpcEnv.setupEndpoint("driver", rpcManagerMasterEndpoint)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reported by @LuciferYang 
OapRpcManagerMasterEndpoint calls SparkContext.getOrCreate() which may cause issues if it happens before user creating the SparkContext.

Furthermore, OapRpcManagerMasterEndpoint is created in SparkEnv and SparkEnv is created in SparkContext, which means a SparkContext is being created. So we can pass the liveListenerBus to OapRpcManagerMasterEndpoint. 

## How was this patch tested?
Existing tests.
