### PR TITLE
 Add a config to set Fiber cache use offheap ratio.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.hadoop.fs.FSDataInputStream
-import org.apache.spark.SparkEnv
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.execution.datasources.OapException

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -20,11 +20,12 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.hadoop.fs.FSDataInputStream
-
 import org.apache.spark.SparkEnv
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.storage.{BlockManager, TestBlockId}
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.memory.{MemoryAllocator, MemoryBlock}
@@ -52,9 +53,14 @@ private[oap] object MemoryManager extends Logging {
   private val (_cacheMemory, _cacheGuardianMemory) = {
     assert(SparkEnv.get != null, "Oap can't run without SparkContext")
     val memoryManager = SparkEnv.get.memoryManager
-    // TODO: make 0.7 configurable
     assert(memoryManager.maxOffHeapStorageMemory > 0, "Oap can't run without offHeap memory")
-    val oapMemory = (memoryManager.maxOffHeapStorageMemory * 0.7).toLong
+    val useOffHeapRatio = SparkEnv.get.conf.getDouble(
+      OapConf.OAP_FIBERCACHE_USE_OFFHEAP_RATIO.key,
+      OapConf.OAP_FIBERCACHE_USE_OFFHEAP_RATIO.defaultValue.get)
+    logInfo(s"Oap use ${useOffHeapRatio * 100}% of 'spark.memory.offHeap.size' for fiber cache.")
+    assert(useOffHeapRatio > 0,
+      "OapConf 'spark.sql.oap.fiberCache.use.offheap.ratio' must positive")
+    val oapMemory = (memoryManager.maxOffHeapStorageMemory * useOffHeapRatio).toLong
     if (memoryManager.acquireStorageMemory(
       DUMMY_BLOCK_ID, oapMemory, MemoryMode.OFF_HEAP)) {
       // TODO: make 0.9, 0.1 configurable

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -58,8 +58,8 @@ private[oap] object MemoryManager extends Logging {
       OapConf.OAP_FIBERCACHE_USE_OFFHEAP_RATIO.key,
       OapConf.OAP_FIBERCACHE_USE_OFFHEAP_RATIO.defaultValue.get)
     logInfo(s"Oap use ${useOffHeapRatio * 100}% of 'spark.memory.offHeap.size' for fiber cache.")
-    assert(useOffHeapRatio > 0,
-      "OapConf 'spark.sql.oap.fiberCache.use.offheap.ratio' must positive")
+    assert(useOffHeapRatio > 0 && useOffHeapRatio <1,
+      "OapConf 'spark.sql.oap.fiberCache.use.offheap.ratio' must more than 0 and less than 1.")
     val oapMemory = (memoryManager.maxOffHeapStorageMemory * useOffHeapRatio).toLong
     if (memoryManager.acquireStorageMemory(
       DUMMY_BLOCK_ID, oapMemory, MemoryMode.OFF_HEAP)) {

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -103,6 +103,13 @@ object OapConf {
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_FIBERCACHE_USE_OFFHEAP_RATIO =
+    SQLConfigBuilder("spark.sql.oap.fiberCache.use.offheap.ratio")
+      .internal()
+      .doc("Define the ratio of fiber cache use 'spark.memory.offHeap.size' ratio.")
+      .doubleConf
+      .createWithDefault(0.7)
+
   val OAP_COMPRESSION = SQLConfigBuilder("spark.sql.oap.compression.codec")
     .internal()
     .doc("Sets the compression codec use when writing Parquet files. Acceptable values include: " +


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fiber cache  use offheap memory ratio is 0.7, If data cache disabled, more offheap memory waste, and 0.3 of offheap memory for other may not enough, Some Error as follow will occur on our production environment.

`java.lang.OutOfMemoryError: Unable to acquire 262144 bytes of memory, got 0
        at org.apache.spark.memory.MemoryConsumer.allocateArray(MemoryConsumer.java:100)
        at org.apache.spark.unsafe.map.BytesToBytesMap.allocate(BytesToBytesMap.java:791)
        at org.apache.spark.unsafe.map.BytesToBytesMap.reset(BytesToBytesMap.java:913)
        at org.apache.spark.sql.execution.UnsafeKVExternalSorter.<init>(UnsafeKVExternalSorter.java:148)
        at org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMap.destructAndCreateExternalSorter(UnsafeFixedWidthAggregationMap.java:244)
        at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.agg_doAggregateWithKeys$(Unknown Source)
        at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.processNext(Unknown Source)
        at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
        at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$8$$anon$1.hasNext(WholeStageCodegenExec.scala:380)
        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
        at org.apache.spark.shuffle.sort.UnsafeShuffleWriter.write(UnsafeShuffleWriter.java:166)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
        at org.apache.spark.scheduler.Task.run(Task.scala:99)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:289)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:748)
`
Add a new Oapconf to set this ratio to config memory usage

## How was this patch tested?

mvn test pass