### PR TITLE
Set Minimum Sample Statistics Size

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -81,9 +81,11 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
   lazy val sampleRate: Double = conf.getDouble(
     OapConf.OAP_STATISTICS_SAMPLE_RATE.key, OapConf.OAP_STATISTICS_SAMPLE_RATE.defaultValue.get)
 
-  protected var sampleArray: Array[Key] = _
+  private val minSampleSize = conf.getInt(
+    OapConf.OAP_STATISTICS_SAMPLE_MIN_SIZE.key,
+    OapConf.OAP_STATISTICS_SAMPLE_MIN_SIZE.defaultValue.get)
 
-  private val minSampleSize = 24
+  protected var sampleArray: Array[Key] = _
 
   // SampleBasedStatistics file structure
   // statistics_id        4 Bytes, Int, specify the [[Statistic]] type

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -96,7 +96,8 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
   // | unsafeRow-(sample_size) sizeInBytes | unsafeRow-(sample_size) content |
   override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
     var offset = super.write(writer, sortedKeys)
-    val size = math.max((sortedKeys.size * sampleRate).toInt, minSampleSize)
+    val size = math.max(
+      (sortedKeys.size * sampleRate).toInt, math.min(minSampleSize, sortedKeys.size))
     sampleArray = takeSample(sortedKeys, size)
 
     IndexUtils.writeInt(writer, size)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -83,6 +83,8 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
 
   protected var sampleArray: Array[Key] = _
 
+  private val minSampleSize = 24
+
   // SampleBasedStatistics file structure
   // statistics_id        4 Bytes, Int, specify the [[Statistic]] type
   // sample_size          4 Bytes, Int, number of UnsafeRow
@@ -94,7 +96,7 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
   // | unsafeRow-(sample_size) sizeInBytes | unsafeRow-(sample_size) content |
   override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
     var offset = super.write(writer, sortedKeys)
-    val size = (sortedKeys.size * sampleRate).toInt
+    val size = math.max((sortedKeys.size * sampleRate).toInt, minSampleSize)
     sampleArray = takeSample(sortedKeys, size)
 
     IndexUtils.writeInt(writer, size)

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -74,6 +74,13 @@ object OapConf {
       .doubleConf
       .createWithDefault(0.05)
 
+  val OAP_STATISTICS_SAMPLE_MIN_SIZE =
+    SQLConfigBuilder("spark.sql.oap.statistics.sampleMinSize")
+      .internal()
+      .doc("Minimum sample size for Sample Statistics, default value 24")
+      .intConf
+      .createWithDefault(24)
+
   val OAP_BLOOMFILTER_MAXBITS =
     SQLConfigBuilder("spark.sql.oap.statistics.bloom.maxBits")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #525 - MetricsSuite random failure issue.
Use a minimum sample size if data set is too small.

## How was this patch tested?

Unit test pass.
Without this PR 100 cycles stress test has 4 failures.
With this PR 100 cycles stress test has no failure.

