### PR TITLE
[support spark2.3] adaptered codes to support spark2.3

### DIFF
--- a/src/main/spark2.1/scala/org/apache/spark/sql/oap/adapter/TaskContextImplAdapter.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/oap/adapter/TaskContextImplAdapter.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import java.util.Properties
+
+import org.apache.spark.{TaskContext, TaskContextImpl}
+import org.apache.spark.memory.TaskMemoryManager
+import org.apache.spark.metrics.MetricsSystem
+
+
+object TaskContextImplAdapter {
+
+  def createTaskContextImpl(
+      stageId: Int,
+      partitionId: Int,
+      taskAttemptId: Long,
+      attemptNumber: Int,
+      taskMemoryManager: TaskMemoryManager,
+      localProperties: Properties,
+      metricsSystem: MetricsSystem): TaskContext = {
+    new TaskContextImpl(
+      stageId,
+      partitionId,
+      taskAttemptId,
+      attemptNumber,
+      taskMemoryManager,
+      localProperties,
+      metricsSystem)
+  }
+}

--- a/src/main/spark2.2/scala/org/apache/spark/sql/oap/adapter/TaskContextImplAdapter.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/oap/adapter/TaskContextImplAdapter.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import java.util.Properties
+
+import org.apache.spark.{TaskContext, TaskContextImpl}
+import org.apache.spark.memory.TaskMemoryManager
+import org.apache.spark.metrics.MetricsSystem
+
+
+object TaskContextImplAdapter {
+
+  def createTaskContextImpl(
+      stageId: Int,
+      partitionId: Int,
+      taskAttemptId: Long,
+      attemptNumber: Int,
+      taskMemoryManager: TaskMemoryManager,
+      localProperties: Properties,
+      metricsSystem: MetricsSystem): TaskContext = {
+    new TaskContextImpl(
+      stageId,
+      partitionId,
+      taskAttemptId,
+      attemptNumber,
+      taskMemoryManager,
+      localProperties,
+      metricsSystem)
+  }
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/AggregateFunctionAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/AggregateFunctionAdapter.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
+
+object AggregateFunctionAdapter {
+  // In Spark 2.2 and later, all aggregation functions support partial aggregate, see SPARK-19060
+  def supportsPartial(func: AggregateFunction): Boolean = true
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/ColumnVectorAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/ColumnVectorAdapter.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapColumnVector, WritableColumnVector}
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.vectorized.ColumnVector
+
+object ColumnVectorAdapter {
+
+  def allocate(capacity: Int, dt: DataType, memMode: MemoryMode): WritableColumnVector = {
+    if (memMode == MemoryMode.OFF_HEAP) {
+      new OffHeapColumnVector(capacity, dt)
+    } else {
+      new OnHeapColumnVector(capacity, dt)
+    }
+  }
+
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/FileIndexAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/FileIndexAdapter.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory}
+
+object FileIndexAdapter {
+  /**
+   * Parameter dataFilters is added in Spark 2.2 and later. In 2.1, we just ignore it.
+   */
+  def listFiles(
+      fileIndex: FileIndex,
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+    fileIndex.listFiles(partitionFilters, dataFilters)
+  }
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/FileSourceScanExecAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/FileSourceScanExecAdapter.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Expression, Attribute}
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation}
+import org.apache.spark.sql.types.StructType
+
+object FileSourceScanExecAdapter {
+  def createFileSourceScanExec(
+      relation: HadoopFsRelation,
+      output: Seq[Attribute],
+      requiredSchema: StructType,
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression],
+      metastoreTableIdentifier: Option[TableIdentifier]): FileSourceScanExec = {
+    FileSourceScanExec(
+      relation,
+      output,
+      requiredSchema,
+      partitionFilters,
+      dataFilters,
+      metastoreTableIdentifier)
+  }
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/InputFileNameHolderAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/InputFileNameHolderAdapter.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import org.apache.spark.rdd.InputFileBlockHolder
+import org.apache.spark.unsafe.types.UTF8String
+
+object InputFileNameHolderAdapter {
+  /**
+   * Returns the holding file name or empty string if it is unknown.
+   */
+  def getInputFileName(): UTF8String = InputFileBlockHolder.getInputFilePath
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/LogicalPlanAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/LogicalPlanAdapter.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import org.apache.spark.sql.catalyst.plans.logical.{Statistics, LogicalPlan}
+import org.apache.spark.sql.internal.SQLConf
+
+object LogicalPlanAdapter {
+  def getStatistics(plan: LogicalPlan, conf:SQLConf): Statistics = plan.stats
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/RpcEndpointRefAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/RpcEndpointRefAdapter.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.rpc.RpcEndpointRef
+
+object RpcEndpointRefAdapter {
+  def askSync[T: ClassTag](endpoint: RpcEndpointRef, message: Any): T = {
+    endpoint.askSync(message)
+  }
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/SqlConfAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/SqlConfAdapter.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import org.apache.spark.internal.config.ConfigBuilder
+import org.apache.spark.sql.internal.SQLConf
+
+object SqlConfAdapter {
+  def buildConf(key: String): ConfigBuilder = SQLConf.buildConf(key)
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/TaskContextImplAdapter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/adapter/TaskContextImplAdapter.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap.adapter
+
+import java.util.Properties
+
+import org.apache.spark.{TaskContext, TaskContextImpl}
+import org.apache.spark.memory.TaskMemoryManager
+import org.apache.spark.metrics.MetricsSystem
+
+
+object TaskContextImplAdapter {
+
+  def createTaskContextImpl(
+      stageId: Int,
+      partitionId: Int,
+      taskAttemptId: Long,
+      attemptNumber: Int,
+      taskMemoryManager: TaskMemoryManager,
+      localProperties: Properties,
+      metricsSystem: MetricsSystem): TaskContext = {
+    new TaskContextImpl(
+      stageId,
+      stageAttemptNumber = 0,
+      partitionId,
+      taskAttemptId,
+      attemptNumber,
+      taskMemoryManager,
+      localProperties,
+      metricsSystem)
+  }
+}

--- a/src/test/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/adapter/PropertiesAdapter.scala
+++ b/src/test/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/adapter/PropertiesAdapter.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.adapter
+
+import org.scalacheck.{Prop, Properties}
+
+object PropertiesAdapter {
+
+  def getProp(properties: Properties): Prop = {
+    properties
+  }
+
+}

--- a/src/test/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/adapter/WholeStageCodeGenAdapter.scala
+++ b/src/test/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/adapter/WholeStageCodeGenAdapter.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.adapter
+
+object WholeStageCodeGenAdapter {
+
+  def getKeywordPrefix(): String = {
+    "*"
+  }
+
+}

--- a/src/test/spark2.2/scala/org/apache/spark/sql/execution/datasources/adapter/PropertiesAdapter.scala
+++ b/src/test/spark2.2/scala/org/apache/spark/sql/execution/datasources/adapter/PropertiesAdapter.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.adapter
+
+import org.scalacheck.{Prop, Properties}
+
+object PropertiesAdapter {
+
+  def getProp(properties: Properties): Prop = {
+    properties
+  }
+
+}

--- a/src/test/spark2.2/scala/org/apache/spark/sql/execution/datasources/adapter/WholeStageCodeGenAdapter.scala
+++ b/src/test/spark2.2/scala/org/apache/spark/sql/execution/datasources/adapter/WholeStageCodeGenAdapter.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.adapter
+
+object WholeStageCodeGenAdapter {
+
+  def getKeywordPrefix(): String = {
+    "*"
+  }
+
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/adapter/PropertiesAdapter.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/adapter/PropertiesAdapter.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.adapter
+
+import org.scalacheck.{Prop, Properties}
+
+object PropertiesAdapter {
+
+  def getProp(properties: Properties): Prop = {
+    Prop.all(properties.properties.map(_._2): _*)
+  }
+
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/adapter/WholeStageCodeGenAdapter.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/adapter/WholeStageCodeGenAdapter.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.adapter
+
+object WholeStageCodeGenAdapter {
+
+  def getKeywordPrefix(): String = {
+    "*(1) "
+  }
+
+}


### PR DESCRIPTION
Compared to the version of "spark 2.2", "ColumnVectorAdapter.scala" has been added, and "LogicalPlanAdapter.scala" has been changed.
Others, the same as the "spark 2.2" version.
