### PR TITLE
Get or cache a fiber doesn't need conf

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/Fiber.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/Fiber.scala
@@ -17,16 +17,14 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
-import org.apache.hadoop.conf.Configuration
-
 import org.apache.spark.sql.execution.datasources.oap.io.DataFile
 
 private[oap] trait Fiber {
-  def cache(conf: Configuration): FiberCache
+  def cache(): FiberCache
 }
 
 private[oap] case class DataFiber(file: DataFile, columnIndex: Int, rowGroupId: Int) extends Fiber {
-  override def cache(conf: Configuration): FiberCache =
+  override def cache(): FiberCache =
     file.cache(rowGroupId, columnIndex)
 
   override def hashCode(): Int = (file.path + columnIndex + rowGroupId).hashCode
@@ -49,7 +47,7 @@ private[oap] case class BTreeFiber(
     file: String,
     section: Int,
     idx: Int) extends Fiber {
-  override def cache(conf: Configuration): FiberCache = getFiberData()
+  override def cache(): FiberCache = getFiberData()
 
   override def hashCode(): Int = (file + section + idx).hashCode
 
@@ -73,7 +71,7 @@ private[oap] case class BitmapFiber(
     sectionIdxOfFile: Int,
     // "0" means no smaller loading units.
     loadUnitIdxOfSection: Int) extends Fiber {
-  override def cache(conf: Configuration): FiberCache = getFiberData()
+  override def cache(): FiberCache = getFiberData()
 
   override def hashCode(): Int = (file + sectionIdxOfFile + loadUnitIdxOfSection).hashCode
 
@@ -91,7 +89,7 @@ private[oap] case class BitmapFiber(
 }
 
 private[oap] case class TestFiber(getData: () => FiberCache, name: String) extends Fiber {
-  override def cache(conf: Configuration): FiberCache = getData()
+  override def cache(): FiberCache = getData()
 
   override def hashCode(): Int = name.hashCode()
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import com.google.common.cache._
-import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
@@ -111,9 +110,9 @@ private[sql] class FiberCacheManager(
   // NOTE: all members' init should be placed before this line.
   logDebug(s"Initialized FiberCacheManager")
 
-  def get(fiber: Fiber, conf: Configuration): FiberCache = {
+  def get(fiber: Fiber): FiberCache = {
     logDebug(s"Getting Fiber: $fiber")
-    cacheBackend.get(fiber, conf)
+    cacheBackend.get(fiber)
   }
 
   def releaseIndexCache(indexName: String): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -23,10 +23,10 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.collection.JavaConverters._
 
 import com.google.common.cache._
-import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
+
 
 trait OapCache {
   val dataFiberSize: AtomicLong = new AtomicLong(0)
@@ -34,7 +34,7 @@ trait OapCache {
   val dataFiberCount: AtomicLong = new AtomicLong(0)
   val indexFiberCount: AtomicLong = new AtomicLong(0)
 
-  def get(fiber: Fiber, conf: Configuration): FiberCache
+  def get(fiber: Fiber): FiberCache
   def getIfPresent(fiber: Fiber): FiberCache
   def getFibers: Set[Fiber]
   def invalidate(fiber: Fiber): Unit
@@ -72,8 +72,8 @@ class SimpleOapCache extends OapCache with Logging {
   private val cacheGuardian = new CacheGuardian(Int.MaxValue)
   cacheGuardian.start()
 
-  override def get(fiber: Fiber, conf: Configuration): FiberCache = {
-    val fiberCache = fiber.cache(conf)
+  override def get(fiber: Fiber): FiberCache = {
+    val fiberCache = fiber.cache()
     incFiberCountAndSize(fiber, 1, fiberCache.size())
     fiberCache.occupy()
     // We only use fiber for once, and CacheGuardian will dispose it after release.
@@ -132,11 +132,11 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
    * To avoid storing configuration in each Cache, use a loader.
    * After all, configuration is not a part of Fiber.
    */
-  private def cacheLoader(fiber: Fiber, configuration: Configuration) =
+  private def cacheLoader(fiber: Fiber) =
     new Callable[FiberCache] {
       override def call(): FiberCache = {
         val startLoadingTime = System.currentTimeMillis()
-        val fiberCache = fiber.cache(configuration)
+        val fiberCache = fiber.cache()
         incFiberCountAndSize(fiber, 1, fiberCache.size())
         logDebug("Load missed fiber took %s. Fiber: %s"
           .format(Utils.getUsedTimeMs(startLoadingTime), fiber))
@@ -153,11 +153,11 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
     .concurrencyLevel(CONCURRENCY_LEVEL)
     .build[Fiber, FiberCache]()
 
-  override def get(fiber: Fiber, conf: Configuration): FiberCache = {
+  override def get(fiber: Fiber): FiberCache = {
     val readLock = FiberLockManager.getFiberLock(fiber).readLock()
     readLock.lock()
     try {
-      val fiberCache = cache.get(fiber, cacheLoader(fiber, conf))
+      val fiberCache = cache.get(fiber, cacheLoader(fiber))
       // Avoid loading a fiber larger than MAX_WEIGHT / CONCURRENCY_LEVEL
       assert(fiberCache.size() <= MAX_WEIGHT * KB / CONCURRENCY_LEVEL,
         s"Failed to cache fiber(${Utils.bytesToString(fiberCache.size())}) " +

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -27,7 +27,6 @@ import com.google.common.cache._
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
-
 trait OapCache {
   val dataFiberSize: AtomicLong = new AtomicLong(0)
   val indexFiberSize: AtomicLong = new AtomicLong(0)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
@@ -88,7 +88,7 @@ private[index] abstract class BTreeIndexRecordReader(
     val readFunc =
       () => OapRuntime.getOrCreate.memoryManager.toIndexFiberCache(readData(offset, length))
     val fiber = BTreeFiber(readFunc, fileReader.getName, sectionId, idx)
-    OapRuntime.getOrCreate.fiberCacheManager.get(fiber, configuration)
+    OapRuntime.getOrCreate.fiberCacheManager.get(fiber)
   }
 
   protected def getLongFromBuffer(buffer: Array[Byte], offset: Int): Long =

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.IndexMeta
 import org.apache.spark.sql.execution.datasources.oap.index.OapIndexProperties.IndexVersion
 import org.apache.spark.sql.execution.datasources.oap.index.impl.IndexFileReaderImpl
-import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 import org.apache.spark.sql.execution.datasources.oap.statistics.StatsAnalysisResult
 
 private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(idxMeta) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReader.scala
@@ -67,7 +67,7 @@ private[oap] case class BitmapReader(
     val footerFiber = BitmapFiber(
       () => fileReader.readFiberCache(footerOffset, BITMAP_FOOTER_SIZE),
       fileReader.getName, BitmapIndexSectionId.footerSection, 0)
-    bmFooterCache = fiberCacheManager.get(footerFiber, conf)
+    bmFooterCache = fiberCacheManager.get(footerFiber)
     // Calculate total rows right after footer cache is loaded.
     _totalRows = bmFooterCache.getInt(IndexUtils.INT_SIZE * 7)
 
@@ -156,12 +156,12 @@ private[oap] case class BitmapReader(
     val uniqueKeyListFiber = BitmapFiber(
       () => fileReader.readFiberCache(uniqueKeyListOffset, uniqueKeyListTotalSize),
       fileReader.getName, BitmapIndexSectionId.keyListSection, 0)
-    bmUniqueKeyListCache = fiberCacheManager.get(uniqueKeyListFiber, conf)
+    bmUniqueKeyListCache = fiberCacheManager.get(uniqueKeyListFiber)
 
     val offsetListFiber = BitmapFiber(
       () => fileReader.readFiberCache(offsetListOffset, offsetListTotalSize),
       fileReader.getName, BitmapIndexSectionId.entryOffsetsSection, 0)
-    bmOffsetListCache = fiberCacheManager.get(offsetListFiber, conf)
+    bmOffsetListCache = fiberCacheManager.get(offsetListFiber)
 
     bmNullListFiber = BitmapFiber(
       () => fileReader.readFiberCache(bmNullEntryOffset, bmNullEntrySize),
@@ -191,7 +191,7 @@ private[oap] case class BitmapReader(
     val bmStatsContentFiber = BitmapFiber(
       () => fileReader.readFiberCache(statsOffset.toInt, statsSize.toInt),
       fileReader.getName, BitmapIndexSectionId.statsContentSection, 0)
-    val bmStatsContentCache = fiberCacheManager.get(bmStatsContentFiber, conf)
+    val bmStatsContentCache = fiberCacheManager.get(bmStatsContentFiber)
     val stats = StatisticsManager.read(bmStatsContentCache, 0, keySchema)
     val res = StatisticsManager.analyse(stats, intervalArray, conf)
     bmFooterCache.release

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV1.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV1.scala
@@ -17,19 +17,16 @@
 
 package org.apache.spark.sql.execution.datasources.oap.index
 
-import java.io.DataInput
-import java.io.EOFException
+import java.io.{DataInput, EOFException}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
-import org.roaringbitmap.FastAggregation
-import org.roaringbitmap.RoaringBitmap
+import org.roaringbitmap.{FastAggregation, RoaringBitmap}
 
 import org.apache.spark.sql.execution.datasources.oap.filecache.{BitmapFiber, FiberCache}
 import org.apache.spark.sql.execution.datasources.oap.index.impl.IndexFileReaderImpl
-import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 import org.apache.spark.sql.types.StructType
 
 private[oap] class BitmapReaderV1(
@@ -77,14 +74,14 @@ private[oap] class BitmapReaderV1(
             val entrySize = getIdxOffset(bmOffsetListCache, 0L, idx + 1) - curIdxOffset
             val entryFiber = BitmapFiber(() => fileReader.readFiberCache(curIdxOffset, entrySize),
               fileReader.getName, BitmapIndexSectionId.entryListSection, idx)
-            val entryCache = fiberCacheManager.get(entryFiber, conf)
+            val entryCache = fiberCacheManager.get(entryFiber)
             val entry = getDesiredBitmap(entryCache)
             entryCache.release
             entry
           })
         }
       case range if range.isNullPredicate =>
-        bmNullListCache = fiberCacheManager.get(bmNullListFiber, conf)
+        bmNullListCache = fiberCacheManager.get(bmNullListFiber)
         if (bmNullListCache.size != 0) {
           Seq(getDesiredBitmap(bmNullListCache))
         } else {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV2.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV2.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.execution.datasources.oap.index.impl.IndexFileReader
 import org.apache.spark.sql.execution.datasources.oap.utils.{BitmapUtils, OapBitmapWrappedFiberCache}
 import org.apache.spark.sql.types.StructType
 
-
 private[oap] class BitmapReaderV2(
     fileReader: IndexFileReaderImpl,
     intervalArray: ArrayBuffer[RangeInterval],

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV2.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV2.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.datasources.oap.index
 
 import scala.collection.mutable.ArrayBuffer
-import scala.util.control.Breaks._
 
 import org.apache.hadoop.conf.Configuration
 
@@ -26,6 +25,7 @@ import org.apache.spark.sql.execution.datasources.oap.filecache.BitmapFiber
 import org.apache.spark.sql.execution.datasources.oap.index.impl.IndexFileReaderImpl
 import org.apache.spark.sql.execution.datasources.oap.utils.{BitmapUtils, OapBitmapWrappedFiberCache}
 import org.apache.spark.sql.types.StructType
+
 
 private[oap] class BitmapReaderV2(
     fileReader: IndexFileReaderImpl,
@@ -78,12 +78,12 @@ private[oap] class BitmapReaderV2(
             val entrySize = getIdxOffset(bmOffsetListCache, 0L, idx + 1) - curIdxOffset
             val entryFiber = BitmapFiber(() => fileReader.readFiberCache(curIdxOffset, entrySize),
               fileReader.getName, BitmapIndexSectionId.entryListSection, idx)
-            new OapBitmapWrappedFiberCache(fiberCacheManager.get(entryFiber, conf))
+            new OapBitmapWrappedFiberCache(fiberCacheManager.get(entryFiber))
           })
         }
       case range if range.isNullPredicate =>
         val nullListCache =
-          new OapBitmapWrappedFiberCache(fiberCacheManager.get(bmNullListFiber, conf))
+          new OapBitmapWrappedFiberCache(fiberCacheManager.get(bmNullListFiber))
         if (nullListCache.size != 0) {
           Seq(nullListCache)
         } else {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -158,7 +158,7 @@ private[oap] case class OapDataFile(
       groupId =>
         val fiberCacheGroup = requiredIds.map { id =>
           val fiberCache = OapRuntime.getOrCreate.fiberCacheManager.get(
-            DataFiber(this, id, groupId), conf)
+            DataFiber(this, id, groupId))
           update(id, fiberCache)
           fiberCache
         }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -267,7 +267,7 @@ private[oap] case class ParquetDataFile(
     val groupId = blockMetaData.getRowGroupId
     val fiberCacheGroup = requiredColumnIds.map { id =>
       val fiberCache =
-        OapRuntime.getOrCreate.fiberCacheManager.get(DataFiber(this, id, groupId), conf)
+        OapRuntime.getOrCreate.fiberCacheManager.get(DataFiber(this, id, groupId))
       update(id, fiberCache)
       fiberCache
     }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtilsSuite.scala
@@ -86,7 +86,7 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
     val footerFiber = BitmapFiber(
       () => loadBmSection(fin, footerOffset, BITMAP_FOOTER_SIZE),
       idxPath.toString, BitmapIndexSectionId.footerSection, 0)
-    val footerCache = fiberCacheManager.get(footerFiber, conf)
+    val footerCache = fiberCacheManager.get(footerFiber)
     val uniqueKeyListTotalSize = footerCache.getInt(IndexUtils.INT_SIZE)
     val keyCount = footerCache.getInt(IndexUtils.INT_SIZE * 2)
     val entryListTotalSize = footerCache.getInt(IndexUtils.INT_SIZE * 3)
@@ -97,7 +97,7 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
     val offsetListFiber = BitmapFiber(
       () => loadBmSection(fin, offsetListOffset.toLong, offsetListTotalSize),
       idxPath.toString, BitmapIndexSectionId.entryOffsetsSection, 0)
-    val offsetListCache = fiberCacheManager.get(offsetListFiber, conf)
+    val offsetListCache = fiberCacheManager.get(offsetListFiber)
     (keyCount, offsetListCache, footerCache)
   }
 
@@ -123,7 +123,7 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
               () => loadBmSection(fin, curIdxOffset.toLong, entrySize), idxPath.toString,
             BitmapIndexSectionId.entryListSection, idx)
             val wrappedFiberCacheSeq =
-              Seq(new OapBitmapWrappedFiberCache(fiberCacheManager.get(entryFiber, conf)))
+              Seq(new OapBitmapWrappedFiberCache(fiberCacheManager.get(entryFiber)))
             BitmapUtils.iterator(wrappedFiberCacheSeq).foreach(rowId => {
               actualRowIdSeq :+= rowId + accumulatorRowId
               if (maxRowIdInPartition < rowId) maxRowIdInPartition = rowId
@@ -164,7 +164,7 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
             val entryFiber = BitmapFiber(
               () => loadBmSection(fin, curIdxOffset.toLong, entrySize), idxPath.toString,
               BitmapIndexSectionId.entryListSection, idx)
-            new OapBitmapWrappedFiberCache(fiberCacheManager.get(entryFiber, conf))
+            new OapBitmapWrappedFiberCache(fiberCacheManager.get(entryFiber))
           })
           BitmapUtils.iterator(wrappedFiberCacheSeq).foreach(rowId => {
             actualRowIdSeq :+= rowId + accumulatorRowId

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
@@ -17,18 +17,17 @@
 
 package org.apache.spark.sql.execution.datasources.oap.utils
 
-import java.io.{ByteArrayOutputStream, DataOutputStream, File, FileOutputStream}
+import java.io.{ByteArrayOutputStream, DataOutputStream, FileOutputStream}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
-import org.roaringbitmap.RoaringBitmap
-
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.filecache.{BitmapFiber, FiberCache}
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.util.Utils
+import org.roaringbitmap.RoaringBitmap
 
 // Below are used to test the functionality of OapBitmapWrappedFiberCache class.
 class OapBitmapWrappedFiberCacheSuite
@@ -66,7 +65,7 @@ class OapBitmapWrappedFiberCacheSuite
       val rbFileSize = rbPath.getFileSystem(conf).getFileStatus(rbPath).getLen
       val rbFiber = BitmapFiber(() => loadRbFile(fin, 0L, rbFileSize.toInt), rbPath.toString, 0, 0)
       val rbWfc = new OapBitmapWrappedFiberCache(
-        OapRuntime.getOrCreate.fiberCacheManager.get(rbFiber, conf))
+        OapRuntime.getOrCreate.fiberCacheManager.get(rbFiber))
       rbWfc.init
       val chunkLength = rbWfc.getTotalChunkLength
       val length = dataIdx.size / CHUNK_SIZE

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
@@ -21,13 +21,14 @@ import java.io.{ByteArrayOutputStream, DataOutputStream, FileOutputStream}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
+import org.roaringbitmap.RoaringBitmap
+
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.datasources.OapException
 import org.apache.spark.sql.execution.datasources.oap.filecache.{BitmapFiber, FiberCache}
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.util.Utils
-import org.roaringbitmap.RoaringBitmap
 
 // Below are used to test the functionality of OapBitmapWrappedFiberCache class.
 class OapBitmapWrappedFiberCacheSuite


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified corresponding `FiberCacheManager.get` and `Fiber.cache` functions' signature, removed `conf`.

## How was this patch tested?

Existing tests.
