### PR TITLE
Reduce 1 nested loop, unecessary CompletionIterator

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -52,8 +52,17 @@ abstract class DataFile {
   }
 }
 
+// An Iterator automatically calling close() after iterations of all items
 private[oap] class OapIterator[T](inner: Iterator[T]) extends Iterator[T] with Closeable {
-  override def hasNext: Boolean = inner.hasNext
+  private[this] var completed = false
+  override def hasNext: Boolean = {
+    val r = inner.hasNext
+    if (!r && !completed) {
+      completed = true
+      close()
+    }
+    r
+  }
   override def next(): T = inner.next()
   override def close(): Unit = {}
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -40,9 +40,10 @@ abstract class DataFile {
 
   def getDataFileMeta(): DataFileMeta
   def cache(groupId: Int, fiberId: Int): FiberCache
-  def iterator(requiredIds: Array[Int], filters: Seq[Filter] = Nil): OapIterator[InternalRow]
+  def iterator(requiredIds: Array[Int], filters: Seq[Filter] = Nil)
+    : OapCompletionIterator[InternalRow]
   def iteratorWithRowIds(requiredIds: Array[Int], rowIds: Array[Int], filters: Seq[Filter] = Nil)
-    : OapIterator[InternalRow]
+    : OapCompletionIterator[InternalRow]
 
   def totalRows(): Long
   override def hashCode(): Int = path.hashCode
@@ -53,9 +54,11 @@ abstract class DataFile {
 }
 
 // An OAP wrapped iterator calling completionFunction() automatically after iterations of all items
-// Also, it contains a close interface to do cleaning even if tasks fail
-private[oap] class OapIterator[T](inner: Iterator[T], completionFunction: => Unit = {}) extends
-    Iterator[T] with Closeable {
+// Also, it contains a close interface to do cleaning(extra listener is needed) if tasks fail
+// Note that completionFunction & close are slightly different, the latter one contains something
+// you do not wish to clean immediately after the iteration
+private[oap] class OapCompletionIterator[T](inner: Iterator[T], completionFunction: => Unit)
+    extends Iterator[T] with Closeable {
 
   private[this] var completed = false
   override def hasNext: Boolean = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -52,14 +52,17 @@ abstract class DataFile {
   }
 }
 
-// An Iterator automatically calling close() after iterations of all items
-private[oap] class OapIterator[T](inner: Iterator[T]) extends Iterator[T] with Closeable {
+// An OAP wrapped iterator calling completionFunction() automatically after iterations of all items
+// Also, it contains a close interface to do cleaning even if tasks fail
+private[oap] class OapIterator[T](inner: Iterator[T], completionFunction: => Unit = {}) extends
+    Iterator[T] with Closeable {
+
   private[this] var completed = false
   override def hasNext: Boolean = {
     val r = inner.hasNext
     if (!r && !completed) {
       completed = true
-      close()
+      completionFunction
     }
     r
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -176,7 +176,7 @@ private[oap] case class OapDataFile(
           case None => rows.toIterator
         }
     }
-    new OapIterator[InternalRow](iterator) {
+    new OapIterator[InternalRow](iterator, inUseFiberCache.indices.foreach(release)) {
       override def close(): Unit = {
         // To ensure if any exception happens, caches are still released after calling close()
         inUseFiberCache.indices.foreach(release)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -31,8 +31,6 @@ import org.apache.spark.sql.execution.datasources.oap.filecache._
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
-import org.apache.spark.util.CompletionIterator
-
 
 private[oap] case class OapDataFile(
     path: String,
@@ -172,12 +170,11 @@ private[oap] case class OapDataFile(
           if (groupId < meta.groupCount - 1) meta.rowCountInEachGroup else meta.rowCountInLastGroup
         rows.reset(rowCount, columns)
 
-        val iter = groupIdToRowIds match {
+        groupIdToRowIds match {
           case Some(map) =>
             map(groupId).iterator.map(rowId => rows.moveToRow(rowId % meta.rowCountInEachGroup))
           case None => rows.toIterator
         }
-        CompletionIterator[InternalRow, Iterator[InternalRow]](iter, requiredIds.foreach(release))
     }
     new OapIterator[InternalRow](iterator) {
       override def close(): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -142,7 +142,7 @@ private[oap] case class OapDataFile(
       conf: Configuration,
       requiredIds: Array[Int],
       rowIds: Option[Array[Int]],
-      filters: Seq[Filter]): OapIterator[InternalRow] = {
+      filters: Seq[Filter]): OapCompletionIterator[InternalRow] = {
     val rows = new BatchColumn()
     val groupIdToRowIds = rowIds.map(_.groupBy(rowId => rowId / meta.rowCountInEachGroup))
     val groupIds = groupIdToRowIds.map(_.keys).getOrElse(0 until meta.groupCount)
@@ -176,7 +176,7 @@ private[oap] case class OapDataFile(
           case None => rows.toIterator
         }
     }
-    new OapIterator[InternalRow](iterator, inUseFiberCache.indices.foreach(release)) {
+    new OapCompletionIterator[InternalRow](iterator, inUseFiberCache.indices.foreach(release)) {
       override def close(): Unit = {
         // To ensure if any exception happens, caches are still released after calling close()
         inUseFiberCache.indices.foreach(release)
@@ -186,7 +186,8 @@ private[oap] case class OapDataFile(
   }
 
   // full file scan
-  def iterator(requiredIds: Array[Int], filters: Seq[Filter] = Nil): OapIterator[InternalRow] = {
+  def iterator(requiredIds: Array[Int], filters: Seq[Filter] = Nil)
+    : OapCompletionIterator[InternalRow] = {
     buildIterator(configuration, requiredIds, rowIds = None, filters)
   }
 
@@ -194,7 +195,7 @@ private[oap] case class OapDataFile(
   def iteratorWithRowIds(
       requiredIds: Array[Int],
       rowIds: Array[Int],
-      filters: Seq[Filter] = Nil): OapIterator[InternalRow] = {
+      filters: Seq[Filter] = Nil): OapCompletionIterator[InternalRow] = {
     buildIterator(configuration, requiredIds, Some(rowIds), filters)
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -209,7 +209,7 @@ private[oap] class OapDataReader(
   def initialize(
       conf: Configuration,
       options: Map[String, String] = Map.empty,
-      filters: Seq[Filter] = Nil): OapIterator[InternalRow] = {
+      filters: Seq[Filter] = Nil): OapCompletionIterator[InternalRow] = {
     logDebug("Initializing OapDataReader...")
     // TODO how to save the additional FS operation to get the Split size
     val fileScanner = DataFile(pathStr, meta.schema, meta.dataReaderClassName, conf)
@@ -217,7 +217,7 @@ private[oap] class OapDataReader(
       fileScanner.asInstanceOf[ParquetDataFile].setVectorizedContext(context)
     }
 
-    def fullScan: OapIterator[InternalRow] = {
+    def fullScan: OapCompletionIterator[InternalRow] = {
       val start = if (log.isDebugEnabled) System.currentTimeMillis else 0
       val iter = fileScanner.iterator(requiredIds, filters)
       val end = if (log.isDebugEnabled) System.currentTimeMillis else 0

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -149,12 +149,12 @@ private[oap] case class ParquetDataFile(
   private def buildIterator(
        conf: Configuration,
        requiredColumnIds: Array[Int],
-       rowIds: Option[Array[Int]]): OapIterator[InternalRow] = {
+       rowIds: Option[Array[Int]]): OapCompletionIterator[InternalRow] = {
     val iterator = rowIds match {
       case Some(ids) => buildIndexedIterator(conf, requiredColumnIds, ids)
       case None => buildFullScanIterator(conf, requiredColumnIds)
     }
-    new OapIterator[InternalRow](iterator, requiredColumnIds.foreach(release)) {
+    new OapCompletionIterator[InternalRow](iterator, requiredColumnIds.foreach(release)) {
       override def close(): Unit = {
         // To ensure if any exception happens, caches are still released after calling close()
         inUseFiberCache.indices.foreach(release)
@@ -162,7 +162,8 @@ private[oap] case class ParquetDataFile(
     }
   }
 
-  def iterator(requiredIds: Array[Int], filters: Seq[Filter] = Nil): OapIterator[InternalRow] = {
+  def iterator(requiredIds: Array[Int], filters: Seq[Filter] = Nil)
+    : OapCompletionIterator[InternalRow] = {
     addRequestSchemaToConf(configuration, requiredIds)
     context match {
       case Some(c) =>
@@ -186,9 +187,9 @@ private[oap] case class ParquetDataFile(
   def iteratorWithRowIds(
       requiredIds: Array[Int],
       rowIds: Array[Int],
-      filters: Seq[Filter] = Nil): OapIterator[InternalRow] = {
+      filters: Seq[Filter] = Nil): OapCompletionIterator[InternalRow] = {
     if (rowIds == null || rowIds.length == 0) {
-      new OapIterator(Iterator.empty)
+      new OapCompletionIterator(Iterator.empty, {})
     } else {
       addRequestSchemaToConf(configuration, requiredIds)
       context match {
@@ -214,7 +215,7 @@ private[oap] case class ParquetDataFile(
   private def initRecordReader(reader: RecordReader[UnsafeRow]) = {
     reader.initialize()
     val iterator = new FileRecordReaderIterator[UnsafeRow](reader)
-    new OapIterator[InternalRow](iterator) {
+    new OapCompletionIterator[InternalRow](iterator, {}) {
       override def close(): Unit = iterator.close()
     }
   }
@@ -226,7 +227,7 @@ private[oap] case class ParquetDataFile(
       reader.enableReturningBatches()
     }
     val iterator = new FileRecordReaderIterator(reader)
-    new OapIterator[InternalRow](iterator.asInstanceOf[Iterator[InternalRow]]) {
+    new OapCompletionIterator[InternalRow](iterator.asInstanceOf[Iterator[InternalRow]], {}) {
       override def close(): Unit = iterator.close()
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -154,7 +154,7 @@ private[oap] case class ParquetDataFile(
       case Some(ids) => buildIndexedIterator(conf, requiredColumnIds, ids)
       case None => buildFullScanIterator(conf, requiredColumnIds)
     }
-    new OapIterator[InternalRow](iterator) {
+    new OapIterator[InternalRow](iterator, requiredColumnIds.foreach(release)) {
       override def close(): Unit = {
         // To ensure if any exception happens, caches are still released after calling close()
         inUseFiberCache.indices.foreach(release)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
-import org.apache.spark.util.CompletionIterator
 
 /**
  * ParquetDataFile use xxRecordReader read Parquet Data File,
@@ -239,9 +238,7 @@ private[oap] case class ParquetDataFile(
     footer.getBlocks.asScala.iterator.flatMap { rowGroupMeta =>
       val orderedBlockMetaData = rowGroupMeta.asInstanceOf[OrderedBlockMetaData]
       val rows = buildBatchColumnFromCache(orderedBlockMetaData, conf, requiredColumnIds)
-      val iter = rows.toIterator
-      CompletionIterator[InternalRow, Iterator[InternalRow]](
-        iter, requiredColumnIds.foreach(release))
+      rows.toIterator
     }
   }
 
@@ -253,10 +250,7 @@ private[oap] case class ParquetDataFile(
     footer.getBlocks.asScala.iterator.flatMap { rowGroupMeta =>
       val indexedBlockMetaData = rowGroupMeta.asInstanceOf[IndexedBlockMetaData]
       val rows = buildBatchColumnFromCache(indexedBlockMetaData, conf, requiredColumnIds)
-      val iter = indexedBlockMetaData.getNeedRowIds.iterator.
-        asScala.map(rowId => rows.moveToRow(rowId))
-      CompletionIterator[InternalRow, Iterator[InternalRow]](
-        iter, requiredColumnIds.foreach(release))
+      indexedBlockMetaData.getNeedRowIds.iterator.asScala.map(rowId => rows.moveToRow(rowId))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`inUseFiberCache` array is released whenever necessary: 
- In `update`
- In `close` of `OapIterator`

Accordingly, no need an extra nested CompletionIterator

## How was this patch tested?

N/A

