### PR TITLE
Fall back to unsafe projection path if whole stage code gen is disabled.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -307,6 +307,7 @@ private[sql] class OapFileFormat extends FileFormat
         val enableVectorizedReader: Boolean =
           m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
           sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
+          sparkSession.sessionState.conf.wholeStageEnabled &&
           resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
         val returningBatch = supportBatch(sparkSession, resultSchema)
         val parquetDataCacheEnable = sparkSession.conf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -301,8 +301,9 @@ private[sql] class OapFileFormat extends FileFormat
         val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
         val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
-        // refer to ParquetFileFormat, use resultSchema to decide if this query support
-        // Vectorized Read and returningBatch.
+        // Refer to ParquetFileFormat, use resultSchema to decide if this query support
+        // Vectorized Read and returningBatch. Also it depends on WHOLE_STAGE_CODE_GEN,
+        // as the essential unsafe projection is done by that.
         val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
         val enableVectorizedReader: Boolean =
           m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&


### PR DESCRIPTION
## What changes were proposed in this pull request?

If WHOLE_STAGE_CODE_GEN is disabled, vectorized reader should be
also disabled as there is no auto gen code to transfer column iterator
to unsafe iterator.

Signed-off-by: Wang, Yue A <yue.a.wang@intel.com>

## How was this patch tested?
mvn test pass