### PR TITLE
fix the issue of index directory containing schema

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -180,9 +180,12 @@ private[oap] object IndexUtils {
     if (indexDirectory.trim != "") {
       // here the outputPath = indexDirectory + tablePath or
       // indexDirectory + tablePath+ partitionPath
+      // we should also remove the schema of indexDirectory when get the tablePath
+      // to avoid the wrong tablePath when the indexDirectory contain schema. file:/tmp
+      // For example: indexDirectory = file:/tmp outputPath = file:/tmp/tablePath
       val tablePath =
-      Path.getPathWithoutSchemeAndAuthority(
-        outputPath).toString.replaceFirst(indexDirectory.toString, "")
+      Path.getPathWithoutSchemeAndAuthority(outputPath).toString.replaceFirst(
+        Path.getPathWithoutSchemeAndAuthority(new Path(indexDirectory)).toString, "")
       val partitionPath =
         Path.getPathWithoutSchemeAndAuthority(
           inputFilePath.getParent).toString.replaceFirst(tablePath.toString, "")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -21,9 +21,9 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row, SaveMode}
+import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex, TestPartition}
 import org.apache.spark.util.Utils
-import org.apache.spark.sql.internal.oap.OapConf
 
 class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
   import testImplicits._

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -21,7 +21,6 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row, SaveMode}
-import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex, TestPartition}
 import org.apache.spark.util.Utils
 
@@ -41,11 +40,6 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     sql(s"""CREATE TABLE oap_partition_table (a int, b int, c STRING)
             | USING parquet
             | PARTITIONED by (b, c)""".stripMargin)
-    sql(s"""CREATE TABLE oap_partition_table_index_directory (a int, b int, c STRING)
-            | USING parquet
-            | PARTITIONED by (b, c)""".stripMargin)
-    sql(s"""CREATE TABLE oap_table_index_directory (a int)
-            | USING parquet""".stripMargin)
   }
 
   override def afterEach(): Unit = {
@@ -102,53 +96,6 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
           Row("oap_test_2", "index6", 0, "a", "A", "BITMAP", true) ::
           Row("oap_test_2", "index1", 0, "a", "D", "BTREE", true) ::
           Row("oap_test_2", "index1", 1, "b", "D", "BTREE", true) :: Nil)
