### PR TITLE
[Orc-support-03] Add OrcDataFile and unit tests 

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -22,8 +22,8 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 import org.apache.hadoop.util.StringUtils
-import org.apache.orc._
-import org.apache.orc.mapreduce._
+import org.apache.orc.OrcFile
+import org.apache.orc.mapreduce.OrcInputFormat
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Row, SparkSession}
@@ -247,7 +247,8 @@ private[sql] class OapFileFormat extends FileFormat
         val isOrc = m.dataReaderClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME)
         val enableOffHeapColumnVector =
           sparkSession.sessionState.conf.getConf(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED)
-        val copyToSpark = sparkSession.sessionState.conf.getConf(OapConf.ORC_COPY_BATCH_TO_SPARK)
+        val copyToSpark =
+          sparkSession.sessionState.conf.getConf(OapConf.ORC_COPY_BATCH_TO_SPARK)
         val isCaseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
 
         // Push down the filters to the orc record reader.
@@ -271,7 +272,7 @@ private[sql] class OapFileFormat extends FileFormat
           val fs = path.getFileSystem(broadcastedHadoopConf.value.value)
 
           val version = if (isParquet || isOrc) {
-            // Currently Parquet is using OapDataReaderV1
+            // Currently both Parquet and Orc are using OapDataReaderV1.
             DataFileVersion.OAP_DATAFILE_V1
           } else {
             // Below is for Oap format file.

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -22,6 +22,8 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 import org.apache.hadoop.util.StringUtils
+import org.apache.orc._
+import org.apache.orc.mapreduce._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Row, SparkSession}
@@ -32,6 +34,8 @@ import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, Scann
 import org.apache.spark.sql.execution.datasources.oap.io._
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion
 import org.apache.spark.sql.execution.datasources.oap.utils.{FilterHelper, OapUtils}
+import org.apache.spark.sql.execution.datasources.orc.OrcFilters
+import org.apache.spark.sql.execution.datasources.orc.OrcUtils
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
@@ -143,8 +147,10 @@ private[sql] class OapFileFormat extends FileFormat
     }
     val conf = sparkSession.sessionState.conf
     // TODO modify conditions after oap support batch return
-    readerClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
-      conf.parquetVectorizedReaderEnabled &&
+    ((readerClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
+      conf.parquetVectorizedReaderEnabled) ||
+      (readerClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME) &&
+      conf.getConf(OapConf.ORC_VECTORIZED_READER_ENABLED))) &&
       conf.wholeStageEnabled &&
       schema.length <= conf.wholeStageMaxNumFields &&
       schema.forall(_.dataType.isInstanceOf[AtomicType])
@@ -238,12 +244,21 @@ private[sql] class OapFileFormat extends FileFormat
         // Vectorized Read and returningBatch. Also it depends on WHOLE_STAGE_CODE_GEN,
         // as the essential unsafe projection is done by that.
         val isParquet = m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME)
+        val isOrc = m.dataReaderClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME)
+        val enableOffHeapColumnVector =
+          sparkSession.sessionState.conf.getConf(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED)
+        val copyToSpark = sparkSession.sessionState.conf.getConf(OapConf.ORC_COPY_BATCH_TO_SPARK)
+        val isCaseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
+
+        // Push down the filters to the orc record reader.
+        if (isOrc && sparkSession.sessionState.conf.orcFilterPushDown) {
+          OrcFilters.createFilter(dataSchema,
+            filters).foreach { f =>
+            OrcInputFormat.setSearchArgument(hadoopConf, f, dataSchema.fieldNames)
+          }
+        }
+
         val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
-        val enableVectorizedReader: Boolean =
-          m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
-          sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
-          sparkSession.sessionState.conf.wholeStageEnabled &&
-          resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
         val returningBatch = supportBatch(sparkSession, resultSchema)
         val broadcastedHadoopConf =
           sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
@@ -252,37 +267,68 @@ private[sql] class OapFileFormat extends FileFormat
           assert(file.partitionValues.numFields == partitionSchema.size)
           val conf = broadcastedHadoopConf.value.value
 
-          // if enableVectorizedReader == true, init VectorizedContext,
-          // else context is None.
-          val context = if (enableVectorizedReader) {
-            Some(VectorizedContext(partitionSchema, file.partitionValues, returningBatch))
-          } else {
-            None
-          }
-
           val path = new Path(StringUtils.unEscapeString(file.filePath))
           val fs = path.getFileSystem(broadcastedHadoopConf.value.value)
 
