### PR TITLE
Add classifier tag to default-jar build process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -514,6 +514,15 @@
         <version>2.3</version>
         <executions>
           <execution>
+            <id>default-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>with-spark-${spark.internal.version}</classifier>
+            </configuration>
+          </execution>
+          <execution>
             <id>prepare-test-jar</id>
             <phase>prepare-package</phase>
             <goals>
@@ -741,5 +750,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Modify maven-jar-plugin config add `<classifier>with-spark-${spark.internal.version}</classifier>`,  after this patch exec `mvn clean install` will build target jar name  like `oap-xxx-with-spark-2.x.x.jar`  

## How was this patch tested?

NA