### PR TITLE
[support spark2.3]  remaining changed codes to support spark2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ sudo: required
 dist: trusty
 language: java
 script:
-- mvn clean -Pspark-2.1 -Dmaven.test.skip=true package
-- mvn clean -Pspark-2.2 -Dmaven.test.skip=true package

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ sudo: required
 dist: trusty
 language: java
 script:
-- mvn clean -Pspark-2.1 -Dmaven.test.skip=true package
-- mvn clean -Pspark-2.2 -Dmaven.test.skip=true package
+- mvn clean -Pspark-2.1 test
+- mvn clean -Pspark-2.2 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ sudo: required
 dist: trusty
 language: java
 script:
-- mvn clean -Pspark-2.1 test
-- mvn clean -Pspark-2.2 test
+- mvn clean -Pspark-2.1 -Dmaven.test.skip=true package
+- mvn clean -Pspark-2.2 -Dmaven.test.skip=true package

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ sudo: required
 dist: trusty
 language: java
 script:
+- mvn clean -Pspark-2.1 -Dmaven.test.skip=true package
+- mvn clean -Pspark-2.2 -Dmaven.test.skip=true package

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OapOutputWriter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OapOutputWriter.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{OutputWriter, WriteResult}
+import org.apache.spark.sql.execution.datasources.oap.io.OapDataWriter
+import org.apache.spark.sql.types.StructType
+
+
+private[oap] class OapOutputWriter(
+    path: String,
+    dataSchema: StructType,
+    context: TaskAttemptContext) extends OutputWriter {
+  private var rowCount = 0
+  private var partitionString: String = ""
+
+  override def setPartitionString(ps: String): Unit = {
+    partitionString = ps
+  }
+
+  private val writer: OapDataWriter = {
+    val isCompressed = FileOutputFormat.getCompressOutput(context)
+    val conf = context.getConfiguration
+    val file: Path = new Path(path)
+    val fs = file.getFileSystem(conf)
+    val fileOut = fs.create(file, false)
+
+    new OapDataWriter(isCompressed, fileOut, dataSchema, conf)
+  }
+
+  override def write(row: InternalRow): Unit = {
+    rowCount += 1
+    writer.write(row)
+  }
+
+  override def close(): Unit = {
+    writer.close()
+  }
+
+  override def writeStatus(): WriteResult = {
+    OapWriteResult(dataFileName, rowCount, partitionString)
+  }
+
+  def dataFileName: String = new Path(path).getName
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputWriter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputWriter.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.index
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
+import org.apache.parquet.hadoop.util.ContextUtil
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.OutputWriter
+import org.apache.spark.sql.oap.adapter.InputFileNameHolderAdapter
+
+// TODO: parameter name "path" is ambiguous
+private[index] class OapIndexOutputWriter(
+    path: String,
+    context: TaskAttemptContext
+) extends OutputWriter {
+
+  private val outputFormat = new OapIndexOutputFormat() {
+    override def getDefaultWorkFile(context: TaskAttemptContext, extension: String): Path = {
+      val outputPath = FileOutputFormat.getOutputPath(context)
+      val configuration = ContextUtil.getConfiguration(context)
+      IndexUtils.generateTempIndexFilePath(
+        configuration, inputFileName, outputPath, path, extension)
+    }
+  }
+
+  private var recordWriter: RecordWriter[Void, InternalRow] = _
+
+  private var inputFileName: String = _
+
+  private var results: Seq[IndexBuildResult] = Nil
+
+  private var rowCount: Long = 0
+
+  override def write(row: InternalRow): Unit = {
+    checkStartOfNewFile()
+    recordWriter.write(null, row)
+    rowCount += 1
+  }
+
+  override def close(): Unit = {
+    closeWriter()
+  }
+
+  override def writeStatus(): Seq[IndexBuildResult] = {
+    results
+  }
+
+  private def initWriter(): Unit = {
+    inputFileName = InputFileNameHolderAdapter.getInputFileName().toString
+    recordWriter = outputFormat.getRecordWriter(context)
+    rowCount = 0
+  }
+
+  private def closeWriter(): Unit = {
+    if (recordWriter != null) {
+      recordWriter.close(context)
+      recordWriter = null
+      results = results :+ IndexBuildResult(
+        new Path(inputFileName).getName, rowCount, "", new Path(inputFileName).getParent.toString)
+    }
+  }
+
+  private def checkStartOfNewFile(): Unit = {
+    if (inputFileName != InputFileNameHolderAdapter.getInputFileName().toString) {
+      closeWriter()
+      initWriter()
+    }
+  }
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/hive/OapSessionStateBuilder.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/hive/OapSessionStateBuilder.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.parser.{ParserInterface, SqlBaseParser}
+import org.apache.spark.sql.execution.{SparkPlanner, SparkSqlParser}
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, FileSourceStrategy}
+import org.apache.spark.sql.execution.datasources.oap.OapStrategies
+import org.apache.spark.sql.internal.{SQLConf, SessionState, VariableSubstitution}
+
+class OapSessionStateBuilder(session: SparkSession, parentState: Option[SessionState] = None)
+  extends HiveSessionStateBuilder(session, parentState) {
+
+  override lazy val sqlParser: ParserInterface = new OapSqlParser(conf)
+
+  override protected def planner: SparkPlanner = {
+    new SparkPlanner(session.sparkContext, conf, experimentalMethods)
+      with HiveStrategies
+      with OapStrategies {
+      override val sparkSession: SparkSession = session
+
+      override def extraPlanningStrategies: Seq[Strategy] =
+        super.extraPlanningStrategies ++ customPlanningStrategies
+
+      override def strategies: Seq[Strategy] = {
+        experimentalMethods.extraStrategies ++
+          extraPlanningStrategies ++
+          oapStrategies ++ Seq(
+          FileSourceStrategy,
+          DataSourceStrategy(conf),
+          SpecialLimits,
+          InMemoryScans,
+          HiveTableScans,
+          Scripts,
+          Aggregation,
+          JoinSelection,
+          BasicOperators
+        )
+      }
+    }
+  }
+
+  override protected def newBuilder: NewBuilder = new OapSessionStateBuilder(_, _)
+}
+
+
+/**
+ * Concrete parser for Spark SQL statements.
+ */
+class OapSqlParser(conf: SQLConf) extends SparkSqlParser(conf) {
+  private val substitutor = new VariableSubstitution(conf)
+
+  protected override def parse[T](command: String)(toResult: SqlBaseParser => T): T = {
+    super.parse(substitutor.substitute(command))(toResult)
+  }
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import java.io.PrintStream
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
+import org.apache.spark.sql.oap.OapSession
+import org.apache.spark.sql.oap.listener.OapListener
+import org.apache.spark.sql.oap.ui.OapTab
+import org.apache.spark.util.Utils
+
+/**
+ * Most of the code in init() are copied from SparkSQLEnv. Please include code from the
+ * corresponding Spark version.
+ */
+private[spark] object OapEnv extends Logging {
+  logDebug("Initializing Oap Env")
+
+  var sqlContext: SQLContext = _
+  var sparkContext: SparkContext = _
+
+  var initialized: Boolean = false
+
+  def init(): Unit = synchronized {
+    if (!initialized && !Utils.isTesting) {
+      if (sqlContext == null) {
+        val sparkConf = new SparkConf(loadDefaults = true)
+        // If user doesn't specify the appName, we want to get [SparkSQL::localHostName] instead of
+        // the default appName [SparkSQLCLIDriver] in cli or beeline.
+        val maybeAppName = sparkConf
+          .getOption("spark.app.name")
+          .filterNot(_ == classOf[SparkSQLCLIDriver].getName)
+          .filterNot(_ == classOf[HiveThriftServer2].getName)
+
+        sparkConf.setAppName(maybeAppName.getOrElse(s"SparkSQL::${Utils.localHostName()}"))
+
+        val sparkSession = OapSession.builder.config(sparkConf).enableHiveSupport().getOrCreate()
+        sparkContext = sparkSession.sparkContext
+        sqlContext = sparkSession.sqlContext
+
+        val metadataHive = sparkSession
+          .sharedState.externalCatalog.asInstanceOf[HiveExternalCatalog]
+          .client.newSession()
+        metadataHive.setOut(new PrintStream(System.out, true, "UTF-8"))
+        metadataHive.setInfo(new PrintStream(System.err, true, "UTF-8"))
+        metadataHive.setError(new PrintStream(System.err, true, "UTF-8"))
+        sparkSession.conf.set("spark.sql.hive.version", HiveUtils.builtinHiveVersion)
+      }
+
+      sparkContext.addSparkListener(new OapListener)
+
+      SparkSQLEnv.sparkContext = sparkContext
+      SparkSQLEnv.sqlContext = sqlContext
+
+      sparkContext.ui.foreach(new OapTab(_))
+      initialized = true
+    }
+  }
+
+  // This is to enable certain OAP features, like UI, in non-Spark SQL CLI/ThriftServer conditions
+  def initWithoutCreatingOapSession(): Unit = synchronized {
+    if (!initialized && !Utils.isTesting) {
+      val sc = SparkContext.getOrCreate()
+      sc.addSparkListener(new OapListener)
+      sc.ui.foreach(new OapTab(_))
+      initialized = true
+    }
+  }
+
+  /** Cleans up and shuts down the Spark SQL environments. */
+  def stop() {
+    SparkSQLEnv.stop()
+  }
+}

--- a/src/main/spark2.3/scala/org/apache/spark/sql/oap/OapSession.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/oap/OapSession.scala
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.oap
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.annotation.InterfaceStability
+import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
+import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
+// import org.apache.spark.sql.execution.ui.SQLListener
+import org.apache.spark.sql.internal.{BaseSessionStateBuilder, SessionState, SessionStateBuilder, StaticSQLConf}
+import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
+import org.apache.spark.util.Utils
+
+class OapSession(sparkContext: SparkContext) extends SparkSession(sparkContext) { self =>
+  @InterfaceStability.Unstable
+  @transient
+  override lazy val sessionState: SessionState = {
+    OapSession.instantiateSessionState(
+      OapSession.sessionStateClassName(sparkContext.conf),
+      self)
+  }
+}
+
+object OapSession {
+  class OapSessionBuilder extends SparkSession.Builder {
+    private[this] val options = new scala.collection.mutable.HashMap[String, String]
+
+    private[this] val extensions = new SparkSessionExtensions
+
+    private[this] var userSuppliedContext: Option[SparkContext] = None
+
+    override private[spark] def sparkContext(sparkContext: SparkContext): OapSessionBuilder = synchronized {
+      userSuppliedContext = Option(sparkContext)
+      this
+    }
+
+    /**
+     * Sets a name for the application, which will be shown in the Spark web UI.
+     * If no application name is set, a randomly generated name will be used.
+     *
+     * @since 2.0.0
+     */
+    override def appName(name: String): OapSessionBuilder = config("spark.app.name", name)
+
+    /**
+     * Sets a config option. Options set using this method are automatically propagated to
+     * both `SparkConf` and SparkSession's own configuration.
+     *
+     * @since 2.0.0
+     */
+    override def config(key: String, value: String): OapSessionBuilder = synchronized {
+      options += key -> value
+      this
+    }
+
+    /**
+     * Sets a config option. Options set using this method are automatically propagated to
+     * both `SparkConf` and SparkSession's own configuration.
+     *
+     * @since 2.0.0
+     */
+    override def config(key: String, value: Long): OapSessionBuilder = synchronized {
+      options += key -> value.toString
+      this
+    }
+
+    /**
+     * Sets a config option. Options set using this method are automatically propagated to
+     * both `SparkConf` and SparkSession's own configuration.
+     *
+     * @since 2.0.0
+     */
+    override def config(key: String, value: Double): OapSessionBuilder = synchronized {
+      options += key -> value.toString
+      this
+    }
+
+    /**
+     * Sets a config option. Options set using this method are automatically propagated to
+     * both `SparkConf` and SparkSession's own configuration.
+     *
+     * @since 2.0.0
+     */
+    override def config(key: String, value: Boolean): OapSessionBuilder = synchronized {
+      options += key -> value.toString
+      this
+    }
+
+    /**
+     * Sets a list of config options based on the given `SparkConf`.
+     *
+     * @since 2.0.0
+     */
+    override def config(conf: SparkConf): OapSessionBuilder = synchronized {
+      conf.getAll.foreach { case (k, v) => options += k -> v }
+      this
+    }
+
+    /**
+     * Sets the Spark master URL to connect to, such as "local" to run locally, "local[4]" to
+     * run locally with 4 cores, or "spark://master:7077" to run on a Spark standalone cluster.
+     *
+     * @since 2.0.0
+     */
+    override def master(master: String): OapSessionBuilder = config("spark.master", master)
+
+    /**
+     * Enables Hive support, including connectivity to a persistent Hive metastore, support for
+     * Hive serdes, and Hive user-defined functions.
+     *
+     * @since 2.0.0
+     */
+    override def enableHiveSupport(): OapSessionBuilder = synchronized {
+      if (hiveClassesArePresent) {
+        config(CATALOG_IMPLEMENTATION.key, "hive")
+      } else {
+        throw new IllegalArgumentException(
+          "Unable to instantiate SparkSession with Hive support because " +
+            "Hive classes are not found.")
+      }
+    }
+
+    /**
+     * Inject extensions into the [[SparkSession]]. This allows a user to add Analyzer rules,
+     * Optimizer rules, Planning Strategies or a customized parser.
+     *
+     * @since 2.2.0
+     */
+    override def withExtensions(f: SparkSessionExtensions => Unit): OapSessionBuilder = {
+      f(extensions)
+      this
+    }
+
+    /**
+     * Gets an existing [[SparkSession]] or, if there is no existing one, creates a new
+     * one based on the options set in this builder.
+     *
+     * This method first checks whether there is a valid thread-local SparkSession,
+     * and if yes, return that one. It then checks whether there is a valid global
+     * default SparkSession, and if yes, return that one. If no valid global default
+     * SparkSession exists, the method creates a new SparkSession and assigns the
+     * newly created SparkSession as the global default.
+     *
+     * In case an existing SparkSession is returned, the config options specified in
+     * this builder will be applied to the existing SparkSession.
+     *
+     * @since 2.0.0
+     */
+    override def getOrCreate(): OapSession = synchronized {
+      // Get the session from current thread's active session.
+      var session = activeThreadSession.get()
+      if ((session ne null) && !session.sparkContext.isStopped) {
+        options.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
+        if (options.nonEmpty) {
+          logWarning("Using an existing SparkSession; some configuration may not take effect.")
+        }
+        return session
+      }
+
+      // Global synchronization so we will only set the default session once.
+      OapSession.synchronized {
+        // If the current thread does not have an active session, get it from the global session.
+        session = defaultSession.get()
+        if ((session ne null) && !session.sparkContext.isStopped) {
+          options.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
+          if (options.nonEmpty) {
+            logWarning("Using an existing SparkSession; some configuration may not take effect.")
+          }
+          return session
+        }
+
+        // No active nor global default session. Create a new one.
+        val sparkContext = userSuppliedContext.getOrElse {
+          // set app name if not given
+          val randomAppName = java.util.UUID.randomUUID().toString
+          val sparkConf = new SparkConf()
+          options.foreach { case (k, v) => sparkConf.set(k, v) }
+          if (!sparkConf.contains("spark.app.name")) {
+            sparkConf.setAppName(randomAppName)
+          }
+          val sc = SparkContext.getOrCreate(sparkConf)
+          // maybe this is an existing SparkContext, update its SparkConf which maybe used
+          // by SparkSession
+          options.foreach { case (k, v) => sc.conf.set(k, v) }
+          if (!sc.conf.contains("spark.app.name")) {
+            sc.conf.setAppName(randomAppName)
+          }
+          sc
+        }
+
+        // Initialize extensions if the user has defined a configurator class.
+        val extensionConfOption = sparkContext.conf.get(StaticSQLConf.SPARK_SESSION_EXTENSIONS)
+        if (extensionConfOption.isDefined) {
+          val extensionConfClassName = extensionConfOption.get
+          try {
+            val extensionConfClass = Utils.classForName(extensionConfClassName)
+            val extensionConf = extensionConfClass.newInstance()
+              .asInstanceOf[SparkSessionExtensions => Unit]
+            extensionConf(extensions)
+          } catch {
+            // Ignore the error if we cannot find the class or when the class has the wrong type.
+            case e @ (_: ClassCastException |
+                      _: ClassNotFoundException |
+                      _: NoClassDefFoundError) =>
+              logWarning(s"Cannot use $extensionConfClassName to configure session extensions.", e)
+          }
+        }
+
+        session = new OapSession(sparkContext)
+        options.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
+        defaultSession.set(session)
+
+        // Register a successfully instantiated context to the singleton. This should be at the
+        // end of the class definition so that the singleton is updated only if there is no
+        // exception in the construction of the instance.
+        sparkContext.addSparkListener(new SparkListener {
+          override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
+            defaultSession.set(null)
+//            sqlListener.set(null)
+          }
+        })
+      }
+
+      return session
+    }
+  }
+
+  /**
+   * Creates a [[SparkSession.Builder]] for constructing a [[SparkSession]].
+   *
+   * @since 2.0.0
+   */
+  def builder(): OapSessionBuilder = new OapSessionBuilder
+
+  /**
+   * Changes the SparkSession that will be returned in this thread and its children when
+   * SparkSession.getOrCreate() is called. This can be used to ensure that a given thread receives
+   * a SparkSession with an isolated session, instead of the global (first created) context.
+   *
+   * @since 2.0.0
+   */
+  def setActiveSession(session: OapSession): Unit = {
+    activeThreadSession.set(session)
+  }
+
+  /**
+   * Clears the active SparkSession for current thread. Subsequent calls to getOrCreate will
+   * return the first created context instead of a thread-local override.
+   *
+   * @since 2.0.0
+   */
+  def clearActiveSession(): Unit = {
+    activeThreadSession.remove()
+  }
+
+  /**
+   * Sets the default SparkSession that is returned by the builder.
+   *
+   * @since 2.0.0
+   */
+  def setDefaultSession(session: OapSession): Unit = {
+    defaultSession.set(session)
+  }
+
+  /**
+   * Clears the default SparkSession that is returned by the builder.
+   *
+   * @since 2.0.0
+   */
+  def clearDefaultSession(): Unit = {
+    defaultSession.set(null)
+  }
+
+  /**
+   * Returns the active SparkSession for the current thread, returned by the builder.
+   *
+   * @since 2.2.0
+   */
+  def getActiveSession: Option[OapSession] = Option(activeThreadSession.get)
+
+  /**
+   * Returns the default SparkSession that is returned by the builder.
+   *
+   * @since 2.2.0
+   */
+  def getDefaultSession: Option[OapSession] = Option(defaultSession.get)
+
+  /** A global SQL listener used for the SQL UI. */
+//  private[sql] val sqlListener = new AtomicReference[SQLListener]()
+
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // Private methods from now on
+  ////////////////////////////////////////////////////////////////////////////////////////
+
+  /** The active SparkSession for the current thread. */
+  private val activeThreadSession = new InheritableThreadLocal[OapSession]
+
+  /** Reference to the root SparkSession. */
+  private val defaultSession = new AtomicReference[OapSession]
+
+  private val HIVE_SESSION_STATE_BUILDER_CLASS_NAME =
+    "org.apache.spark.sql.hive.OapSessionStateBuilder"
+
+  private def sessionStateClassName(conf: SparkConf): String = {
+    conf.get(CATALOG_IMPLEMENTATION) match {
+      case "hive" => HIVE_SESSION_STATE_BUILDER_CLASS_NAME
+      case "in-memory" => classOf[SessionStateBuilder].getCanonicalName
+    }
+  }
+
+  /**
+   * Helper method to create an instance of `SessionState` based on `className` from conf.
+   * The result is either `SessionState` or a Hive based `SessionState`.
+   */
+  private def instantiateSessionState(
+      className: String,
+      oapSession: OapSession): SessionState = {
+    try {
+      // invoke `new [Hive]SessionStateBuilder(SparkSession, Option[SessionState])`
+      val clazz = Utils.classForName(className)
+      val ctor = clazz.getConstructors.head
+      ctor.newInstance(oapSession, None).asInstanceOf[BaseSessionStateBuilder].build()
+    } catch {
+      case NonFatal(e) =>
+        throw new IllegalArgumentException(s"Error while instantiating '$className':", e)
+    }
+  }
+
+  /**
+   * @return true if Hive classes can be loaded, otherwise false.
+   */
+  private[spark] def hiveClassesArePresent: Boolean = {
+    try {
+      Utils.classForName(HIVE_SESSION_STATE_BUILDER_CLASS_NAME)
+      Utils.classForName("org.apache.hadoop.hive.conf.HiveConf")
+      true
+    } catch {
+      case _: ClassNotFoundException | _: NoClassDefFoundError => false
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -99,6 +99,7 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
       "UnCompressed").foreach { codec =>
       sqlContext.conf.setConfString(OapConf.OAP_COMPRESSION.key, codec)
       val df = sqlContext.read.format("oap").load(path.getAbsolutePath)
+      Utils.deleteRecursively(path)
       df.write.format("oap").mode(SaveMode.Overwrite).save(path.getAbsolutePath)
       val compressionType =
         sqlContext.conf.getConfString(OapConf.OAP_COMPRESSION.key).toLowerCase

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkipAndReadValueWithPackedDefinitionLevelsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkipAndReadValueWithPackedDefinitionLevelsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.parquet.io.api.Binary
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
-import org.apache.spark.sql.execution.vectorized.ColumnVector
+import org.apache.spark.sql.oap.adapter.ColumnVectorAdapter
 import org.apache.spark.sql.types.BinaryType
 
 class SkipAndReadValueWithPackedDefinitionLevelsSuite extends SparkFunSuite with Logging {
@@ -212,7 +212,7 @@ class SkipAndReadValueWithPackedDefinitionLevelsSuite extends SparkFunSuite with
     reader.skipBinarys(0, 1, valueReader)
 
     // read binary to a vector and assert read value
-    val vector = ColumnVector.allocate(10, BinaryType, MemoryMode.ON_HEAP)
+    val vector = ColumnVectorAdapter.allocate(10, BinaryType, MemoryMode.ON_HEAP)
     valueReader.readBinary(1, vector, 0)
     assert(vector.getBinary(0).sameElements("F".getBytes))
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkipAndReadValueWithRleDefinitionLevelsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkipAndReadValueWithRleDefinitionLevelsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.parquet.io.api.Binary
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
-import org.apache.spark.sql.execution.vectorized.ColumnVector
+import org.apache.spark.sql.oap.adapter.ColumnVectorAdapter
 import org.apache.spark.sql.types.BinaryType
 
 class SkipAndReadValueWithRleDefinitionLevelsSuite extends SparkFunSuite with Logging {
@@ -219,7 +219,7 @@ class SkipAndReadValueWithRleDefinitionLevelsSuite extends SparkFunSuite with Lo
     reader.skipBinarys(0, 1, valueReader)
 
     // read binary to a vector and assert read value
-    val vector = ColumnVector.allocate(10, BinaryType, MemoryMode.ON_HEAP)
+    val vector = ColumnVectorAdapter.allocate(10, BinaryType, MemoryMode.ON_HEAP)
     valueReader.readBinary(1, vector, 0)
     assert(vector.getBinary(0).sameElements("F".getBytes))
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkippableVectorizedPlainValuesReaderSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkippableVectorizedPlainValuesReaderSuite.scala
@@ -23,7 +23,7 @@ import org.apache.parquet.io.api.Binary
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
-import org.apache.spark.sql.execution.vectorized.ColumnVector
+import org.apache.spark.sql.oap.adapter.ColumnVectorAdapter
 import org.apache.spark.sql.types.BinaryType
 
 class SkippableVectorizedPlainValuesReaderSuite extends SparkFunSuite with Logging {
@@ -178,7 +178,7 @@ class SkippableVectorizedPlainValuesReaderSuite extends SparkFunSuite with Loggi
 
     // test skip and read boolean data
     reader.skipBinary(2)
-    val vector = ColumnVector.allocate(10, BinaryType, MemoryMode.ON_HEAP)
+    val vector = ColumnVectorAdapter.allocate(10, BinaryType, MemoryMode.ON_HEAP)
     reader.readBinary(3, vector, 0)
     assert(vector.getBinary(0).sameElements("F".getBytes))
     assert(vector.getBinary(1).sameElements("GHI".getBytes))


### PR DESCRIPTION
The following code files are modified in the public "test" directory :

src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkipAndReadValueWithPackedDefinitionLevelsSuite.scala
src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkipAndReadValueWithRleDefinitionLevelsSuite.scala
src/test/scala/org/apache/spark/sql/execution/datasources/parquet/SkippableVectorizedPlainValuesReaderSuite.scala
src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala








The following code files are modified in the separate "src/main/spark2.3" directory :

src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OapOutputWriter.scala
src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/index/OapIndexOutputWriter.scala
src/main/spark2.3/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
src/main/spark2.3/scala/org/apache/spark/sql/hive/OapSessionStateBuilder.scala
src/main/spark2.3/scala/org/apache/spark/sql/oap/OapSession.scala