-          val version = if (isParquet) {
+          val version = if (isParquet || isOrc) {
             // Currently Parquet is using OapDataReaderV1
             DataFileVersion.OAP_DATAFILE_V1
           } else {
+            // Below is for Oap format file.
             OapDataReader.readVersion(fs.open(path), fs.getFileStatus(path).getLen)
           }
 
-          version match {
-            case DataFileVersion.OAP_DATAFILE_V1 =>
-              val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
-                filterScanners, requiredIds, pushed, oapMetrics, conf, enableVectorizedReader,
-                options, filters, context = context)
-              reader.read(file)
-            // Actually it shouldn't get to this line, because unsupported version will cause
-            // exception thrown in readVersion call
-            case _ =>
-              throw new OapException("Unexpected data file version")
-              Iterator.empty
+          var orcWithEmptyColIds = false
+          // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
+          // Otherwise context is none.
+          // For Orc, the context is used by both vectorized readers and map reduce readers.
+          // See the comments in DataFile.scala.
+          var context: Option[DataFileContext] = None
+          if (isParquet) {
+            returningBatch match {
+              case true =>
+                context = Some(ParquetVectorizedContext(partitionSchema,
+                  file.partitionValues, returningBatch))
+              case false =>
+                context = None
+            }
+          } else if (isOrc) {
+            val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
+            val reader = OrcFile.createReader(path, readerOptions)
+            val requestedColIdsOrEmptyFile = OrcUtils.requestedColumnIds(
+              isCaseSensitive, dataSchema, requiredSchema, reader, conf)
+            if (!requestedColIdsOrEmptyFile.isEmpty) {
+              val requestedColIds = requestedColIdsOrEmptyFile.get
+              assert(requestedColIds.length == requiredSchema.length,
+                "[BUG] requested column IDs do not match required schema")
+              context = Some(OrcDataFileContext(partitionSchema, file.partitionValues,
+                returningBatch, requiredSchema, dataSchema, enableOffHeapColumnVector,
+                  copyToSpark, requestedColIds))
+            } else {
+              orcWithEmptyColIds = true
+              context = None
+            }
+          } else {
+            context = None
           }
 
+          if (orcWithEmptyColIds) {
+            // For the case of Orc with empty required column Ids.
+            Iterator.empty
+          } else {
+            version match {
+              case DataFileVersion.OAP_DATAFILE_V1 =>
+                val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
+                  filterScanners, requiredIds, pushed, oapMetrics, conf, returningBatch, options,
+                  filters, context)
+                reader.read(file)
+              // Actually it shouldn't get to this line, because unsupported version will cause
+              // exception thrown in readVersion call
+              case _ =>
+                throw new OapException("Unexpected data file version")
+                Iterator.empty
+            }
+          }
         }
       case None => (_: PartitionedFile) => {
         // TODO need to think about when there is no oap.meta file at all
@@ -441,6 +487,7 @@ private[sql] object OapFileFormat {
   val OAP_DATA_FILE_V1_CLASSNAME = classOf[OapDataFileV1].getCanonicalName
 
   val PARQUET_DATA_FILE_CLASSNAME = classOf[ParquetDataFile].getCanonicalName
+  val ORC_DATA_FILE_CLASSNAME = classOf[OrcDataFile].getCanonicalName
 
   val COMPRESSION = "oap.compression"
   val DEFAULT_COMPRESSION = OapConf.OAP_COMPRESSION.defaultValueString

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -188,16 +188,18 @@ private[oap] case class OapDataFileV1(
 
   // full file scan
   def iterator(requiredIds: Array[Int], filters: Seq[Filter] = Nil)
-    : OapCompletionIterator[InternalRow] = {
-    buildIterator(configuration, requiredIds, rowIds = None, filters)
+    : OapCompletionIterator[Any] = {
+    val iterator = buildIterator(configuration, requiredIds, rowIds = None, filters)
+    iterator.asInstanceOf[OapCompletionIterator[Any]]
   }
 
   // scan by given row ids, and we assume the rowIds are sorted
   def iteratorWithRowIds(
       requiredIds: Array[Int],
       rowIds: Array[Int],
-      filters: Seq[Filter] = Nil): OapCompletionIterator[InternalRow] = {
-    buildIterator(configuration, requiredIds, Some(rowIds), filters)
+      filters: Seq[Filter] = Nil): OapCompletionIterator[Any] = {
+    val iterator = buildIterator(configuration, requiredIds, Some(rowIds), filters)
+    iterator.asInstanceOf[OapCompletionIterator[Any]]
   }
 
   def close(): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReader.scala
@@ -62,6 +62,7 @@ object OapDataReader extends Logging {
     = {
     dataReaderClassFromDataSourceMeta match {
       case c if c == OapFileFormat.PARQUET_DATA_FILE_CLASSNAME => c
+      case c if c == OapFileFormat.ORC_DATA_FILE_CLASSNAME => c
       case c if c == OapFileFormat.OAP_DATA_FILE_CLASSNAME =>
         reader match {
           case r: OapDataReaderV1 => OapFileFormat.OAP_DATA_FILE_V1_CLASSNAME

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.oap.io
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataOutputStream, Path}
+import org.apache.orc.mapred.OrcStruct
 import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.format.CompressionCodec
 import org.apache.parquet.io.api.Binary
@@ -26,13 +27,14 @@ import org.apache.parquet.io.api.Binary
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Ascending, JoinedRow}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, JoinedRow, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache.DataFiberBuilder
 import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.execution.datasources.oap.utils.{FilterHelper, OapIndexInfoStatusSerDe}
+import org.apache.spark.sql.execution.datasources.orc.OrcDeserializer
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.oap.listener.SparkListenerOapIndexInfoUpdate
 import org.apache.spark.sql.sources.Filter
@@ -205,7 +207,7 @@ private[oap] class OapDataReaderV1(
     enableVectorizedReader: Boolean = false,
     options: Map[String, String] = Map.empty,
     filters: Seq[Filter] = Seq.empty,
-    context: Option[VectorizedContext] = None) extends OapDataReader with Logging {
+    context: Option[DataFileContext] = None) extends OapDataReader with Logging {
 
   import org.apache.spark.sql.execution.datasources.oap.INDEX_STAT._
 
@@ -237,15 +239,20 @@ private[oap] class OapDataReaderV1(
     false
   }
 
-  def initialize(): OapCompletionIterator[InternalRow] = {
+  def initialize(): OapCompletionIterator[Any] = {
     logDebug("Initializing OapDataReader...")
     // TODO how to save the additional FS operation to get the Split size
     val fileScanner = DataFile(pathStr, meta.schema, dataFileClassName, conf)
-    if (meta.dataReaderClassName.contains("ParquetDataFile")) {
-      fileScanner.asInstanceOf[ParquetDataFile].setVectorizedContext(context)
+    if (meta.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME)) {
+      fileScanner.asInstanceOf[ParquetDataFile].setParquetVectorizedContext(
+        context.asInstanceOf[Option[ParquetVectorizedContext]])
+    } else if (meta.dataReaderClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME)) {
+      // For orc, the context will be used by both vectorization and non vectorization.
+      fileScanner.asInstanceOf[OrcDataFile].setOrcDataFileContext(
+        context.get.asInstanceOf[OrcDataFileContext])
     }
 
-    def fullScan: OapCompletionIterator[InternalRow] = {
+    def fullScan: OapCompletionIterator[Any] = {
       val start = if (log.isDebugEnabled) System.currentTimeMillis else 0
       val iter = fileScanner.iterator(requiredIds, filters)
       val end = if (log.isDebugEnabled) System.currentTimeMillis else 0
@@ -281,7 +288,11 @@ private[oap] class OapDataReaderV1(
           }
 
           // Parquet reader does not support backward scan, so rowIds must be sorted.
-          if (meta.dataReaderClassName.contains("ParquetDataFile")) {
+          // Actually Orc readers support the backward scan, thus no need to sort row Ids.
+          // But with the sorted row Ids, the adjacment rows will be scanned in the same batch.
+          // This will reduce IO cost.
+          if (meta.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) ||
+            meta.dataReaderClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME)) {
             rowIds.sorted
           } else {
             rowIds
@@ -319,16 +330,35 @@ private[oap] class OapDataReaderV1(
       metrics.updateTotalRows(tot)
       metrics.updateIndexAndRowRead(this, tot)
       // if enableVectorizedReader == true , return iter directly because of partitionValues
-      // already filled by VectorizedReader, else use original branch.
+      // already filled by VectorizedReader, else use original branch as Parquet or Orc.
       if (enableVectorizedReader) {
-        iter
+        iter.asInstanceOf[Iterator[InternalRow]]
       } else {
-        val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
-        val joinedRow = new JoinedRow()
-        val appendPartitionColumns =
-          GenerateUnsafeProjection.generate(fullSchema, fullSchema)
+         meta.dataReaderClassName match {
+           // Parquet and Oap are the same branch.
+           case dataReader if (dataReader.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) ||
+             dataReader.equals(OapFileFormat.OAP_DATA_FILE_CLASSNAME)) =>
+             val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
+             val joinedRow = new JoinedRow()
+             val appendPartitionColumns =
+               GenerateUnsafeProjection.generate(fullSchema, fullSchema)
 
-        iter.map(d => appendPartitionColumns(joinedRow(d, file.partitionValues)))
+             iter.asInstanceOf[Iterator[InternalRow]].map(d => {
+               appendPartitionColumns(joinedRow(d, file.partitionValues))
+             })
+           case dataReader if (dataReader.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME)) =>
+             val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
+             val orcDataFileContext = context.get.asInstanceOf[OrcDataFileContext]
+             val deserializer = new OrcDeserializer(orcDataFileContext.dataSchema, requiredSchema,
+               orcDataFileContext.requestedColIds)
+             val joinedRow = new JoinedRow()
+             val appendPartitionColumns =
+               GenerateUnsafeProjection.generate(fullSchema, fullSchema)
+
+             iter.asInstanceOf[Iterator[OrcStruct]].map(value => {
+               appendPartitionColumns(joinedRow(deserializer.deserialize(value),
+               file.partitionValues))})
+         }
       }
     }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import java.io.Closeable
+
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.RecordReader
+import org.apache.orc._
+import org.apache.orc.mapred.OrcStruct
+import org.apache.orc.mapreduce._
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.oap.filecache._
+import org.apache.spark.sql.execution.datasources.oap.orc.{IndexedOrcColumnarBatchReader, IndexedOrcMapreduceRecordReader, OrcColumnarBatchReader, OrcMapreduceRecordReader}
+import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types._
+import org.apache.spark.util.CompletionIterator
+
+/**
+ * OrcDataFile is using below four record readers to read orc data file.
+ *
+ * For vectorization, one is with oap index while the other is without oap index.
+ * The above two readers are OrcColumnarBatchReader and extended
+ * IndexedOrcColumnarBatchReader.
+ *
+ * For no vectorization, similarly one is with oap index while the other is without oap index.
+ * The above two readers are OrcMapreduceRecordReader and extended
+ * IndexedOrcMapreduceRecordReader.
+ *
+ * For the option to enable vectorization or not, it's similar to Parquet.
+ * All of the above four readers are under
+ * src/main/java/org/apache/spark/sql/execution/datasources/oap/orc.
+ *
+ * @param path data file path
+ * @param schema orc data file schema
+ * @param configuration hadoop configuration
+ */
+private[oap] case class OrcDataFile(
+    path: String,
+    schema: StructType,
+    configuration: Configuration) extends DataFile {
+
+  def iterator(
+    requiredIds: Array[Int],
+    filters: Seq[Filter] = Nil): OapCompletionIterator[Any] = {
+    val iterator = context.returningBatch match {
+      case true =>
+        initVectorizedReader(context,
+          new OrcColumnarBatchReader(context.enableOffHeapColumnVector, context.copyToSpark))
+      case false =>
+        initRecordReader(
+          new OrcMapreduceRecordReader[OrcStruct](filePath, configuration))
+    }
+    iterator.asInstanceOf[OapCompletionIterator[Any]]
+  }
+
+  def iteratorWithRowIds(
+      requiredIds: Array[Int],
+      rowIds: Array[Int],
+      filters: Seq[Filter] = Nil): OapCompletionIterator[Any] = {
+    if (rowIds == null || rowIds.length == 0) {
+      new OapCompletionIterator(Iterator.empty, {})
+    } else {
+      val iterator = context.returningBatch match {
+        case true =>
+          initVectorizedReader(context,
+            new IndexedOrcColumnarBatchReader(context.enableOffHeapColumnVector,
+              context.copyToSpark, rowIds))
+        case false =>
+          initRecordReader(
+            new IndexedOrcMapreduceRecordReader[OrcStruct](filePath, configuration, rowIds))
+      }
+      iterator.asInstanceOf[OapCompletionIterator[Any]]
+    }
+  }
+
+  def setOrcDataFileContext(context: OrcDataFileContext): Unit =
+    this.context = context
+
+  private def initVectorizedReader(c: OrcDataFileContext,
+      reader: OrcColumnarBatchReader) = {
+    reader.initialize(filePath, configuration)
+    reader.initBatch(fileReader.getSchema, c.requestedColIds, c.requiredSchema.fields,
+      c.partitionColumns, c.partitionValues)
+    val iterator = new FileRecordReaderIterator(reader)
+    new OapCompletionIterator[InternalRow](iterator.asInstanceOf[Iterator[InternalRow]], {}) {
+      override def close(): Unit = iterator.close()
+    }
+  }
+
+  private def initRecordReader(
+      reader: OrcMapreduceRecordReader[OrcStruct]) = {
+    val iterator =
+      new FileRecordReaderIterator[OrcStruct](reader.asInstanceOf[RecordReader[_, OrcStruct]])
+    new OapCompletionIterator[OrcStruct](iterator, {}) {
+      override def close(): Unit = iterator.close()
+    }
+  }
+
+  private class FileRecordReaderIterator[V](private[this] var rowReader: RecordReader[_, V])
+    extends Iterator[V] with Closeable {
+    private[this] var havePair = false
+    private[this] var finished = false
+
+    override def hasNext: Boolean = {
+      if (!finished && !havePair) {
+        finished = !rowReader.nextKeyValue
+        if (finished) {
+          close()
+        }
+        havePair = !finished
+      }
+      !finished
+    }
+
+    override def next(): V = {
+      if (!hasNext) {
+        throw new java.util.NoSuchElementException("End of stream")
+      }
+      havePair = false
+      rowReader.getCurrentValue
+    }
+
+    override def close(): Unit = {
+      if (rowReader != null) {
+        try {
+          rowReader.close()
+        } finally {
+          rowReader = null
+        }
+      }
+    }
+  }
+
+  private var context: OrcDataFileContext = _
+  private val filePath: Path = new Path(path)
+  private val fileReader: Reader = {
+    import scala.collection.JavaConverters._
+    val meta =
+      OapRuntime.getOrCreate.dataFileMetaCacheManager.get(this).asInstanceOf[OrcDataFileMeta]
+    meta.getOrcFileReader()
+  }
+
+  override def totalRows(): Long =
+    fileReader.getNumberOfRows()
+
+  override def getDataFileMeta(): DataFileMeta =
+    new OrcDataFileMeta(filePath, configuration)
+
+  // Cache will be added after parquet usage is verified to have the expected
+  // benefit from the data cache in the production environment.
+  override def cache(groupId: Int, fiberId: Int): FiberCache = Nil.asInstanceOf[FiberCache]
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFileMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFileMeta.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FSDataInputStream
+import org.apache.hadoop.fs.Path
+import org.apache.orc.OrcFile
+import org.apache.orc.Reader
+
+private[oap] class OrcDataFileMeta(val path: Path, val configuration: Configuration)
+    extends DataFileMeta {
+
+  private val fs = path.getFileSystem(configuration)
+  private val readerOptions = OrcFile.readerOptions(configuration).filesystem(fs)
+  private val fileReader = OrcFile.createReader(path, readerOptions)
+
+  def getOrcFileReader(): Reader = fileReader
+
+  override def len: Long = fileReader.getContentLength()
+  override def getGroupCount: Int = fileReader.getStripes().size()
+  override def getFieldCount: Int = fileReader.getSchema().getFieldNames().size()
+  // Not used by orc data file.
+  override def fin: FSDataInputStream = null
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
@@ -54,7 +54,7 @@ import org.apache.spark.sql.types._
  * builder methods mentioned above can only be found in test code, where all tested filters are
  * known to be convertible.
  */
-private[orc] object OrcFilters {
+private[datasources] object OrcFilters {
 
   /**
    * Create ORC filter as a SearchArgument instance.

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -72,7 +72,7 @@ private[oap] case class ParquetDataFile(
     schema: StructType,
     configuration: Configuration) extends DataFile {
 
-  private var context: Option[VectorizedContext] = None
+  private var context: Option[ParquetVectorizedContext] = None
   private lazy val meta =
     OapRuntime.getOrCreate.dataFileMetaCacheManager.get(this).asInstanceOf[ParquetDataFileMeta]
   private val file = new Path(StringUtils.unEscapeString(path))
@@ -113,7 +113,7 @@ private[oap] case class ParquetDataFile(
   private def buildIterator(
        conf: Configuration,
        requiredColumnIds: Array[Int],
-       context: VectorizedContext,
+       context: ParquetVectorizedContext,
        rowIds: Option[Array[Int]] = None): OapCompletionIterator[InternalRow] = {
     var requestSchema = new StructType
     for (index <- requiredColumnIds) {
@@ -145,8 +145,8 @@ private[oap] case class ParquetDataFile(
 
   def iterator(
     requiredIds: Array[Int],
-    filters: Seq[Filter] = Nil): OapCompletionIterator[InternalRow] = {
-    context match {
+    filters: Seq[Filter] = Nil): OapCompletionIterator[Any] = {
+    val iterator = context match {
       case Some(c) =>
         // Parquet RowGroupCount can more than Int.MaxValue,
         // in that sence we should not cache data in memory
@@ -165,16 +165,17 @@ private[oap] case class ParquetDataFile(
           new MrOapRecordReader[UnsafeRow](new ParquetReadSupportWrapper,
             file, configuration, meta.footer))
     }
+    iterator.asInstanceOf[OapCompletionIterator[Any]]
   }
 
   def iteratorWithRowIds(
       requiredIds: Array[Int],
       rowIds: Array[Int],
-      filters: Seq[Filter] = Nil): OapCompletionIterator[InternalRow] = {
+      filters: Seq[Filter] = Nil): OapCompletionIterator[Any] = {
     if (rowIds == null || rowIds.length == 0) {
       new OapCompletionIterator(Iterator.empty, {})
     } else {
-      context match {
+      val iterator = context match {
         case Some(c) =>
           // Parquet RowGroupCount can more than Int.MaxValue,
           // in that sence we should not cache data in memory
@@ -194,10 +195,11 @@ private[oap] case class ParquetDataFile(
             new IndexedMrOapRecordReader[UnsafeRow](new ParquetReadSupportWrapper,
               file, configuration, rowIds, meta.footer))
       }
+      iterator.asInstanceOf[OapCompletionIterator[Any]]
     }
   }
 
-  def setVectorizedContext(context: Option[VectorizedContext]): Unit =
+  def setParquetVectorizedContext(context: Option[ParquetVectorizedContext]): Unit =
     this.context = context
 
   private def initRecordReader(reader: RecordReader[UnsafeRow]) = {
@@ -208,7 +210,8 @@ private[oap] case class ParquetDataFile(
     }
   }
 
-  private def initVectorizedReader(c: VectorizedContext, reader: VectorizedOapRecordReader) = {
+  private def initVectorizedReader(c: ParquetVectorizedContext,
+      reader: VectorizedOapRecordReader) = {
     reader.initialize()
     reader.initBatch(c.partitionColumns, c.partitionValues)
     if (c.returningBatch) {
@@ -224,7 +227,7 @@ private[oap] case class ParquetDataFile(
       conf: Configuration,
       requiredColumnIds: Array[Int],
       requestSchema: StructType,
-      context: VectorizedContext): Iterator[InternalRow] = {
+      context: ParquetVectorizedContext): Iterator[InternalRow] = {
     val footer = meta.footer.toParquetMetadata
     footer.getBlocks.asScala.iterator.flatMap { rowGroupMeta =>
       val orderedBlockMetaData = rowGroupMeta.asInstanceOf[OrderedBlockMetaData]
@@ -242,7 +245,7 @@ private[oap] case class ParquetDataFile(
       conf: Configuration,
       requiredColumnIds: Array[Int],
       requestSchema: StructType,
-      context: VectorizedContext,
+      context: ParquetVectorizedContext,
       rowIds: Array[Int]): Iterator[InternalRow] = {
     val footer = meta.footer.toParquetMetadata(rowIds)
     footer.getBlocks.asScala.iterator.flatMap { rowGroupMeta =>
@@ -266,7 +269,7 @@ private[oap] case class ParquetDataFile(
       conf: Configuration,
       requestSchema: StructType,
       requiredColumnIds: Array[Int],
-      context: VectorizedContext): ColumnarBatch = {
+      context: ParquetVectorizedContext): ColumnarBatch = {
     val groupId = blockMetaData.getRowGroupId
     val fiberCacheGroup = requiredColumnIds.map { id =>
       val fiberCache =

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -75,7 +75,7 @@ private[oap] case class ParquetDataFile(
     schema: StructType,
     configuration: Configuration) extends DataFile {
 
-  private var context: Option[VectorizedContext] = None
+  private var context: Option[ParquetVectorizedContext] = None
   private lazy val meta =
     OapRuntime.getOrCreate.dataFileMetaCacheManager.get(this).asInstanceOf[ParquetDataFileMeta]
   private val file = new Path(StringUtils.unEscapeString(path))
@@ -116,7 +116,7 @@ private[oap] case class ParquetDataFile(
   private def buildIterator(
        conf: Configuration,
        requiredColumnIds: Array[Int],
-       context: VectorizedContext,
+       context: ParquetVectorizedContext,
        rowIds: Option[Array[Int]] = None): OapCompletionIterator[InternalRow] = {
     var requestSchema = new StructType
     for (index <- requiredColumnIds) {
@@ -148,8 +148,8 @@ private[oap] case class ParquetDataFile(
 
   def iterator(
     requiredIds: Array[Int],
-    filters: Seq[Filter] = Nil): OapCompletionIterator[InternalRow] = {
-    context match {
+    filters: Seq[Filter] = Nil): OapCompletionIterator[Any] = {
+    val iterator = context match {
       case Some(c) =>
         // Parquet RowGroupCount can more than Int.MaxValue,
         // in that sence we should not cache data in memory
@@ -168,16 +168,17 @@ private[oap] case class ParquetDataFile(
           new MrOapRecordReader[UnsafeRow](new ParquetReadSupportWrapper,
             file, configuration, meta.footer))
     }
+    iterator.asInstanceOf[OapCompletionIterator[Any]]
   }
 
   def iteratorWithRowIds(
       requiredIds: Array[Int],
       rowIds: Array[Int],
-      filters: Seq[Filter] = Nil): OapCompletionIterator[InternalRow] = {
+      filters: Seq[Filter] = Nil): OapCompletionIterator[Any] = {
     if (rowIds == null || rowIds.length == 0) {
       new OapCompletionIterator(Iterator.empty, {})
     } else {
-      context match {
+      val iterator = context match {
         case Some(c) =>
           // Parquet RowGroupCount can more than Int.MaxValue,
           // in that sence we should not cache data in memory
@@ -197,10 +198,11 @@ private[oap] case class ParquetDataFile(
             new IndexedMrOapRecordReader[UnsafeRow](new ParquetReadSupportWrapper,
               file, configuration, rowIds, meta.footer))
       }
+      iterator.asInstanceOf[OapCompletionIterator[Any]]
     }
   }
 
-  def setVectorizedContext(context: Option[VectorizedContext]): Unit =
+  def setParquetVectorizedContext(context: Option[ParquetVectorizedContext]): Unit =
     this.context = context
 
   private def initRecordReader(reader: RecordReader[UnsafeRow]) = {
@@ -211,7 +213,7 @@ private[oap] case class ParquetDataFile(
     }
   }
 
-  private def initVectorizedReader(c: VectorizedContext, reader: VectorizedOapRecordReader) = {
+  private def initVectorizedReader(c: ParquetVectorizedContext, reader: VectorizedOapRecordReader) = {
     reader.initialize()
     reader.initBatch(c.partitionColumns, c.partitionValues)
     if (c.returningBatch) {
@@ -227,7 +229,7 @@ private[oap] case class ParquetDataFile(
       conf: Configuration,
       requiredColumnIds: Array[Int],
       requestSchema: StructType,
-      context: VectorizedContext): Iterator[InternalRow] = {
+      context: ParquetVectorizedContext): Iterator[InternalRow] = {
     val footer = meta.footer.toParquetMetadata
     footer.getBlocks.asScala.iterator.flatMap { rowGroupMeta =>
       val orderedBlockMetaData = rowGroupMeta.asInstanceOf[OrderedBlockMetaData]
@@ -245,7 +247,7 @@ private[oap] case class ParquetDataFile(
       conf: Configuration,
       requiredColumnIds: Array[Int],
       requestSchema: StructType,
-      context: VectorizedContext,
+      context: ParquetVectorizedContext,
       rowIds: Array[Int]): Iterator[InternalRow] = {
     val footer = meta.footer.toParquetMetadata(rowIds)
     footer.getBlocks.asScala.iterator.flatMap { rowGroupMeta =>
@@ -269,7 +271,7 @@ private[oap] case class ParquetDataFile(
       conf: Configuration,
       requestSchema: StructType,
       requiredColumnIds: Array[Int],
-      context: VectorizedContext): ColumnarBatch = {
+      context: ParquetVectorizedContext): ColumnarBatch = {
     val groupId = blockMetaData.getRowGroupId
     val fiberCacheGroup = requiredColumnIds.map { id =>
       val fiberCache =

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSuite.scala
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.execution.datasources.oap.{DataSourceMeta, OapFileFormat}
 import org.apache.spark.sql.execution.datasources.oap.io._
@@ -208,7 +209,7 @@ class FiberSuite extends SharedOapContext with Logging {
       StructType(Seq()), None, requiredIds, None, OapRuntime.getOrCreate.oapMetricsManager,
       conf = configuration)
 
-    val it = reader.initialize()
+    val it = reader.initialize().asInstanceOf[Iterator[InternalRow]]
 
     var idx = 0
     while (it.hasNext) {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFileSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFileSuite.scala
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import java.io.File
+import java.lang.String
+
+import org.apache.orc.mapred.OrcStruct
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.Utils
+
+class OrcDataFileSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
+  import testImplicits._
+  private var path: File = _
+  private var fileName: String = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    path = Utils.createTempDir()
+    path.delete()
+
+    val df = sparkContext.parallelize(1 to 5000, 1)
+      .map(i => (i, i + 100L, s"this is row $i"))
+      .toDF("a", "b", "c")
+
+    df.write.format("orc").mode(SaveMode.Overwrite).save(path.getAbsolutePath)
+
+    for (iterator <- path.listFiles()) {
+      if (iterator.toString.endsWith(".orc")) {
+        fileName = iterator.toString()
+      }
+    }
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      Utils.deleteRecursively(path)
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  private val partitionSchema: StructType = new StructType()
+    .add(StructField("int32_field", IntegerType))
+    .add(StructField("int64_field", LongType))
+    .add(StructField("string_field", StringType))
+
+  private val partitionValues: InternalRow =
+    InternalRow(1, 101L, UTF8String.fromString("this is row 1"))
+
+  private val requestSchema: StructType = new StructType()
+    .add(StructField("int32_field", IntegerType))
+    .add(StructField("string_field", StringType))
+
+  test("read by columnIds with columnar batch") {
+    val reader = OrcDataFile(fileName, requestSchema, configuration)
+    val requiredIds = Array(0, 2)
+    val context = OrcDataFileContext(partitionSchema, partitionValues, true, requestSchema,
+      partitionSchema, false, false, requiredIds)
+    reader.setOrcDataFileContext(context)
+    val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[ColumnarBatch]]
+    var totalRows = 0
+    var totalBatches = 0
+    // By default, the columnar batch has 4096 rows.
+    while (iterator.hasNext) {
+      val columnarBatch = iterator.next
+      assert(columnarBatch.isInstanceOf[ColumnarBatch])
+      totalRows += columnarBatch.numRows
+      totalBatches += 1
+    }
+    iterator.close()
+    assert(totalRows == 5000)
+    assert(totalBatches == (5000 / 4096 + 1))
+  }
+
+  test("read by columnIds and rowIds with columnar batch") {
+    val reader = OrcDataFile(fileName, requestSchema, configuration)
+    val requiredIds = Array(0, 2)
+    val context = OrcDataFileContext(partitionSchema, partitionValues, true, requestSchema,
+      partitionSchema, false, false, requiredIds)
+    reader.setOrcDataFileContext(context)
+    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382)
+    val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[ColumnarBatch]]
+    var totalRows = 0
+    var totalBatches = 0
+    while (iterator.hasNext) {
+      val columnarBatch = iterator.next
+      assert(columnarBatch.isInstanceOf[ColumnarBatch])
+      totalRows += columnarBatch.numRows
+      totalBatches += 1
+    }
+    iterator.close()
+    // The batch is only 1, since the row Ids are covered by the same batch.
+    assert(totalRows == 4096)
+    assert(totalBatches == 1)
+  }
+
+  test("read by columnIds and empty rowIds with columnar batch") {
+    val reader = OrcDataFile(fileName, requestSchema, configuration)
+    val requiredIds = Array(0, 2)
+    val context = OrcDataFileContext(partitionSchema, partitionValues, true, requestSchema,
+      partitionSchema, false, false, requiredIds)
+    reader.setOrcDataFileContext(context)
+    val rowIds = Array.emptyIntArray
+    val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[ColumnarBatch]]
+    assert(!iterator.hasNext)
+    val e = intercept[java.util.NoSuchElementException] {
+      iterator.next()
+    }.getMessage
+    iterator.close()
+    assert(e.contains("next on empty iterator"))
+  }
+
+  test("read by columnIds without columnar batch") {
+    val reader = OrcDataFile(fileName, requestSchema, configuration)
+    val requiredIds = Array(0, 2)
+    val context = OrcDataFileContext(partitionSchema, partitionValues, false, requestSchema,
+      partitionSchema, false, false, requiredIds)
+    reader.setOrcDataFileContext(context)
+    val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[OrcStruct]]
+    var totalRows = 0
+    while (iterator.hasNext) {
+      val orcStruct = iterator.next
+      assert(orcStruct.isInstanceOf[OrcStruct])
+      totalRows += 1
+    }
+    iterator.close()
+    assert(totalRows == 5000)
+  }
+
+  test("read by columnIds and rowIds without columnar batch") {
+    val reader = OrcDataFile(fileName, requestSchema, configuration)
+    val requiredIds = Array(0, 2)
+    val context = OrcDataFileContext(partitionSchema, partitionValues, false, requestSchema,
+      partitionSchema, false, false, requiredIds)
+    reader.setOrcDataFileContext(context)
+    val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382)
+    val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[OrcStruct]]
+    var totalRows = 0
+    while (iterator.hasNext) {
+      val value = iterator.next
+      assert(value.isInstanceOf[OrcStruct])
+      totalRows += 1
+    }
+    iterator.close()
+    assert(totalRows < 5000 && totalRows > rowIds.length)
+  }
+
+  test("test orc data file meta") {
+    val reader = OrcDataFile(fileName, requestSchema, configuration)
+    val meta = reader.getDataFileMeta()
+    assert(meta != null && meta.isInstanceOf[OrcDataFileMeta])
+    assert(meta.getFieldCount == 3)
+  }
+
+}

--- a/src/test/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -40,6 +40,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetReadSupportWrapper, SkippableVectorizedColumnReader}
 import org.apache.spark.sql.execution.vectorized.{ColumnarBatch, ColumnVector}
@@ -146,6 +147,7 @@ class SimpleDataSuite extends ParquetDataFileSuite {
     val requiredIds = Array(0, 1)
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val row = iterator.next
@@ -164,6 +166,7 @@ class SimpleDataSuite extends ParquetDataFileSuite {
     val requiredIds = Array(0, 1)
     val rowIds = Array.emptyIntArray
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     assert(!iterator.hasNext)
     val e = intercept[java.util.NoSuchElementException] {
       iterator.next()
@@ -176,6 +179,7 @@ class SimpleDataSuite extends ParquetDataFileSuite {
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[ Int ]()
     while (iterator.hasNext) {
       val row = iterator.next
@@ -259,6 +263,7 @@ class NestedDataSuite extends ParquetDataFileSuite {
     val requiredIds = Array(0, 1, 2)
     val rowIds = Array(1)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     assert(iterator.hasNext)
     val row = iterator.next
     assert(row.numFields == 3)
@@ -271,6 +276,7 @@ class NestedDataSuite extends ParquetDataFileSuite {
     val reader = ParquetDataFile(fileName, requestStructType, configuration)
     val requiredIds = Array(0, 2)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     assert(iterator.hasNext)
     val rowOne = iterator.next
     assert(rowOne.numFields == 2)
@@ -314,12 +320,13 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and rowIds disable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 1134, 1753, 2222, 3928, 4200, 4734)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[Iterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val row = iterator.next()
@@ -333,9 +340,9 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and rowIds enable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = true))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     // RowGroup0 => page0: [0, 1, 7, 8, 120, 121, 381, 382]
     // RowGroup0 => page5: [23000]
@@ -359,9 +366,9 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and empty rowIds array disable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array.emptyIntArray
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
@@ -373,9 +380,9 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and empty rowIds array enable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = true))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array.emptyIntArray
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
@@ -387,11 +394,12 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds disable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[Iterator[InternalRow]]
     val result = ArrayBuffer[ Int ]()
     while (iterator.hasNext) {
       val row = iterator.next()
@@ -405,9 +413,9 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds enable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = true))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
     val result = ArrayBuffer[ Int ]()
@@ -467,12 +475,13 @@ class ParquetCacheDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and rowIds in fiberCache") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 1134, 1753, 2222, 3928, 4200, 4734)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[Iterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val row = iterator.next()
@@ -487,11 +496,12 @@ class ParquetCacheDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds in fiberCache") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[Iterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val row = iterator.next()

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -42,6 +42,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetReadSupportWrapper, VectorizedColumnReader, VectorizedColumnReaderWrapper}
 import org.apache.spark.sql.internal.SQLConf
@@ -149,6 +150,7 @@ class SimpleDataSuite extends ParquetDataFileSuite {
     val requiredIds = Array(0, 1)
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val row = iterator.next
@@ -167,6 +169,7 @@ class SimpleDataSuite extends ParquetDataFileSuite {
     val requiredIds = Array(0, 1)
     val rowIds = Array.emptyIntArray
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     assert(!iterator.hasNext)
     val e = intercept[java.util.NoSuchElementException] {
       iterator.next()
@@ -179,6 +182,7 @@ class SimpleDataSuite extends ParquetDataFileSuite {
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[ Int ]()
     while (iterator.hasNext) {
       val row = iterator.next
@@ -262,6 +266,7 @@ class NestedDataSuite extends ParquetDataFileSuite {
     val requiredIds = Array(0, 1, 2)
     val rowIds = Array(1)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     assert(iterator.hasNext)
     val row = iterator.next
     assert(row.numFields == 3)
@@ -274,6 +279,7 @@ class NestedDataSuite extends ParquetDataFileSuite {
     val reader = ParquetDataFile(fileName, requestStructType, configuration)
     val requiredIds = Array(0, 2)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     assert(iterator.hasNext)
     val rowOne = iterator.next
     assert(rowOne.numFields == 2)
@@ -317,12 +323,13 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and rowIds disable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 1134, 1753, 2222, 3928, 4200, 4734)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val row = iterator.next()
@@ -336,15 +343,16 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and rowIds enable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = true))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     // RowGroup0 => page0: [0, 1, 7, 8, 120, 121, 381, 382]
     // RowGroup0 => page5: [23000]
     // RowGroup2 => page0: [50752]
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 23000, 50752)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val batch = iterator.next().asInstanceOf[ColumnarBatch]
@@ -362,12 +370,13 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and empty rowIds array disable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array.emptyIntArray
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     assert(!iterator.hasNext)
     val e = intercept[java.util.NoSuchElementException] {
       iterator.next()
@@ -376,12 +385,13 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and empty rowIds array enable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = true))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array.emptyIntArray
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     assert(!iterator.hasNext)
     val e = intercept[java.util.NoSuchElementException] {
       iterator.next()
@@ -390,11 +400,12 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds disable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[ Int ]()
     while (iterator.hasNext) {
       val row = iterator.next()
@@ -408,11 +419,12 @@ class VectorizedDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds enable returningBatch") {
-    val context = Some(VectorizedContext(null, null, returningBatch = true))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = true))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[ Int ]()
     while (iterator.hasNext) {
       val batch = iterator.next().asInstanceOf[ColumnarBatch]
@@ -470,12 +482,13 @@ class ParquetCacheDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds and rowIds in fiberCache") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0, 1)
     val rowIds = Array(0, 1, 7, 8, 120, 121, 381, 382, 1134, 1753, 2222, 3928, 4200, 4734)
     val iterator = reader.iteratorWithRowIds(requiredIds, rowIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val row = iterator.next()
@@ -490,11 +503,12 @@ class ParquetCacheDataSuite extends ParquetDataFileSuite {
   }
 
   test("read by columnIds in fiberCache") {
-    val context = Some(VectorizedContext(null, null, returningBatch = false))
+    val context = Some(ParquetVectorizedContext(null, null, returningBatch = false))
     val reader = ParquetDataFile(fileName, requestSchema, configuration)
-    reader.setVectorizedContext(context)
+    reader.setParquetVectorizedContext(context)
     val requiredIds = Array(0)
     val iterator = reader.iterator(requiredIds)
+      .asInstanceOf[OapCompletionIterator[InternalRow]]
     val result = ArrayBuffer[Int]()
     while (iterator.hasNext) {
       val row = iterator.next()


### PR DESCRIPTION
## What changes were proposed in this pull request?

The primary code changes are below:
 1. Add the changes in OapFileFormat.scala and
 OapDataReaderWriter.scala in order to support Orc data source,
 because currently Parquet, Oap and Orc are using the same OapFileFormat
 and the same OapDataReaderWriter. The major changes are in
 buildReaderWithPartitionValues method of OapFileFormat and initialize
 and read two methods of OapDataReaderV1.
 2. Add new OrcDataFile.scala which is responsible for building iterators with
 and without oap index for OapDataReaderWriter.
 3. Add new OrcDataFileMeta.scala in order to cache the orc file reader.

OrcDataFile extends the common DataFile and doesn't support orc data cache currently.
The OrcDataFile is the only caller in OAP to use the specific orc record readers which are defined under ./src/main/java/org/apache/spark/sql/execution/datasources/oap/orc directory.

## How was this patch tested?

All of the oap unit tests passed.