### PR TITLE
[WIP] Backward compatible framework for OAP data file

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataFile
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileV1
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ShutdownHookManager
 
@@ -404,7 +404,7 @@ private[oap] class DataSourceMetaBuilder {
   val fileMetas = ArrayBuffer.empty[FileMeta]
   val indexMetas = ArrayBuffer.empty[IndexMeta]
   var schema: StructType = new StructType()
-  var dataReaderClassName: String = classOf[OapDataFile].getCanonicalName
+  var dataReaderClassName: String = classOf[OapDataFileV1].getCanonicalName
 
   def addFileMeta(fileMeta: FileMeta): this.type = {
     fileMetas += fileMeta

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -165,8 +165,8 @@ private[sql] class OapFileFormat extends FileFormat
     meta match {
       case Some(m) =>
         logDebug("Building OapDataReader with "
-            + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
-            + " ...")
+          + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
+          + " ...")
 
         // Check whether this filter conforms to certain patterns that could benefit from index
         def canTriggerIndex(filter: Filter): Boolean = {
@@ -177,50 +177,23 @@ private[sql] class OapFileFormat extends FileFormat
             case And(left, right) =>
               checkAttribute(left) && checkAttribute(right)
             case EqualTo(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case LessThan(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case LessThanOrEqual(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case GreaterThan(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case GreaterThanOrEqual(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case In(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case IsNull(attribute) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case IsNotNull(attribute) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case StringStartsWith(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute;
-                true
-              } else false
+              if (attr == null || attr == attribute) {attr = attribute; true} else false
             case _ => false
           }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsManager.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.oap
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataReader
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataScannerV1
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
 private[spark] class OapMetricsManager extends Serializable {
@@ -103,7 +103,7 @@ private[spark] class OapMetricsManager extends Serializable {
     _totalTasks.foreach(_.add(1L))
   }
 
-  def updateIndexAndRowRead(r: OapDataReader, totalRows: Long): Unit = {
+  def updateIndexAndRowRead(r: OapDataScannerV1, totalRows: Long): Unit = {
     import org.apache.spark.sql.execution.datasources.oap.INDEX_STAT._
     r.indexStat match {
       case HIT_INDEX =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -62,7 +62,7 @@ case class CreateIndexCommand(
     val (fileCatalog, schema, readerClassName, identifier, relation) = optimized match {
       case LogicalRelation(
       _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id) =>
-        (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, id, optimized)
+        (f, s, OapFileFormat.OAP_DATA_FILE_V1_CLASSNAME, id, optimized)
       case LogicalRelation(
       _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id) =>
         if (!sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED)) {
@@ -308,7 +308,7 @@ case class RefreshIndexCommand(
     val (fileCatalog, schema, readerClassName, relation) = optimized match {
       case LogicalRelation(
           HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, _) =>
-        (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, optimized)
+        (f, s, OapFileFormat.OAP_DATA_FILE_V1_CLASSNAME, optimized)
       case LogicalRelation(
       _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id) =>
         // Use ReadOnlyParquetFileFormat instead of ParquetFileFormat because of

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/FiberParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/FiberParser.scala
@@ -21,7 +21,7 @@ import org.apache.parquet.column.Dictionary
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader
 import org.apache.parquet.column.values.dictionary.DictionaryValuesReader
 import org.apache.parquet.format.Encoding
-
+import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.collection.BitSet

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/FiberParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/FiberParser.scala
@@ -21,6 +21,7 @@ import org.apache.parquet.column.Dictionary
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader
 import org.apache.parquet.column.values.dictionary.DictionaryValuesReader
 import org.apache.parquet.format.Encoding
+
 import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/FiberParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/FiberParser.scala
@@ -26,47 +26,46 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.collection.BitSet
 
-private[oap] trait DataFiberParser {
+private[oap] trait DataFiberParserV1 {
   def parse(bytes: Array[Byte], rowCount: Int): Array[Byte]
 }
 
-object DataFiberParser {
+object DataFiberParserV1 {
   def apply(
       encoding: Encoding,
-      meta: OapDataFileMeta,
-      dataType: DataType): DataFiberParser = {
+      meta: OapDataFileMetaV1,
+      dataType: DataType): DataFiberParserV1 = {
 
     encoding match {
-      case Encoding.PLAIN => PlainDataFiberParser(meta)
-      case Encoding.DELTA_BYTE_ARRAY => DeltaByteArrayDataFiberParser(meta, dataType)
+      case Encoding.PLAIN => new PlainDataFiberParser
+      case Encoding.DELTA_BYTE_ARRAY => DeltaByteArrayDataFiberParserV1(meta, dataType)
       case _ => sys.error(s"Not support encoding type: $encoding")
     }
   }
 }
 
-object DictionaryBasedDataFiberParser {
+object DictionaryBasedDataFiberParserV1 {
 
   def apply(
       encoding: Encoding,
-      meta: OapDataFileMeta,
+      meta: OapDataFileMetaV1,
       dictionary: Dictionary,
-      dataType: DataType): DataFiberParser = {
+      dataType: DataType): DataFiberParserV1 = {
     encoding match {
-      case Encoding.PLAIN_DICTIONARY => PlainDictionaryFiberParser(meta, dictionary, dataType)
+      case Encoding.PLAIN_DICTIONARY => PlainDictionaryFiberParserV1(meta, dictionary, dataType)
       case _ => sys.error(s"Not support encoding type: $encoding")
     }
   }
 }
 
-private[oap] case class PlainDataFiberParser(
-    meta: OapDataFileMeta) extends DataFiberParser{
+private[oap] class PlainDataFiberParser extends DataFiberParserV1{
 
   override def parse(bytes: Array[Byte], rowCount: Int): Array[Byte] = bytes
 }
 
-private[oap] case class DeltaByteArrayDataFiberParser(
-    meta: OapDataFileMeta,
-    dataType: DataType) extends DataFiberParser{
+private[oap] case class DeltaByteArrayDataFiberParserV1(
+    meta: OapDataFileMetaV1,
+    dataType: DataType) extends DataFiberParserV1{
 
   override def parse(bytes: Array[Byte], rowCount: Int): Array[Byte] = {
 
@@ -113,10 +112,10 @@ private[oap] case class DeltaByteArrayDataFiberParser(
   }
 }
 
-private[oap] case class PlainDictionaryFiberParser(
-    meta: OapDataFileMeta,
+private[oap] case class PlainDictionaryFiberParserV1(
+    meta: OapDataFileMetaV1,
     dictionary: Dictionary,
-    dataType: DataType) extends DataFiberParser {
+    dataType: DataType) extends DataFiberParserV1 {
 
   override def parse(bytes: Array[Byte], rowCount: Int): Array[Byte] = {
     val valuesReader = new DictionaryValuesReader(dictionary)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -24,6 +24,7 @@ import org.apache.parquet.bytes.BytesInput
 import org.apache.parquet.column.Dictionary
 import org.apache.parquet.column.page.DictionaryPage
 import org.apache.parquet.column.values.dictionary.PlainValuesDictionary.{PlainBinaryDictionary, PlainIntegerDictionary}
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache._

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -24,10 +24,10 @@ import org.apache.parquet.bytes.BytesInput
 import org.apache.parquet.column.Dictionary
 import org.apache.parquet.column.page.DictionaryPage
 import org.apache.parquet.column.values.dictionary.PlainValuesDictionary.{PlainBinaryDictionary, PlainIntegerDictionary}
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache._
+import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.CompletionIterator

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileMeta.scala
@@ -120,7 +120,6 @@ private[oap] class RowGroupMeta {
     fiberUncompressedLens.indices.foreach(fiberUncompressedLens(_) = is.readInt())
     statistics = new Array[ColumnStatistics](fieldCount)
     statistics.indices.foreach(statistics(_) = ColumnStatistics(is))
-    this
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileMeta.scala
@@ -29,11 +29,11 @@ import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-//  Meta Part Format
+//  OAP Data File Meta Part
 //  ..
 //  Field                               Length In Byte
 //  Meta
-//    Magic                             4
+//    Magic and Version                 4
 //    Row Count In Each Row Group       4
 //    Row Count In Last Row Group       4
 //    Row Group Count                   4
@@ -67,50 +67,52 @@ import org.apache.spark.unsafe.types.UTF8String
 //    RowGroup Meta #N                  16 + 4 * Field Count In Each Row * 2
 //    Meta Data Length                  4
 
-private[oap] class RowGroupMeta {
+abstract class OapDataFileMeta extends DataFileMeta
+
+private[oap] class RowGroupMetaV1 {
   var start: Long = _
   var end: Long = _
   var fiberLens: Array[Int] = _
   var fiberUncompressedLens: Array[Int] = _
-  var statistics: Array[ColumnStatistics] = _
+  var statistics: Array[ColumnStatisticsV1] = _
 
-  def withNewStart(newStart: Long): RowGroupMeta = {
+  def withNewStart(newStart: Long): RowGroupMetaV1 = {
     this.start = newStart
     this
   }
 
-  def withNewEnd(newEnd: Long): RowGroupMeta = {
+  def withNewEnd(newEnd: Long): RowGroupMetaV1 = {
     this.end = newEnd
     this
   }
 
-  def withNewFiberLens(newFiberLens: Array[Int]): RowGroupMeta = {
+  def withNewFiberLens(newFiberLens: Array[Int]): RowGroupMetaV1 = {
     this.fiberLens = newFiberLens
     this
   }
 
-  def withNewUncompressedFiberLens(newUncompressedFiberLens: Array[Int]): RowGroupMeta = {
+  def withNewUncompressedFiberLens(newUncompressedFiberLens: Array[Int]): RowGroupMetaV1 = {
     this.fiberUncompressedLens = newUncompressedFiberLens
     this
   }
 
-  def withNewStatistics(newStatistics: Array[ColumnStatistics]): RowGroupMeta = {
+  def withNewStatistics(newStatistics: Array[ColumnStatisticsV1]): RowGroupMetaV1 = {
     this.statistics = newStatistics
     this
   }
 
-  def write(os: FSDataOutputStream): RowGroupMeta = {
+  def write(os: FSDataOutputStream): RowGroupMetaV1 = {
     os.writeLong(start)
     os.writeLong(end)
     fiberLens.foreach(os.writeInt)
     fiberUncompressedLens.foreach(os.writeInt)
     statistics.foreach {
-      case ColumnStatistics(bytes) => os.write(bytes)
+      case ColumnStatisticsV1(bytes) => os.write(bytes)
     }
     this
   }
 
-  def read(is: DataInputStream, fieldCount: Int): RowGroupMeta = {
+  def read(is: DataInputStream, fieldCount: Int): RowGroupMetaV1 = {
     start = is.readLong()
     end = is.readLong()
     fiberLens = new Array[Int](fieldCount)
@@ -118,19 +120,19 @@ private[oap] class RowGroupMeta {
 
     fiberLens.indices.foreach(fiberLens(_) = is.readInt())
     fiberUncompressedLens.indices.foreach(fiberUncompressedLens(_) = is.readInt())
-    statistics = new Array[ColumnStatistics](fieldCount)
-    statistics.indices.foreach(statistics(_) = ColumnStatistics(is))
+    statistics = new Array[ColumnStatisticsV1](fieldCount)
+    statistics.indices.foreach(statistics(_) = ColumnStatisticsV1(is))
     this
   }
 }
 
-private[oap] class ColumnStatistics(val min: Array[Byte], val max: Array[Byte]) {
+private[oap] class ColumnStatisticsV1(val min: Array[Byte], val max: Array[Byte]) {
   def hasNonNullValue: Boolean = min != null && max != null
 
   def isEmpty: Boolean = !hasNonNullValue
 }
 
-private[oap] object ColumnStatistics {
+private[oap] object ColumnStatisticsV1 {
 
   type ParquetStatistics = org.apache.parquet.column.statistics.Statistics[_ <: Comparable[_]]
 
@@ -150,15 +152,15 @@ private[oap] object ColumnStatistics {
     schema.map{ field => getStatsBasedOnType(field.dataType)}
   }
 
-  def apply(stat: ParquetStatistics): ColumnStatistics = {
+  def apply(stat: ParquetStatistics): ColumnStatisticsV1 = {
     if (!stat.hasNonNullValue) {
-      new ColumnStatistics(null, null)
+      new ColumnStatisticsV1(null, null)
     } else {
-      new ColumnStatistics(stat.getMinBytes, stat.getMaxBytes)
+      new ColumnStatisticsV1(stat.getMinBytes, stat.getMaxBytes)
     }
   }
 
-  def apply(in: DataInputStream): ColumnStatistics = {
+  def apply(in: DataInputStream): ColumnStatisticsV1 = {
 
     val minLength = in.readInt()
     val min = if (minLength != 0) {
@@ -178,10 +180,10 @@ private[oap] object ColumnStatistics {
       null
     }
 
-    new ColumnStatistics(min, max)
+    new ColumnStatisticsV1(min, max)
   }
 
-  def unapply(statistics: ColumnStatistics): Option[Array[Byte]] = {
+  def unapply(statistics: ColumnStatisticsV1): Option[Array[Byte]] = {
     val buf = new ByteArrayOutputStream()
     val out = new DataOutputStream(buf)
 
@@ -199,26 +201,26 @@ private[oap] object ColumnStatistics {
   }
 }
 
-private[oap] class ColumnMeta(
+private[oap] class ColumnMetaV1(
     val encoding: Encoding,
     val dictionaryDataLength: Int,
     val dictionaryIdSize: Int,
-    val fileStatistics: ColumnStatistics) {}
+    val fileStatistics: ColumnStatisticsV1) {}
 
-private[oap] object ColumnMeta {
+private[oap] object ColumnMetaV1 {
 
-  def apply(in: DataInputStream): ColumnMeta = {
+  def apply(in: DataInputStream): ColumnMetaV1 = {
 
     val encoding = Encoding.findByValue(in.readInt())
     val dictionaryDataLength = in.readInt()
     val dictionaryIdSize = in.readInt()
 
-    val fileStatistics = ColumnStatistics(in)
+    val fileStatistics = ColumnStatisticsV1(in)
 
-    new ColumnMeta(encoding, dictionaryDataLength, dictionaryIdSize, fileStatistics)
+    new ColumnMetaV1(encoding, dictionaryDataLength, dictionaryIdSize, fileStatistics)
   }
 
-  def unapply(columnMeta: ColumnMeta): Option[Array[Byte]] = {
+  def unapply(columnMeta: ColumnMetaV1): Option[Array[Byte]] = {
     val buf = new ByteArrayOutputStream()
     val out = new DataOutputStream(buf)
 
@@ -227,26 +229,26 @@ private[oap] object ColumnMeta {
     out.writeInt(columnMeta.dictionaryIdSize)
 
     columnMeta.fileStatistics match {
-      case ColumnStatistics(bytes) => out.write(bytes)
+      case ColumnStatisticsV1(bytes) => out.write(bytes)
     }
 
     Some(buf.toByteArray)
   }
 }
 
-private[oap] class OapDataFileMeta(
-    var rowGroupsMeta: ArrayBuffer[RowGroupMeta] = new ArrayBuffer[RowGroupMeta](),
-    var columnsMeta: ArrayBuffer[ColumnMeta] = new ArrayBuffer[ColumnMeta](),
+private[oap] class OapDataFileMetaV1(
+    var rowGroupsMeta: ArrayBuffer[RowGroupMetaV1] = new ArrayBuffer[RowGroupMetaV1](),
+    var columnsMeta: ArrayBuffer[ColumnMetaV1] = new ArrayBuffer[ColumnMetaV1](),
     var rowCountInEachGroup: Int = 0,
     var rowCountInLastGroup: Int = 0,
     var groupCount: Int = 0,
     var fieldCount: Int = 0,
-    var codec: CompressionCodec = CompressionCodec.UNCOMPRESSED) extends DataFileMeta {
+    var codec: CompressionCodec = CompressionCodec.UNCOMPRESSED) extends OapDataFileMeta {
   private var _fin: FSDataInputStream = _
   private var _len: Long = 0
 
-  // Please change this value when Data File Format is changed
-  private val MAGIC = "OAP1"
+  // Magic bytes and version number
+  private val MAGIC_VERSION = "OAP1"
 
   def fin: FSDataInputStream = _fin
   def len: Long = _len
@@ -259,22 +261,22 @@ private[oap] class OapDataFileMeta(
     }
   }
 
-  def appendRowGroupMeta(meta: RowGroupMeta): OapDataFileMeta = {
+  def appendRowGroupMeta(meta: RowGroupMetaV1): OapDataFileMetaV1 = {
     this.rowGroupsMeta.append(meta)
     this
   }
 
-  def appendColumnMeta(meta: ColumnMeta): OapDataFileMeta = {
+  def appendColumnMeta(meta: ColumnMetaV1): OapDataFileMetaV1 = {
     this.columnsMeta.append(meta)
     this
   }
 
-  def withRowCountInLastGroup(count: Int): OapDataFileMeta = {
+  def withRowCountInLastGroup(count: Int): OapDataFileMetaV1 = {
     this.rowCountInLastGroup = count
     this
   }
 
-  def withGroupCount(count: Int): OapDataFileMeta = {
+  def withGroupCount(count: Int): OapDataFileMetaV1 = {
     this.groupCount = count
     this
   }
@@ -290,14 +292,14 @@ private[oap] class OapDataFileMeta(
     validateConsistency()
 
     val startPos = os.getPos
-    os.writeBytes(MAGIC)
+    os.writeBytes(MAGIC_VERSION)
     os.writeInt(this.rowCountInEachGroup)
     os.writeInt(this.rowCountInLastGroup)
     os.writeInt(this.groupCount)
     os.writeInt(this.fieldCount)
     os.writeInt(this.codec.getValue)
 
-    columnsMeta.foreach { case ColumnMeta(bytes) => os.write(bytes) }
+    columnsMeta.foreach { case ColumnMetaV1(bytes) => os.write(bytes) }
 
     rowGroupsMeta.foreach(_.write(os))
     val endPos = os.getPos
@@ -305,7 +307,7 @@ private[oap] class OapDataFileMeta(
     os.writeInt((endPos - startPos).toInt)
   }
 
-  def read(is: FSDataInputStream, fileLen: Long): OapDataFileMeta = is.synchronized {
+  def read(is: FSDataInputStream, fileLen: Long): OapDataFileMetaV1 = is.synchronized {
     this._fin = is
     this._len = fileLen
 
@@ -322,10 +324,10 @@ private[oap] class OapDataFileMeta(
 
     val in = new DataInputStream(new ByteArrayInputStream(metaBytes))
 
-    val buffer = new Array[Byte](MAGIC.length)
+    val buffer = new Array[Byte](MAGIC_VERSION.length)
     in.readFully(buffer)
     val magic = UTF8String.fromBytes(buffer).toString
-    if (magic != MAGIC) {
+    if (magic != MAGIC_VERSION) {
       throw new OapException("Not a valid Oap Data File")
     }
 
@@ -335,10 +337,10 @@ private[oap] class OapDataFileMeta(
     this.fieldCount = in.readInt()
     this.codec = CompressionCodec.findByValue(in.readInt())
 
-    (0 until fieldCount).foreach(_ => columnsMeta.append(ColumnMeta(in)))
+    (0 until fieldCount).foreach(_ => columnsMeta.append(ColumnMetaV1(in)))
 
     (0 until groupCount).foreach(_ =>
-      rowGroupsMeta.append(new RowGroupMeta().read(in, this.fieldCount)))
+      rowGroupsMeta.append(new RowGroupMetaV1().read(in, this.fieldCount)))
 
     validateConsistency()
     this

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileMeta.scala
@@ -120,6 +120,7 @@ private[oap] class RowGroupMeta {
     fiberUncompressedLens.indices.foreach(fiberUncompressedLens(_) = is.readInt())
     statistics = new Array[ColumnStatistics](fieldCount)
     statistics.indices.foreach(statistics(_) = ColumnStatistics(is))
+    this
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileProperties.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileProperties.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.sql.execution.datasources.OapException
+
+/**
+ * This class represents all the configurable OAP Data File properties.
+ * For now, only contains file version.
+ */
+private[index] object OapDataFileProperties {
+
+  import DataFileVersion.DataFileVersion
+
+  val DEFAULT_WRITER_VERSION: DataFileVersion = DataFileVersion.fromString("v1")
+
+  object DataFileVersion extends Enumeration {
+
+    type DataFileVersion = Value
+
+    val OAP_DATAFILE_V1: DataFileVersion = Value(1, "v1")
+
+    // Same to Enumeration.withName. But re-write the Exception message
+    def fromString(name: String): DataFileVersion = {
+      this.values.find(v => v.toString == name).getOrElse {
+        throw new OapException(s"Unsupported data file version. name: $name")
+      }
+    }
+
+    // Same to Enumeration.apply. But re-write the Exception message
+    def fromId(id: Int): DataFileVersion = {
+      this.values.find(v => v.id == id).getOrElse {
+        throw new OapException(s"Unsupported data file version. id: $id")
+      }
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileProperties.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileProperties.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.execution.datasources.OapException
  * This class represents all the configurable OAP Data File properties.
  * For now, only contains file version.
  */
-private[index] object OapDataFileProperties {
+private[io] object OapDataFileProperties {
 
   import DataFileVersion.DataFileVersion
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReader.scala
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import java.net.URI
+
+import scala.collection.mutable
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FSDataInputStream, Path}
+import org.apache.hadoop.util.StringUtils
+
+import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.JoinedRow
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
+import org.apache.spark.sql.execution.datasources.{OapException, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.oap._
+import org.apache.spark.sql.execution.datasources.oap.filecache.DataFileMetaCacheManager
+import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, ScannerBuilder}
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion._
+import org.apache.spark.sql.execution.datasources.oap.utils.FilterHelper
+import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.types.{AtomicType, StructType}
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.SerializableConfiguration
+
+object OapDataReader extends Logging {
+
+  def read(meta: Option[DataSourceMeta],
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hitIndexColumns: mutable.Map[String, IndexType],
+      hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+    // TODO we need to pass the extra data source meta information via the func parameter
+    meta match {
+      case Some(m) =>
+        logDebug("Building OapDataReader with "
+            + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
+            + " ...")
+
+        // Check whether this filter conforms to certain patterns that could benefit from index
+        def canTriggerIndex(filter: Filter): Boolean = {
+          var attr: String = null
+          def checkAttribute(filter: Filter): Boolean = filter match {
+            case Or(left, right) =>
+              checkAttribute(left) && checkAttribute(right)
+            case And(left, right) =>
+              checkAttribute(left) && checkAttribute(right)
+            case EqualTo(attribute, _) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case LessThan(attribute, _) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case LessThanOrEqual(attribute, _) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case GreaterThan(attribute, _) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case GreaterThanOrEqual(attribute, _) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case In(attribute, _) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case IsNull(attribute) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case IsNotNull(attribute) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case StringStartsWith(attribute, _) =>
+              if (attr == null || attr == attribute) {
+                attr = attribute; true
+              } else false
+            case _ => false
+          }
+
+          checkAttribute(filter)
+        }
+
+        val ic = new IndexContext(m)
+
+        if (m.indexMetas.nonEmpty) {
+          // check and use index
+          logDebug("Supported Filters by Oap:")
+          // filter out the "filters" on which we can use index
+          val supportFilters = filters.toArray.filter(canTriggerIndex)
+          // After filtered, supportFilter only contains:
+          // 1. Or predicate that contains only one attribute internally;
+          // 2. Some atomic predicates, such as LessThan, EqualTo, etc.
+          if (supportFilters.nonEmpty) {
+            // determine whether we can use index
+            supportFilters.foreach(filter => logDebug("\t" + filter.toString))
+            // get index options such as limit, order, etc.
+            val indexOptions = options.filterKeys(OapFileFormat.oapOptimizationKeySeq.contains(_))
+            val maxChooseSize = sparkSession.conf.get(OapConf.OAP_INDEXER_CHOICE_MAX_SIZE)
+            val indexDisableList = sparkSession.conf.get(OapConf.OAP_INDEX_DISABLE_LIST)
+            ScannerBuilder.build(supportFilters, ic, indexOptions, maxChooseSize, indexDisableList)
+          }
+        }
+
+        val filterScanners = ic.getScanners
+        filterScanners match {
+          case Some(s) =>
+            hitIndexColumns ++= s.scanners.flatMap { scanner =>
+              scanner.keyNames.map(n => n -> scanner.meta.indexType)
+            }.toMap
+          case _ =>
+        }
+
+        val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
+        val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
+
+        // Refer to ParquetFileFormat, use resultSchema to decide if this query support
+        // Vectorized Read and returningBatch. Also it depends on WHOLE_STAGE_CODE_GEN,
+        // as the essential unsafe projection is done by that.
+        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+        val enableVectorizedReader: Boolean =
+          m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
+              sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
+              sparkSession.sessionState.conf.wholeStageEnabled &&
+              resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
+        val returningBatch = supportBatch(sparkSession, resultSchema)
+        val parquetDataCacheEnable = sparkSession.conf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED)
+        val broadcastedHadoopConf =
+          sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+        (file: PartitionedFile) => {
+
+          val path = new Path(StringUtils.unEscapeString(file.filePath))
+          val fs = path.getFileSystem(broadcastedHadoopConf.value.value)
+          val version = readVersion(fs.open(path), fs.getFileStatus(path).getLen)
+          version match {
+            case DataFileVersion.OAP_DATAFILE_V1 => new OapDataReaderV1().read()
+          }
+
+          assert(file.partitionValues.numFields == partitionSchema.size)
+          val conf = broadcastedHadoopConf.value.value
+
+          def isSkippedByFile: Boolean = {
+            if (m.dataReaderClassName == OapFileFormat.OAP_DATA_FILE_CLASSNAME) {
+              val dataFile = DataFile(file.filePath, m.schema, m.dataReaderClassName, conf)
+              val dataFileMeta = DataFileMetaCacheManager(dataFile)
+                  .asInstanceOf[OapDataFileMetaV1]
+              if (filters.exists(filter => isSkippedByStatistics(
+                dataFileMeta.columnsMeta.map(_.fileStatistics).toArray, filter, m.schema))) {
+                val totalRows = dataFileMeta.totalRowCount()
+                oapMetrics.updateTotalRows(totalRows)
+                oapMetrics.skipForStatistic(totalRows)
+                return true
+              }
+            }
+            false
+          }
+
+          if (isSkippedByFile) {
+            Iterator.empty
+          } else {
+            OapIndexInfo.partitionOapIndex.put(file.filePath, false)
+            FilterHelper.setFilterIfExist(conf, pushed)
+            // if enableVectorizedReader == true, init VectorizedContext,
+            // else context is None.
+            val context = if (enableVectorizedReader) {
+              Some(VectorizedContext(partitionSchema, file.partitionValues, returningBatch))
+            } else {
+              None
+            }
+            val reader = new OapDataScannerV1(
+              new Path(new URI(file.filePath)), m, filterScanners, requiredIds, context)
+            val iter = reader.initialize(conf, options, filters)
+            Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
+            val totalRows = reader.totalRows()
+            oapMetrics.updateTotalRows(totalRows)
+            oapMetrics.updateIndexAndRowRead(reader, totalRows)
+            // if enableVectorizedReader == true and parquetDataCacheEnable = false,
+            // return iter directly because of partitionValues
+            // already filled by VectorizedReader, else use original branch.
+            if (enableVectorizedReader && !parquetDataCacheEnable) {
+              iter
+            } else {
+              val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
+              val joinedRow = new JoinedRow()
+              val appendPartitionColumns =
+                GenerateUnsafeProjection.generate(fullSchema, fullSchema)
+
+              iter.map(d => appendPartitionColumns(joinedRow(d, file.partitionValues)))
+            }
+          }
+        }
+      case None => (_: PartitionedFile) => {
+        // TODO need to think about when there is no oap.meta file at all
+        Iterator.empty
+      }
+    }
+  }
+
+
+
+  def readVersion(is: FSDataInputStream, fileLen: Long): DataFileVersion = {
+    val MAGIC_VERSION_LENGTH = 4
+    val oapDataFileMetaLengthIndex = fileLen - 4
+
+    // seek to the position of data file meta length
+    is.seek(oapDataFileMetaLengthIndex)
+    val oapDataFileMetaLength = is.readInt()
+    // read all bytes of data file meta
+    val magicBuffer = new Array[Byte](MAGIC_VERSION_LENGTH)
+    is.readFully(oapDataFileMetaLengthIndex - oapDataFileMetaLength, magicBuffer)
+
+    val magic = UTF8String.fromBytes(magicBuffer).toString
+    if (! magic.contains("OAP")) {
+      throw new OapException("Not a valid Oap Data File")
+    } else if (magic == "OAP1") {
+      DataFileVersion.OAP_DATAFILE_V1
+    } else {
+      throw new OapException("Not a supported Oap Data File version")
+    }
+  }
+
+}
+
+abstract class OapDataReader {
+  def read(file: PartitionedFile): Iterator[InternalRow]
+}
+
+class OapDataReaderV1 extends OapDataReader {
+
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReader.scala
@@ -19,13 +19,13 @@ package org.apache.spark.sql.execution.datasources.oap.io
 
 import java.net.URI
 
-import scala.collection.mutable
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
 import org.apache.hadoop.util.StringUtils
+import org.apache.parquet.filter2.predicate.FilterPredicate
 
-import org.apache.spark.TaskContext
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -34,212 +34,156 @@ import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjectio
 import org.apache.spark.sql.execution.datasources.{OapException, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache.DataFileMetaCacheManager
-import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, ScannerBuilder}
+import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, IndexScanners, ScannerBuilder}
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion._
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion.DataFileVersion
 import org.apache.spark.sql.execution.datasources.oap.utils.FilterHelper
 import org.apache.spark.sql.internal.oap.OapConf
-import org.apache.spark.sql.sources._
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{AtomicType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SerializableConfiguration
 
+abstract class OapDataReader {
+  def read: PartitionedFile => Iterator[InternalRow]
+}
+
+class OapDataReaderV1(
+    m: DataSourceMeta,
+    filterScanners: Option[IndexScanners],
+    requiredIds: Array[Int],
+    partitionSchema: StructType,
+    requiredSchema: StructType,
+    filters: Seq[Filter],
+    options: Map[String, String],
+    broadcastedHadoopConf: Broadcast[SerializableConfiguration],
+    pushed: Option[FilterPredicate],
+    enableVectorizedReader: Boolean,
+    returningBatch: Boolean,
+    parquetDataCacheEnable: Boolean,
+    oapMetrics: OapMetricsManager) extends OapDataReader {
+
+  override def read: (PartitionedFile) => Iterator[InternalRow] = {
+
+    (file: PartitionedFile) => {
+
+      assert(file.partitionValues.numFields == partitionSchema.size)
+      val conf = broadcastedHadoopConf.value.value
+
+      def isSkippedByFile: Boolean = {
+        if (m.dataReaderClassName == OapFileFormat.OAP_DATA_FILE_V1_CLASSNAME) {
+          val dataFile = DataFile(file.filePath, m.schema, m.dataReaderClassName, conf)
+          val dataFileMeta = DataFileMetaCacheManager(dataFile)
+              .asInstanceOf[OapDataFileMetaV1]
+          if (filters.exists(filter => isSkippedByStatistics(
+            dataFileMeta.columnsMeta.map(_.fileStatistics).toArray, filter, m.schema))) {
+            val totalRows = dataFileMeta.totalRowCount()
+            oapMetrics.updateTotalRows(totalRows)
+            oapMetrics.skipForStatistic(totalRows)
+            return true
+          }
+        }
+        false
+      }
+
+      if (isSkippedByFile) {
+        Iterator.empty
+      } else {
+        OapIndexInfo.partitionOapIndex.put(file.filePath, false)
+        FilterHelper.setFilterIfExist(conf, pushed)
+        // if enableVectorizedReader == true, init VectorizedContext,
+        // else context is None.
+        val context = if (enableVectorizedReader) {
+          Some(VectorizedContext(partitionSchema, file.partitionValues, returningBatch))
+        } else {
+          None
+        }
+        val reader = new OapDataScannerV1(new Path(
+          new URI(file.filePath)), m, filterScanners, requiredIds, context)
+        val iter = reader.initialize(conf, options, filters)
+        Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
+        val totalRows = reader.totalRows()
+        oapMetrics.updateTotalRows(totalRows)
+        oapMetrics.updateIndexAndRowRead(reader, totalRows)
+        // if enableVectorizedReader == true and parquetDataCacheEnable = false,
+        // return iter directly because of partitionValues
+        // already filled by VectorizedReader, else use original branch.
+        if (enableVectorizedReader && !parquetDataCacheEnable) {
+          iter
+        } else {
+          val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
+          val joinedRow = new JoinedRow()
+          val appendPartitionColumns =
+            GenerateUnsafeProjection.generate(fullSchema, fullSchema)
+
+          iter.map(d => appendPartitionColumns(joinedRow(d, file.partitionValues)))
+        }
+      }
+    }
+  }
+}
+
 object OapDataReader extends Logging {
 
-  def read(meta: Option[DataSourceMeta],
+  def read(m: DataSourceMeta,
       sparkSession: SparkSession,
+      filterScanners: Option[IndexScanners],
       dataSchema: StructType,
       partitionSchema: StructType,
       requiredSchema: StructType,
       filters: Seq[Filter],
       options: Map[String, String],
-      hitIndexColumns: mutable.Map[String, IndexType],
+      supportBatch: (SparkSession, StructType) => Boolean,
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
-    // TODO we need to pass the extra data source meta information via the func parameter
-    meta match {
-      case Some(m) =>
-        logDebug("Building OapDataReader with "
-            + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
-            + " ...")
 
-        // Check whether this filter conforms to certain patterns that could benefit from index
-        def canTriggerIndex(filter: Filter): Boolean = {
-          var attr: String = null
-          def checkAttribute(filter: Filter): Boolean = filter match {
-            case Or(left, right) =>
-              checkAttribute(left) && checkAttribute(right)
-            case And(left, right) =>
-              checkAttribute(left) && checkAttribute(right)
-            case EqualTo(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case LessThan(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case LessThanOrEqual(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case GreaterThan(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case GreaterThanOrEqual(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case In(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case IsNull(attribute) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case IsNotNull(attribute) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case StringStartsWith(attribute, _) =>
-              if (attr == null || attr == attribute) {
-                attr = attribute; true
-              } else false
-            case _ => false
-          }
+    val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
+    val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
-          checkAttribute(filter)
-        }
+    // Refer to ParquetFileFormat, use resultSchema to decide if this query support
+    // Vectorized Read and returningBatch. Also it depends on WHOLE_STAGE_CODE_GEN,
+    // as the essential unsafe projection is done by that.
+    val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+    val isParquet = m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME)
+    val enableVectorizedReader: Boolean =
+      isParquet && sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
+        sparkSession.sessionState.conf.wholeStageEnabled &&
+          resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
+    val returningBatch = supportBatch(sparkSession, resultSchema)
+    val parquetDataCacheEnable = sparkSession.conf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED)
+    val broadcastedHadoopConf =
+      sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
-        val ic = new IndexContext(m)
+    val oapMetrics = SparkEnv.get.oapManager.metricsManager
 
-        if (m.indexMetas.nonEmpty) {
-          // check and use index
-          logDebug("Supported Filters by Oap:")
-          // filter out the "filters" on which we can use index
-          val supportFilters = filters.toArray.filter(canTriggerIndex)
-          // After filtered, supportFilter only contains:
-          // 1. Or predicate that contains only one attribute internally;
-          // 2. Some atomic predicates, such as LessThan, EqualTo, etc.
-          if (supportFilters.nonEmpty) {
-            // determine whether we can use index
-            supportFilters.foreach(filter => logDebug("\t" + filter.toString))
-            // get index options such as limit, order, etc.
-            val indexOptions = options.filterKeys(OapFileFormat.oapOptimizationKeySeq.contains(_))
-            val maxChooseSize = sparkSession.conf.get(OapConf.OAP_INDEXER_CHOICE_MAX_SIZE)
-            val indexDisableList = sparkSession.conf.get(OapConf.OAP_INDEX_DISABLE_LIST)
-            ScannerBuilder.build(supportFilters, ic, indexOptions, maxChooseSize, indexDisableList)
-          }
-        }
-
-        val filterScanners = ic.getScanners
-        filterScanners match {
-          case Some(s) =>
-            hitIndexColumns ++= s.scanners.flatMap { scanner =>
-              scanner.keyNames.map(n => n -> scanner.meta.indexType)
-            }.toMap
-          case _ =>
-        }
-
-        val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
-        val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
-
-        // Refer to ParquetFileFormat, use resultSchema to decide if this query support
-        // Vectorized Read and returningBatch. Also it depends on WHOLE_STAGE_CODE_GEN,
-        // as the essential unsafe projection is done by that.
-        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
-        val enableVectorizedReader: Boolean =
-          m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
-              sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
-              sparkSession.sessionState.conf.wholeStageEnabled &&
-              resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
-        val returningBatch = supportBatch(sparkSession, resultSchema)
-        val parquetDataCacheEnable = sparkSession.conf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED)
-        val broadcastedHadoopConf =
-          sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
-
-        (file: PartitionedFile) => {
-
-          val path = new Path(StringUtils.unEscapeString(file.filePath))
-          val fs = path.getFileSystem(broadcastedHadoopConf.value.value)
-          val version = readVersion(fs.open(path), fs.getFileStatus(path).getLen)
-          version match {
-            case DataFileVersion.OAP_DATAFILE_V1 => new OapDataReaderV1().read()
-          }
-
-          assert(file.partitionValues.numFields == partitionSchema.size)
-          val conf = broadcastedHadoopConf.value.value
-
-          def isSkippedByFile: Boolean = {
-            if (m.dataReaderClassName == OapFileFormat.OAP_DATA_FILE_CLASSNAME) {
-              val dataFile = DataFile(file.filePath, m.schema, m.dataReaderClassName, conf)
-              val dataFileMeta = DataFileMetaCacheManager(dataFile)
-                  .asInstanceOf[OapDataFileMetaV1]
-              if (filters.exists(filter => isSkippedByStatistics(
-                dataFileMeta.columnsMeta.map(_.fileStatistics).toArray, filter, m.schema))) {
-                val totalRows = dataFileMeta.totalRowCount()
-                oapMetrics.updateTotalRows(totalRows)
-                oapMetrics.skipForStatistic(totalRows)
-                return true
-              }
-            }
-            false
-          }
-
-          if (isSkippedByFile) {
-            Iterator.empty
-          } else {
-            OapIndexInfo.partitionOapIndex.put(file.filePath, false)
-            FilterHelper.setFilterIfExist(conf, pushed)
-            // if enableVectorizedReader == true, init VectorizedContext,
-            // else context is None.
-            val context = if (enableVectorizedReader) {
-              Some(VectorizedContext(partitionSchema, file.partitionValues, returningBatch))
-            } else {
-              None
-            }
-            val reader = new OapDataScannerV1(
-              new Path(new URI(file.filePath)), m, filterScanners, requiredIds, context)
-            val iter = reader.initialize(conf, options, filters)
-            Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
-            val totalRows = reader.totalRows()
-            oapMetrics.updateTotalRows(totalRows)
-            oapMetrics.updateIndexAndRowRead(reader, totalRows)
-            // if enableVectorizedReader == true and parquetDataCacheEnable = false,
-            // return iter directly because of partitionValues
-            // already filled by VectorizedReader, else use original branch.
-            if (enableVectorizedReader && !parquetDataCacheEnable) {
-              iter
-            } else {
-              val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
-              val joinedRow = new JoinedRow()
-              val appendPartitionColumns =
-                GenerateUnsafeProjection.generate(fullSchema, fullSchema)
-
-              iter.map(d => appendPartitionColumns(joinedRow(d, file.partitionValues)))
-            }
-          }
-        }
-      case None => (_: PartitionedFile) => {
-        // TODO need to think about when there is no oap.meta file at all
-        Iterator.empty
+    (file: PartitionedFile) => {
+      val path = new Path(StringUtils.unEscapeString(file.filePath))
+      val fs = path.getFileSystem(broadcastedHadoopConf.value.value)
+      val version = if (isParquet) {
+        DataFileVersion.OAP_DATAFILE_V1
+      } else {
+        readVersion(fs.open(path), fs.getFileStatus(path).getLen)
+      }
+      version match {
+        case DataFileVersion.OAP_DATAFILE_V1 => new OapDataReaderV1(m, filterScanners, requiredIds,
+          partitionSchema, requiredSchema, filters, options, broadcastedHadoopConf, pushed,
+            enableVectorizedReader, returningBatch, parquetDataCacheEnable, oapMetrics).read(file)
+        // Actually it won't get to this line, because unsupported version will cause exception
+        // thrown in readVersion call
+        case _ => Iterator.empty
       }
     }
   }
 
-
-
-  def readVersion(is: FSDataInputStream, fileLen: Long): DataFileVersion = {
+  private def readVersion(is: FSDataInputStream, fileLen: Long): DataFileVersion = {
     val MAGIC_VERSION_LENGTH = 4
-    val oapDataFileMetaLengthIndex = fileLen - 4
+    val metaEnd = fileLen - 4
 
     // seek to the position of data file meta length
-    is.seek(oapDataFileMetaLengthIndex)
-    val oapDataFileMetaLength = is.readInt()
+    is.seek(metaEnd)
+    val metaLength = is.readInt()
     // read all bytes of data file meta
     val magicBuffer = new Array[Byte](MAGIC_VERSION_LENGTH)
-    is.readFully(oapDataFileMetaLengthIndex - oapDataFileMetaLength, magicBuffer)
+    is.readFully(metaEnd - metaLength, magicBuffer)
 
     val magic = UTF8String.fromBytes(magicBuffer).toString
     if (! magic.contains("OAP")) {
@@ -250,13 +194,4 @@ object OapDataReader extends Logging {
       throw new OapException("Not a supported Oap Data File version")
     }
   }
-
-}
-
-abstract class OapDataReader {
-  def read(file: PartitionedFile): Iterator[InternalRow]
-}
-
-class OapDataReaderV1 extends OapDataReader {
-
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReader.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.execution.datasources.oap.filecache.DataFileMetaCach
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, IndexScanners, ScannerBuilder}
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion.DataFileVersion
+import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.sql.execution.datasources.oap.utils.FilterHelper
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.sources.Filter

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataWriter.scala
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FSDataOutputStream
+import org.apache.parquet.format.CompressionCodec
+import org.apache.parquet.io.api.Binary
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
+import org.apache.spark.sql.execution.datasources.oap.filecache.DataFiberBuilder
+import org.apache.spark.sql.types._
+
+// TODO: [linhong] Let's remove the `isCompressed` argument
+// Note: For Oap dataFile writer, we only main a single latest version
+private[oap] class OapDataWriter(
+    isCompressed: Boolean,
+    out: FSDataOutputStream,
+    schema: StructType,
+    conf: Configuration) extends Logging {
+
+  private val ROW_GROUP_SIZE =
+    conf.get(OapFileFormat.ROW_GROUP_SIZE, OapFileFormat.DEFAULT_ROW_GROUP_SIZE).toInt
+  logDebug(s"${OapFileFormat.ROW_GROUP_SIZE} setting to $ROW_GROUP_SIZE")
+
+  private val COMPRESSION_CODEC = CompressionCodec.valueOf(
+    conf.get(OapFileFormat.COMPRESSION, OapFileFormat.DEFAULT_COMPRESSION).toUpperCase())
+  logDebug(s"${OapFileFormat.COMPRESSION} setting to ${COMPRESSION_CODEC.name()}")
+
+  private var rowCount: Int = 0
+  private var rowGroupCount: Int = 0
+
+  private val rowGroup: Array[DataFiberBuilder] =
+    DataFiberBuilder.initializeFromSchema(schema, ROW_GROUP_SIZE)
+
+  private val fileStatiscs = ColumnStatisticsV1.getStatsFromSchema(schema)
+  private var rowGroupstatistics = ColumnStatisticsV1.getStatsFromSchema(schema)
+
+  private def updateStats(
+      stats: ColumnStatisticsV1.ParquetStatistics,
+      row: InternalRow,
+      index: Int,
+      dataType: DataType): Unit = {
+    dataType match {
+      case BooleanType => stats.updateStats(row.getBoolean(index))
+      case IntegerType => stats.updateStats(row.getInt(index))
+      case ByteType => stats.updateStats(row.getByte(index))
+      case DateType => stats.updateStats(row.getInt(index))
+      case ShortType => stats.updateStats(row.getShort(index))
+      case StringType => stats.updateStats(
+        Binary.fromConstantByteArray(row.getString(index).getBytes))
+      case BinaryType => stats.updateStats(
+        Binary.fromConstantByteArray(row.getBinary(index)))
+      case FloatType => stats.updateStats(row.getFloat(index))
+      case DoubleType => stats.updateStats(row.getDouble(index))
+      case LongType => stats.updateStats(row.getLong(index))
+      case _ => sys.error(s"Not support data type: $dataType")
+    }
+  }
+
+  private val fiberMeta = new OapDataFileMetaV1(
+    rowCountInEachGroup = ROW_GROUP_SIZE,
+    fieldCount = schema.length,
+    codec = COMPRESSION_CODEC)
+
+  private val codecFactory = new CodecFactory(conf)
+
+  def write(row: InternalRow) {
+    rowGroup.zipWithIndex.foreach { case (dataFiberBuilder, i) =>
+      dataFiberBuilder.append(row)
+      if (!row.isNullAt(i)) {
+        updateStats(fileStatiscs(i), row, i, schema(i).dataType)
+        updateStats(rowGroupstatistics(i), row, i, schema(i).dataType)
+      }
+    }
+    rowCount += 1
+    if (rowCount % ROW_GROUP_SIZE == 0) {
+      writeRowGroup()
+    }
+  }
+
+  private def writeRowGroup(): Unit = {
+    rowGroupCount += 1
+    val compressor: BytesCompressor = codecFactory.getCompressor(COMPRESSION_CODEC)
+    val fiberLens = new Array[Int](rowGroup.length)
+    val fiberUncompressedLens = new Array[Int](rowGroup.length)
+    var idx: Int = 0
+    var totalDataSize = 0L
+    val rowGroupMeta = new RowGroupMetaV1()
+
+    rowGroupMeta.withNewStart(out.getPos)
+        .withNewFiberLens(fiberLens)
+        .withNewUncompressedFiberLens(fiberUncompressedLens)
+        .withNewStatistics(rowGroupstatistics.map(ColumnStatisticsV1(_)).toArray)
+
+    while (idx < rowGroup.length) {
+      val fiberByteData = rowGroup(idx).build()
+      val newUncompressedFiberData = fiberByteData.fiberData
+      val newFiberData = compressor.compress(newUncompressedFiberData)
+      totalDataSize += newFiberData.length
+      fiberLens(idx) = newFiberData.length
+      fiberUncompressedLens(idx) = newUncompressedFiberData.length
+      out.write(newFiberData)
+      rowGroup(idx).clear()
+      idx += 1
+    }
+    rowGroupstatistics = ColumnStatisticsV1.getStatsFromSchema(schema)
+    fiberMeta.appendRowGroupMeta(rowGroupMeta.withNewEnd(out.getPos))
+  }
+
+  def close() {
+    val remainingRowCount = rowCount % ROW_GROUP_SIZE
+    if (remainingRowCount != 0) {
+      // should be end of the insertion, put the row groups into the last row group
+      writeRowGroup()
+    }
+
+    rowGroup.zipWithIndex.foreach { case (dataFiberBuilder, i) =>
+      val dictByteData = dataFiberBuilder.buildDictionary
+      val encoding = dataFiberBuilder.getEncoding
+      val dictionaryDataLength = dictByteData.length
+      val dictionaryIdSize = dataFiberBuilder.getDictionarySize
+      if (dictionaryDataLength > 0) {
+        out.write(dictByteData)
+      }
+      fiberMeta.appendColumnMeta(
+        new ColumnMetaV1(
+          encoding, dictionaryDataLength, dictionaryIdSize, ColumnStatisticsV1(fileStatiscs(i))))
+    }
+
+    // and update the group count and row count in the last group
+    fiberMeta
+        .withGroupCount(rowGroupCount)
+        .withRowCountInLastGroup(
+          if (remainingRowCount != 0 || rowCount == 0) remainingRowCount else ROW_GROUP_SIZE)
+
+    fiberMeta.write(out)
+    codecFactory.release()
+    out.close()
+  }
+}
+

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -21,11 +21,13 @@ import java.io.Closeable
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.util.StringUtils
 import org.apache.parquet.hadoop._
 import org.apache.parquet.hadoop.api.RecordReader
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.execution.datasources.OapException

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -21,18 +21,17 @@ import java.io.Closeable
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.util.StringUtils
 import org.apache.parquet.hadoop._
 import org.apache.parquet.hadoop.api.RecordReader
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.{BatchColumn, ColumnValues}
 import org.apache.spark.sql.execution.datasources.oap.filecache.{MemoryManager, _}
+import org.apache.spark.sql.execution.datasources.oap.io.meta.ParquetDataFileMeta
 import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportWrapper
 import org.apache.spark.sql.execution.vectorized.ColumnarBatch
 import org.apache.spark.sql.internal.oap.OapConf

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/meta/OapDataFileMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/meta/OapDataFileMeta.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io.meta
+
+import java.io.{ByteArrayOutputStream, DataInputStream, DataOutputStream}
+
+import org.apache.parquet.column.statistics._
+
+import org.apache.spark.sql.execution.datasources.oap.io.DataFileMeta
+import org.apache.spark.sql.types._
+
+abstract class OapDataFileMeta extends DataFileMeta
+
+private[oap] class ColumnStatistics(val min: Array[Byte], val max: Array[Byte]) {
+  def hasNonNullValue: Boolean = min != null && max != null
+
+  def isEmpty: Boolean = !hasNonNullValue
+}
+
+private[oap] object ColumnStatistics {
+
+  type ParquetStatistics = org.apache.parquet.column.statistics.Statistics[_ <: Comparable[_]]
+
+  def getStatsBasedOnType(dataType: DataType): ParquetStatistics = {
+    dataType match {
+      case BooleanType => new BooleanStatistics()
+      case IntegerType | ByteType | DateType | ShortType => new IntStatistics()
+      case StringType | BinaryType => new BinaryStatistics()
+      case FloatType => new FloatStatistics()
+      case DoubleType => new DoubleStatistics()
+      case LongType => new LongStatistics()
+      case _ => sys.error(s"Not support data type: $dataType")
+    }
+  }
+
+  def getStatsFromSchema(schema: StructType): Seq[ParquetStatistics] = {
+    schema.map{ field => getStatsBasedOnType(field.dataType)}
+  }
+
+  def apply(stat: ParquetStatistics): ColumnStatistics = {
+    if (!stat.hasNonNullValue) {
+      new ColumnStatistics(null, null)
+    } else {
+      new ColumnStatistics(stat.getMinBytes, stat.getMaxBytes)
+    }
+  }
+
+  def apply(in: DataInputStream): ColumnStatistics = {
+
+    val minLength = in.readInt()
+    val min = if (minLength != 0) {
+      val bytes = new Array[Byte](minLength)
+      in.readFully(bytes)
+      bytes
+    } else {
+      null
+    }
+
+    val maxLength = in.readInt()
+    val max = if (maxLength != 0) {
+      val bytes = new Array[Byte](maxLength)
+      in.readFully(bytes)
+      bytes
+    } else {
+      null
+    }
+
+    new ColumnStatistics(min, max)
+  }
+
+  def unapply(statistics: ColumnStatistics): Option[Array[Byte]] = {
+    val buf = new ByteArrayOutputStream()
+    val out = new DataOutputStream(buf)
+
+    if (statistics.hasNonNullValue) {
+      out.writeInt(statistics.min.length)
+      out.write(statistics.min)
+      out.writeInt(statistics.max.length)
+      out.write(statistics.max)
+    } else {
+      out.writeInt(0)
+      out.writeInt(0)
+    }
+
+    Some(buf.toByteArray)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/meta/ParquetDataFileMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/meta/ParquetDataFileMeta.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.datasources.oap.io
+package org.apache.spark.sql.execution.datasources.oap.io.meta
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
@@ -23,6 +23,8 @@ import org.apache.hadoop.util.StringUtils
 import org.apache.parquet.format.converter.ParquetMetadataConverter._
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.metadata.ParquetMetadata
+
+import org.apache.spark.sql.execution.datasources.oap.io.DataFileMeta
 
 private[oap] class ParquetDataFileMeta(val footer: ParquetMetadata) extends DataFileMeta {
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/package.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/package.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
-import org.apache.spark.sql.execution.datasources.oap.io.ColumnStatisticsV1
+import org.apache.spark.sql.execution.datasources.oap.io.meta.ColumnStatistics
 import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{StructField, StructType}
@@ -31,7 +31,7 @@ package object oap {
 
   // Return if the rowGroup or file can be skipped by min max statistics
   def isSkippedByStatistics(
-      columnStats: Array[ColumnStatisticsV1],
+      columnStats: Array[ColumnStatistics],
       filter: Filter,
       schema: StructType): Boolean = filter match {
     case Or(left, right) =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/package.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/package.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
-import org.apache.spark.sql.execution.datasources.oap.io.ColumnStatistics
+import org.apache.spark.sql.execution.datasources.oap.io.ColumnStatisticsV1
 import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{StructField, StructType}
@@ -31,7 +31,7 @@ package object oap {
 
   // Return if the rowGroup or file can be skipped by min max statistics
   def isSkippedByStatistics(
-      columnStats: Array[ColumnStatistics],
+      columnStats: Array[ColumnStatisticsV1],
       filter: Filter,
       schema: StructType): Boolean = filter match {
     case Or(left, right) =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDe.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDe.scala
@@ -22,7 +22,7 @@ import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheStatus
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileMeta
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileMetaV1
 import org.apache.spark.util.collection.BitSet
 
 /**
@@ -72,19 +72,19 @@ private[oap] object CacheStatusSerDe extends SerDe[String, Seq[FiberCacheStatus]
 
   // we only transfer 4 items in DataFileMeta to driver, ther are rowCountInEachGroup,
   // rowCountInLastGroup, groupCount, fieldCount respectively
-  private[oap] def dataFileMetaToJson(dataFileMeta: OapDataFileMeta): JValue = {
+  private[oap] def dataFileMetaToJson(dataFileMeta: OapDataFileMetaV1): JValue = {
     ("rowCountInEachGroup" -> dataFileMeta.rowCountInEachGroup) ~
       ("rowCountInLastGroup" -> dataFileMeta.rowCountInLastGroup) ~
       ("groupCount" -> dataFileMeta.groupCount) ~
       ("fieldCount" -> dataFileMeta.fieldCount)
   }
 
-  private[oap] def dataFileMetaFromJson(json: JValue): OapDataFileMeta = {
+  private[oap] def dataFileMetaFromJson(json: JValue): OapDataFileMetaV1 = {
     val rowCountInEachGroup = (json \ "rowCountInEachGroup").extract[Int]
     val rowCountInLastGroup = (json \ "rowCountInLastGroup").extract[Int]
     val groupCount = (json \ "groupCount").extract[Int]
     val fieldCount = (json \ "fieldCount").extract[Int]
-    new OapDataFileMeta(
+    new OapDataFileMetaV1(
       rowCountInEachGroup = rowCountInEachGroup,
       rowCountInLastGroup = rowCountInLastGroup,
       groupCount = groupCount,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDe.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDe.scala
@@ -20,9 +20,8 @@ package org.apache.spark.sql.execution.datasources.oap.utils
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
-
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheStatus
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileMetaV1
+import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.util.collection.BitSet
 
 /**

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDe.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDe.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.oap.utils
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
+
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheStatus
 import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.util.collection.BitSet

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -136,7 +136,7 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     assert(oapMeta.fileMetas.length === 0)
     assert(oapMeta.indexMetas.length === 0)
     assert(oapMeta.schema.length === 0)
-    assert(oapMeta.dataReaderClassName === OapFileFormat.OAP_DATA_FILE_CLASSNAME)
+    assert(oapMeta.dataReaderClassName === OapFileFormat.OAP_DATA_FILE_V1_CLASSNAME)
   }
 
   test("Oap Meta integration test") {
@@ -311,7 +311,7 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     assert(fileMetas.length === 3)
     assert(fileMetas.map(_.recordCount).sum === 50)
     assert(fileMetas(0).dataFileName.endsWith(OapFileFormat.OAP_DATA_EXTENSION))
-    assert(oapMeta.dataReaderClassName === OapFileFormat.OAP_DATA_FILE_CLASSNAME)
+    assert(oapMeta.dataReaderClassName === OapFileFormat.OAP_DATA_FILE_V1_CLASSNAME)
 
 
     val readDf = sqlContext.read.format("oap").load(tmpDir.getAbsolutePath)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, ScannerBuilder}
-import org.apache.spark.sql.execution.datasources.oap.io.{OapDataReader, OapIndexInfo, OapIndexInfoStatus}
+import org.apache.spark.sql.execution.datasources.oap.io.{OapDataScannerV1, OapIndexInfo, OapIndexInfoStatus}
 import org.apache.spark.sql.execution.datasources.oap.utils.OapIndexInfoStatusSerDe
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
@@ -144,7 +144,7 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
       val dataSourceMeta = DataSourceMeta.initialize(metaPath, conf)
       val requiredIds = Array(0, 1)
       // No index scanner is used.
-      val readerNoIndex = new OapDataReader(filePath, dataSourceMeta, None, requiredIds)
+      val readerNoIndex = new OapDataScannerV1(filePath, dataSourceMeta, None, requiredIds)
       val itNoIndex = readerNoIndex.initialize(conf)
       assert(itNoIndex.size == 100)
       val ic = new IndexContext(dataSourceMeta)
@@ -152,7 +152,7 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
         And(GreaterThan("a", 9), LessThan("a", 14)))
       ScannerBuilder.build(filters, ic)
       val filterScanners = ic.getScanners
-      val readerIndex = new OapDataReader(filePath, dataSourceMeta, filterScanners, requiredIds)
+      val readerIndex = new OapDataScannerV1(filePath, dataSourceMeta, filterScanners, requiredIds)
       val itIndex = readerIndex.initialize(conf)
       assert(itIndex.size == 4)
       conf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key, false)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
@@ -107,7 +107,7 @@ class FiberSuite extends SharedOapContext with Logging {
     for (i <- rowCounts.indices) {
       val path = new Path(file.getAbsolutePath, rowCounts(i).toString)
       writeData(path, schema, rowCounts(i))
-      val meta = OapDataFile(path.toString, schema, configuration).getDataFileMeta()
+      val meta = OapDataFileV1(path.toString, schema, configuration).getDataFileMeta()
       assert(meta.totalRowCount() === rowCounts(i))
       assert(meta.rowCountInLastGroup === rowCountInLastGroups(i))
       assert(meta.rowGroupsMeta.length === rowGroupCounts(i))
@@ -132,7 +132,7 @@ class FiberSuite extends SharedOapContext with Logging {
     val path = new Path(file.getAbsolutePath, 10.toString)
     writeData(path, schema, 10)
 
-    val meta = OapDataFile(path.toString, schema, configuration).getDataFileMeta()
+    val meta = OapDataFileV1(path.toString, schema, configuration).getDataFileMeta()
     assert(meta.totalRowCount() === 10)
     assert(meta.rowCountInEachGroup === 12345)
     assert(meta.rowCountInLastGroup === 10)
@@ -203,7 +203,7 @@ class FiberSuite extends SharedOapContext with Logging {
     val m = DataSourceMeta.newBuilder().
       withNewSchema(schema).
       withNewDataReaderClassName(OapFileFormat.OAP_DATA_FILE_CLASSNAME).build()
-    val reader = new OapDataReader(path, m, None, requiredIds)
+    val reader = new OapDataScannerV1(path, m, None, requiredIds)
     val it = reader.initialize(configuration)
 
     var idx = 0

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
@@ -202,7 +202,7 @@ class FiberSuite extends SharedOapContext with Logging {
       count: Int): Unit = {
     val m = DataSourceMeta.newBuilder().
       withNewSchema(schema).
-      withNewDataReaderClassName(OapFileFormat.OAP_DATA_FILE_CLASSNAME).build()
+      withNewDataReaderClassName(OapFileFormat.OAP_DATA_FILE_V1_CLASSNAME).build()
     val reader = new OapDataScannerV1(path, m, None, requiredIds)
     val it = reader.initialize(configuration)
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DeltaByteArrayEncoderSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DeltaByteArrayEncoderSuite.scala
@@ -46,8 +46,8 @@ class DeltaByteArrayEncoderCheck extends Properties("DeltaByteArrayEncoder") {
           // to validate.
           val referenceFiberBuilder = StringFiberBuilder(rowCount, 0)
           val fiberBuilder = DeltaByteArrayFiberBuilder(rowCount, 0, StringType)
-          val fiberParser = DeltaByteArrayDataFiberParser(
-            new OapDataFileMeta(rowCountInEachGroup = rowCount), StringType)
+          val fiberParser = DeltaByteArrayDataFiberParserV1(
+            new OapDataFileMetaV1(rowCountInEachGroup = rowCount), StringType)
           !(0 until groupCount).exists { group =>
             // If lastCount > rowCount, assume lastCount = rowCount
             val count = if (group < groupCount - 1) {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DeltaByteArrayEncoderSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DeltaByteArrayEncoderSuite.scala
@@ -20,10 +20,10 @@ package org.apache.spark.sql.execution.datasources.oap.io
 import org.scalacheck.{Gen, Properties}
 import org.scalacheck.Prop.forAll
 import org.scalatest.prop.Checkers
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap.filecache.StringFiberBuilder
+import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DictionaryBasedEncoderSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DictionaryBasedEncoderSuite.scala
@@ -23,10 +23,10 @@ import org.apache.parquet.column.values.dictionary.PlainValuesDictionary.PlainBi
 import org.scalacheck.{Gen, Properties}
 import org.scalacheck.Prop.forAll
 import org.scalatest.prop.Checkers
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap.filecache.StringFiberBuilder
+import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DictionaryBasedEncoderSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DictionaryBasedEncoderSuite.scala
@@ -69,8 +69,8 @@ class DictionaryBasedEncoderCheck extends Properties("DictionaryBasedEncoder") {
                 BytesInput.from(fiberBuilder.buildDictionary),
                 fiberBuilder.getDictionarySize,
                 org.apache.parquet.column.Encoding.PLAIN))
-            val fiberParser = PlainDictionaryFiberParser(
-              new OapDataFileMeta(rowCountInEachGroup = rowCount), dictionary, StringType)
+            val fiberParser = PlainDictionaryFiberParserV1(
+              new OapDataFileMetaV1(rowCountInEachGroup = rowCount), dictionary, StringType)
             val parsedBytes = fiberParser.parse(bytes, count)
             val referenceBytes = referenceFiberBuilder.build().fiberData
             referenceFiberBuilder.clear()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileMetaV1Suite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileMetaV1Suite.scala
@@ -26,8 +26,9 @@ import org.scalacheck._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
 import org.scalatest.prop.Checkers
+
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.execution.datasources.oap.io.meta.{ColumnMetaV1, ColumnStatistics$, OapDataFileMetaV1, RowGroupMetaV1}
+import org.apache.spark.sql.execution.datasources.oap.io.meta.{ColumnMetaV1, ColumnStatistics, OapDataFileMetaV1, RowGroupMetaV1}
 import org.apache.spark.util.Utils
 
 class OapDataFileMetaCheck extends Properties("OapDataFileMeta") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileV1Suite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFileV1Suite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
-class DataFileSuite extends QueryTest with SharedOapContext {
+class OapDataFileV1Suite extends QueryTest with SharedOapContext {
 
   override def beforeEach(): Unit = {
     val path = Utils.createTempDir().getAbsolutePath
@@ -46,7 +46,7 @@ class DataFileSuite extends QueryTest with SharedOapContext {
       df.repartition(1).write.format("oap").save(dir.getAbsolutePath)
       val file = SpecificParquetRecordReaderBase.listDirectory(dir).get(0)
       val datafile =
-        DataFile(file, schema, OapFileFormat.OAP_DATA_FILE_CLASSNAME, config)
+        DataFile(file, schema, OapFileFormat.OAP_DATA_FILE_V1_CLASSNAME, config)
       assert(datafile.path == file)
       assert(datafile.schema == schema)
       assert(datafile.configuration == config)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDeSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDeSuite.scala
@@ -18,12 +18,10 @@
 package org.apache.spark.sql.execution.datasources.oap.utils
 
 import scala.collection.mutable.ArrayBuffer
-
 import org.json4s.jackson.JsonMethods._
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheStatus
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileMetaV1
+import org.apache.spark.sql.execution.datasources.oap.io.meta.OapDataFileMetaV1
 import org.apache.spark.util.collection.BitSet
 
 class CacheStatusSerDeSuite extends SparkFunSuite {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDeSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/CacheStatusSerDeSuite.scala
@@ -23,7 +23,7 @@ import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheStatus
-import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileMeta
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileMetaV1
 import org.apache.spark.util.collection.BitSet
 
 class CacheStatusSerDeSuite extends SparkFunSuite {
@@ -44,7 +44,7 @@ class CacheStatusSerDeSuite extends SparkFunSuite {
   }
 
   test("test data file meta") {
-    val dataFileMeta = new OapDataFileMeta(
+    val dataFileMeta = new OapDataFileMetaV1(
       rowCountInEachGroup = 3, rowCountInLastGroup = 2, groupCount = 3, fieldCount = 3)
     val dataFileMetaStr = compact(render(CacheStatusSerDe.dataFileMetaToJson(dataFileMeta)))
     val newDataFileMeta = CacheStatusSerDe.dataFileMetaFromJson(parse(dataFileMetaStr))
@@ -106,8 +106,8 @@ class CacheStatusSerDeSuite extends SparkFunSuite {
   }
 
   private def assertDataFileMetaEquals(
-                                        dataFileMeta1: OapDataFileMeta,
-                                        dataFileMeta2: OapDataFileMeta) {
+                                        dataFileMeta1: OapDataFileMetaV1,
+                                        dataFileMeta2: OapDataFileMetaV1) {
     assert(dataFileMeta1.rowCountInEachGroup === dataFileMeta2.rowCountInEachGroup)
     assert(dataFileMeta1.rowCountInLastGroup === dataFileMeta2.rowCountInLastGroup)
     assert(dataFileMeta1.groupCount === dataFileMeta2.groupCount)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Split OAP data file reading to 2-level classes: `OapDataReader`(higher level) & `OapDataScanner`
- `OapDataReader` identifies the version of `PartitionedFile`, then use different versions of `OapDataReader` like `OapDataReaderV1`, inside which `OapDataScannerV1` is used. It will follow the meta definition in `OapDataFileMetaV1`.
- Refactor, like extract `OapDataReader`, `OapDataWriter` from `OapDataReaderWriter.scala`


## How was this patch tested?

Existing tests.
