### PR TITLE
[Orc-support-02] Add four orc record readers

### DIFF
--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/IndexedOrcColumnarBatchReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/IndexedOrcColumnarBatchReader.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.orc;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.orc.storage.ql.exec.vector.ColumnVector;
+
+import org.apache.spark.sql.execution.datasources.orc.OrcColumnVector;
+import org.apache.spark.sql.vectorized.WritableColumnVector;
+import org.apache.spark.sql.types.StructField;
+
+/**
+ * The OapIndexOrcColumnarBatchReader class has rowIds in order to scan the data
+ * from the predefined row ids.
+ */
+public class IndexedOrcColumnarBatchReader extends OrcColumnarBatchReader {
+
+  // Below three fields are added by Oap index.
+  private int[] rowIds;
+
+  private int curRowIndex;
+
+  private int rowLength;
+
+  public IndexedOrcColumnarBatchReader(boolean useOffHeap, boolean copyToSpark, int[] rowIds) {
+    super(useOffHeap, copyToSpark);
+    this.rowIds = rowIds;
+  }
+
+  /**
+   * Initialize ORC file reader and batch record reader.
+   * Please note that `initBatch` is needed to be called after this.
+   * This method is customized by Oap.
+   */
+  @Override
+  public void initialize(
+      Path file, Configuration conf) throws IOException {
+    super.initialize(file, conf);
+    this.rowLength = this.rowIds.length;
+    this.curRowIndex = 0;
+    recordReader.seekToRow(rowIds[curRowIndex]);
+  }
+
+  /**
+   * Return true if there exists more data in the next batch. If exists, prepare the next batch
+   * by copying from ORC VectorizedRowBatch columns to Spark ColumnarBatch columns.
+   */
+  @Override
+  public boolean nextBatch() throws IOException {
+    if (curRowIndex >= rowLength) return false;
+    recordReader.nextBatch(batch);
+    int batchSize = batch.size;
+    if (batchSize == 0) {
+      return false;
+    }
+    int j = curRowIndex + 1;
+    /* Orc readers support backward scan if the row Ids are out of order.
+     * However, with the ascending ordered row Ids, the adjacent rows will
+     * be scanned in the same batch. Below is expected that the row Ids are
+     * ascending order.
+     * Find the next row Id which is not in the same batch with the current row Id.
+     */
+    while (j < rowLength && (rowIds[curRowIndex] + batchSize) >= rowIds[j]) {
+      j++;
+    }
+    curRowIndex = j;
+    // Prepare to jump to the row for the next batch.
+    if (j < rowLength) {
+      recordReader.seekToRow(rowIds[curRowIndex]);
+    }
+    columnarBatch.setNumRows(batchSize);
+
+    if (!copyToSpark) {
+      for (int i = 0; i < requiredFields.length; i++) {
+        if (requestedColIds[i] != -1) {
+          ((OrcColumnVector) orcVectorWrappers[i]).setBatchSize(batchSize);
+        }
+      }
+      return true;
+    }
+
+    for (WritableColumnVector vector : columnVectors) {
+      vector.reset();
+    }
+
+    for (int i = 0; i < requiredFields.length; i++) {
+      StructField field = requiredFields[i];
+      WritableColumnVector toColumn = columnVectors[i];
+
+      if (requestedColIds[i] >= 0) {
+        ColumnVector fromColumn = batch.cols[requestedColIds[i]];
+
+        if (fromColumn.isRepeating) {
+          putRepeatingValues(batchSize, field, fromColumn, toColumn);
+        } else if (fromColumn.noNulls) {
+          putNonNullValues(batchSize, field, fromColumn, toColumn);
+        } else {
+          putValues(batchSize, field, fromColumn, toColumn);
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/IndexedOrcMapreduceRecordReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/IndexedOrcMapreduceRecordReader.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.oap.orc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.mapred.OrcMapredRecordReader;
+import org.apache.orc.mapred.OrcStruct;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * This record reader has rowIds in order to seek to specific rows to skip unused data.
+ * @param <V> the root type of the file
+ */
+public class IndexedOrcMapreduceRecordReader<V extends WritableComparable>
+    extends OrcMapreduceRecordReader<V> {
+
+  // Below three fields are added by Oap index.
+  private int[] rowIds;
+
+  private int rowLength;
+
+  private int curRowIndex;
+
+  private int preRowIndex;
+
+  public IndexedOrcMapreduceRecordReader(Path file, Configuration conf,
+                                              int[] rowIds) throws IOException {
+    super(file, conf);
+    this.rowIds = rowIds;
+    this.rowLength = rowIds.length;
+    this.curRowIndex = 0;
+    this.preRowIndex = 0;
+    batchReader.seekToRow(rowIds[curRowIndex]);
+  }
+
+  /**
+   * If the current batch is empty, get a new one.
+   * @return true if we have rows available.
+   * @throws IOException
+   */
+  @Override
+  boolean ensureBatch() throws IOException {
+    if (rowInBatch >= batch.size) {
+      rowInBatch = 0;
+      if (curRowIndex >= rowLength) return false;
+      boolean ret = batchReader.nextBatch(batch);
+      int batchSize = batch.size;
+      if (batchSize == 0) {
+        return false;
+      }
+      int i = curRowIndex + 1;
+      /* Orc readers support backward scan if the row Ids are out of order.
+       * However, with the ascending ordered row Ids, the adjacent rows will
+       * be scanned in the same batch. Below is expected that the row Ids are
+       * ascending order.
+       * Find the next row Id which is not in the same batch with the current row Id.
+       */
+      preRowIndex = curRowIndex;
+      while (i < rowLength && (rowIds[curRowIndex] + batchSize) >= rowIds[i]) {
+        i++;
+      }
+      curRowIndex = i;
+      // Prepare to jump to the row for the next batch.
+      if (i < rowLength) {
+        batchReader.seekToRow(rowIds[curRowIndex]);
+      }
+      return ret;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    if (!ensureBatch()) {
+      return false;
+    }
+    // The first row in this current batch is definitely in the row Ids, because
+    // it's the just seeking row.
+    if (schema.getCategory() == TypeDescription.Category.STRUCT) {
+      OrcStruct result = (OrcStruct) row;
+      List<TypeDescription> children = schema.getChildren();
+      int numberOfChildren = children.size();
+      for(int i=0; i < numberOfChildren; ++i) {
+        result.setFieldValue(i, OrcMapredRecordReader.nextValue(batch.cols[i], rowInBatch,
+            children.get(i), result.getFieldValue(i)));
+      }
+    } else {
+      OrcMapredRecordReader.nextValue(batch.cols[0], rowInBatch, schema, row);
+    }
+    rowInBatch += 1;
+    // Skip the rows in the current batch which is not in the row Ids.
+    // preRowIndex is the starting row in the current batch.
+    // Then jump to the next row which matches the next row Id.
+    while (rowInBatch < batch.size && (preRowIndex + 1) < rowLength &&
+      (rowInBatch + rowIds[preRowIndex]) < rowIds[preRowIndex + 1]) {
+      rowInBatch += 1;
+    }
+    if ((preRowIndex + 1) < rowLength) {
+      preRowIndex += 1;
+    }
+    return true;
+  }
+}

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
@@ -1,0 +1,562 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.orc;
+
+import java.io.IOException;
+import java.util.stream.IntStream;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.orc.OrcConf;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.mapred.OrcInputFormat;
+import org.apache.orc.storage.common.type.HiveDecimal;
+import org.apache.orc.storage.ql.exec.vector.*;
+import org.apache.orc.storage.serde2.io.HiveDecimalWritable;
+
+import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.datasources.orc.OrcColumnVector;
+import org.apache.spark.sql.vectorized.ColumnVectorUtils;
+import org.apache.spark.sql.vectorized.OffHeapColumnVector;
+import org.apache.spark.sql.vectorized.OnHeapColumnVector;
+import org.apache.spark.sql.vectorized.WritableColumnVector;
+import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+
+/**
+ * This class is a copy of OrcColumnarBatchReader with minor changes to be able to
+ * have a child class OapIndexOrcColumnarBatchReader.
+ * To support vectorization in WholeStageCodeGen, this reader returns ColumnarBatch.
+ * After creating, `initialize` and `initBatch` should be called sequentially.
+ */
+public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
+  // TODO: make this configurable.
+  private static final int CAPACITY = 4 * 1024;
+
+  // Vectorized ORC Row Batch
+  protected VectorizedRowBatch batch;
+
+  /**
+   * The column IDs of the physical ORC file schema which are required by this reader.
+   * -1 means this required column doesn't exist in the ORC file.
+   */
+  protected int[] requestedColIds;
+
+  // Record reader from ORC row batch.
+  protected org.apache.orc.RecordReader recordReader;
+
+  protected StructField[] requiredFields;
+
+  // The result columnar batch for vectorized execution by whole-stage codegen.
+  protected ColumnarBatch columnarBatch;
+
+  // Writable column vectors of the result columnar batch.
+  protected WritableColumnVector[] columnVectors;
+
+  // The wrapped ORC column vectors. It should be null if `copyToSpark` is true.
+  protected org.apache.spark.sql.vectorized.ColumnVector[] orcVectorWrappers;
+
+  // The memory mode of the columnarBatch
+  protected final MemoryMode MEMORY_MODE;
+
+  // Whether or not to copy the ORC columnar batch to Spark columnar batch.
+  protected final boolean copyToSpark;
+
+  public OrcColumnarBatchReader(boolean useOffHeap, boolean copyToSpark) {
+    MEMORY_MODE = useOffHeap ? MemoryMode.OFF_HEAP : MemoryMode.ON_HEAP;
+    this.copyToSpark = copyToSpark;
+  }
+
+
+  @Override
+  public Void getCurrentKey() {
+    return null;
+  }
+
+  @Override
+  public ColumnarBatch getCurrentValue() {
+    return columnarBatch;
+  }
+
+  @Override
+  public float getProgress() throws IOException {
+    return recordReader.getProgress();
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException {
+    return nextBatch();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (columnarBatch != null) {
+      columnarBatch.close();
+      columnarBatch = null;
+    }
+    if (recordReader != null) {
+      recordReader.close();
+      recordReader = null;
+    }
+  }
+
+  @Override
+  public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) {
+    // nothing required
+  }
+
+  /**
+   * Initialize ORC file reader and batch record reader.
+   * Please note that `initBatch` is needed to be called after this.
+   * This method is customized by Oap.
+   */
+  public void initialize(
+      Path file, Configuration conf) throws IOException {
+    FileSystem fileSystem = file.getFileSystem(conf);
+    long length = fileSystem.getFileStatus(file).getLen();
+    Reader reader = OrcFile.createReader(
+      file,
+      OrcFile.readerOptions(conf)
+        .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(conf))
+        .filesystem(fileSystem));
+    Reader.Options options =
+      OrcInputFormat.buildOptions(conf, reader, 0, length);
+    recordReader = reader.rows(options);
+  }
+
+  /**
+   * Initialize columnar batch by setting required schema and partition information.
+   * With this information, this creates ColumnarBatch with the full schema.
+   */
+  public void initBatch(
+      TypeDescription orcSchema,
+      int[] requestedColIds,
+      StructField[] requiredFields,
+      StructType partitionSchema,
+      InternalRow partitionValues) {
+    batch = orcSchema.createRowBatch(CAPACITY);
+    assert(!batch.selectedInUse); // `selectedInUse` should be initialized with `false`.
+
+    this.requiredFields = requiredFields;
+    this.requestedColIds = requestedColIds;
+    assert(requiredFields.length == requestedColIds.length);
+
+    StructType resultSchema = new StructType(requiredFields);
+    for (StructField f : partitionSchema.fields()) {
+      resultSchema = resultSchema.add(f);
+    }
+
+    if (copyToSpark) {
+      if (MEMORY_MODE == MemoryMode.OFF_HEAP) {
+        columnVectors = OffHeapColumnVector.allocateColumns(CAPACITY, resultSchema);
+      } else {
+        columnVectors = OnHeapColumnVector.allocateColumns(CAPACITY, resultSchema);
+      }
+
+      // Initialize the missing columns once.
+      for (int i = 0; i < requiredFields.length; i++) {
+        if (requestedColIds[i] == -1) {
+          columnVectors[i].putNulls(0, CAPACITY);
+          columnVectors[i].setIsConstant();
+        }
+      }
+
+      if (partitionValues.numFields() > 0) {
+        int partitionIdx = requiredFields.length;
+        for (int i = 0; i < partitionValues.numFields(); i++) {
+          ColumnVectorUtils.populate(columnVectors[i + partitionIdx], partitionValues, i);
+          columnVectors[i + partitionIdx].setIsConstant();
+        }
+      }
+
+      columnarBatch = new ColumnarBatch(columnVectors);
+    } else {
+      // Just wrap the ORC column vector instead of copying it to Spark column vector.
+      orcVectorWrappers = new org.apache.spark.sql.vectorized.ColumnVector[resultSchema.length()];
+
+      for (int i = 0; i < requiredFields.length; i++) {
+        DataType dt = requiredFields[i].dataType();
+        int colId = requestedColIds[i];
+        // Initialize the missing columns once.
+        if (colId == -1) {
+          OnHeapColumnVector missingCol = new OnHeapColumnVector(CAPACITY, dt);
+          missingCol.putNulls(0, CAPACITY);
+          missingCol.setIsConstant();
+          orcVectorWrappers[i] = missingCol;
+        } else {
+          orcVectorWrappers[i] = new OrcColumnVector(dt, batch.cols[colId]);
+        }
+      }
+
+      if (partitionValues.numFields() > 0) {
+        int partitionIdx = requiredFields.length;
+        for (int i = 0; i < partitionValues.numFields(); i++) {
+          DataType dt = partitionSchema.fields()[i].dataType();
+          OnHeapColumnVector partitionCol = new OnHeapColumnVector(CAPACITY, dt);
+          ColumnVectorUtils.populate(partitionCol, partitionValues, i);
+          partitionCol.setIsConstant();
+          orcVectorWrappers[partitionIdx + i] = partitionCol;
+        }
+      }
+
+      columnarBatch = new ColumnarBatch(orcVectorWrappers);
+    }
+  }
+
+  /**
+   * Return true if there exists more data in the next batch. If exists, prepare the next batch
+   * by copying from ORC VectorizedRowBatch columns to Spark ColumnarBatch columns.
+   */
+  public boolean nextBatch() throws IOException {
+    recordReader.nextBatch(batch);
+    int batchSize = batch.size;
+    if (batchSize == 0) {
+      return false;
+    }
+    columnarBatch.setNumRows(batchSize);
+
+    if (!copyToSpark) {
+      for (int i = 0; i < requiredFields.length; i++) {
+        if (requestedColIds[i] != -1) {
+          ((OrcColumnVector) orcVectorWrappers[i]).setBatchSize(batchSize);
+        }
+      }
+      return true;
+    }
+
+    for (WritableColumnVector vector : columnVectors) {
+      vector.reset();
+    }
+
+    for (int i = 0; i < requiredFields.length; i++) {
+      StructField field = requiredFields[i];
+      WritableColumnVector toColumn = columnVectors[i];
+
+      if (requestedColIds[i] >= 0) {
+        ColumnVector fromColumn = batch.cols[requestedColIds[i]];
+
+        if (fromColumn.isRepeating) {
+          putRepeatingValues(batchSize, field, fromColumn, toColumn);
+        } else if (fromColumn.noNulls) {
+          putNonNullValues(batchSize, field, fromColumn, toColumn);
+        } else {
+          putValues(batchSize, field, fromColumn, toColumn);
+        }
+      }
+    }
+    return true;
+  }
+
+  protected void putRepeatingValues(
+      int batchSize,
+      StructField field,
+      ColumnVector fromColumn,
+      WritableColumnVector toColumn) {
+    if (fromColumn.isNull[0]) {
+      toColumn.putNulls(0, batchSize);
+    } else {
+      DataType type = field.dataType();
+      if (type instanceof BooleanType) {
+        toColumn.putBooleans(0, batchSize, ((LongColumnVector)fromColumn).vector[0] == 1);
+      } else if (type instanceof ByteType) {
+        toColumn.putBytes(0, batchSize, (byte)((LongColumnVector)fromColumn).vector[0]);
+      } else if (type instanceof ShortType) {
+        toColumn.putShorts(0, batchSize, (short)((LongColumnVector)fromColumn).vector[0]);
+      } else if (type instanceof IntegerType || type instanceof DateType) {
+        toColumn.putInts(0, batchSize, (int)((LongColumnVector)fromColumn).vector[0]);
+      } else if (type instanceof LongType) {
+        toColumn.putLongs(0, batchSize, ((LongColumnVector)fromColumn).vector[0]);
+      } else if (type instanceof TimestampType) {
+        toColumn.putLongs(0, batchSize,
+          fromTimestampColumnVector((TimestampColumnVector)fromColumn, 0));
+      } else if (type instanceof FloatType) {
+        toColumn.putFloats(0, batchSize, (float)((DoubleColumnVector)fromColumn).vector[0]);
+      } else if (type instanceof DoubleType) {
+        toColumn.putDoubles(0, batchSize, ((DoubleColumnVector)fromColumn).vector[0]);
+      } else if (type instanceof StringType || type instanceof BinaryType) {
+        BytesColumnVector data = (BytesColumnVector)fromColumn;
+        int size = data.vector[0].length;
+        toColumn.arrayData().reserve(size);
+        toColumn.arrayData().putBytes(0, size, data.vector[0], 0);
+        for (int index = 0; index < batchSize; index++) {
+          toColumn.putArray(index, 0, size);
+        }
+      } else if (type instanceof DecimalType) {
+        DecimalType decimalType = (DecimalType)type;
+        putDecimalWritables(
+          toColumn,
+          batchSize,
+          decimalType.precision(),
+          decimalType.scale(),
+          ((DecimalColumnVector)fromColumn).vector[0]);
+      } else {
+        throw new UnsupportedOperationException("Unsupported Data Type: " + type);
+      }
+    }
+  }
+
+  protected void putNonNullValues(
+      int batchSize,
+      StructField field,
+      ColumnVector fromColumn,
+      WritableColumnVector toColumn) {
+    DataType type = field.dataType();
+    if (type instanceof BooleanType) {
+      long[] data = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        toColumn.putBoolean(index, data[index] == 1);
+      }
+    } else if (type instanceof ByteType) {
+      long[] data = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        toColumn.putByte(index, (byte)data[index]);
+      }
+    } else if (type instanceof ShortType) {
+      long[] data = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        toColumn.putShort(index, (short)data[index]);
+      }
+    } else if (type instanceof IntegerType || type instanceof DateType) {
+      long[] data = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        toColumn.putInt(index, (int)data[index]);
+      }
+    } else if (type instanceof LongType) {
+      toColumn.putLongs(0, batchSize, ((LongColumnVector)fromColumn).vector, 0);
+    } else if (type instanceof TimestampType) {
+      TimestampColumnVector data = ((TimestampColumnVector)fromColumn);
+      for (int index = 0; index < batchSize; index++) {
+        toColumn.putLong(index, fromTimestampColumnVector(data, index));
+      }
+    } else if (type instanceof FloatType) {
+      double[] data = ((DoubleColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        toColumn.putFloat(index, (float)data[index]);
+      }
+    } else if (type instanceof DoubleType) {
+      toColumn.putDoubles(0, batchSize, ((DoubleColumnVector)fromColumn).vector, 0);
+    } else if (type instanceof StringType || type instanceof BinaryType) {
+      BytesColumnVector data = ((BytesColumnVector)fromColumn);
+      WritableColumnVector arrayData = toColumn.arrayData();
+      int totalNumBytes = IntStream.of(data.length).sum();
+      arrayData.reserve(totalNumBytes);
+      for (int index = 0, pos = 0; index < batchSize; pos += data.length[index], index++) {
+        arrayData.putBytes(pos, data.length[index], data.vector[index], data.start[index]);
+        toColumn.putArray(index, pos, data.length[index]);
+      }
+    } else if (type instanceof DecimalType) {
+      DecimalType decimalType = (DecimalType)type;
+      DecimalColumnVector data = ((DecimalColumnVector)fromColumn);
+      if (decimalType.precision() > Decimal.MAX_LONG_DIGITS()) {
+        toColumn.arrayData().reserve(batchSize * 16);
+      }
+      for (int index = 0; index < batchSize; index++) {
+        putDecimalWritable(
+          toColumn,
+          index,
+          decimalType.precision(),
+          decimalType.scale(),
+          data.vector[index]);
+      }
+    } else {
+      throw new UnsupportedOperationException("Unsupported Data Type: " + type);
+    }
+  }
+
+  protected void putValues(
+      int batchSize,
+      StructField field,
+      ColumnVector fromColumn,
+      WritableColumnVector toColumn) {
+    DataType type = field.dataType();
+    if (type instanceof BooleanType) {
+      long[] vector = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          toColumn.putBoolean(index, vector[index] == 1);
+        }
+      }
+    } else if (type instanceof ByteType) {
+      long[] vector = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          toColumn.putByte(index, (byte)vector[index]);
+        }
+      }
+    } else if (type instanceof ShortType) {
+      long[] vector = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          toColumn.putShort(index, (short)vector[index]);
+        }
+      }
+    } else if (type instanceof IntegerType || type instanceof DateType) {
+      long[] vector = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          toColumn.putInt(index, (int)vector[index]);
+        }
+      }
+    } else if (type instanceof LongType) {
+      long[] vector = ((LongColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          toColumn.putLong(index, vector[index]);
+        }
+      }
+    } else if (type instanceof TimestampType) {
+      TimestampColumnVector vector = ((TimestampColumnVector)fromColumn);
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          toColumn.putLong(index, fromTimestampColumnVector(vector, index));
+        }
+      }
+    } else if (type instanceof FloatType) {
+      double[] vector = ((DoubleColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          toColumn.putFloat(index, (float)vector[index]);
+        }
+      }
+    } else if (type instanceof DoubleType) {
+      double[] vector = ((DoubleColumnVector)fromColumn).vector;
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          toColumn.putDouble(index, vector[index]);
+        }
+      }
+    } else if (type instanceof StringType || type instanceof BinaryType) {
+      BytesColumnVector vector = (BytesColumnVector)fromColumn;
+      WritableColumnVector arrayData = toColumn.arrayData();
+      int totalNumBytes = IntStream.of(vector.length).sum();
+      arrayData.reserve(totalNumBytes);
+      for (int index = 0, pos = 0; index < batchSize; pos += vector.length[index], index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          arrayData.putBytes(pos, vector.length[index], vector.vector[index], vector.start[index]);
+          toColumn.putArray(index, pos, vector.length[index]);
+        }
+      }
+    } else if (type instanceof DecimalType) {
+      DecimalType decimalType = (DecimalType)type;
+      HiveDecimalWritable[] vector = ((DecimalColumnVector)fromColumn).vector;
+      if (decimalType.precision() > Decimal.MAX_LONG_DIGITS()) {
+        toColumn.arrayData().reserve(batchSize * 16);
+      }
+      for (int index = 0; index < batchSize; index++) {
+        if (fromColumn.isNull[index]) {
+          toColumn.putNull(index);
+        } else {
+          putDecimalWritable(
+            toColumn,
+            index,
+            decimalType.precision(),
+            decimalType.scale(),
+            vector[index]);
+        }
+      }
+    } else {
+      throw new UnsupportedOperationException("Unsupported Data Type: " + type);
+    }
+  }
+
+  /**
+   * Returns the number of micros since epoch from an element of TimestampColumnVector.
+   */
+  private static long fromTimestampColumnVector(TimestampColumnVector vector, int index) {
+    return vector.time[index] * 1000 + (vector.nanos[index] / 1000 % 1000);
+  }
+
+  /**
+   * Put a `HiveDecimalWritable` to a `WritableColumnVector`.
+   */
+  private static void putDecimalWritable(
+      WritableColumnVector toColumn,
+      int index,
+      int precision,
+      int scale,
+      HiveDecimalWritable decimalWritable) {
+    HiveDecimal decimal = decimalWritable.getHiveDecimal();
+    Decimal value =
+      Decimal.apply(decimal.bigDecimalValue(), decimal.precision(), decimal.scale());
+    value.changePrecision(precision, scale);
+
+    if (precision <= Decimal.MAX_INT_DIGITS()) {
+      toColumn.putInt(index, (int) value.toUnscaledLong());
+    } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+      toColumn.putLong(index, value.toUnscaledLong());
+    } else {
+      byte[] bytes = value.toJavaBigDecimal().unscaledValue().toByteArray();
+      toColumn.arrayData().putBytes(index * 16, bytes.length, bytes, 0);
+      toColumn.putArray(index, index * 16, bytes.length);
+    }
+  }
+
+  /**
+   * Put `HiveDecimalWritable`s to a `WritableColumnVector`.
+   */
+  private static void putDecimalWritables(
+      WritableColumnVector toColumn,
+      int size,
+      int precision,
+      int scale,
+      HiveDecimalWritable decimalWritable) {
+    HiveDecimal decimal = decimalWritable.getHiveDecimal();
+    Decimal value =
+      Decimal.apply(decimal.bigDecimalValue(), decimal.precision(), decimal.scale());
+    value.changePrecision(precision, scale);
+
+    if (precision <= Decimal.MAX_INT_DIGITS()) {
+      toColumn.putInts(0, size, (int) value.toUnscaledLong());
+    } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+      toColumn.putLongs(0, size, value.toUnscaledLong());
+    } else {
+      byte[] bytes = value.toJavaBigDecimal().unscaledValue().toByteArray();
+      toColumn.arrayData().reserve(bytes.length);
+      toColumn.arrayData().putBytes(0, bytes.length, bytes, 0);
+      for (int index = 0; index < size; index++) {
+        toColumn.putArray(index, 0, bytes.length);
+      }
+    }
+  }
+}

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.datasources.oap.orc;
 
 import java.io.IOException;
