### PR TITLE
Distinguish size ratio config between full loading and partial loading

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BPlusTreeScanner.scala
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.statistics.StatsAnalysisResult
+import org.apache.spark.sql.internal.oap.OapConf
 
 // we scan the index from the smallest to the largest,
 // this will scan the B+ Tree (index) leaf node.
@@ -67,4 +68,8 @@ private[oap] class BPlusTreeScanner(idxMeta: IndexMeta) extends IndexScanner(idx
   override def hasNext: Boolean = recordReader.hasNext
 
   override def next(): Int = recordReader.next()
+
+  override protected def indexFileSizeMaxRatio(conf: Configuration): Double =
+    conf.getDouble(OapConf.OAP_INDEX_WITH_PARTIAL_LOADING_FILE_SIZE_MAX_RATIO.key,
+      OapConf.OAP_INDEX_WITH_PARTIAL_LOADING_FILE_SIZE_MAX_RATIO.defaultValue.get)
 }

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -184,6 +184,15 @@ object OapConf {
       .doubleConf
       .createWithDefault(0.7)
 
+  val OAP_INDEX_WITH_PARTIAL_LOADING_FILE_SIZE_MAX_RATIO =
+    SQLConfigBuilder("spark.sql.oap.oindex.partial.loading.size.ratio")
+      .internal()
+      .doc("To indicate if enable/disable index cbo which helps to choose a fast query path, " +
+        "this config has the same effect as OAP_INDEX_FILE_SIZE_MAX_RATIO, " +
+        "the difference is this index support partial loading.")
+      .doubleConf
+      .createWithDefault(1.0)
+
   val OAP_INDEXER_CHOICE_MAX_SIZE =
     SQLConfigBuilder("spark.sql.oap.indexer.max.use.size")
       .internal()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/CombiningIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/CombiningIndexSuite.scala
@@ -31,6 +31,7 @@ class CombiningIndexSuite extends QueryTest with SharedOapContext with BeforeAnd
     spark.conf.set(OapConf.OAP_INDEXER_CHOICE_MAX_SIZE.key, "2")
     spark.conf.set(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "true")
     spark.conf.set(OapConf.OAP_INDEX_FILE_SIZE_MAX_RATIO.key, "1000")
+    spark.conf.set(OapConf.OAP_INDEX_WITH_PARTIAL_LOADING_FILE_SIZE_MAX_RATIO.key, "1000")
     val path = Utils.createTempDir().getAbsolutePath
     currentPath = path
     sql(s"""CREATE TEMPORARY VIEW oap_test (a INT, b INT, c INT)


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the production environment, we found that btree index have a good effect even if the index file and data file has a similar size because btree index support partital loading, so I think we should add a new config to distinguish value of `FILE_SIZE_MAX_RATIO` between full loading and partial loading.

## How was this patch tested?

mvn test pass
