### PR TITLE
Add ParquetFiberDataLoader#789

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -105,7 +105,7 @@ case class FiberCache(protected val fiberData: MemoryBlock) extends Logging {
     }
     fiberData.getBaseObject
   }
-  protected def getBaseOffset: Long = fiberData.getBaseOffset
+  def getBaseOffset: Long = fiberData.getBaseOffset
 
   def getBoolean(offset: Long): Boolean = Platform.getBoolean(getBaseObj, getBaseOffset + offset)
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -109,7 +109,7 @@ private[sql] class MemoryManager(sparkEnv: SparkEnv) extends Logging {
     FiberCache(memoryBlock)
   }
 
-  def getEmptyDataFiberCache(length: Int): FiberCache = {
+  def getEmptyDataFiberCache(length: Long): FiberCache = {
     val memoryBlock = allocate(length)
     FiberCache(memoryBlock)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -109,6 +109,11 @@ private[sql] class MemoryManager(sparkEnv: SparkEnv) extends Logging {
     FiberCache(memoryBlock)
   }
 
+  def getEmptyDataFiberCache(length: Int): FiberCache = {
+    val memoryBlock = allocate(length)
+    FiberCache(memoryBlock)
+  }
+
   def stop(): Unit = {
     memoryManager.releaseStorageMemory(oapMemory, MemoryMode.OFF_HEAP)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetFiberDataLoader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetFiberDataLoader.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import java.io.IOException
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.Preconditions
+import org.apache.parquet.hadoop.ParquetFiberDataReader
+import org.apache.parquet.hadoop.api.InitContext
+import org.apache.parquet.hadoop.utils.Collections3
+import org.apache.parquet.schema.{MessageType, Type}
+
+import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetReadSupportWrapper, VectorizedColumnReader, VectorizedColumnReaderWrapper}
+import org.apache.spark.sql.execution.vectorized.{ColumnVector, OnHeapColumnVector, OnHeapColumnVectorFiber}
+import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.sql.types._
+
+private[oap] case class ParquetFiberDataLoader(
+    configuration: Configuration,
+    reader: ParquetFiberDataReader,
+    blockId: Int,
+    rowCount: Int) {
+
+  @throws[IOException]
+  def loadSingleColumn: FiberCache = {
+    val footer = reader.getFooter
+    val fileSchema = footer.getFileMetaData.getSchema
+    val fileMetadata = footer.getFileMetaData.getKeyValueMetaData
+    val readContext = new ParquetReadSupportWrapper()
+      .init(new InitContext(configuration, Collections3.toSetMultiMap(fileMetadata), fileSchema))
+    val requestedSchema = readContext.getRequestedSchema
+    val sparkRequestedSchemaString =
+      configuration.get(ParquetReadSupportWrapper.SPARK_ROW_REQUESTED_SCHEMA)
+    val sparkSchema = StructType.fromString(sparkRequestedSchemaString)
+    Preconditions.checkArgument(sparkSchema.length == 1, "Can not get multi-columns every time")
+    val dataType = sparkSchema.fields(0).dataType
+    val vector = ColumnVector.allocate(rowCount, dataType, MemoryMode.ON_HEAP)
+
+    // Construct OapOnHeapColumnVectorFiber out of try block because of no exception throw when init
+    // OapOnHeapColumnVectorFiber instance.
+    val fiber =
+      new OnHeapColumnVectorFiber(vector.asInstanceOf[OnHeapColumnVector], rowCount, dataType)
+
+    try {
+      if (isMissingColumn(fileSchema, requestedSchema)) {
+        vector.putNulls(0, rowCount)
+        vector.setIsConstant()
+      } else {
+        val columnDescriptor = requestedSchema.getColumns.get(0)
+        val blockMetaData = footer.getBlocks.get(blockId)
+        val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+        val columnReader =
+          new VectorizedColumnReaderWrapper(
+            new VectorizedColumnReader(columnDescriptor, fiberData.getPageReader(columnDescriptor)))
+        columnReader.readBatch(rowCount, vector)
+      }
+
+      fixedAndLength(dataType) match {
+        case (true, length) =>
+          val fiberCache = OapRuntime.getOrCreate.memoryManager.
+            getEmptyDataFiberCache(rowCount * length)
+          // Fixed-length data type can be copied directly to FiberCache.
+          fiber.dumpBytesToCache(fiberCache.getBaseOffset)
+          fiberCache
+        case (false, _) =>
+          fiber.dumpBytesToCache
+      }
+    } finally {
+      fiber.close()
+    }
+  }
+
+  @throws[UnsupportedOperationException]
+  @throws[IOException]
+  private def isMissingColumn(fileSchema: MessageType, requestedSchema: MessageType) = {
+    val dataType = requestedSchema.getType(0)
+    if (!dataType.isPrimitive || dataType.isRepetition(Type.Repetition.REPEATED)) {
+      throw new UnsupportedOperationException(s"Complex types ${dataType.getName} not supported.")
+    }
+    val colPath = requestedSchema.getPaths.get(0)
+    if (fileSchema.containsPath(colPath)) {
+      val fd = fileSchema.getColumnDescription(colPath)
+      if (!fd.equals(requestedSchema.getColumns.get(0))) {
+        throw new UnsupportedOperationException("Schema evolution not supported.")
+      }
+      false
+    } else {
+      if (requestedSchema.getColumns.get(0).getMaxDefinitionLevel == 0) {
+        throw new IOException(s"Required column is missing in data file. Col: ${colPath.mkString}")
+      }
+      true
+    }
+  }
+
+  private def fixedAndLength(dataType: DataType): (Boolean, Int) = dataType match {
+    // data: 1 byte, nulls: 1 byte
+    case ByteType | BooleanType => (true, 2)
+    // data: 2 byte, nulls: 1 byte
+    case ShortType => (true, 3)
+    // data: 4 byte, nulls: 1 byte
+    case IntegerType | DateType | FloatType => (true, 5)
+    // data: 8 byte, nulls: 1 byte
+    case LongType | DoubleType => (true, 9)
+    // data: variable length, such as StringType and BinaryType
+    case StringType | BinaryType => (false, -1)
+    case otherTypes: DataType => throw new OapException(s"${otherTypes.simpleString}" +
+      s" data type is not implemented for cache.")
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -21,6 +21,7 @@ import java.io.{File, IOException}
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.column.ParquetProperties.WriterVersion
@@ -39,13 +40,15 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
-import org.apache.spark.sql.execution.datasources.parquet.{VectorizedColumnReader, VectorizedColumnReaderWrapper}
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetReadSupportWrapper, VectorizedColumnReader, VectorizedColumnReaderWrapper}
 import org.apache.spark.sql.execution.vectorized.{ColumnarBatch, ColumnVector}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
 
 abstract class ParquetDataFileSuite extends SparkFunSuite with SharedOapContext
@@ -554,6 +557,89 @@ class ParquetFiberDataReaderSuite extends ParquetDataFileSuite {
       reader.readFiberData(blockMetaData, columnDescriptor)
     }
     assert(exception.getMessage.contains("Can not find column meta of column"))
+  }
+}
+
+class ParquetFiberDataLoaderSuite extends ParquetDataFileSuite {
+
+  private val requestSchema: StructType = new StructType()
+    .add(StructField("int32_field", IntegerType))
+    .add(StructField("int64_field", LongType))
+    .add(StructField("boolean_field", BooleanType))
+    .add(StructField("float_field", FloatType))
+    .add(StructField("string_field", StringType))
+
+  override def parquetSchema: MessageType = new MessageType("test",
+    new PrimitiveType(REQUIRED, INT32, "int32_field"),
+    new PrimitiveType(REQUIRED, INT64, "int64_field"),
+    new PrimitiveType(REQUIRED, BOOLEAN, "boolean_field"),
+    new PrimitiveType(REQUIRED, FLOAT, "float_field"),
+    new PrimitiveType(REQUIRED, BINARY, "string_field")
+  )
+
+  override def dataVersion: WriterVersion = PARQUET_1_0
+
+  override def data: Seq[Group] = {
+    val factory = new SimpleGroupFactory(parquetSchema)
+    (0 until 100).map(i => factory.newGroup()
+      .append("int32_field", i)
+      .append("int64_field", 64L)
+      .append("boolean_field", true)
+      .append("float_field", 1.0f)
+      .append("string_field", s"str$i"))
+  }
+
+  var reader: ParquetFiberDataReader = null
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reader = ParquetFiberDataReader.open(configuration, new Path(fileName),
+      ParquetDataFileMeta(configuration, fileName).footer.toParquetMetadata)
+  }
+
+  override def afterEach(): Unit = {
+    reader.close()
+    super.afterEach()
+  }
+
+  private def addRequestSchemaToConf(conf: Configuration, requiredIds: Array[Int]): Unit = {
+    val requestSchemaString = {
+      var schema = new StructType
+      for (index <- requiredIds) {
+        schema = schema.add(requestSchema(index))
+      }
+      schema.json
+    }
+    conf.set(ParquetReadSupportWrapper.SPARK_ROW_REQUESTED_SCHEMA, requestSchemaString)
+  }
+
+  private def loadSingleColumn(requiredId: Array[Int]): (FiberCache, Int) = {
+    val conf = new Configuration(configuration)
+    addRequestSchemaToConf(conf, requiredId)
+    val rowCount = reader.getFooter.getBlocks.get(0).getRowCount.toInt
+    val fiberCache = ParquetFiberDataLoader(conf, reader, 0, rowCount).loadSingleColumn
+    (fiberCache, rowCount)
+  }
+
+  test("test loadSingleColumn with reuse reader") {
+    // fixed length data type
+    val (intFiberCache, intRowCount) = loadSingleColumn(Array(0))
+    (0 until intRowCount).foreach(i => assert(intFiberCache.getInt(i * 4) == i))
+    // variable length data type
+    val (strFiberCache, strRowCount) = loadSingleColumn(Array(4))
+    (0 until strRowCount).map { i =>
+      val length = strFiberCache.getInt(i * 4)
+      val offset = strFiberCache.getInt(strRowCount * 4 + i * 4)
+      assert(strFiberCache.getUTF8String(strRowCount * 9 + offset, length).
+        equals(UTF8String.fromString(s"str$i")))
+    }
+  }
+
+  test("test load multi-columns every time") {
+    val exception = intercept[IllegalArgumentException] {
+      loadSingleColumn(Array(0, 1))
+    }
+    assert(exception.getMessage.contains("Can not get multi-columns every time"))
   }
 }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -639,7 +639,7 @@ class ParquetFiberDataLoaderSuite extends ParquetDataFileSuite {
     val exception = intercept[IllegalArgumentException] {
       loadSingleColumn(Array(0, 1))
     }
-    assert(exception.getMessage.contains("Can not get multi-columns every time"))
+    assert(exception.getMessage.contains("Only can get single column every time"))
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add ParquetFiberDataLoader.

ParquetFiberDataLoader provides an interface loadSingleColumn which can return a FiberCache of one column every time.

Change def getBaseOffset property from protected to public in FiberCache.

Add a function  def getEmptyDataFiberCache(length: Int): FiberCache in MemoryManager.

## How was this patch tested?

All exists test cases passed.

Add two test cases in ParquetFiberDataLoaderSuite.
1. test loadSingleColumn with reuse reader
2. test load multi-columns every time