-import java.util.stream.IntStream;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -361,7 +360,10 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
     } else if (type instanceof StringType || type instanceof BinaryType) {
       BytesColumnVector data = ((BytesColumnVector)fromColumn);
       WritableColumnVector arrayData = toColumn.arrayData();
-      int totalNumBytes = IntStream.of(data.length).sum();
+      int totalNumBytes = 0;
+      for (int index = 0; index < batchSize; index++) {
+        totalNumBytes += data.length[index];
+      }
       arrayData.reserve(totalNumBytes);
       for (int index = 0, pos = 0; index < batchSize; pos += data.length[index], index++) {
         arrayData.putBytes(pos, data.length[index], data.vector[index], data.start[index]);
@@ -467,7 +469,10 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
     } else if (type instanceof StringType || type instanceof BinaryType) {
       BytesColumnVector vector = (BytesColumnVector)fromColumn;
       WritableColumnVector arrayData = toColumn.arrayData();
-      int totalNumBytes = IntStream.of(vector.length).sum();
+      int totalNumBytes = 0;
+      for (int index = 0; index < batchSize; index++) {
+        totalNumBytes += vector.length[index];
+      }
       arrayData.reserve(totalNumBytes);
       for (int index = 0, pos = 0; index < batchSize; pos += vector.length[index], index++) {
         if (fromColumn.isNull[index]) {

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
@@ -37,12 +37,12 @@ import org.apache.orc.storage.serde2.io.HiveDecimalWritable;
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.datasources.orc.OrcColumnVector;
-import org.apache.spark.sql.vectorized.ColumnVectorUtils;
-import org.apache.spark.sql.vectorized.OffHeapColumnVector;
-import org.apache.spark.sql.vectorized.OnHeapColumnVector;
-import org.apache.spark.sql.vectorized.WritableColumnVector;
+import org.apache.spark.sql.vectorized.oap.orc.ColumnVectorUtils;
+import org.apache.spark.sql.vectorized.oap.orc.OffHeapColumnVector;
+import org.apache.spark.sql.vectorized.oap.orc.OnHeapColumnVector;
+import org.apache.spark.sql.vectorized.oap.orc.WritableColumnVector;
 import org.apache.spark.sql.types.*;
-import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch;
 
 
 /**
@@ -80,7 +80,7 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
   protected WritableColumnVector[] columnVectors;
 
   // The wrapped ORC column vectors. It should be null if `copyToSpark` is true.
-  protected org.apache.spark.sql.vectorized.ColumnVector[] orcVectorWrappers;
+  protected org.apache.spark.sql.vectorized.oap.orc.ColumnVector[] orcVectorWrappers;
 
   // The memory mode of the columnarBatch
   protected final MemoryMode MEMORY_MODE;
@@ -198,7 +198,8 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
       columnarBatch = new ColumnarBatch(columnVectors);
     } else {
       // Just wrap the ORC column vector instead of copying it to Spark column vector.
-      orcVectorWrappers = new org.apache.spark.sql.vectorized.ColumnVector[resultSchema.length()];
+      orcVectorWrappers =
+        new org.apache.spark.sql.vectorized.oap.orc.ColumnVector[resultSchema.length()];
 
       for (int i = 0; i < requiredFields.length; i++) {
         DataType dt = requiredFields[i].dataType();

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcMapreduceRecordReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcMapreduceRecordReader.java
@@ -95,15 +95,13 @@ public class OrcMapreduceRecordReader<V extends WritableComparable>
 
   @Override
   public void initialize(InputSplit inputSplit,
-                         TaskAttemptContext taskAttemptContext) {
+      TaskAttemptContext taskAttemptContext) {
     // nothing required
   }
 
-  @Override
-  public boolean nextKeyValue() throws IOException, InterruptedException {
-    if (!ensureBatch()) {
-      return false;
-    }
+  // Below common code is extracted from nextKeyValue method.
+  // The child class IndexedOrcMapreduceRecordReader will use it as well.
+  protected void readNextRow() {
     if (schema.getCategory() == TypeDescription.Category.STRUCT) {
       OrcStruct result = (OrcStruct) row;
       List<TypeDescription> children = schema.getChildren();
@@ -115,6 +113,14 @@ public class OrcMapreduceRecordReader<V extends WritableComparable>
     } else {
       OrcMapredRecordReader.nextValue(batch.cols[0], rowInBatch, schema, row);
     }
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    if (!ensureBatch()) {
+      return false;
+    }
+    readNextRow();
     rowInBatch += 1;
     return true;
   }

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcMapreduceRecordReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcMapreduceRecordReader.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.oap.orc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.orc.OrcConf;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.RecordReader;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.mapred.OrcMapredRecordReader;
+import org.apache.orc.mapred.OrcStruct;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * This record reader is a copy of OrcMapreduceRecordReader with minor changes
+ * to be able to have a child class OapIndexOrcMapreduceRecordReader.
+ * This OrcMapreduceRecordReader implements the org.apache.hadoop.mapreduce API.
+ * It is in the org.apache.orc.mapreduce package to share implementation with
+ * the mapreduce API record reader.
+ * @param <V> the root type of the file
+ */
+public class OrcMapreduceRecordReader<V extends WritableComparable>
+    extends org.apache.hadoop.mapreduce.RecordReader<NullWritable, V> {
+
+  protected final V row;
+  protected final TypeDescription schema;
+  protected final RecordReader batchReader;
+  protected final VectorizedRowBatch batch;
+  protected int rowInBatch;
+
+  public OrcMapreduceRecordReader(Path file, Configuration conf)
+      throws IOException {
+    FileSystem fileSystem = file.getFileSystem(conf);
+    long length = fileSystem.getFileStatus(file).getLen();
+
+    Reader fileReader = OrcFile.createReader(file,
+        OrcFile.readerOptions(conf)
+            .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(conf)));
+    Reader.Options options = org.apache.orc.mapred.OrcInputFormat.buildOptions(conf,
+        fileReader, 0, length);
+
+    this.batchReader = fileReader.rows(options);
+    if (options.getSchema() == null) {
+      schema = fileReader.getSchema();
+    } else {
+      schema = options.getSchema();
+    }
+    this.batch = schema.createRowBatch();
+    rowInBatch = 0;
+    this.row = (V) OrcStruct.createValue(schema);
+  }
+
+  /**
+   * If the current batch is empty, get a new one.
+   * @return true if we have rows available.
+   * @throws IOException
+   */
+  boolean ensureBatch() throws IOException {
+    if (rowInBatch >= batch.size) {
+      rowInBatch = 0;
+      return batchReader.nextBatch(batch);
+    }
+    return true;
+  }
+
+  @Override
+  public void close() throws IOException {
+    batchReader.close();
+  }
+
+  @Override
+  public void initialize(InputSplit inputSplit,
+                         TaskAttemptContext taskAttemptContext) {
+    // nothing required
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    if (!ensureBatch()) {
+      return false;
+    }
+    if (schema.getCategory() == TypeDescription.Category.STRUCT) {
+      OrcStruct result = (OrcStruct) row;
+      List<TypeDescription> children = schema.getChildren();
+      int numberOfChildren = children.size();
+      for(int i=0; i < numberOfChildren; ++i) {
+        result.setFieldValue(i, OrcMapredRecordReader.nextValue(batch.cols[i], rowInBatch,
+            children.get(i), result.getFieldValue(i)));
+      }
+    } else {
+      OrcMapredRecordReader.nextValue(batch.cols[0], rowInBatch, schema, row);
+    }
+    rowInBatch += 1;
+    return true;
+  }
+
+  @Override
+  public NullWritable getCurrentKey() throws IOException, InterruptedException {
+    return NullWritable.get();
+  }
+
+  @Override
+  public V getCurrentValue() throws IOException, InterruptedException {
+    return row;
+  }
+
+  @Override
+  public float getProgress() throws IOException {
+    return batchReader.getProgress();
+  }
+}

--- a/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnVector.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnVector.java
@@ -24,8 +24,8 @@ import org.apache.orc.storage.ql.exec.vector.*;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.TimestampType;
-import org.apache.spark.sql.vectorized.ColumnarArray;
-import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.sql.vectorized.oap.orc.ColumnarArray;
+import org.apache.spark.sql.vectorized.oap.orc.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -33,7 +33,7 @@ import org.apache.spark.unsafe.types.UTF8String;
  * Spark's vectorized.ColumnVector, this column vector is used to adapt Hive ColumnVector with
  * Spark ColumnarVector.
  */
-public class OrcColumnVector extends org.apache.spark.sql.vectorized.ColumnVector {
+public class OrcColumnVector extends org.apache.spark.sql.vectorized.oap.orc.ColumnVector {
   private ColumnVector baseData;
   private LongColumnVector longData;
   private DoubleColumnVector doubleData;
@@ -187,7 +187,7 @@ public class OrcColumnVector extends org.apache.spark.sql.vectorized.ColumnVecto
   }
 
   @Override
-  public org.apache.spark.sql.vectorized.ColumnVector getChild(int ordinal) {
+  public org.apache.spark.sql.vectorized.oap.orc.ColumnVector getChild(int ordinal) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnVector.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnVector.java
@@ -44,7 +44,7 @@ public class OrcColumnVector extends org.apache.spark.sql.vectorized.ColumnVecto
 
   private int batchSize;
 
-  OrcColumnVector(DataType type, ColumnVector vector) {
+  public OrcColumnVector(DataType type, ColumnVector vector) {
     super(type);
 
     if (type instanceof TimestampType) {

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnVector.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnVector.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.types.DataType;

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnVectorUtils.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnVectorUtils.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnarArray.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnarArray.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.catalyst.util.ArrayData;

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnarBatch.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnarBatch.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import java.util.*;
 

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnarMap.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnarMap.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import org.apache.spark.sql.catalyst.util.MapData;
 

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnarRow.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/ColumnarRow.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.catalyst.InternalRow;

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/Dictionary.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/Dictionary.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 /**
  * The interface for dictionary in ColumnVector to decode dictionary encoded values.

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/MutableColumnarRow.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/MutableColumnarRow.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/OffHeapColumnVector.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/OffHeapColumnVector.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/OnHeapColumnVector.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/OnHeapColumnVector.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/src/main/java/org/apache/spark/sql/vectorized/oap/orc/WritableColumnVector.java
+++ b/src/main/java/org/apache/spark/sql/vectorized/oap/orc/WritableColumnVector.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.apache.spark.sql.vectorized.oap.orc;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add four orc record readers as follows:
1. OrcColumnarBatchReader.java and extended IndexedOrcColumnarBatchReader.java
2. OrcMapreduceRecordReader.java and extended IndexedOrcMapreduceRecordReader.java

OrcColumnarBatchReader is a copy of OrcColumnarBatchReader from Spark2.3 with minor changes to be able to have a child class IndexedOrcColumnarBatchReader.

OrcMapreduceRecordReader is a copy of OrcMapreduceRecordReader from orc upstream with minor changes to be able to have a child class IndexedOrcMapreduceRecordReader.

The above four readers are specifically used by oap orc readers in order to use oap index. 
Except this, others in OAP will not use these readers.

The minor changes are categorized below:
1. change some fields from private to protected in order to have a child class
2. Replace IntStream with for loop in OrcColumnarBatchReader.java
    The IntStream is the JDK1.8 feature. Spark2.1 is using 1.7. Thus change back to for loop.
3. for index orc readers, use rowIds to skip some batches or records during iterating.

## How was this patch tested?

All of oap unit tests passed in both profile 2.1 and 2.2.
    