### PR TITLE
Use ExternalSorter for Statistics while buiding index

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapIndexRecordWriter.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.sql.execution.datasources.oap.index
 
-import java.io.{ByteArrayOutputStream, DataOutput, DataOutputStream, OutputStream}
+import java.io.{ByteArrayOutputStream, DataOutputStream, OutputStream}
 
-import scala.collection.immutable
-import scala.collection.mutable
+import scala.collection.{immutable, mutable}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -127,7 +127,7 @@ private[oap] class BloomFilterStatisticsWriter(
     projectors.foreach(p => bfIndex.addValue(p(key).getBytes))
   }
 
-  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
+  override def write(writer: OutputStream, sortedKeys: Iterator[Key]): Int = {
     var offset = super.write(writer, sortedKeys)
 
     // Bloom filter index file format:

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -104,7 +104,7 @@ private[oap] class MinMaxStatisticsWriter(
     }
   }
 
-  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
+  override def write(writer: OutputStream, sortedKeys: Iterator[Key]): Int = {
     var offset = super.write(writer, sortedKeys)
     if (min != null) {
       val tempWriter = new ByteArrayOutputStream()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -158,7 +158,7 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
 
   protected lazy val metas: ArrayBuffer[PartedByValueMeta] = new ArrayBuffer[PartedByValueMeta]()
 
-  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
+  override def write(writer: OutputStream, sortedKeys: Iterator[Key]): Int = {
     var offset = super.write(writer, sortedKeys)
     val hashMap = new java.util.HashMap[Key, Int]()
     val uniqueKeys: ArrayBuffer[Key] = new ArrayBuffer[Key]()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -121,8 +121,8 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
     offset
   }
 
-  protected def takeSample(keys: Iterator[InternalRow], size: Int): Array[InternalRow] = {
-    val indices = Random.shuffle((0 until rowCount).toList).take(size).toArray
+  private[statistics] def takeSample(keys: Iterator[InternalRow], size: Int): Array[InternalRow] = {
+    val indices = Random.shuffle((0 until rowCount).toList).take(size).sorted.toArray
     var i = 0
     def getItemsFromIter(keys: Iterator[InternalRow], indices: Array[Int]): Array[InternalRow] = {
       val took = ArrayBuffer[InternalRow]()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -23,7 +23,6 @@ import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
@@ -76,7 +75,7 @@ private[oap] class SampleBasedStatisticsReader(
 }
 
 private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configuration)
-  extends StatisticsWriter(schema, conf) with Logging {
+  extends StatisticsWriter(schema, conf) {
   override val id: Int = StatisticsType.TYPE_SAMPLE_BASE
 
   var rowCount = 0

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -76,11 +76,12 @@ abstract class StatisticsWriter(schema: StructType, conf: Configuration) {
   /**
    * Statistics write function, by default, only a Statistics id should be
    * written into the writer.
+ *
    * @param writer IndexOutputWrite, where to write the information
    * @param sortedKeys sorted keys stored related to this statistics
    * @return number of bytes written in writer
    */
-  def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
+  def write(writer: OutputStream, sortedKeys: Iterator[Key]): Int = {
     IndexUtils.writeInt(writer, id)
     4
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -76,7 +76,7 @@ abstract class StatisticsWriter(schema: StructType, conf: Configuration) {
   /**
    * Statistics write function, by default, only a Statistics id should be
    * written into the writer.
- *
+   *
    * @param writer IndexOutputWrite, where to write the information
    * @param sortedKeys sorted keys stored related to this statistics
    * @return number of bytes written in writer

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
@@ -55,7 +55,7 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     val keys = (1 to 300).map(i => rowGen(i)).toArray // keys needs to be sorted
 
     val testPartByValueWriter = new TestPartByValueWriter(schema)
-    testPartByValueWriter.write(out, keys.to[ArrayBuffer])
+    testPartByValueWriter.write(out, keys.toIterator)
 
     var offset = 0
     val fiber = wrapToFiberCache(out)
@@ -116,7 +116,7 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     val keys = (1 to 300).map(i => rowGen(i)).toArray // keys needs to be sorted
 
     val partByValueWrite = new TestPartByValueWriter(schema)
-    partByValueWrite.write(out, keys.to[ArrayBuffer])
+    partByValueWrite.write(out, keys.toIterator)
 
     val fiber = wrapToFiberCache(out)
 
@@ -143,7 +143,7 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     val dummyEnd = new JoinedRow(InternalRow(300), IndexScanner.DUMMY_KEY_END)
 
     val partByValueWrite = new TestPartByValueWriter(schema)
-    partByValueWrite.write(out, keys.to[ArrayBuffer])
+    partByValueWrite.write(out, keys.toIterator)
 
     val fiber = wrapToFiberCache(out)
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatisticsSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexScanner, IndexUtils}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class SampleBasedStatisticsSuite extends StatisticsTest {
 
@@ -157,5 +157,17 @@ class SampleBasedStatisticsSuite extends StatisticsTest {
     generateInterval(rowGen(301), dummyEnd,
       startInclude = true, endInclude = true)
     assert(sampleRead.analyse(intervalArray) == StatsAnalysisResult.USE_INDEX)
+  }
+
+  test("take sample from iterator") {
+    val sampleWriter = new SampleBasedStatisticsWriter(null, new Configuration())
+
+    val takeNum = 1000
+    val total = takeNum * 3
+    sampleWriter.rowCount = total
+
+    val iter = (0 until takeNum * 3).map(InternalRow(_)).toIterator
+    val ans = sampleWriter.takeSample(iter, takeNum)
+    assert(ans.size == takeNum)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManagerSuite.scala
@@ -22,6 +22,7 @@ import java.sql.Date
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.util.Utils
@@ -199,5 +200,15 @@ class StatisticsManagerSuite extends QueryTest with SharedOapContext with Before
       s"WHERE attr_date = '${DateTimeUtils.toJavaDate(1).toString}'"),
       Row.fromTuple(rowGen(1)) :: Nil)
     sql("drop oindex index5 on oap_test")
+  }
+
+  test("SortedKeys wrapper class") {
+    val row1 = InternalRow(1)
+    val times1 = 1
+    val row2 = InternalRow(2)
+    val times2 = 3
+
+    val arr = Array((row1, times1), (row2, times2))
+    assert(new SortedKeys(arr.toIterator).size == times1 + times2)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To resolve #785 , in local test building B+ tree index for 3 * 10^7 rows, original takes 2.1min with 1.5min GC, with this PR it takes 1.8min with 58s GC. 

Current implementation has 1 not so graceful point: because Part-by-value & sample both need this sortedKeys, and one Iterator can only be traversed once, a duplicate ExternalSorter is created. 

Still trying to avoid creating 2...Another consideration is after the current sqlite version of sample PR is merged, we remove the original Part-by-value & sample code path, than this problem will resolve.

## How was this patch tested?

SampleBasedStatisticsSuite.scala, StatisticsManagerSuite.scala

