### PR TITLE
Refactor OapConf to several categories

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -118,10 +118,11 @@ private[sql] class OapFileFormat extends FileFormat
 
     // First use table option, if not, use SqlConf, else, use default value.
     conf.set(OapFileFormat.COMPRESSION, options.getOrElse("compression",
-      sparkSession.conf.get(OapConf.OAP_COMPRESSION.key, OapFileFormat.DEFAULT_COMPRESSION)))
+      sparkSession.conf.get(OapConf.OAP_IO_COMPRESSION.key, OapFileFormat.DEFAULT_COMPRESSION)))
 
     conf.set(OapFileFormat.ROW_GROUP_SIZE, options.getOrElse("rowgroup",
-      sparkSession.conf.get(OapConf.OAP_ROW_GROUP_SIZE.key, OapFileFormat.DEFAULT_ROW_GROUP_SIZE)))
+      sparkSession.conf.get(
+        OapConf.OAP_OAPFILEFORMAT_ROWGROUP_SIZE.key, OapFileFormat.DEFAULT_ROW_GROUP_SIZE)))
 
     new OapOutputWriterFactory(
       dataSchema,
@@ -216,7 +217,7 @@ private[sql] class OapFileFormat extends FileFormat
             supportFilters.foreach(filter => logDebug("\t" + filter.toString))
             // get index options such as limit, order, etc.
             val indexOptions = options.filterKeys(OapFileFormat.oapOptimizationKeySeq.contains(_))
-            val maxChooseSize = sparkSession.conf.get(OapConf.OAP_INDEXER_CHOICE_MAX_SIZE)
+            val maxChooseSize = sparkSession.conf.get(OapConf.OAP_INDEX_INDEXER_CHOICE_MAX_SIZE)
             val indexDisableList = sparkSession.conf.get(OapConf.OAP_INDEX_DISABLE_LIST)
             ScannerBuilder.build(supportFilters, ic, indexOptions, maxChooseSize, indexDisableList)
           }
