### PR TITLE
[BRANCH-0.3]#764 Fix BloomFilterStatisticsReader#analyse unexpected return SkipFile

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -81,16 +81,20 @@ private[oap] class BloomFilterStatisticsReader(
      *    2.1 interval.start == interval.end (numFields == schema.length) and NOT exist in bfIndex
      *    2.2 interval.start != interval.end (not equal or DUMMY_KEY). Just return false
      */
-    val skipIndex = intervalArray.exists { interval =>
+    val skipIndex = !intervalArray.exists { interval =>
       val numFields = math.min(interval.start.numFields, interval.end.numFields)
       if (schema.length > 1) {
         if (numFields == schema.length && ordering.compare(interval.start, interval.end) == 0) {
-          !bfIndex.checkExist(converter(interval.start).getBytes)
-        } else !bfIndex.checkExist(partialConverter(interval.start).getBytes)
+          bfIndex.checkExist(converter(interval.start).getBytes)
+        } else {
+          bfIndex.checkExist(partialConverter(interval.start).getBytes)
+        }
       } else {
         if (numFields == 1 && ordering.compare(interval.start, interval.end) == 0) {
-          !bfIndex.checkExist(converter(interval.start).getBytes)
-        } else false
+          bfIndex.checkExist(converter(interval.start).getBytes)
+        } else {
+          true
+        }
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. add a new test case `OAP-764 BloomFilterStatisticsReader#analyse unexpected return SkipFile` to produce unexpected return SkipFile
2. change `BloomFilterStatisticsReader#analyse` intervalArray.exists -> intervalArray.forall
## How was this patch tested?
mvn test pass

After this pr `OAP-764 BloomFilterStatisticsReader#analyse unexpected return SkipFile`  test pass.