### PR TITLE
fix the issue of #772 (Can't acquire memory from spark Memory Manager)

### DIFF
--- a/src/main/scala/org/apache/spark/sql/oap/OapRuntime.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/OapRuntime.scala
@@ -131,11 +131,13 @@ object OapRuntime {
   // OapRuntime always ready, since Oap can take a lot of memory. By manually call stop(),
   // user can delete every instance of OAP, use stock spark without restart cluster.
   // Now we rely on SparkEnv to call stop() for us.
-  def init(sparkEnv: SparkEnv): OapRuntime = {
-    rt = if (isDriver(sparkEnv.conf)) {
-      new OapDriverRuntime(sparkEnv)
-    } else {
-      new OapExecutorRuntime(sparkEnv)
+  def init(sparkEnv: SparkEnv): OapRuntime = synchronized {
+    if (rt == null) {
+      rt = if (isDriver(sparkEnv.conf)) {
+        new OapDriverRuntime(sparkEnv)
+      } else {
+        new OapExecutorRuntime(sparkEnv)
+      }
     }
     rt
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The init method should be synchronized and the OapRuntime object is created only when the rt is null to make sure the OapRuntime object be created only one time.



## How was this patch tested?
N/A