@@ -301,7 +302,7 @@ private[sql] class OapFileFormat extends FileFormat
   def hasAvailableIndex(
       expressions: Seq[Expression],
       requiredTypes: Seq[IndexType] = Nil): Boolean = {
-    if (expressions.nonEmpty && sparkSession.conf.get(OapConf.OAP_ENABLE_OINDEX)) {
+    if (expressions.nonEmpty && sparkSession.conf.get(OapConf.OAP_INDEX_ENABLED)) {
       meta match {
         case Some(m) if requiredTypes.isEmpty =>
           expressions.exists(m.isSupportedByIndex(_, None))
@@ -443,9 +444,9 @@ private[sql] object OapFileFormat {
   val PARQUET_DATA_FILE_CLASSNAME = classOf[ParquetDataFile].getCanonicalName
 
   val COMPRESSION = "oap.compression"
-  val DEFAULT_COMPRESSION = OapConf.OAP_COMPRESSION.defaultValueString
+  val DEFAULT_COMPRESSION = OapConf.OAP_IO_COMPRESSION.defaultValueString
   val ROW_GROUP_SIZE = "oap.rowgroup.size"
-  val DEFAULT_ROW_GROUP_SIZE = OapConf.OAP_ROW_GROUP_SIZE.defaultValueString
+  val DEFAULT_ROW_GROUP_SIZE = OapConf.OAP_OAPFILEFORMAT_ROWGROUP_SIZE.defaultValueString
 
   /**
    * Oap Optimization Options.

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
@@ -295,7 +295,7 @@ trait OapStrategies extends Logging {
       indexHint: Seq[Expression],
       indexRequirements: Seq[IndexType]): Option[SparkPlan] = {
     val conf = SparkSession.getActiveSession.get.sessionState.conf
-    if (!conf.getConf(OapConf.OAP_STRATEGIES_ENABLED) ||
+    if (!conf.getConf(OapConf.OAP_STRATEGY_ENABLED) ||
         conf.getConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION)) {
       // If executor index selection (spark.sql.oap.oindex.eis.enabled) is enabled,
       // oapStrategies does not work because exeutor may skip the index scan.

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategies.scala
@@ -295,8 +295,8 @@ trait OapStrategies extends Logging {
       indexHint: Seq[Expression],
       indexRequirements: Seq[IndexType]): Option[SparkPlan] = {
     val conf = SparkSession.getActiveSession.get.sessionState.conf
-    if (!conf.getConf(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES) ||
-        conf.getConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)) {
+    if (!conf.getConf(OapConf.OAP_STRATEGIES_ENABLED) ||
+        conf.getConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION)) {
       // If executor index selection (spark.sql.oap.oindex.eis.enabled) is enabled,
       // oapStrategies does not work because exeutor may skip the index scan.
       return None

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheStats.scala
@@ -162,8 +162,8 @@ object CacheStats extends Logging {
     updateInterval = if (updateInterval != -1) {
       updateInterval
     } else {
-      conf.getLong(OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SEC.key,
-        OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SEC.defaultValue.get) * 1000
+      conf.getLong(OapConf.OAP_METRICS_UPDATE_FIBER_CACHE_INTERVAL_SEC.key,
+        OapConf.OAP_METRICS_UPDATE_FIBER_CACHE_INTERVAL_SEC.defaultValue.get) * 1000
     }
     if (System.currentTimeMillis() - lastUpdateTime > updateInterval) {
       lastUpdateTime = System.currentTimeMillis()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -119,7 +119,7 @@ private[sql] object MemoryManager {
   def apply(sparkEnv: SparkEnv): MemoryManager = {
     val conf = sparkEnv.conf
     val memoryManagerOpt =
-      conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
+      conf.get(OapConf.OAP_CACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
     memoryManagerOpt match {
       case "offheap" => new OffHeapMemoryManager(sparkEnv)
       case _ => throw new UnsupportedOperationException(
@@ -140,8 +140,8 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
   private lazy val oapMemory = {
     assert(memoryManager.maxOffHeapStorageMemory > 0, "Oap can't run without offHeap memory")
     val useOffHeapRatio = sparkEnv.conf.getDouble(
-      OapConf.OAP_FIBERCACHE_USE_OFFHEAP_RATIO.key,
-      OapConf.OAP_FIBERCACHE_USE_OFFHEAP_RATIO.defaultValue.get)
+      OapConf.OAP_CACHE_OFFHEAP_RATIO.key,
+      OapConf.OAP_CACHE_OFFHEAP_RATIO.defaultValue.get)
     logInfo(s"Oap use ${useOffHeapRatio * 100}% of 'spark.memory.offHeap.size' for fiber cache.")
     assert(useOffHeapRatio > 0 && useOffHeapRatio <1,
       "OapConf 'spark.sql.oap.fiberCache.use.offheap.ratio' must more than 0 and less than 1.")

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReaderV1.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordReaderV1.scala
@@ -38,7 +38,7 @@ private[index] case class BTreeIndexRecordReaderV1(
   protected var meta: BTreeMeta = _
 
   protected[index] val rowIdListSizePerSection: Int =
-    configuration.getInt(OapConf.OAP_BTREE_ROW_LIST_PART_SIZE.key, 1024 * 1024)
+    configuration.getInt(OapConf.OAP_INDEX_BTREE_ROW_LIST_PART_SIZE.key, 1024 * 1024)
 
   protected[index] def initializeReader(): Unit = {
     val sectionLengthIndex = fileReader.getLen - FOOTER_LENGTH_SIZE - ROW_ID_LIST_LENGTH_SIZE

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -197,7 +197,7 @@ abstract class BTreeIndexRecordWriter(
   }
 
   protected val rowIdListSizePerSection: Int =
-    configuration.getInt(OapConf.OAP_BTREE_ROW_LIST_PART_SIZE.key, 1024 * 1024)
+    configuration.getInt(OapConf.OAP_INDEX_BTREE_ROW_LIST_PART_SIZE.key, 1024 * 1024)
   protected val rowIdListPartLengthArray = new ArrayBuffer[Int]()
 
   private def storeRowId(id: Int, buf: ByteArrayOutputStream, writer: IndexFileWriter): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -86,13 +86,13 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
       logDebug("No index file exist for data file: " + dataPath)
       StatsAnalysisResult.FULL_SCAN
     } else {
-      val enableIndex = conf.getBoolean(OapConf.OAP_ENABLE_OINDEX.key,
-        OapConf.OAP_ENABLE_OINDEX.defaultValue.get)
+      val enableIndex = conf.getBoolean(OapConf.OAP_INDEX_ENABLED.key,
+        OapConf.OAP_INDEX_ENABLED.defaultValue.get)
       if (!enableIndex) {
         StatsAnalysisResult.FULL_SCAN
       } else {
-        val enableIndexSelection = conf.getBoolean(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key,
-          OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.defaultValue.get)
+        val enableIndexSelection = conf.getBoolean(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION.key,
+          OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION.defaultValue.get)
         if (!enableIndexSelection) {
           // Index selection is disabled, executor always uses the index
           StatsAnalysisResult.USE_INDEX
@@ -114,11 +114,11 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
     val fs = dataPath.getFileSystem(conf)
     require(fs.isFile(indexPath), s"Index file path $indexPath is a directory, it should be a file")
 
-    // Policy 3: index file size < data file size)
+    // Policy 3: index file size < data file size * ratio)
 
     val filePolicyEnable =
-      conf.getBoolean(OapConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.key,
-        OapConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.defaultValue.get)
+      conf.getBoolean(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_FILE_POLICY.key,
+        OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_FILE_POLICY.defaultValue.get)
 
     val indexFileSize = fs.getFileStatus(indexPath).getLen
     val dataFileSize = fs.getFileStatus(dataPath).getLen
@@ -129,8 +129,8 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
       StatsAnalysisResult.FULL_SCAN
     } else {
       val statsPolicyEnable =
-        conf.getBoolean(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY.key,
-          OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY.defaultValue.get)
+        conf.getBoolean(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY.key,
+          OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY.defaultValue.get)
 
       // Policy 4: statistics tells the scan cost
       if (statsPolicyEnable) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -77,8 +77,8 @@ private[oap] case class ParquetDataFile(
     OapRuntime.getOrCreate.dataFileMetaCacheManager.get(this).asInstanceOf[ParquetDataFileMeta]
   private val file = new Path(StringUtils.unEscapeString(path))
   private val parquetDataCacheEnable =
-    configuration.getBoolean(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key,
-      OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.defaultValue.get)
+    configuration.getBoolean(OapConf.OAP_CACHE_PARQUET_DATA_FILE_ENABLED.key,
+      OapConf.OAP_CACHE_PARQUET_DATA_FILE_ENABLED.defaultValue.get)
 
   private var fiberDataReader: ParquetFiberDataReader = _
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -113,9 +113,11 @@ private[oap] class BloomFilterStatisticsWriter(
   protected var bfIndex: BloomFilter = new BloomFilter(bfMaxBits, bfHashFuncs)()
 
   private lazy val bfMaxBits: Int = conf.getInt(
-    OapConf.OAP_BLOOMFILTER_MAXBITS.key, OapConf.OAP_BLOOMFILTER_MAXBITS.defaultValue.get)
+    OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_MAXBITS.key,
+    OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_MAXBITS.defaultValue.get)
   private lazy val bfHashFuncs: Int = conf.getInt(
-    OapConf.OAP_BLOOMFILTER_NUMHASHFUNC.key, OapConf.OAP_BLOOMFILTER_NUMHASHFUNC.defaultValue.get)
+    OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_NUMHASHFUNC.key,
+    OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_NUMHASHFUNC.defaultValue.get)
 
   @transient
   private lazy val projectors: Array[UnsafeProjection] = schema.zipWithIndex.map(x =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -153,7 +153,8 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
   override val id: Int = StatisticsType.TYPE_PART_BY_VALUE
 
   private lazy val maxPartNum: Int = conf.getInt(
-    OapConf.OAP_STATISTICS_PART_NUM.key, OapConf.OAP_STATISTICS_PART_NUM.defaultValue.get)
+    OapConf.OAP_INDEX_STATISTICS_PART_NUM.key,
+    OapConf.OAP_INDEX_STATISTICS_PART_NUM.defaultValue.get)
   @transient private lazy val ordering = GenerateOrdering.create(schema)
 
   protected lazy val metas: ArrayBuffer[PartedByValueMeta] = new ArrayBuffer[PartedByValueMeta]()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -79,11 +79,12 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
   override val id: Int = StatisticsType.TYPE_SAMPLE_BASE
 
   lazy val sampleRate: Double = conf.getDouble(
-    OapConf.OAP_STATISTICS_SAMPLE_RATE.key, OapConf.OAP_STATISTICS_SAMPLE_RATE.defaultValue.get)
+    OapConf.OAP_INDEX_STATISTICS_SAMPLE_RATE.key,
+    OapConf.OAP_INDEX_STATISTICS_SAMPLE_RATE.defaultValue.get)
 
   private val minSampleSize = conf.getInt(
-    OapConf.OAP_STATISTICS_SAMPLE_MIN_SIZE.key,
-    OapConf.OAP_STATISTICS_SAMPLE_MIN_SIZE.defaultValue.get)
+    OapConf.OAP_INDEX_STATISTICS_SAMPLE_MIN_SIZE.key,
+    OapConf.OAP_INDEX_STATISTICS_SAMPLE_MIN_SIZE.defaultValue.get)
 
   protected var sampleArray: Array[Key] = _
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -137,8 +137,8 @@ object StatisticsManager {
       intervalArray: ArrayBuffer[RangeInterval],
       conf: Configuration): StatsAnalysisResult = {
     val fullScanThreshold = conf.getDouble(
-      OapConf.OAP_INDEX_FULL_SCAN_THRESHOLD.key,
-      OapConf.OAP_INDEX_FULL_SCAN_THRESHOLD.defaultValue.get)
+      OapConf.OAP_INDEX_STATISTICS_FULL_SCAN_THRESHOLD.key,
+      OapConf.OAP_INDEX_STATISTICS_FULL_SCAN_THRESHOLD.defaultValue.get)
     val analysisResults = stats.map(_.analyse(intervalArray))
 
     if (analysisResults.exists(_ == StatsAnalysisResult.SKIP_INDEX)) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -54,8 +54,8 @@ class StatisticsWriteManager {
   // which is created from `SparkUtils`, hence containing all spark config values.
   def initialize(indexType: OapIndexType, s: StructType, conf: Configuration): Unit = {
     val statsTypes = StatisticsManager.statisticsTypeMap(indexType).filter { statType =>
-      val typeFromConfig = conf.get(OapConf.OAP_STATISTICS_TYPES.key,
-        OapConf.OAP_STATISTICS_TYPES.defaultValueString).split(",").map(_.trim)
+      val typeFromConfig = conf.get(OapConf.OAP_INDEX_STATISTICS_TYPES.key,
+        OapConf.OAP_INDEX_STATISTICS_TYPES.defaultValueString).split(",").map(_.trim)
       typeFromConfig.contains(statType)
     }
     schema = s
@@ -137,7 +137,8 @@ object StatisticsManager {
       intervalArray: ArrayBuffer[RangeInterval],
       conf: Configuration): StatsAnalysisResult = {
     val fullScanThreshold = conf.getDouble(
-      OapConf.OAP_FULL_SCAN_THRESHOLD.key, OapConf.OAP_FULL_SCAN_THRESHOLD.defaultValue.get)
+      OapConf.OAP_INDEX_FULL_SCAN_THRESHOLD.key,
+      OapConf.OAP_INDEX_FULL_SCAN_THRESHOLD.defaultValue.get)
     val analysisResults = stats.map(_.analyse(intervalArray))
 
     if (analysisResults.exists(_ == StatsAnalysisResult.SKIP_INDEX)) {

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -28,14 +28,14 @@ import org.apache.spark.sql.oap.adapter.SqlConfAdapter
 object OapConf {
 
   val OAP_PARQUET_ENABLED =
-    SqlConfAdapter.buildConf("spark.sql.oap.parquet.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.enabled")
       .internal()
       .doc("Whether enable oap file format when encounter parquet files")
       .booleanConf
       .createWithDefault(true)
 
-  val OAP_FULL_SCAN_THRESHOLD =
-    SqlConfAdapter.buildConf("spark.sql.oap.statistics.fullScanThreshold")
+  val OAP_INDEX_FULL_SCAN_THRESHOLD =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistics.fullScanThreshold")
       .internal()
       .doc("Define the full scan threshold based on oap statistics in index file. " +
         "If the analysis result is above this threshold, it will full scan data file, " +
@@ -43,8 +43,8 @@ object OapConf {
       .doubleConf
       .createWithDefault(0.2)
 
-  val OAP_STATISTICS_TYPES =
-    SqlConfAdapter.buildConf("spark.sql.oap.statistics.type")
+  val OAP_INDEX_STATISTICS_TYPES =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistics.types")
       .internal()
       .doc("Which types of pre-defined statistics are added in index file. " +
         "And here you should just write the statistics name. " +
@@ -62,71 +62,71 @@ object OapConf {
         Set("MINMAX", "SAMPLE", "PARTBYVALUE", "BLOOM").subsets().map(_.toSeq.sorted).toSet)
       .createWithDefault(Seq("BLOOM", "MINMAX", "PARTBYVALUE", "SAMPLE"))
 
-  val OAP_STATISTICS_PART_NUM =
-    SqlConfAdapter.buildConf("spark.sql.oap.statistics.partNum")
+  val OAP_INDEX_STATISTICS_PART_NUM =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistics.partNum")
       .internal()
       .doc("PartedByValueStatistics gives statistics with the value interval, default 5")
       .intConf
       .createWithDefault(5)
 
-  val OAP_STATISTICS_SAMPLE_RATE =
-    SqlConfAdapter.buildConf("spark.sql.oap.statistics.sampleRate")
+  val OAP_INDEX_STATISTICS_SAMPLE_RATE =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistics.sampleRate")
       .internal()
       .doc("Sample rate for sample based statistics, default value 0.05")
       .doubleConf
       .createWithDefault(0.05)
 
-  val OAP_STATISTICS_SAMPLE_MIN_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.statistics.sampleMinSize")
+  val OAP_INDEX_STATISTICS_SAMPLE_MIN_SIZE =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistics.sampleMinSize")
       .internal()
       .doc("Minimum sample size for Sample Statistics, default value 24")
       .intConf
       .createWithDefault(24)
 
-  val OAP_BLOOMFILTER_MAXBITS =
-    SqlConfAdapter.buildConf("spark.sql.oap.statistics.bloom.maxBits")
+  val OAP_INDEX_STATISTICS_BLOOMFILTER_MAXBITS =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistics.bloomFilter.maxBits")
       .internal()
       .doc("Define the max bit count parameter used in bloom " +
         "filter, default 33554432")
       .intConf
       .createWithDefault(1 << 20)
 
-  val OAP_BLOOMFILTER_NUMHASHFUNC =
-    SqlConfAdapter.buildConf("spark.sql.oap.statistics.bloom.numHashFunc")
+  val OAP_INDEX_STATISTICS_BLOOMFILTER_NUMHASHFUNC =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistics.bloomFilter.numHashFunc")
       .internal()
       .doc("Define the number of hash functions used in bloom filter, default 3")
       .intConf
       .createWithDefault(3)
 
-  val OAP_FIBERCACHE_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.size")
+  val OAP_CACHE_SIZE =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.size")
       .internal()
       .doc("Define the size of fiber cache in KB, default 300 * 1024 KB")
       .longConf
       .createWithDefault(307200)
 
-  val OAP_FIBERCACHE_STATS =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.stats")
+  val OAP_CACHE_STATS =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.stats")
       .internal()
       .doc("Whether enable cach stats record, default false")
       .booleanConf
       .createWithDefault(false)
 
-  val OAP_FIBERCACHE_USE_OFFHEAP_RATIO =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.use.offheap.ratio")
+  val OAP_CACHE_OFFHEAP_RATIO =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.offheapRatio")
       .internal()
       .doc("Define the ratio of fiber cache use 'spark.memory.offHeap.size' ratio.")
       .doubleConf
       .createWithDefault(0.7)
 
-  val OAP_FIBERCACHE_MEMORY_MANAGER =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.memory.manager")
+  val OAP_CACHE_MEMORY_MANAGER =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.memoryManager")
       .internal()
-      .doc("Sets the implement of memory manager, it only supports off heap currently.")
+      .doc("Sets the implementation of memory manager, it only supports off heap currently.")
       .stringConf
       .createWithDefault("offheap")
 
-  val OAP_COMPRESSION = SqlConfAdapter.buildConf("spark.sql.oap.compression.codec")
+  val OAP_IO_COMPRESSION = SqlConfAdapter.buildConf("spark.sql.oap.io.compression.codec")
     .internal()
     .doc("Sets the compression codec use when writing Parquet files. Acceptable values include: " +
       "uncompressed, snappy, gzip, lzo.")
@@ -145,42 +145,42 @@ object OapConf {
     .checkValues(Set("UNCOMPRESSED", "SNAPPY", "GZIP", "LZO"))
     .createWithDefault("GZIP")
 
-  val OAP_ROW_GROUP_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.rowgroup.size")
+  val OAP_OAPFILEFORMAT_ROWGROUP_SIZE =
+    SqlConfAdapter.buildConf("spark.sql.oap.oapFileFormat.rowGroupSize")
       .internal()
       .doc("Define the row number for each row group")
       .intConf
       .createWithDefault(1024 * 1024)
 
-  val OAP_ENABLE_OINDEX =
-    SqlConfAdapter.buildConf("spark.sql.oap.oindex.enabled")
+  val OAP_INDEX_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.enabled")
       .internal()
-      .doc("To indicate to enable/disable oindex for developers even if the index file is there")
+      .doc("Whether directly ignore OAP index files even if they exist")
       .booleanConf
       .createWithDefault(true)
 
-  val OAP_ENABLE_EXECUTOR_INDEX_SELECTION =
-    SqlConfAdapter.buildConf("spark.sql.oap.oindex.eis.enabled")
+  val OAP_INDEX_ENABLE_EXECUTOR_SELECTION =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.eis.enabled")
       .internal()
       .doc("To indicate if enable/disable index cbo which helps to choose a fast query path")
       .booleanConf
       .createWithDefault(true)
 
-  val OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY =
-    SqlConfAdapter.buildConf("spark.sql.oap.oindex.file.policy")
+  val OAP_INDEX_ENABLE_EXECUTOR_SELECTION_FILE_POLICY =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.eis.filePolicyEnabled")
       .internal()
       .doc("To indicate if enable/disable file based index selection")
       .booleanConf
       .createWithDefault(true)
 
-  val OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY =
-    SqlConfAdapter.buildConf("spark.sql.oap.oindex.statistics.policy")
+  val OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.eis.statisticsPolicyEnabled")
       .internal()
       .doc("To indicate if enable/disable statistics based index selection")
       .booleanConf
       .createWithDefault(true)
 
-  val OAP_ENABLE_OPTIMIZATION_STRATEGIES =
+  val OAP_STRATEGIES_ENABLED =
     SqlConfAdapter.buildConf("spark.sql.oap.strategies.enabled")
       .internal()
       .doc("To indicate if enable/disable oap strategies")
@@ -188,58 +188,58 @@ object OapConf {
       .createWithDefault(false)
 
   val OAP_INDEX_FILE_SIZE_MAX_RATIO =
-    SqlConfAdapter.buildConf("spark.sql.oap.oindex.size.ratio")
+    SqlConfAdapter.buildConf("spark.sql.oap.index.size.ratio")
       .internal()
       .doc("To indicate if enable/disable index cbo which helps to choose a fast query path")
       .doubleConf
       .createWithDefault(0.7)
 
-  val OAP_INDEXER_CHOICE_MAX_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.indexer.max.use.size")
+  val OAP_INDEX_INDEXER_CHOICE_MAX_SIZE =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.indexerMaxChooseSize")
       .internal()
-      .doc("The max availabe indexer choose size.")
+      .doc("The max available indexer choose size.")
       .intConf
       .createWithDefault(1)
 
-  val OAP_BTREE_ROW_LIST_PART_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.btree.rowList.part.size")
+  val OAP_INDEX_BTREE_ROW_LIST_PART_SIZE =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.btree.rowListPartSize")
       .internal()
       .doc("The row count of each part of row list in btree index")
       .intConf
       .createWithDefault(1024 * 1024)
 
   val OAP_INDEX_DISABLE_LIST =
-    SqlConfAdapter.buildConf("spark.sql.oap.oindex.disable.list")
+    SqlConfAdapter.buildConf("spark.sql.oap.index.disableList")
     .internal()
     .doc("To disable specific index by index names for test purpose, this is supposed to be in " +
       "the format of indexA,indexB,indexC")
     .stringConf
     .createWithDefault("")
 
-  val OAP_HEARTBEAT_INTERVAL =
-    SqlConfAdapter.buildConf("spark.sql.oap.heartbeatInterval")
+  val OAP_RPC_HEARTBEAT_INTERVAL =
+    SqlConfAdapter.buildConf("spark.sql.oap.rpc.heartbeatInterval")
     .internal()
     .doc("To Configure the OAP status update interval, for example OAP metrics")
     .stringConf
     .createWithDefault("2s")
 
-  val OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SEC =
-    SqlConfAdapter.buildConf("spark.sql.oap.update.fiber.cache.metrics.interval.sec")
+  val OAP_METRICS_UPDATE_FIBER_CACHE_INTERVAL_SEC =
+    SqlConfAdapter.buildConf("spark.sql.oap.metrics.updateFiberCacheIntervalSec")
       .internal()
       .doc("The interval of fiber cache metrics update")
       .longConf
       .createWithDefault(10L)
 
   val OAP_INDEX_BTREE_WRITER_VERSION =
-    SqlConfAdapter.buildConf("spark.sql.oap.index.btree.writer.version")
+    SqlConfAdapter.buildConf("spark.sql.oap.index.btree.writerVersion")
       .internal()
       .doc("The writer version of BTree index")
       .stringConf
       .checkValues(Set("v1", "v2"))
       .createWithDefault("v1")
 
-  val OAP_PARQUET_DATA_CACHE_ENABLED =
-    SqlConfAdapter.buildConf("spark.sql.oap.parquet.data.cache.enable")
+  val OAP_CACHE_PARQUET_DATA_FILE_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.parquetDataFileEnabled")
       .internal()
       .doc("To indicate if enable parquet data cache, default false")
       .booleanConf
@@ -248,8 +248,8 @@ object OapConf {
   val OAP_INDEX_DIRECTORY =
     SqlConfAdapter.buildConf("spark.sql.oap.index.directory")
       .internal()
-      .doc("To specify the directory of index file, if the value " +
-        "is empty, it will store in the data file path")
+      .doc("To specify the directory of index file, if the value is empty, it will store in the" +
+        " data file path")
       .stringConf
       .createWithDefault("")
 }

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -34,7 +34,7 @@ object OapConf {
       .booleanConf
       .createWithDefault(true)
 
-  val OAP_INDEX_FULL_SCAN_THRESHOLD =
+  val OAP_INDEX_STATISTICS_FULL_SCAN_THRESHOLD =
     SqlConfAdapter.buildConf("spark.sql.oap.index.statistics.fullScanThreshold")
       .internal()
       .doc("Define the full scan threshold based on oap statistics in index file. " +
@@ -180,8 +180,8 @@ object OapConf {
       .booleanConf
       .createWithDefault(true)
 
-  val OAP_STRATEGIES_ENABLED =
-    SqlConfAdapter.buildConf("spark.sql.oap.strategies.enabled")
+  val OAP_STRATEGY_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.strategy.enabled")
       .internal()
       .doc("To indicate if enable/disable oap strategies")
       .booleanConf

--- a/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
@@ -82,7 +82,7 @@ private[spark] class OapRpcManagerSlave(
     }
 
     val intervalMs = conf.getTimeAsMs(
-      OapConf.OAP_HEARTBEAT_INTERVAL.key, OapConf.OAP_HEARTBEAT_INTERVAL.defaultValue.get)
+      OapConf.OAP_RPC_HEARTBEAT_INTERVAL.key, OapConf.OAP_RPC_HEARTBEAT_INTERVAL.defaultValue.get)
 
     // Wait a random interval so the heartbeats don't end up in sync
     val initialDelay = intervalMs + (math.random * intervalMs).asInstanceOf[Int]

--- a/src/test/scala/org/apache/spark/sql/TestOap.scala
+++ b/src/test/scala/org/apache/spark/sql/TestOap.scala
@@ -39,5 +39,5 @@ class TestOapContext(
   protected def sqlContext: SQLContext = sparkSession.sqlContext
 
   // OapStrategy conflicts with EXECUTOR_INDEX_SELECTION.
-  sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "false")
+  sqlContext.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION.key, "false")
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/CombiningIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/CombiningIndexSuite.scala
@@ -28,8 +28,8 @@ class CombiningIndexSuite extends QueryTest with SharedOapContext with BeforeAnd
   private var currentPath: String = _
 
   override def beforeEach(): Unit = {
-    spark.conf.set(OapConf.OAP_INDEXER_CHOICE_MAX_SIZE.key, "2")
-    spark.conf.set(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "true")
+    spark.conf.set(OapConf.OAP_INDEX_INDEXER_CHOICE_MAX_SIZE.key, "2")
+    spark.conf.set(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION.key, "true")
     spark.conf.set(OapConf.OAP_INDEX_FILE_SIZE_MAX_RATIO.key, "1000")
     val path = Utils.createTempDir().getAbsolutePath
     currentPath = path
@@ -45,8 +45,8 @@ class CombiningIndexSuite extends QueryTest with SharedOapContext with BeforeAnd
   override def afterEach(): Unit = {
     sqlContext.dropTempTable("oap_test")
     sqlContext.dropTempTable("parquet_test")
-    spark.conf.unset(OapConf.OAP_INDEXER_CHOICE_MAX_SIZE.key)
-    spark.conf.unset(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key)
+    spark.conf.unset(OapConf.OAP_INDEX_INDEXER_CHOICE_MAX_SIZE.key)
+    spark.conf.unset(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION.key)
     spark.conf.unset(OapConf.OAP_INDEX_FILE_SIZE_MAX_RATIO.key)
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -131,7 +131,7 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
   }
 
   test("startswith using index") {
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, false)
+    sqlContext.conf.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY, false)
     val data: Seq[(Int, String)] =
       scala.util.Random.shuffle(1 to 30).map(i => (i, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
@@ -141,11 +141,11 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
         Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     }
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
+    sqlContext.conf.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY, true)
   }
 
   test("startswith using multi-dimension index") {
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, false)
+    sqlContext.conf.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY, false)
     val data: Seq[(Int, String)] =
       scala.util.Random.shuffle(1 to 30).map(i => (i, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
@@ -155,11 +155,11 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
         Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     }
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
+    sqlContext.conf.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY, true)
   }
 
   test("startswith using multi-dimension index - multi-filters") {
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, false)
+    sqlContext.conf.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY, false)
     val data: Seq[(Int, String)] =
       scala.util.Random.shuffle(1 to 30).map(i => (i % 7, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
@@ -169,11 +169,11 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       checkAnswer(sql("SELECT * FROM oap_test_1 WHERE a = 3 and b like 'this3%'"),
         Row(3, "this3 is test") :: Nil)
     }
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
+    sqlContext.conf.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY, true)
   }
 
   test("startswith using multi-dimension index 2") {
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, false)
+    sqlContext.conf.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY, false)
     val data: Seq[(Int, String)] = Seq(
       15, 29, 26, 4, 28, 17, 16, 11, 12, 27, 22, 6, 10, 18, 19, 20, 30, 21, 14, 25, 1, 2,
       13, 23, 7, 24, 3, 8, 5, 9).map(i => (i, s"this$i is test"))
@@ -184,6 +184,6 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
         Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     }
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
+    sqlContext.conf.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_STATISTICS_POLICY, true)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsSuite.scala
@@ -177,7 +177,8 @@ class OapMetricsSuite extends QueryTest with SharedOapContext with BeforeAndAfte
     sql("create oindex idx1 on parquet_test (a)")
 
     // satisfy indexFile / dataFile > 0.7
-    sqlContext.conf.setConfString(OapConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.key, "true")
+    sqlContext.conf.setConfString(
+      OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_FILE_POLICY.key, "true")
 
     // SQL 4: ignore index => readBehavior return FULL_SCAN
     val df = sql("SELECT * FROM parquet_test WHERE a = 1")
@@ -190,7 +191,8 @@ class OapMetricsSuite extends QueryTest with SharedOapContext with BeforeAndAfte
       Some(TaskMetrics(3, 0, 0, 3, 0)))
 
     sql("drop oindex idx1 on parquet_test")
-    sqlContext.conf.setConfString(OapConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.key, "false")
+    sqlContext.conf.setConfString(
+      OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_FILE_POLICY.key, "false")
   }
 
   test("test OAP accumulators on Oap when miss index") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -84,13 +84,13 @@ class OapPlannerSuite
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.conf.set(OapConf.OAP_STRATEGIES_ENABLED.key, true)
+    spark.conf.set(OapConf.OAP_STRATEGY_ENABLED.key, true)
   }
 
   override def afterAll(): Unit = {
     spark.conf.set(
-      OapConf.OAP_STRATEGIES_ENABLED.key,
-      OapConf.OAP_STRATEGIES_ENABLED.defaultValue.get)
+      OapConf.OAP_STRATEGY_ENABLED.key,
+      OapConf.OAP_STRATEGY_ENABLED.defaultValue.get)
     spark.stop()
     super.afterAll()
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapPlannerSuite.scala
@@ -84,13 +84,13 @@ class OapPlannerSuite
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.conf.set(OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key, true)
+    spark.conf.set(OapConf.OAP_STRATEGIES_ENABLED.key, true)
   }
 
   override def afterAll(): Unit = {
     spark.conf.set(
-      OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.key,
-      OapConf.OAP_ENABLE_OPTIMIZATION_STRATEGIES.defaultValue.get)
+      OapConf.OAP_STRATEGIES_ENABLED.key,
+      OapConf.OAP_STRATEGIES_ENABLED.defaultValue.get)
     spark.stop()
     super.afterAll()
   }
@@ -279,12 +279,12 @@ class OapPlannerSuite
       checkKeywordsExist(sql("explain " + sqlString), "*OapAggregationFileScanExec")
       val oapDF = sql(sqlString).collect()
 
-      spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "true")
+      spark.sqlContext.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION.key, "true")
       checkKeywordsNotExist(sql("explain " + sqlString), "OapAggregationFileScanExec")
       val baseDF = sql(sqlString)
       checkAnswer(baseDF, oapDF)
     } finally {
-      spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "false")
+      spark.sqlContext.setConf(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION.key, "false")
       sql("drop oindex index1 on oap_fix_length_schema_table")
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -97,11 +97,11 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
       "lZo",
       "UNCOMPRESSED",
       "UnCompressed").foreach { codec =>
-      sqlContext.conf.setConfString(OapConf.OAP_COMPRESSION.key, codec)
+      sqlContext.conf.setConfString(OapConf.OAP_IO_COMPRESSION.key, codec)
       val df = sqlContext.read.format("oap").load(path.getAbsolutePath)
       df.write.format("oap").mode(SaveMode.Overwrite).save(path.getAbsolutePath)
       val compressionType =
-        sqlContext.conf.getConfString(OapConf.OAP_COMPRESSION.key).toLowerCase
+        sqlContext.conf.getConfString(OapConf.OAP_IO_COMPRESSION.key).toLowerCase
       val fileNameIterator = path.listFiles()
       for (fileName <- fileNameIterator) {
         if (fileName.toString.endsWith(OapFileFormat.OAP_DATA_EXTENSION)) {
@@ -116,7 +116,7 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
     }
     // Restore compression type back to default.
     sqlContext.conf.setConfString(
-      OapConf.OAP_COMPRESSION.key, OapConf.OAP_COMPRESSION.defaultValueString)
+      OapConf.OAP_IO_COMPRESSION.key, OapConf.OAP_IO_COMPRESSION.defaultValueString)
   }
 
   test("Enable/disable using OAP index after the index is created already") {
@@ -160,10 +160,10 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
         OapRuntime.getOrCreate.oapMetricsManager, conf)
       val itIndex = readerIndex.initialize()
       assert(itIndex.size == 4)
-      conf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key, false)
+      conf.setBoolean(OapConf.OAP_INDEX_ENABLED.key, false)
       val itSetIgnoreIndex = readerIndex.initialize()
       assert(itSetIgnoreIndex.size == 100)
-      conf.setBoolean(OapConf.OAP_ENABLE_OINDEX.key, true)
+      conf.setBoolean(OapConf.OAP_INDEX_ENABLED.key, true)
       val itSetUseIndex = readerIndex.initialize()
       assert(itSetUseIndex.size == 4)
       dir.delete()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensorSuite.scala
@@ -71,7 +71,7 @@ class FiberSensorSuite extends QueryTest with SharedOapContext with BeforeAndAft
     // make each dataFile has 2 rowGroup.
     // 3000 columns in total, 2 data file by default, 1500 columns each file.
     // So, each file will have 2 rowGroup.
-    sqlContext.conf.setConfString(OapConf.OAP_ROW_GROUP_SIZE.key, "1000")
+    sqlContext.conf.setConfString(OapConf.OAP_OAPFILEFORMAT_ROWGROUP_SIZE.key, "1000")
 
     // Insert data, build index and query, expected hit-index, range ensure all
     // row groups are cached.
@@ -139,7 +139,7 @@ class FiberSensorSuite extends QueryTest with SharedOapContext with BeforeAndAft
     // Test normal msg
     CacheStats.reset
     val conf: SparkConf = new SparkConf()
-    conf.set(OapConf.OAP_UPDATE_FIBER_CACHE_METRICS_INTERVAL_SEC.key, 0L.toString)
+    conf.set(OapConf.OAP_METRICS_UPDATE_FIBER_CACHE_INTERVAL_SEC.key, 0L.toString)
     val cacheStats = CacheStats(2, 19, 10, 2, 0, 0, 213, 23, 23, 123131, 2)
     listener.onOtherEvent(SparkListenerCustomInfoUpdate(
       host, execID, messager, CacheStats.status(cacheStats, conf)))

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -447,13 +447,13 @@ class ParquetCacheDataSuite extends ParquetDataFileSuite {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    configuration.setBoolean(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key, true)
+    configuration.setBoolean(OapConf.OAP_CACHE_PARQUET_DATA_FILE_ENABLED.key, true)
     OapRuntime.getOrCreate.fiberCacheManager.clearAllFibers()
   }
 
   override def afterEach(): Unit = {
     super.afterEach()
-    configuration.unset(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key)
+    configuration.unset(OapConf.OAP_CACHE_PARQUET_DATA_FILE_ENABLED.key)
   }
 
   override def data: Seq[Group] = {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatisticsSuite.scala
@@ -54,8 +54,8 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
   test("write function test") {
     val keys = Random.shuffle(1 to 300).map(i => rowGen(i)).toArray
 
-    val maxBits = OapConf.OAP_BLOOMFILTER_MAXBITS.defaultValue.get
-    val numOfHashFunc = OapConf.OAP_BLOOMFILTER_NUMHASHFUNC.defaultValue.get
+    val maxBits = OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_MAXBITS.defaultValue.get
+    val numOfHashFunc = OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_NUMHASHFUNC.defaultValue.get
     val bfIndex = new BloomFilter(maxBits, numOfHashFunc)()
     val boundReference = schema.zipWithIndex.map(x =>
       BoundReference(x._2, x._1.dataType, nullable = true))
@@ -93,8 +93,8 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
   test("read function test") {
     val keys = Random.shuffle(1 to 300).map(i => rowGen(i)).toArray
 
-    val maxBits = OapConf.OAP_BLOOMFILTER_MAXBITS.defaultValue.get
-    val numOfHashFunc = OapConf.OAP_BLOOMFILTER_NUMHASHFUNC.defaultValue.get
+    val maxBits = OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_MAXBITS.defaultValue.get
+    val numOfHashFunc = OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_NUMHASHFUNC.defaultValue.get
     val bfIndex = new BloomFilter(maxBits, numOfHashFunc)()
     val boundReference = schema.zipWithIndex.map(x =>
       BoundReference(x._2, x._1.dataType, nullable = true))
@@ -122,8 +122,8 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
   test("read AND write test") {
     val keys = Random.shuffle(1 to 300).map(i => rowGen(i)).toArray
 
-    val maxBits = OapConf.OAP_BLOOMFILTER_MAXBITS.defaultValue.get
-    val numOfHashFunc = OapConf.OAP_BLOOMFILTER_NUMHASHFUNC.defaultValue.get
+    val maxBits = OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_MAXBITS.defaultValue.get
+    val numOfHashFunc = OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_NUMHASHFUNC.defaultValue.get
     val bfIndex = new BloomFilter(maxBits, numOfHashFunc)()
     val boundReference = schema.zipWithIndex.map(x =>
       BoundReference(x._2, x._1.dataType, nullable = true))
@@ -155,8 +155,8 @@ class BloomFilterStatisticsSuite extends StatisticsTest {
   test("test analyze function") {
     val keys = Random.shuffle(1 to 300).map(i => rowGen(i)).toArray
 
-    val maxBits = OapConf.OAP_BLOOMFILTER_MAXBITS.defaultValue.get
-    val numOfHashFunc = OapConf.OAP_BLOOMFILTER_NUMHASHFUNC.defaultValue.get
+    val maxBits = OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_MAXBITS.defaultValue.get
+    val numOfHashFunc = OapConf.OAP_INDEX_STATISTICS_BLOOMFILTER_NUMHASHFUNC.defaultValue.get
     val bfIndex = new BloomFilter(maxBits, numOfHashFunc)()
     val boundReference = schema.zipWithIndex.map(x =>
       BoundReference(x._2, x._1.dataType, nullable = true))

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatisticsSuite.scala
@@ -62,7 +62,7 @@ class PartByValueStatisticsSuite extends StatisticsTest {
     assert(fiber.getInt(offset) == StatisticsType.TYPE_PART_BY_VALUE)
     offset += 4
 
-    val part = OapConf.OAP_STATISTICS_PART_NUM.defaultValue.get + 1
+    val part = OapConf.OAP_INDEX_STATISTICS_PART_NUM.defaultValue.get + 1
     val cntPerPart = keys.length / (part - 1)
     assert(fiber.getInt(offset) == part)
     offset += 4

--- a/src/test/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSuite.scala
@@ -103,7 +103,7 @@ class OapRpcManagerSuite extends SparkFunSuite with BeforeAndAfterEach with Priv
 
     // Initial delay is at most 2 * interval
     Thread.sleep(2000 + 2 * sc.conf.getTimeAsMs(
-      OapConf.OAP_HEARTBEAT_INTERVAL.key, OapConf.OAP_HEARTBEAT_INTERVAL.defaultValue.get))
+      OapConf.OAP_RPC_HEARTBEAT_INTERVAL.key, OapConf.OAP_RPC_HEARTBEAT_INTERVAL.defaultValue.get))
     verify(rpcManagerMasterEndpoint, new AtLeast(1)).invokePrivate(_handleHeartbeat(heartbeat))
 
     rpcManagerSlave1.stop()

--- a/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -58,11 +58,11 @@ trait SharedOapContextBase extends SharedSQLContext {
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.sqlContext.setConf(OapConf.OAP_BTREE_ROW_LIST_PART_SIZE, 64)
+    spark.sqlContext.setConf(OapConf.OAP_INDEX_BTREE_ROW_LIST_PART_SIZE, 64)
   }
 
   // disable file based cbo for all test suite, as it always fails.
-  oapSparkConf.set(OapConf.OAP_EXECUTOR_INDEX_SELECTION_FILE_POLICY.key, "false")
+  oapSparkConf.set(OapConf.OAP_INDEX_ENABLE_EXECUTOR_SELECTION_FILE_POLICY.key, "false")
 
   protected lazy val configuration: Configuration = spark.sessionState.newHadoopConf()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

a certain entry of `OapConf` will be in one of the following categories: 
- parquet
- io
- index
- cache
- strategy
- rpc
- metrics
- oapfileformat

## How was this patch tested?

N/A
