### PR TITLE
[Do Not Merge]Using the BitmapReaderV2 by default

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapScanner.scala
@@ -48,7 +48,7 @@ private[oap] case class BitMapScanner(idxMeta: IndexMeta) extends IndexScanner(i
       case Some(version) =>
         IndexVersion(version) match {
           case IndexVersion.OAP_INDEX_V1 =>
-            val reader = new BitmapReaderV1(
+            val reader = new BitmapReaderV2(
               fileReader, intervalArray, internalLimit, keySchema, conf)
             reader.initRowIdIterator
             bmRowIdIterator = reader


### PR DESCRIPTION
This is for internal benchmark tests.

## What changes were proposed in this pull request?

Using BitmapReaderV2 by default.

## How was this patch tested?

mvn clean test package and all tests passed.
