### PR TITLE
Remove getProgress method from RecordReader.java

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/IndexedMrOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedMrOapRecordReader.java
@@ -63,10 +63,6 @@ public class IndexedMrOapRecordReader<T> implements RecordReader<T> {
     }
 
     @Override
-    public float getProgress() throws IOException, InterruptedException {
-      return internalReader.getProgress();
-    }
-
     public void initialize() throws IOException, InterruptedException {
 
       OapParquetFileReader reader = OapParquetFileReader.open(configuration, file,

--- a/src/main/java/org/apache/parquet/hadoop/InternalOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/InternalOapRecordReader.java
@@ -183,13 +183,6 @@ public class InternalOapRecordReader<T> {
       return currentValue;
     }
 
-    public float getProgress() throws IOException, InterruptedException {
-      if (total == 0L) {
-        return 1F;
-      }
-      return (float) current / total;
-    }
-
     private void checkIOState(PageReadStore pages) throws IOException {
       if (pages == null) {
         throw new IOException(

--- a/src/main/java/org/apache/parquet/hadoop/MrOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/MrOapRecordReader.java
@@ -61,10 +61,6 @@ public class MrOapRecordReader<T> implements RecordReader<T> {
     }
 
     @Override
-    public float getProgress() throws IOException, InterruptedException {
-      return internalReader.getProgress();
-    }
-
     public void initialize() throws IOException, InterruptedException {
       ParquetFileReader parquetFileReader =
         ParquetFileReader.open(configuration, file, footer.toParquetMetadata());

--- a/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
@@ -193,17 +193,6 @@ public class VectorizedOapRecordReader extends SpecificOapRecordReaderBase<Objec
     }
 
     /**
-     * From VectorizedParquetRecordReader,no change.
-     * @return
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    @Override
-    public float getProgress() throws IOException, InterruptedException {
-      return (float) rowsReturned / totalRowCount;
-    }
-
-    /**
      * Returns the ColumnarBatch object that will be used for all rows returned by this reader.
      * This object is reused. Calling this enables the vectorized reader. This should be called
      * before any calls to nextKeyValue/nextBatch.

--- a/src/main/java/org/apache/parquet/hadoop/api/RecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/api/RecordReader.java
@@ -48,15 +48,6 @@ public interface RecordReader<T> extends Closeable {
     T getCurrentValue() throws IOException, InterruptedException;
 
     /**
-     * The current progress of the record reader through its data.
-     *
-     * @return a number between 0.0 and 1.0 that is the fraction of the data read
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    float getProgress() throws IOException, InterruptedException;
-
-    /**
      * Close the record reader.
      */
     void close() throws IOException;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove getProgress() method from RecordReader.java, we don't need this api.


## How was this patch tested?

mvn test pass
mvn test -Pspark-2.2 pass