### PR TITLE
Improving CacheGuardian to free evicted fibers as soon as possible

### DIFF
--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/io/FiberCacheSerDe.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/io/FiberCacheSerDe.java
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.oap.io;
 
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache;
+import org.apache.spark.unsafe.memory.MemoryBlock;
 
 /**
  * Define two interfaces for ColumnVector.
@@ -26,7 +26,7 @@ public interface FiberCacheSerDe {
    * Pass data bytes to external components.
    * @return FiberCache which is an alias of MemoryBlock.
    */
-  FiberCache dumpBytesToCache();
+  MemoryBlock dumpBytesToCache();
 
   /**
    * Pass data bytes to external components.

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -28,8 +28,7 @@ import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.memory.MemoryBlock
 import org.apache.spark.unsafe.types.UTF8String
 
-// TODO: make it an alias of MemoryBlock
-case class FiberCache(var fiberId: FiberId, protected val fiberData: MemoryBlock) extends Logging {
+case class FiberCache(val fiberId: FiberId, protected val fiberData: MemoryBlock) extends Logging {
 
   // We use readLock to lock occupy. _refCount need be atomic to make sure thread-safe
   protected val _refCount = new AtomicLong(0)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -43,8 +43,8 @@ case class FiberCache(protected val fiberData: MemoryBlock) extends Logging {
 
   def getFiber(): Fiber = _fiber
 
-  def setFiber(fb: Fiber): Unit =
-    _fiber = fb
+  def setFiber(fiber: Fiber): Unit =
+    _fiber = fiber
 
   def occupy(): Unit = {
     _refCount.incrementAndGet()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -31,12 +31,6 @@ import org.apache.spark.unsafe.types.UTF8String
 // TODO: make it an alias of MemoryBlock
 case class FiberCache(var fiberId: FiberId, protected val fiberData: MemoryBlock) extends Logging {
 
-  // This is and only is set in `cache() of OapCache`
-  // TODO: make it immutable
-  var fiberId: FiberId = _
-
-  val DISPOSE_TIMEOUT = 3000
-
   // We use readLock to lock occupy. _refCount need be atomic to make sure thread-safe
   protected val _refCount = new AtomicLong(0)
   def refCount: Long = _refCount.get()
@@ -52,7 +46,7 @@ case class FiberCache(var fiberId: FiberId, protected val fiberData: MemoryBlock
     assert(refCount > 0, "release a non-used fiber")
     _refCount.decrementAndGet()
     if (refCount == 0 && fiberData != null &&
-      OapRuntime.getOrCreate.fiberCacheManager.removeFromEvictedQueue(fiber, this)) {
+      OapRuntime.getOrCreate.fiberCacheManager.removeFromEvictedQueue(fiberId, this)) {
       realDispose()
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -43,10 +43,10 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Logging {
 
   private val _pendingFiberSize: AtomicLong = new AtomicLong(0)
 
-  private val removalPendingQueue = new LinkedBlockingQueue[(FiberId, FiberCache)]()
+  private val evictedQueue = new LinkedBlockingQueue[(FiberId, FiberCache)]()
 
-  def removeFromEvictedQueue(fiber: Fiber, fiberCache: FiberCache): Boolean = {
-    if (evictedQueue.remove((fiber, fiberCache))) {
+  def removeFromEvictedQueue(fiberId: FiberId, fiberCache: FiberCache): Boolean = {
+    if (evictedQueue.remove((fiberId, fiberCache))) {
       _pendingFiberSize.addAndGet(-fiberCache.size())
       true
     } else {
@@ -61,18 +61,18 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Logging {
   // After the fiber is evicted by the guava cache manager, this evicted fiber will not
   // be gotten by other users to increase the reference count.
   // If the last user releases the fiber when it's evicted, we will free the memory accordingly.
-  def addEvictedFiberToEvictedQueue(fiber: Fiber, fiberCache: FiberCache): Unit = {
+  def addEvictedFiberToEvictedQueue(fiberId: FiberId, fiberCache: FiberCache): Unit = {
     if (fiberCache != null && fiberCache.refCount == 0) {
       fiberCache.realDispose()
     } else {
       _pendingFiberSize.addAndGet(fiberCache.size())
-      evictedQueue.offer((fiber, fiberCache))
+      evictedQueue.offer((fiberId, fiberCache))
       // The last user thread checks that the fiber is not in the queue just before the another
       // user thread evicts this same fiber and is trying to put it in the queue.
       // Below is the last minute check after putting in the queue in order to resolve the above
       // corner case.
       // Even if not the above case, the remove is synchronized and won't impact the correctness.
-      if (fiberCache.refCount == 0 && evictedQueue.remove((fiber, fiberCache))) {
+      if (fiberCache.refCount == 0 && evictedQueue.remove((fiberId, fiberCache))) {
         _pendingFiberSize.addAndGet(-fiberCache.size())
       }
       if (_pendingFiberSize.get() > maxMemory) {
@@ -108,13 +108,13 @@ private[sql] class FiberCacheManager(
   // NOTE: all members' init should be placed before this line.
   logDebug(s"Initialized FiberCacheManager")
 
-  def get(fiber: FiberId): FiberCache = {
-    logDebug(s"Getting Fiber: $fiber")
-    cacheBackend.get(fiber)
+  def get(fiberId: FiberId): FiberCache = {
+    logDebug(s"Getting Fiber: $fiberId")
+    cacheBackend.get(fiberId)
   }
 
-  def removeFromEvictedQueue(fiber: Fiber, fiberCache: FiberCache): Boolean =
-    cacheBackend.removeFromEvictedQueue(fiber, fiberCache)
+  def removeFromEvictedQueue(fiberId: FiberId, fiberCache: FiberCache): Boolean =
+    cacheBackend.removeFromEvictedQueue(fiberId, fiberCache)
 
   def releaseIndexCache(indexName: String): Unit = {
     logDebug(s"Going to remove all index cache of $indexName")
@@ -128,9 +128,9 @@ private[sql] class FiberCacheManager(
   }
 
   // Used by test suite
-  private[filecache] def releaseFiber(fiber: TestFiberId): Unit = {
-    if (cacheBackend.getIfPresent(fiber) != null) {
-      cacheBackend.invalidate(fiber)
+  private[filecache] def releaseFiber(fiberId: TestFiberId): Unit = {
+    if (cacheBackend.getIfPresent(fiberId) != null) {
+      cacheBackend.invalidate(fiberId)
     }
   }
 
@@ -221,17 +221,17 @@ private[sql] class DataFileMetaCacheManager extends Logging {
 
 private[sql] class FiberLockManager {
   private val lockMap = new ConcurrentHashMap[FiberId, ReentrantReadWriteLock]()
-  def getFiberLock(fiber: FiberId): ReentrantReadWriteLock = {
-    var lock = lockMap.get(fiber)
+  def getFiberLock(fiberId: FiberId): ReentrantReadWriteLock = {
+    var lock = lockMap.get(fiberId)
     if (lock == null) {
       val newLock = new ReentrantReadWriteLock()
-      val prevLock = lockMap.putIfAbsent(fiber, newLock)
+      val prevLock = lockMap.putIfAbsent(fiberId, newLock)
       lock = if (prevLock == null) newLock else prevLock
     }
     lock
   }
 
-  def removeFiberLock(fiber: FiberId): Unit = {
-    lockMap.remove(fiber)
+  def removeFiberLock(fiberId: FiberId): Unit = {
+    lockMap.remove(fiberId)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
 import org.apache.spark.sql.execution.datasources.oap.io.DataFile
+import org.apache.spark.unsafe.memory.MemoryBlock
 
 private[oap] abstract class FiberId {}
 
@@ -40,7 +41,7 @@ private[oap] case class DataFiberId(file: DataFile, columnIndex: Int, rowGroupId
 }
 
 private[oap] case class BTreeFiberId(
-    getFiberData: () => FiberCache,
+    getFiberData: () => MemoryBlock,
     file: String,
     section: Int,
     idx: Int) extends FiberId {
@@ -61,7 +62,7 @@ private[oap] case class BTreeFiberId(
 }
 
 private[oap] case class BitmapFiberId(
-    getFiberData: () => FiberCache,
+    getFiberData: () => MemoryBlock,
     file: String,
     // "0" means no split sections within file.
     sectionIdxOfFile: Int,
@@ -83,7 +84,7 @@ private[oap] case class BitmapFiberId(
   }
 }
 
-private[oap] case class TestFiberId(getData: () => FiberCache, name: String) extends FiberId {
+private[oap] case class TestFiberId(getData: () => MemoryBlock, name: String) extends FiberId {
 
   override def hashCode(): Int = name.hashCode()
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -81,24 +81,24 @@ private[sql] class MemoryManager(sparkEnv: SparkEnv) extends Logging {
   }
 
   // Used by IndexFile
-  def toIndexFiberCache(in: FSDataInputStream, position: Long, length: Int): FiberCache = {
+  def toIndexMemoryBlock(in: FSDataInputStream, position: Long, length: Int): MemoryBlock = {
     val bytes = new Array[Byte](length)
     in.readFully(position, bytes)
-    toFiberCache(bytes)
+    toMemoryBlock(bytes)
   }
 
   // Used by IndexFile. For decompressed data
-  def toIndexFiberCache(bytes: Array[Byte]): FiberCache = {
-    toFiberCache(bytes)
+  def toIndexMemoryBlock(bytes: Array[Byte]): MemoryBlock = {
+    toMemoryBlock(bytes)
   }
 
   // Used by OapDataFile since we need to parse the raw data in on-heap memory before put it into
   // off-heap memory
-  def toDataFiberCache(bytes: Array[Byte]): FiberCache = {
-    toFiberCache(bytes)
+  def toDataMemoryBlock(bytes: Array[Byte]): MemoryBlock = {
+    toMemoryBlock(bytes)
   }
 
-  private def toFiberCache(bytes: Array[Byte]): FiberCache = {
+  private def toMemoryBlock(bytes: Array[Byte]): MemoryBlock = {
     val memoryBlock = allocate(bytes.length)
     Platform.copyMemory(
       bytes,
@@ -106,18 +106,10 @@ private[sql] class MemoryManager(sparkEnv: SparkEnv) extends Logging {
       memoryBlock.getBaseObject,
       memoryBlock.getBaseOffset,
       bytes.length)
-    // Here is just allocating off heap memory for each fiber.
-    // Next at cache manager loader which is the entry point for users to get each fiber cache,
-    // it will first assign the specific fiber to each fiber cache.
-    // TODO: Change the process and data structure from fiber to fiber cache so that we can know
-    // the specific fiber here.
-    FiberCache(null, memoryBlock)
+    memoryBlock
   }
 
-  def getEmptyDataFiberCache(length: Long): FiberCache = {
-    val memoryBlock = allocate(length)
-    FiberCache(null, memoryBlock)
-  }
+  def getEmptyDataMemoryBlock(length: Long): MemoryBlock = allocate(length)
 
   def stop(): Unit = {
     memoryManager.releaseStorageMemory(oapMemory, MemoryMode.OFF_HEAP)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -106,12 +106,17 @@ private[sql] class MemoryManager(sparkEnv: SparkEnv) extends Logging {
       memoryBlock.getBaseObject,
       memoryBlock.getBaseOffset,
       bytes.length)
-    FiberCache(memoryBlock)
+    // Here is just allocating off heap memory for each fiber.
+    // Next at cache manager loader which is the entry point for users to get each fiber cache,
+    // it will first assign the specific fiber to each fiber cache.
+    // TODO: Change the process and data structure from fiber to fiber cache so that we can know
+    // the specific fiber here.
+    FiberCache(null, memoryBlock)
   }
 
   def getEmptyDataFiberCache(length: Long): FiberCache = {
     val memoryBlock = allocate(length)
-    FiberCache(memoryBlock)
+    FiberCache(null, memoryBlock)
   }
 
   def stop(): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -87,7 +87,7 @@ class SimpleOapCache extends OapCache with Logging {
 
   override def get(fiberId: FiberId): FiberCache = {
     val fiberCache = cache(fiberId)
-    fiberCache.setFiber(fiber)
+    fiberCache.fiberId = fiberId
     incFiberCountAndSize(fiberId, 1, fiberCache.size())
     fiberCache.occupy()
     // We only use fiber for once, and CacheGuardian will dispose it after release.
@@ -154,7 +154,7 @@ class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long) extends OapCac
       override def load(key: FiberId): FiberCache = {
         val startLoadingTime = System.currentTimeMillis()
         val fiberCache = cache(key)
-        fiberCache.setFiber(key)
+        fiberCache.fiberId = key
         incFiberCountAndSize(key, 1, fiberCache.size())
         logDebug(
           "Load missed fiber took %s. Fiber: %s".format(Utils.getUsedTimeMs(startLoadingTime), key))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReader.scala
@@ -85,7 +85,7 @@ private[index] abstract class BTreeIndexRecordReader(
       offset: Long, length: Int, sectionId: Int, idx: Int): FiberCache = {
 
     val readFunc =
-      () => OapRuntime.getOrCreate.memoryManager.toIndexFiberCache(readData(offset, length))
+      () => OapRuntime.getOrCreate.memoryManager.toIndexMemoryBlock(readData(offset, length))
     val fiber = BTreeFiberId(readFunc, fileReader.getName, sectionId, idx)
     OapRuntime.getOrCreate.fiberCacheManager.get(fiber)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReader.scala
@@ -65,7 +65,7 @@ private[oap] case class BitmapReader(
   private def getFooterCache(): Unit = {
     val footerOffset = fileReader.getLen.toInt - BITMAP_FOOTER_SIZE
     val footerFiber = BitmapFiberId(
-      () => fileReader.readFiberCache(footerOffset, BITMAP_FOOTER_SIZE),
+      () => fileReader.readMemoryBlock(footerOffset, BITMAP_FOOTER_SIZE),
       fileReader.getName, BitmapIndexSectionId.footerSection, 0)
     bmFooterCache = fiberCacheManager.get(footerFiber)
     // Calculate total rows right after footer cache is loaded.
@@ -154,17 +154,17 @@ private[oap] case class BitmapReader(
     val offsetListOffset = entryListOffset + entryListTotalSize + bmNullEntrySize
 
     val uniqueKeyListFiber = BitmapFiberId(
-      () => fileReader.readFiberCache(uniqueKeyListOffset, uniqueKeyListTotalSize),
+      () => fileReader.readMemoryBlock(uniqueKeyListOffset, uniqueKeyListTotalSize),
       fileReader.getName, BitmapIndexSectionId.keyListSection, 0)
     bmUniqueKeyListCache = fiberCacheManager.get(uniqueKeyListFiber)
 
     val offsetListFiber = BitmapFiberId(
-      () => fileReader.readFiberCache(offsetListOffset, offsetListTotalSize),
+      () => fileReader.readMemoryBlock(offsetListOffset, offsetListTotalSize),
       fileReader.getName, BitmapIndexSectionId.entryOffsetsSection, 0)
     bmOffsetListCache = fiberCacheManager.get(offsetListFiber)
 
     bmNullListFiber = BitmapFiberId(
-      () => fileReader.readFiberCache(bmNullEntryOffset, bmNullEntrySize),
+      () => fileReader.readMemoryBlock(bmNullEntryOffset, bmNullEntrySize),
       fileReader.getName, BitmapIndexSectionId.entryNullSection, 0)
   }
 
@@ -189,7 +189,7 @@ private[oap] case class BitmapReader(
     val statsOffset = bmFooterCache.getLong(BITMAP_FOOTER_SIZE - IndexUtils.LONG_SIZE * 2)
     val statsSize = bmFooterCache.getLong(BITMAP_FOOTER_SIZE - IndexUtils.LONG_SIZE)
     val bmStatsContentFiber = BitmapFiberId(
-      () => fileReader.readFiberCache(statsOffset.toInt, statsSize.toInt),
+      () => fileReader.readMemoryBlock(statsOffset.toInt, statsSize.toInt),
       fileReader.getName, BitmapIndexSectionId.statsContentSection, 0)
     val bmStatsContentCache = fiberCacheManager.get(bmStatsContentFiber)
     val stats = StatisticsManager.read(bmStatsContentCache, 0, keySchema)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV1.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV1.scala
@@ -72,7 +72,8 @@ private[oap] class BitmapReaderV1(
           (startIdx until (endIdx + 1)).map(idx => {
             val curIdxOffset = getIdxOffset(bmOffsetListCache, 0L, idx)
             val entrySize = getIdxOffset(bmOffsetListCache, 0L, idx + 1) - curIdxOffset
-            val entryFiber = BitmapFiberId(() => fileReader.readFiberCache(curIdxOffset, entrySize),
+            val entryFiber = BitmapFiberId(() =>
+              fileReader.readMemoryBlock(curIdxOffset, entrySize),
               fileReader.getName, BitmapIndexSectionId.entryListSection, idx)
             val entryCache = fiberCacheManager.get(entryFiber)
             val entry = getDesiredBitmap(entryCache)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV2.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReaderV2.scala
@@ -75,7 +75,8 @@ private[oap] class BitmapReaderV2(
           (startIdx until (endIdx + 1)).map(idx => {
             val curIdxOffset = getIdxOffset(bmOffsetListCache, 0L, idx)
             val entrySize = getIdxOffset(bmOffsetListCache, 0L, idx + 1) - curIdxOffset
-            val entryFiber = BitmapFiberId(() => fileReader.readFiberCache(curIdxOffset, entrySize),
+            val entryFiber = BitmapFiberId(() =>
+              fileReader.readMemoryBlock(curIdxOffset, entrySize),
               fileReader.getName, BitmapIndexSectionId.entryListSection, idx)
             new OapBitmapWrappedFiberCache(fiberCacheManager.get(entryFiber))
           })

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexFileReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexFileReader.scala
@@ -19,13 +19,13 @@ package org.apache.spark.sql.execution.datasources.oap.index
 
 import java.io.InputStream
 
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.unsafe.memory.MemoryBlock
 
 private[oap] trait IndexFileReader {
 
   protected def is: InputStream
 
-  def readFiberCache(position: Long, length: Int): FiberCache
+  def readMemoryBlock(position: Long, length: Int): MemoryBlock
 
   def read(position: Long, length: Int): Array[Byte]
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/impl/IndexFileReaderImpl.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/impl/IndexFileReaderImpl.scala
@@ -20,9 +20,9 @@ package org.apache.spark.sql.execution.datasources.oap.index.impl
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
 
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index.IndexFileReader
 import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.unsafe.memory.MemoryBlock
 
 private[index] case class IndexFileReaderImpl(
     configuration: Configuration,
@@ -33,8 +33,8 @@ private[index] case class IndexFileReaderImpl(
   override protected val is: FSDataInputStream =
     indexPath.getFileSystem(configuration).open(indexPath)
 
-  override def readFiberCache(position: Long, length: Int): FiberCache =
-    OapRuntime.getOrCreate.memoryManager.toIndexFiberCache(is, position, length)
+  override def readMemoryBlock(position: Long, length: Int): MemoryBlock =
+    OapRuntime.getOrCreate.memoryManager.toIndexMemoryBlock(is, position, length)
 
   override def read(position: Long, length: Int): Array[Byte] = {
     val bytes = new Array[Byte](length)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -28,9 +28,9 @@ import org.apache.hadoop.fs.FSDataInputStream
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.OapException
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.unsafe.memory.MemoryBlock
 import org.apache.spark.util.Utils
 
 abstract class DataFile {
@@ -39,7 +39,7 @@ abstract class DataFile {
   def configuration: Configuration
 
   def getDataFileMeta(): DataFileMeta
-  def cache(groupId: Int, fiberId: Int): FiberCache
+  def cache(groupId: Int, fiberId: Int): MemoryBlock
   def iterator(requiredIds: Array[Int], filters: Seq[Filter] = Nil)
     : OapCompletionIterator[InternalRow]
   def iteratorWithRowIds(requiredIds: Array[Int], rowIds: Array[Int], filters: Seq[Filter] = Nil)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.memory.MemoryBlock
 import org.apache.spark.util.CompletionIterator
 
 /**
@@ -96,7 +97,7 @@ private[oap] case class ParquetDataFile(
     inUseFiberCache.update(idx, fiberCache)
   }
 
-  def cache(groupId: Int, fiberId: Int): FiberCache = {
+  def cache(groupId: Int, fiberId: Int): MemoryBlock = {
     if (fiberDataReader == null) {
       // TODO Is there ParquetFooter enough?
       fiberDataReader =

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -207,9 +207,9 @@ class FiberCacheManagerSuite extends SharedOapContext {
       new TestCaller(work)
     }
     val results = runners.map(t => pool.submit(t))
+    results.foreach(r => r.get())
     pool.shutdown()
     pool.awaitTermination(3000, TimeUnit.MILLISECONDS)
-    results.foreach(r => r.get())
     assert(fiberCacheManager.pendingCount == 0)
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -207,9 +207,13 @@ class FiberCacheManagerSuite extends SharedOapContext {
       new TestCaller(work)
     }
     val results = runners.map(t => pool.submit(t))
-    results.foreach(r => r.get())
+    results.foreach(r =>
+      if (!r.isDone()) {
+        r.get()
+      }
+    )
     pool.shutdown()
-    pool.awaitTermination(3000, TimeUnit.MILLISECONDS)
+    pool.awaitTermination(1000, TimeUnit.MILLISECONDS)
     assert(fiberCacheManager.pendingCount == 0)
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManagerSuite.scala
@@ -82,7 +82,7 @@ class MemoryManagerSuite extends SharedOapContext {
       })
       val nnkw = new NonNullKeyWriter(schema)
       nnkw.writeKey(buf, InternalRow.fromSeq(values))
-      memoryManager.toDataFiberCache(buf.toByteArray)
+      FiberCache(null, memoryManager.toDataMemoryBlock(buf.toByteArray))
     }
   }
 
@@ -108,14 +108,14 @@ class MemoryManagerSuite extends SharedOapContext {
     val bytes = new Array[Byte](10240)
     random.nextBytes(bytes)
     val is = createInputStreamFromBytes(bytes)
-    val indexFiberCache = memoryManager.toIndexFiberCache(is, 0, 10240)
+    val indexFiberCache = FiberCache(null, memoryManager.toIndexMemoryBlock(is, 0, 10240))
     assert(bytes === indexFiberCache.toArray)
   }
 
   test("test data in DataFiberCache") {
     val bytes = new Array[Byte](10240)
     random.nextBytes(bytes)
-    val dataFiberCache = memoryManager.toDataFiberCache(bytes)
+    val dataFiberCache = FiberCache(null, memoryManager.toDataMemoryBlock(bytes))
     assert(bytes === dataFiberCache.toArray)
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterV1Suite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterV1Suite.scala
@@ -28,10 +28,10 @@ import org.apache.spark.{SecurityManager, TaskContext, TaskContextImpl}
 import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.memory.MemoryBlock
 
 class BTreeRecordReaderWriterV1Suite extends SharedOapContext {
 
@@ -64,10 +64,10 @@ class BTreeRecordReaderWriterV1Suite extends SharedOapContext {
   private class TestIndexFileReader(bytes: Array[Byte]) extends IndexFileReader {
     override protected val is: InputStream = new ByteArrayInputStream(bytes)
 
-    override def readFiberCache(position: Long, length: Int): FiberCache = {
+    override def readMemoryBlock(position: Long, length: Int): MemoryBlock = {
       // Note: Use DataFiberCache instead of IndexFiberCache to reuse current interface
       // DataFiberCache and IndexFiberCache are identical actually.
-      OapRuntime.getOrCreate.memoryManager.toDataFiberCache(read(position, length))
+      OapRuntime.getOrCreate.memoryManager.toDataMemoryBlock(read(position, length))
     }
 
     override def read(position: Long, length: Int): Array[Byte] = {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterV2Suite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeRecordReaderWriterV2Suite.scala
@@ -25,10 +25,10 @@ import org.apache.spark.{SecurityManager, TaskContext, TaskContextImpl}
 import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.memory.MemoryBlock
 
 
 class BTreeRecordReaderWriterV2Suite extends SharedOapContext {
@@ -62,10 +62,10 @@ class BTreeRecordReaderWriterV2Suite extends SharedOapContext {
   private class TestIndexFileReader(bytes: Array[Byte]) extends IndexFileReader {
     override protected val is: InputStream = new ByteArrayInputStream(bytes)
 
-    override def readFiberCache(position: Long, length: Int): FiberCache = {
+    override def readMemoryBlock(position: Long, length: Int): MemoryBlock = {
       // Note: Use DataFiberCache instead of IndexFiberCache to reuse current interface
       // DataFiberCache and IndexFiberCache are identical actually.
-      OapRuntime.getOrCreate.memoryManager.toDataFiberCache(read(position, length))
+      OapRuntime.getOrCreate.memoryManager.toDataMemoryBlock(read(position, length))
     }
 
     override def read(position: Long, length: Int): Array[Byte] = {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
@@ -22,6 +22,7 @@ import scala.util.Random
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.sql.catalyst.expressions.{BoundReference, UnsafeProjection}
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index.{BloomFilter, IndexUtils}
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.types.StructType
@@ -69,7 +70,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
     }
     testBloomFilter.write(out, null)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
     var offset = 0L
 
     assert(fiber.getInt(offset) == StatisticsType.TYPE_BLOOM_FILTER)
@@ -111,7 +112,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
 
     for (l <- bfIndex.getBitMapLongArray) IndexUtils.writeLong(out, l)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val testBloomFilter = new TestBloomFilterReader(schema)
     testBloomFilter.read(fiber, 0)
@@ -140,7 +141,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
     }
     bloomFilterWrite.write(out, null)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val bloomFilterRead = new TestBloomFilterReader(schema)
     bloomFilterRead.read(fiber, 0)
@@ -173,7 +174,7 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
     }
     bloomFilterWrite.write(out, null)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val bloomFilterRead = new TestBloomFilterReader(schema)
     bloomFilterRead.read(fiber, 0)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatisticsSuite.scala
@@ -23,6 +23,7 @@ import scala.util.Random
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexScanner, IndexUtils}
 import org.apache.spark.sql.types.StructType
 
@@ -53,7 +54,7 @@ class MinMaxStatisticsSuite extends StatisticsTest {
       assert(ordering.compare(key, max) <= 0)
     }
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
     var offset = 0
 
     assert(fiber.getInt(0) == StatisticsType.TYPE_MIN_MAX)
@@ -81,7 +82,7 @@ class MinMaxStatisticsSuite extends StatisticsTest {
     IndexUtils.writeInt(out, tempWriter.size)
     out.write(tempWriter.toByteArray)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val testMinMax = new TestMinMaxReader(schema)
     testMinMax.read(fiber, 0)
@@ -105,7 +106,7 @@ class MinMaxStatisticsSuite extends StatisticsTest {
     for (key <- keys) minmaxWrite.addOapKey(key)
     minmaxWrite.write(out, null) // MinMax does not need sortKeys parameter
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val minmaxRead = new TestMinMaxReader(schema)
     minmaxRead.read(fiber, 0)
@@ -128,7 +129,7 @@ class MinMaxStatisticsSuite extends StatisticsTest {
     for (key <- keys) minmaxWrite.addOapKey(key)
     minmaxWrite.write(out, null) // MinMax does not need sortKeys parameter
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val minmaxRead = new TestMinMaxReader(schema)
     minmaxRead.read(fiber, 0)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexScanner, IndexUtils}
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.types.StructType
@@ -58,7 +59,7 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     testPartByValueWriter.write(out, keys.to[ArrayBuffer])
 
     var offset = 0
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
     assert(fiber.getInt(offset) == StatisticsType.TYPE_PART_BY_VALUE)
     offset += 4
 
@@ -98,7 +99,7 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     }
     out.write(tempWriter.toByteArray)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
     val testPartByValueReader = new TestPartByValueReader(schema)
     testPartByValueReader.read(fiber, 0)
 
@@ -118,7 +119,7 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     val partByValueWrite = new TestPartByValueWriter(schema)
     partByValueWrite.write(out, keys.to[ArrayBuffer])
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val partByValueRead = new TestPartByValueReader(schema)
     partByValueRead.read(fiber, 0)
@@ -145,7 +146,7 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     val partByValueWrite = new TestPartByValueWriter(schema)
     partByValueWrite.write(out, keys.to[ArrayBuffer])
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val partByValueRead = new TestPartByValueReader(schema)
     partByValueRead.read(fiber, 0)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatisticsSuite.scala
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.execution.datasources.oap._
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexScanner, IndexUtils}
 import org.apache.spark.sql.types.StructType
 
@@ -49,7 +50,7 @@ class SampleBasedStatisticsSuite extends StatisticsTest {
     testSample.write(out, keys.to[ArrayBuffer])
 
     var offset = 0
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
     assert(fiber.getInt(offset) == StatisticsType.TYPE_SAMPLE_BASE)
     offset += 4
     val size = fiber.getInt(offset)
@@ -78,7 +79,7 @@ class SampleBasedStatisticsSuite extends StatisticsTest {
     }
     out.write(tempWriter.toByteArray)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val testSample = new TestSampleReader(schema)
     testSample.read(fiber, 0)
@@ -96,7 +97,7 @@ class SampleBasedStatisticsSuite extends StatisticsTest {
     val sampleWrite = new TestSampleWriter(schema)
     sampleWrite.write(out, keys.to[ArrayBuffer])
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val sampleRead = new TestSampleReader(schema)
     sampleRead.read(fiber, 0)
@@ -117,7 +118,7 @@ class SampleBasedStatisticsSuite extends StatisticsTest {
     val sampleWrite = new TestSampleWriter(schema)
     sampleWrite.write(out, keys.to[ArrayBuffer])
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val sampleRead = new TestSampleReader(schema)
     sampleRead.read(fiber, 0)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsSuite.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexScanner, IndexUtils, RangeInterval}
 import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
 
@@ -51,7 +52,7 @@ class StatisticsSuite extends StatisticsTest with BeforeAndAfterAll {
     val writtenBytes = test.write(out, null)
     assert(writtenBytes == 4)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
     assert(fiber.getInt(0) == test.id)
     out.close()
   }
@@ -60,7 +61,7 @@ class StatisticsSuite extends StatisticsTest with BeforeAndAfterAll {
     val test = new TestStatisticsReader(schema)
     IndexUtils.writeInt(out, test.id)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val readBytes = test.read(fiber, 0)
     assert(readBytes == 4)
@@ -70,7 +71,7 @@ class StatisticsSuite extends StatisticsTest with BeforeAndAfterAll {
     val test = new TestStatisticsReader(schema)
     IndexUtils.writeInt(out, test.id)
 
-    val fiber = wrapToFiberCache(out)
+    val fiber = FiberCache(out)
 
     val readBytes = test.read(fiber, 0)
     assert(readBytes == 4)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsTest.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsTest.scala
@@ -73,9 +73,4 @@ abstract class StatisticsTest extends SparkFunSuite with BeforeAndAfterEach {
     val res = row1 == row2 // it works..
     assert(res, s"row1: $row1 does not match $row2")
   }
-
-  protected def wrapToFiberCache(out: ByteArrayOutputStream): FiberCache = {
-    val bytes = out.toByteArray
-    new FiberCache(new MemoryBlock(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length))
-  }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/BitmapUtilsSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.datasources.oap.index.{BitmapIndexSectionI
 import org.apache.spark.sql.execution.datasources.oap.io.IndexFile
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.unsafe.memory.MemoryBlock
 import org.apache.spark.util.Utils
 
 class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
@@ -69,8 +70,8 @@ class BitmapUtilsSuite extends QueryTest with SharedOapContext with BeforeAndAft
     dir.delete()
   }
 
-  private def loadBmSection(fin: FSDataInputStream, offset: Long, size: Int): FiberCache =
-    OapRuntime.getOrCreate.memoryManager.toIndexFiberCache(fin, offset, size)
+  private def loadBmSection(fin: FSDataInputStream, offset: Long, size: Int): MemoryBlock =
+    OapRuntime.getOrCreate.memoryManager.toIndexMemoryBlock(fin, offset, size)
 
   private def getIdxOffset(fiberCache: FiberCache, baseOffset: Long, idx: Int): Int = {
     val idxOffset = baseOffset + idx * 4

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/NonNullKeySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/NonNullKeySuite.scala
@@ -73,7 +73,7 @@ class NonNullKeySuite extends SparkFunSuite with Logging {
       val row = InternalRow.fromSeq(valueSeq)
       val buf = new ByteBufferOutputStream()
       nnkw.writeKey(buf, row)
-      val answerRow = nnkr.readKey(FiberCache(buf.toByteArray), 0)._1
+      val answerRow = nnkr.readKey(FiberCache(buf), 0)._1
       assert(row.equals(answerRow))
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/utils/OapBitmapWrappedFiberCacheSuite.scala
@@ -25,17 +25,18 @@ import org.roaringbitmap.RoaringBitmap
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.datasources.OapException
-import org.apache.spark.sql.execution.datasources.oap.filecache.{BitmapFiberId, FiberCache}
+import org.apache.spark.sql.execution.datasources.oap.filecache.BitmapFiberId
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.unsafe.memory.MemoryBlock
 import org.apache.spark.util.Utils
 
 // Below are used to test the functionality of OapBitmapWrappedFiberCache class.
 class OapBitmapWrappedFiberCacheSuite
   extends QueryTest with SharedOapContext {
 
-  private def loadRbFile(fin: FSDataInputStream, offset: Long, size: Int): FiberCache =
-    OapRuntime.getOrCreate.memoryManager.toIndexFiberCache(fin, offset, size)
+  private def loadRbFile(fin: FSDataInputStream, offset: Long, size: Int): MemoryBlock =
+    OapRuntime.getOrCreate.memoryManager.toIndexMemoryBlock(fin, offset, size)
 
   test("test the functionality of OapBitmapWrappedFiberCache class") {
     val CHUNK_SIZE = 1 << 16

--- a/src/test/scala/org/apache/spark/sql/execution/vectorized/OnHeapColumnVectorFiberSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/vectorized/OnHeapColumnVectorFiberSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.vectorized
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import org.apache.spark.unsafe.Platform
@@ -45,7 +46,7 @@ class OnHeapColumnVectorFiberSuite extends SparkFunSuite with SharedOapContext w
       vector.appendByteArray(utf8, 0, utf8.length)
     }
     val fiber = new OnHeapColumnVectorFiber(vector, count, StringType)
-    val fiberCache = fiber.dumpBytesToCache()
+    val fiberCache = FiberCache(null, fiber.dumpBytesToCache())
     (0 until count).map { i =>
       val length = fiberCache.getInt(i * 4)
       val offset = fiberCache.getInt(count * 4 + i * 4)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is improving the cache guardian thread in order to:
1. ensure the pending fibers in the evicted queue to be freed as soon as possible
   after it's released by the last user.
2. ensure the queue to be empty as long as all the pending fibers are released by the last users.
With the above assurances, the memory pressure will be significantly mitigated.

We are based on the premise that the guava cache manager has a good eviction mechanism.
That indicates that the evicted fibers are relatively old and not accessed for a while and
won't be accessed in the future with the high possibility. Otherwise, we will upload another PR to address the inefficient eviction algorithm.

## How was this patch tested?

mvn clean test package and all the unit tests passed.

For the total 13 existing fiber cache manager test cases, the peak memory footprint of five are reduced significantly. The maximum memory size of cache manager is 7.34MB.

The detailed result is below:
The peak memory of "remove a fiber is in use" is reduced from 66.06MB to under 7.34MB.
The peak memory of "wait for other thread to release the fiber" is reduced from 31.46MB to under 7.34MB.
The peak memory of "add a very large fiber" is reduced from 39.32MB to under 7.34MB.
The peak memory of "cache guardian remove pending fibers" is reduced from 76.55MB to 69.21MB.
The peak memory of "get different fiber simultaneously" is reduced from 33.55MB to 12.58MB.