### PR TITLE
Better FiberSensor for cache locality

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -44,7 +44,7 @@ private[sql] class FiberSensor extends Logging {
 
   private val fileToHosts = new ConcurrentHashMap[String, Seq[HostFiberCache]]
 
-  private val NUM_GET_HOST = 2
+  private val NUM_GET_HOSTS = 2
 
   private def updateRecordingMap(fromHost: String, commingStatus: FiberCacheStatus) = synchronized {
     val currentHostsForFile = fileToHosts.getOrDefault(commingStatus.file, Seq.empty)
@@ -90,9 +90,9 @@ private[sql] class FiberSensor extends Logging {
    */
   def getHosts(filePath: String): Seq[String] = {
     // From max to min
-    val sorted = fileToHosts.get(filePath).map(
+    val sorted = fileToHosts.getOrDefault(filePath, Seq.empty).map(
       hostAndInfo => (hostAndInfo.host, hostAndInfo.status.cachedFiberCount)).sortBy((_._2 * -1))
-    sorted.take(NUM_GET_HOST).map(_._1)
+    sorted.take(NUM_GET_HOSTS).map(_._1)
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 import com.google.common.base.Throwables
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberSensor.HostFiberCache
 import org.apache.spark.sql.execution.datasources.oap.utils.CacheStatusSerDe
 import org.apache.spark.sql.oap.listener.SparkListenerCustomInfoUpdate
 import org.apache.spark.util.collection.BitSet
@@ -43,13 +44,6 @@ private[oap] case class FiberCacheStatus(
 // (for cache locality) and metrics info
 private[sql] class FiberSensor extends Logging {
 
-  case class HostFiberCache(host: String, status: FiberCacheStatus)
-      extends Ordered[HostFiberCache] {
-    override def compare(another: HostFiberCache): Int = {
-      status.cachedFiberCount - another.status.cachedFiberCount
-    }
-  }
-
   private[filecache] val fileToHosts = new ConcurrentHashMap[String, ArrayBuffer[HostFiberCache]]
 
   private[filecache] def updateRecordingMap(fromHost: String, commingStatus: FiberCacheStatus) =
@@ -65,7 +59,11 @@ private[sql] class FiberSensor extends Logging {
   private[filecache] def discardOutdatedInfo(host: String) = synchronized {
     for ((k: String, v: ArrayBuffer[HostFiberCache]) <- fileToHosts.asScala) {
       val(_, kept) = v.partition(_.host == host)
-      fileToHosts.put(k, kept)
+      if (kept.size == 0) {
+        fileToHosts.remove(k)
+      } else {
+        fileToHosts.put(k, kept)
+      }
     }
   }
 
@@ -78,7 +76,7 @@ private[sql] class FiberSensor extends Logging {
     logDebug(s"Got updated fiber info from host: $updateHostName, executorId: $updateExecId," +
       s"host is $host, info array len is ${fiberCacheStatus.size}")
     // Coming information of a certain executor requires discarding previous records so as to
-    // reflect Fibers' eviction
+    // reflect Fiber eviction
     discardOutdatedInfo(host)
     fiberCacheStatus.foreach(updateRecordingMap(host, _))
   }
@@ -114,6 +112,14 @@ private[sql] class FiberSensor extends Logging {
 }
 
 private[sql] object FiberSensor {
+
+  case class HostFiberCache(host: String, status: FiberCacheStatus)
+      extends Ordered[HostFiberCache] {
+    override def compare(another: HostFiberCache): Int = {
+      status.cachedFiberCount - another.status.cachedFiberCount
+    }
+  }
+
   val NUM_GET_HOSTS = 2
   val MAX_HOSTS_MAINTAINED = 8
   val OAP_CACHE_HOST_PREFIX = "OAP_HOST_"

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -27,6 +27,8 @@ import com.google.common.base.Throwables
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberSensor.HostFiberCache
 import org.apache.spark.sql.execution.datasources.oap.utils.CacheStatusSerDe
+import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.oap.listener.SparkListenerCustomInfoUpdate
 import org.apache.spark.util.collection.BitSet
 
@@ -120,8 +122,14 @@ private[sql] object FiberSensor {
     }
   }
 
-  val NUM_GET_HOSTS = 2
-  val MAX_HOSTS_MAINTAINED = 8
+  private def conf = OapRuntime.getOrCreate.sparkSession.conf
+
+  val NUM_GET_HOSTS = conf.get(
+    OapConf.OAP_CACHE_FIBERSENSOR_GETHOSTS_NUM,
+    OapConf.OAP_CACHE_FIBERSENSOR_GETHOSTS_NUM.defaultValue.get)
+  val MAX_HOSTS_MAINTAINED = conf.get(
+    OapConf.OAP_CACHE_FIBERSENSOR_MAXHOSTSMAINTAINED_NUM,
+    OapConf.OAP_CACHE_FIBERSENSOR_MAXHOSTSMAINTAINED_NUM.defaultValue.get)
   val OAP_CACHE_HOST_PREFIX = "OAP_HOST_"
   val OAP_CACHE_EXECUTOR_PREFIX = "_OAP_EXECUTOR_"
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -44,8 +44,6 @@ private[sql] class FiberSensor extends Logging {
 
   private val fileToHosts = new ConcurrentHashMap[String, Seq[HostFiberCache]]
 
-  private val NUM_GET_HOSTS = 2
-
   private def updateRecordingMap(fromHost: String, commingStatus: FiberCacheStatus) = synchronized {
     val currentHostsForFile = fileToHosts.getOrDefault(commingStatus.file, Seq.empty)
     val (_, theRest) = currentHostsForFile.partition(_.host == fromHost)
@@ -92,11 +90,12 @@ private[sql] class FiberSensor extends Logging {
     // From max to min
     val sorted = fileToHosts.getOrDefault(filePath, Seq.empty).map(
       hostAndInfo => (hostAndInfo.host, hostAndInfo.status.cachedFiberCount)).sortBy((_._2 * -1))
-    sorted.take(NUM_GET_HOSTS).map(_._1)
+    sorted.take(FiberSensor.NUM_GET_HOSTS).map(_._1)
   }
 }
 
-private[oap] object FiberSensor {
+private[sql] object FiberSensor {
+  val NUM_GET_HOSTS = 2
   val OAP_CACHE_HOST_PREFIX = "OAP_HOST_"
   val OAP_CACHE_EXECUTOR_PREFIX = "_OAP_EXECUTOR_"
 }

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -126,6 +126,21 @@ object OapConf {
       .stringConf
       .createWithDefault("offheap")
 
+  val OAP_CACHE_FIBERSENSOR_GETHOSTS_NUM =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.fiberSensor.getHostsNum")
+      .internal()
+      .doc("The length of getHosts function of FiberSensor's result Seq. The funcion returns " +
+        "getHostsNum of hosts with the maximum FiberCache for certain filePath")
+      .intConf
+      .createWithDefault(3)
+
+  val OAP_CACHE_FIBERSENSOR_MAXHOSTSMAINTAINED_NUM =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.fiberSensor.maxHostsMaintainedNum")
+      .internal()
+      .doc("The maximum maintained number of hosts number for a certain filePath in FiberSensor")
+      .intConf
+      .createWithDefault(10)
+
   val OAP_COMPRESSION = SqlConfAdapter.buildConf("spark.sql.oap.compression.codec")
     .internal()
     .doc("Sets the compression codec use when writing Parquet files. Acceptable values include: " +

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.internal.oap
 
-import org.apache.spark.internal.config.ConfigBuilder
 import org.apache.spark.sql.oap.adapter.SqlConfAdapter
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -127,7 +126,7 @@ object OapConf {
       .createWithDefault("offheap")
 
   val OAP_CACHE_FIBERSENSOR_GETHOSTS_NUM =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.fiberSensor.getHostsNum")
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.fiberSensor.getHostsNum")
       .internal()
       .doc("The length of getHosts function of FiberSensor's result Seq. The funcion returns " +
         "getHostsNum of hosts with the maximum FiberCache for certain filePath")
@@ -135,7 +134,7 @@ object OapConf {
       .createWithDefault(3)
 
   val OAP_CACHE_FIBERSENSOR_MAXHOSTSMAINTAINED_NUM =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.fiberSensor.maxHostsMaintainedNum")
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.fiberSensor.maxHostsMaintainedNum")
       .internal()
       .doc("The maximum maintained number of hosts number for a certain filePath in FiberSensor")
       .intConf

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -152,83 +152,86 @@ class FiberSensorSuite extends QueryTest with SharedOapContext with BeforeAndAft
 
   test("get hosts from FiberSensor") {
 
-    def getAns(file: String): Seq[String] = fiberSensor.getHosts(file)
+    withSQLConf(OapConf.OAP_CACHE_FIBERSENSOR_GETHOSTS_NUM.key -> "2") {
 
-    def checkExistence(host: String, execId: String, in: String): Boolean =
-      in.contains(host) && in.contains(execId)
+      def getAns(file: String): Seq[String] = fiberSensor.getHosts(file)
 
-    val filePath = "file1"
-    val groupCount = 30
-    val fieldCount = 3
+      def checkExistence(host: String, execId: String, in: String): Boolean =
+        in.contains(host) && in.contains(execId)
 
-    // executor1 update
-    val host1 = "host1"
-    val execId1 = "executor1"
-    val bitSet1 = new BitSet(90)
-    bitSet1.set(1)
-    bitSet1.set(2)
-    val fcs = Seq(FiberCacheStatus(filePath, bitSet1, groupCount, fieldCount))
-    val fiberInfo = SparkListenerCustomInfoUpdate(host1, execId1,
-      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe.serialize(fcs))
-    fiberSensor.updateLocations(fiberInfo)
-    assert(checkExistence(host1, execId1, getAns(filePath)(0)))
+      val filePath = "file1"
+      val groupCount = 30
+      val fieldCount = 3
 
-    // executor2 update
-    val host2 = "host2"
-    val execId2 = "executor2"
-    val bitSet2 = new BitSet(90)
-    bitSet2.set(3)
-    bitSet2.set(4)
-    bitSet2.set(5)
-    bitSet2.set(6)
-    bitSet2.set(7)
-    bitSet2.set(8)
+      // executor1 update
+      val host1 = "host1"
+      val execId1 = "executor1"
+      val bitSet1 = new BitSet(90)
+      bitSet1.set(1)
+      bitSet1.set(2)
+      val fcs = Seq(FiberCacheStatus(filePath, bitSet1, groupCount, fieldCount))
+      val fiberInfo = SparkListenerCustomInfoUpdate(host1, execId1,
+        "OapFiberCacheHeartBeatMessager", CacheStatusSerDe.serialize(fcs))
+      fiberSensor.updateLocations(fiberInfo)
+      assert(checkExistence(host1, execId1, getAns(filePath)(0)))
 
-    val fiberInfo2 = SparkListenerCustomInfoUpdate(host2, execId2,
-      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
-        .serialize(Seq(FiberCacheStatus(filePath, bitSet2, groupCount, fieldCount))))
-    fiberSensor.updateLocations(fiberInfo2)
-    assert(checkExistence(host2, execId2, getAns(filePath)(0)))
-    assert(checkExistence(host1, execId1, getAns(filePath)(1)))
+      // executor2 update
+      val host2 = "host2"
+      val execId2 = "executor2"
+      val bitSet2 = new BitSet(90)
+      bitSet2.set(3)
+      bitSet2.set(4)
+      bitSet2.set(5)
+      bitSet2.set(6)
+      bitSet2.set(7)
+      bitSet2.set(8)
 
-    // Another file cache update, doesn't influence filePath
-    val filePath2 = "file2"
-    val host3 = "host3"
-    val execId3 = "executor2"
-    val bitSet3 = new BitSet(90)
-    bitSet3.set(7)
-    bitSet3.set(8)
-    bitSet3.set(9)
-    bitSet3.set(10)
-    val fiberInfo3 = SparkListenerCustomInfoUpdate(host3, execId3,
-      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
-        .serialize(Seq(FiberCacheStatus(filePath2, bitSet3, groupCount, fieldCount))))
-    fiberSensor.updateLocations(fiberInfo3)
-    assert(checkExistence(host2, execId2, getAns(filePath)(0)))
-    assert(checkExistence(host1, execId1, getAns(filePath)(1)))
+      val fiberInfo2 = SparkListenerCustomInfoUpdate(host2, execId2,
+        "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
+            .serialize(Seq(FiberCacheStatus(filePath, bitSet2, groupCount, fieldCount))))
+      fiberSensor.updateLocations(fiberInfo2)
+      assert(checkExistence(host2, execId2, getAns(filePath)(0)))
+      assert(checkExistence(host1, execId1, getAns(filePath)(1)))
 
-    // New info for filePath host2:executor2, less cached may because of eviction
-    val bitSet4 = new BitSet(90)
-    bitSet4.set(1)
+      // Another file cache update, doesn't influence filePath
+      val filePath2 = "file2"
+      val host3 = "host3"
+      val execId3 = "executor2"
+      val bitSet3 = new BitSet(90)
+      bitSet3.set(7)
+      bitSet3.set(8)
+      bitSet3.set(9)
+      bitSet3.set(10)
+      val fiberInfo3 = SparkListenerCustomInfoUpdate(host3, execId3,
+        "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
+            .serialize(Seq(FiberCacheStatus(filePath2, bitSet3, groupCount, fieldCount))))
+      fiberSensor.updateLocations(fiberInfo3)
+      assert(checkExistence(host2, execId2, getAns(filePath)(0)))
+      assert(checkExistence(host1, execId1, getAns(filePath)(1)))
 
-    val fiberInfo4 = SparkListenerCustomInfoUpdate(host2, execId2,
-      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
-        .serialize(Seq(FiberCacheStatus(filePath, bitSet4, groupCount, fieldCount))))
-    fiberSensor.updateLocations(fiberInfo4)
-    // Now host1: execId1 comes first
-    assert(checkExistence(host1, execId1, getAns(filePath)(0)))
-    assert(checkExistence(host2, execId2, getAns(filePath)(1)))
+      // New info for filePath host2:executor2, less cached may because of eviction
+      val bitSet4 = new BitSet(90)
+      bitSet4.set(1)
 
-    // New info for filePath, host1: execId2, Driver maintaining 3 records for it, while
-    // NUM_GET_HOSTS returned
-    val bitSet5 = new BitSet(90)
-    bitSet5.set(1)
+      val fiberInfo4 = SparkListenerCustomInfoUpdate(host2, execId2,
+        "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
+            .serialize(Seq(FiberCacheStatus(filePath, bitSet4, groupCount, fieldCount))))
+      fiberSensor.updateLocations(fiberInfo4)
+      // Now host1: execId1 comes first
+      assert(checkExistence(host1, execId1, getAns(filePath)(0)))
+      assert(checkExistence(host2, execId2, getAns(filePath)(1)))
 
-    val fiberInfo5 = SparkListenerCustomInfoUpdate(host1, execId2,
-      "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
-        .serialize(Seq(FiberCacheStatus(filePath, bitSet5, groupCount, fieldCount))))
-    fiberSensor.updateLocations(fiberInfo5)
-    assert(getAns(filePath).length == FiberSensor.NUM_GET_HOSTS)
+      // New info for filePath, host1: execId2, Driver maintaining 3 records for it, while
+      // NUM_GET_HOSTS returned
+      val bitSet5 = new BitSet(90)
+      bitSet5.set(1)
+
+      val fiberInfo5 = SparkListenerCustomInfoUpdate(host1, execId2,
+        "OapFiberCacheHeartBeatMessager", CacheStatusSerDe
+            .serialize(Seq(FiberCacheStatus(filePath, bitSet5, groupCount, fieldCount))))
+      fiberSensor.updateLocations(fiberInfo5)
+      assert(getAns(filePath).length == FiberSensor.NUM_GET_HOSTS)
+    }
   }
 
   test("updateRecordingMap will preserve at most FiberSensor.MAX_HOSTS_MAINTAINED records for " +

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -228,4 +228,29 @@ class FiberSensorSuite extends QueryTest with SharedOapContext with BeforeAndAft
     fiberSensor.updateLocations(fiberInfo5)
     assert(getAns(filePath).length == FiberSensor.NUM_GET_HOSTS)
   }
+
+  test("Limited size SortedSet") {
+    class A(a: Int) extends Ordering[A] {
+      // Reverse order
+      override def compare(x: A, y: A): Int = y.a - x.a
+    }
+
+    val a1 = new A(1)
+    val a2 = new A(2)
+    val a3 = new A(3)
+    val a4 = new A(4)
+
+    var set = new LimitedSortedSet[A](2)
+    set += a2
+    assert(set.toSeq === Seq(a2))
+
+    set += a4
+    assert(set.toSeq == Seq(a4, a2))
+
+    set += a3
+    assert(set.toSeq === Seq(a4, a3))
+
+    set += a1
+    assert(set.toSeq === Seq(a4, a3))
+  }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -242,15 +242,15 @@ class FiberSensorSuite extends QueryTest with SharedOapContext with BeforeAndAft
 
     var set = new LimitedSortedSet[A](2)
     set += a2
-    assert(set.toSeq === Seq(a2))
+    assert(set.values.toSeq === Seq(a2))
 
     set += a4
-    assert(set.toSeq == Seq(a4, a2))
+    assert(set.values.toSeq == Seq(a4, a2))
 
     set += a3
-    assert(set.toSeq === Seq(a4, a3))
+    assert(set.values.toSeq === Seq(a4, a3))
 
     set += a1
-    assert(set.toSeq === Seq(a4, a3))
+    assert(set.values.toSeq === Seq(a4, a3))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Subtask of #757 , steps 2 & 3.

- Record all the cache status update to the new Map, this will take Guava eviction into consideration, since `FiberCacheManager` send full cache information through `Heartbeat`
- Record at most MAX_HOSTS_MAINTAINED records for each filePath, discard the one with the least Fiber whenever Host records is more than it.
- Return at most NUM_GET_HOSTS(with max Fibers for this file) hosts for `getHosts`

## How was this patch tested?

FiberSensorSuite