-    }
-  }
-
-  test("verify the index path is indexDirectory + tablePath or indexFirectory" +
-    " + tablePath + partitionPath when the index directory contain the schema") {
-    val data: Seq[(Int, Int)] = (1 to 10).map { i => (i, i) }
-    data.toDF("key", "value").createOrReplaceTempView("t")
-
-    val path = new Path(sqlConf.warehousePath)
-    sql(
-      """
-        |INSERT OVERWRITE TABLE oap_partition_table_index_directory
-        |partition (b=1, c='c1')
-        |SELECT key from t where value < 4
-      """.stripMargin)
-
-    sql(
-      """
-        |INSERT OVERWRITE TABLE oap_table_index_directory
-        |SELECT key from t where value < 4
-      """.stripMargin)
-
-    withSQLConf(OapConf.OAP_INDEX_DIRECTORY.key -> "file:/tmp") {
-      val indexDirectory = Path.getPathWithoutSchemeAndAuthority(
-        new Path(spark.conf.get(OapConf.OAP_INDEX_DIRECTORY.key)))
-      val parentPath = new Path(
-        indexDirectory + Path.getPathWithoutSchemeAndAuthority(path).toString)
-
-      withIndex(
-        TestIndex("oap_partition_table_index_directory", "index1",
-          TestPartition("b", "1"), TestPartition("c", "c1"))) {
-        sql(
-          "create oindex index1 on oap_partition_table_index_directory (a) partition (b=1, c='c1')")
-
-        assert(path.getFileSystem(
-          configuration).globStatus(new Path(parentPath,
-          "oap_partition_table_index_directory/b=1/c=c1/*.index")).length != 0)
-      }
-
-      withIndex() {
-        sql(
-          "create oindex index1 on oap_table_index_directory (a)")
-
-        assert(path.getFileSystem(
-          configuration).globStatus(new Path(parentPath,
-          "oap_table_index_directory/*.index")).length != 0)
-      }
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
@@ -210,6 +210,35 @@ class IndexUtilsSuite extends SparkFunSuite with SharedOapContext with Logging {
     }
   }
 
+  test("generateTempIndexFilePath: generating temp index file path with specific configuration") {
+    // set the configuration of OapConf.OAP_INDEX_DIRECTORY
+    withSQLConf(OapConf.OAP_INDEX_DIRECTORY.key -> "/tmp") {
+      val indexDirectory = spark.conf.get(OapConf.OAP_INDEX_DIRECTORY.key)
+      val option = Map(
+        OapConf.OAP_INDEX_DIRECTORY.key -> spark.conf.get(OapConf.OAP_INDEX_DIRECTORY.key))
+      val conf = spark.sessionState.newHadoopConfWithOptions(option)
+      // because the indexDirectory is "/tmp", so the index file path is "/tmp" +data file path
+      assertEquals(s"$indexDirectory/path/to/_temp/0/.t1.ABC.index1.index",
+        IndexUtils.generateTempIndexFilePath(conf,
+          "/path/to/t1.data",
+          new Path(s"$indexDirectory/path/to"),
+          s"$indexDirectory/path/to/_temp/0/.index",
+          ".ABC.index1.index").toString)
+      assertEquals(s"$indexDirectory/path/to/_temp/1/a=3/b=4/.t1.ABC.index1.index",
+        IndexUtils.generateTempIndexFilePath(conf,
+          "hdfs:/path/to/a=3/b=4/t1.data",
+          new Path(s"$indexDirectory/path/to"),
+          s"$indexDirectory/path/to/_temp/1/.index",
+          ".ABC.index1.index").toString)
+      assertEquals(s"$indexDirectory/path/to/_temp/2/x=1/.t1.ABC.index1.index",
+        IndexUtils.generateTempIndexFilePath(conf,
+          "hdfs://remote:8020/path/to/x=1/t1.data",
+          new Path(s"$indexDirectory/path/to/"),
+          s"$indexDirectory/path/to/_temp/2/.index",
+          ".ABC.index1.index").toString)
+    }
+  }
+
   test("writeHead to write common and consistent index version to all the index file headers") {
     val buf = new ByteArrayOutputStream(8)
     val out = new DataOutputStream(buf)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
@@ -210,14 +210,15 @@ class IndexUtilsSuite extends SparkFunSuite with SharedOapContext with Logging {
     }
   }
 
-  test("generateTempIndexFilePath: generating temp index file path with specific configuration") {
+  test("generateTempIndexFilePath: generating temp index file path with specific" +
+    " configuration with schema") {
     // set the configuration of OapConf.OAP_INDEX_DIRECTORY with schema
     withSQLConf(OapConf.OAP_INDEX_DIRECTORY.key -> "file:/tmp") {
       val indexDirectory = spark.conf.get(OapConf.OAP_INDEX_DIRECTORY.key)
       val option = Map(
         OapConf.OAP_INDEX_DIRECTORY.key -> spark.conf.get(OapConf.OAP_INDEX_DIRECTORY.key))
       val conf = spark.sessionState.newHadoopConfWithOptions(option)
-      // because the indexDirectory is "/tmp", so the index file path is "/tmp" +data file path
+      // because the indexDirectory is "file:/tmp", so the index file path is "file:/tmp" +data file path
       assertEquals(s"$indexDirectory/path/to/_temp/0/.t1.ABC.index1.index",
         IndexUtils.generateTempIndexFilePath(conf,
           "/path/to/t1.data",

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
@@ -211,8 +211,8 @@ class IndexUtilsSuite extends SparkFunSuite with SharedOapContext with Logging {
   }
 
   test("generateTempIndexFilePath: generating temp index file path with specific configuration") {
-    // set the configuration of OapConf.OAP_INDEX_DIRECTORY
-    withSQLConf(OapConf.OAP_INDEX_DIRECTORY.key -> "/tmp") {
+    // set the configuration of OapConf.OAP_INDEX_DIRECTORY with schema
+    withSQLConf(OapConf.OAP_INDEX_DIRECTORY.key -> "file:/tmp") {
       val indexDirectory = spark.conf.get(OapConf.OAP_INDEX_DIRECTORY.key)
       val option = Map(
         OapConf.OAP_INDEX_DIRECTORY.key -> spark.conf.get(OapConf.OAP_INDEX_DIRECTORY.key))

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
@@ -218,7 +218,8 @@ class IndexUtilsSuite extends SparkFunSuite with SharedOapContext with Logging {
       val option = Map(
         OapConf.OAP_INDEX_DIRECTORY.key -> spark.conf.get(OapConf.OAP_INDEX_DIRECTORY.key))
       val conf = spark.sessionState.newHadoopConfWithOptions(option)
-      // because the indexDirectory is "file:/tmp", so the index file path is "file:/tmp" +data file path
+      // because the indexDirectory is "file:/tmp",
+      // so the index file path is "file:/tmp" +data file path
       assertEquals(s"$indexDirectory/path/to/_temp/0/.t1.ABC.index1.index",
         IndexUtils.generateTempIndexFilePath(conf,
           "/path/to/t1.data",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, if OapConf.OAP_INDEX_DIRECTORY contain the schema, for example: file:/tmp, the final index directory path is not  "indexDirectory+tablePath" or "indexDirectory+tablePath+partitionPath".

Reason in IndexUtils#generateTempIndexFilePath, we get the wrong tablePath, which cause the wrong partitionPath in the following:
`val tablePath=
Path.getPathWithoutSchemeAndAuthority(
outputPath).toString.replaceFirst(indexDirectory.toString, "")`
For example indexDirectory = file:/tmp, outputPath = file:/tmp/tablePath
tablePath = "/tmp/tablePath".replace("file:/tmp", ""). so the tablePath is "/tmp/tablePath" not "/tablePath". So we should remove the schema of indexDirectory when get the tablePath:
`val tablePath=
Path.getPathWithoutSchemeAndAuthority(
outputPath).toString.replaceFirst(Path.getPathWithoutSchemeAndAuthority(new Path(indexDirectory)).toString, "")`



## How was this patch tested?

UT in OapDDLSuite.scala
