### PR TITLE
data file should use path to judge if equal

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -46,7 +46,10 @@ abstract class DataFile {
 
   def totalRows(): Long
   override def hashCode(): Int = path.hashCode
-  override def equals(other: Any): Boolean = path.equals(other.asInstanceOf[DataFile].path)
+  override def equals(other: Any): Boolean = other match {
+    case df: DataFile => path.equals(df.path)
+    case _ => false
+  }
 }
 
 private[oap] class OapIterator[T](inner: Iterator[T]) extends Iterator[T] with Closeable {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -45,6 +45,8 @@ abstract class DataFile {
     : OapIterator[InternalRow]
 
   def totalRows(): Long
+  override def hashCode(): Int = path.hashCode
+  override def equals(other: Any): Boolean = path.equals(other.asInstanceOf[DataFile].path)
 }
 
 private[oap] class OapIterator[T](inner: Iterator[T]) extends Iterator[T] with Closeable {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFileSuite.scala
@@ -84,6 +84,7 @@ class DataFileSuite extends QueryTest with SharedOapContext {
       val datafile2 =
         DataFile(file, schema, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, config)
       assert(datafile1.equals(datafile2))
+      assert(datafile1.hashCode() == datafile2.hashCode())
     }
 
     withTempPath { dir =>
@@ -95,6 +96,7 @@ class DataFileSuite extends QueryTest with SharedOapContext {
       val datafile2 =
         DataFile(file, schema, OapFileFormat.OAP_DATA_FILE_CLASSNAME, config)
       assert(datafile1.equals(datafile2))
+      assert(datafile1.hashCode() == datafile2.hashCode())
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFileSuite.scala
@@ -70,4 +70,31 @@ class DataFileSuite extends QueryTest with SharedOapContext {
       assert(DataFile.cachedConstructorCount == 2)
     }
   }
+
+  test("DataFile equals") {
+    val data = (0 to 10).map(i => (i, (i + 'a').toChar.toString))
+    val schema = new StructType()
+    val config = new Configuration()
+    withTempPath { dir =>
+      val df = spark.createDataFrame(data)
+      df.repartition(1).write.parquet(dir.getAbsolutePath)
+      val file = SpecificParquetRecordReaderBase.listDirectory(dir).get(0)
+      val datafile1 =
+        DataFile(file, schema, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, config)
+      val datafile2 =
+        DataFile(file, schema, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, config)
+      assert(datafile1.equals(datafile2))
+    }
+
+    withTempPath { dir =>
+      val df = spark.createDataFrame(data)
+      df.repartition(1).write.format("oap").save(dir.getAbsolutePath)
+      val file = SpecificParquetRecordReaderBase.listDirectory(dir).get(0)
+      val datafile1 =
+        DataFile(file, schema, OapFileFormat.OAP_DATA_FILE_CLASSNAME, config)
+      val datafile2 =
+        DataFile(file, schema, OapFileFormat.OAP_DATA_FILE_CLASSNAME, config)
+      assert(datafile1.equals(datafile2))
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Otherwise the `DataFileMetaCache` will be loaded over and over again.


## How was this patch tested?

manual test.

