### PR TITLE
[Orc-support-04] Enable index creation, drop and refresh for Orc

### DIFF
--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnVector.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnVector.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.datasources.orc;
+package org.apache.spark.sql.execution.datasources.oap.orc;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
@@ -36,7 +36,6 @@ import org.apache.orc.storage.serde2.io.HiveDecimalWritable;
 
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.execution.datasources.orc.OrcColumnVector;
 import org.apache.spark.sql.vectorized.oap.orc.ColumnVectorUtils;
 import org.apache.spark.sql.vectorized.oap.orc.OffHeapColumnVector;
 import org.apache.spark.sql.vectorized.oap.orc.OnHeapColumnVector;

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyOrcFileFormat.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.orc
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.Job
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+import org.apache.spark.sql.hive.orc.OrcFileFormat
+import org.apache.spark.sql.types.StructType
+
+/**
+ * `ReadOnlyOrcFileFormat` only support read orc operation and not support write,
+ * in oap we use it to create and refresh index because of isSplitable method always return false.
+ */
+class ReadOnlyOrcFileFormat extends OrcFileFormat{
+  override def isSplitable(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      path: Path): Boolean = false
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory =
+    throw new UnsupportedOperationException("ReadOnlyOrcFileFormat not support write operation")
+}

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -26,10 +26,17 @@ import org.apache.spark.sql.oap.adapter.SqlConfAdapter
 
 object OapConf {
 
+  val OAP_ORC_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.orc.enable")
+      .internal()
+      .doc("Whether enable oap file format when encountering orc files")
+      .booleanConf
+      .createWithDefault(true)
+
   val OAP_PARQUET_ENABLED =
     SqlConfAdapter.buildConf("spark.sql.oap.parquet.enable")
       .internal()
-      .doc("Whether enable oap file format when encounter parquet files")
+      .doc("Whether enable oap file format when encountering parquet files")
       .booleanConf
       .createWithDefault(true)
 

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -371,18 +371,20 @@ case class FileSourceScanExec(
     ctx.addMutableState("long", scanTimeTotalNs, s"$scanTimeTotalNs = 0;")
 
     val columnarBatchClz =
-      if (!forOapOrcColumnarBatch)
+      if (!forOapOrcColumnarBatch) {
         "org.apache.spark.sql.execution.vectorized.ColumnarBatch"
-      else
+      } else {
         "org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch"
+      }
     val batch = ctx.freshName("batch")
     ctx.addMutableState(columnarBatchClz, batch, s"$batch = null;")
 
     val columnVectorClz =
-      if (!forOapOrcColumnarBatch)
+      if (!forOapOrcColumnarBatch) {
         "org.apache.spark.sql.execution.vectorized.ColumnVector"
-      else
+      } else {
         "org.apache.spark.sql.vectorized.oap.orc.ColumnVector"
+      }
     val idx = ctx.freshName("batchIdx")
     ctx.addMutableState("int", idx, s"$idx = 0;")
     val colVars = output.indices.map(i => ctx.freshName("colInstance" + i))

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -160,10 +160,11 @@ case class FileSourceScanExec(
 
   @transient private lazy val selectedPartitions = relation.location.listFiles(partitionFilters)
 
- /* With oap index and orc format, forOapOrcColumnarBatch is true. Otherwise, it's false.
+ /**
+  * With oap index and orc format, forOapOrcColumnarBatch is true. Otherwise, it's false.
   * If it's true, the code gen will use org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch which
   * is back ported from Spark 2.3 for OrcColumnarBatchReader.
-  **/
+  */
   private val forOapOrcColumnarBatch =
     relation.options.getOrElse("isOapOrcFileFormat", "false") match {
       case "false" => false

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -86,8 +86,6 @@ object FileSourceStrategy extends Strategy with Logging {
 
       val selectedPartitions = _fsRelation.location.listFiles(partitionKeyFilters.toSeq)
 
-      // Below is used to indicate to read orc data with oap index accelerated.
-      var isOapOrcFileFormat = false
       val fsRelation: HadoopFsRelation = _fsRelation.fileFormat match {
         // TODO a better rule to check if we need to substitute the ParquetFileFormat
         // as OapFileFormat
@@ -130,11 +128,12 @@ object FileSourceStrategy extends Strategy with Logging {
               selectedPartitions.flatMap(p => p.files))
 
           if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
-            isOapOrcFileFormat = true
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+            // isOapOrcFileFormat is used to indicate to read orc data with oap index accelerated.
             val orcOptions: Map[String, String] =
               Map(SQLConf.ORC_FILTER_PUSHDOWN_ENABLED.key ->
                 _fsRelation.sparkSession.sessionState.conf.orcFilterPushDown.toString) ++
+                Map("isOapOrcFileFormat" -> "true") ++
                 _fsRelation.options
 
             _fsRelation.copy(fileFormat = oapFileFormat,
@@ -189,7 +188,7 @@ object FileSourceStrategy extends Strategy with Logging {
           outputSchema,
           partitionKeyFilters.toSeq,
           pushedDownFilters,
-          table.map(_.identifier), isOapOrcFileFormat)
+          table.map(_.identifier))
 
       val afterScanFilter = afterScanFilters.toSeq.reduceOption(expressions.And)
       val withFilter = afterScanFilter.map(execution.FilterExec(_, scan)).getOrElse(scan)

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.hive.orc.OrcFileFormat
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
 
@@ -112,6 +113,29 @@ object FileSourceStrategy extends Strategy with Logging {
 
             _fsRelation.copy(fileFormat = oapFileFormat,
               options = parquetOptions)(_fsRelation.sparkSession)
+
+          } else {
+            logInfo("hasAvailableIndex = false, will retain ParquetFileFormat.")
+            _fsRelation
+          }
+
+        case a: OrcFileFormat
+          if _fsRelation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) =>
+          val oapFileFormat = new OapFileFormat
+          oapFileFormat
+            .init(_fsRelation.sparkSession,
+              _fsRelation.options,
+              selectedPartitions.flatMap(p => p.files))
+
+          if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
+            logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+            val orcOptions: Map[String, String] =
+              Map(SQLConf.ORC_FILTER_PUSHDOWN_ENABLED.key ->
+                _fsRelation.sparkSession.sessionState.conf.orcFilterPushDown.toString) ++
+                _fsRelation.options
+
+            _fsRelation.copy(fileFormat = oapFileFormat,
+              options = orcOptions)(_fsRelation.sparkSession)
 
           } else {
             logInfo("hasAvailableIndex = false, will retain ParquetFileFormat.")

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -63,10 +63,11 @@ case class CreateIndexCommand(
 
     val (fileCatalog, schema, readerClassName, identifier, relation) = optimized match {
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id) =>
         (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, id, optimized)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _),
+          attributes, id) =>
         if (!sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED)) {
           throw new OapException(s"turn on ${
             OapConf.OAP_PARQUET_ENABLED.key} to allow index building on parquet files")
@@ -79,7 +80,7 @@ case class CreateIndexCommand(
         val logical = LogicalRelation(fsRelation, attributes, id)
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, id, logical)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: OrcFileFormat, _), attributes, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: OrcFileFormat, _), attributes, id) =>
         if (!sparkSession.conf.get(OapConf.OAP_ORC_ENABLED)) {
           throw new OapException(s"turn on ${
             OapConf.OAP_ORC_ENABLED.key} to allow index building on orc files")
@@ -327,7 +328,8 @@ case class RefreshIndexCommand(
           HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, _) =>
         (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, optimized)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _),
+          attributes, id) =>
         // Use ReadOnlyParquetFileFormat instead of ParquetFileFormat because of
         // ReadOnlyParquetFileFormat.isSplitable always return false
         val fsRelation = _fsRelation.copy(
@@ -336,7 +338,7 @@ case class RefreshIndexCommand(
         val logical = LogicalRelation(fsRelation, attributes, id)
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, logical)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: OrcFileFormat, _), attributes, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: OrcFileFormat, _), attributes, id) =>
         // Use ReadOnlyOrcFileFormat because ReadOnlyOrcFileFormat.isSplitable is always false.
         val fsRelation = _fsRelation.copy(
           fileFormat = new ReadOnlyOrcFileFormat(),

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -98,10 +98,11 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
     ctx.addMutableState(columnarBatchClz, batch, s"$batch = null;")
 
     val columnVectorClz =
-      if (!forOapOrcColumnarBatch)
+      if (!forOapOrcColumnarBatch) {
         "org.apache.spark.sql.execution.vectorized.ColumnVector"
-      else
+      } else {
         "org.apache.spark.sql.vectorized.oap.orc.ColumnVector"
+      }
     val idx = ctx.freshName("batchIdx")
     ctx.addMutableState("int", idx, s"$idx = 0;")
     val colVars = output.indices.map(i => ctx.freshName("colInstance" + i))

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -32,8 +32,10 @@ import org.apache.spark.sql.types.DataType
 private[sql] trait ColumnarBatchScan extends CodegenSupport {
 
   val inMemoryTableScan: InMemoryTableScanExec = null
-  // Default, the orc is using the same columnar batch as Spark.
-  // For orc, it will use the columnar batch ported from Spark2.3
+ /* With oap index and orc format, forOapOrcColumnarBatch is true. Otherwise, it's false.
+  * If it's true, the code gen will use org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch which
+  * is back ported from Spark 2.3 for OrcColumnarBatchReader.
+  **/
   private var forOapOrcColumnarBatch: Boolean = false
 
   override lazy val metrics = Map(
@@ -66,7 +68,7 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
     ExprCode(code, isNullVar, valueVar)
   }
 
-  def setForOrcColumnarBatch(forOapOrcColumnarBatch: Boolean) =
+  def setForOapOrcColumnarBatch(forOapOrcColumnarBatch: Boolean) =
     this.forOapOrcColumnarBatch = forOapOrcColumnarBatch
 
   /**

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -32,10 +32,11 @@ import org.apache.spark.sql.types.DataType
 private[sql] trait ColumnarBatchScan extends CodegenSupport {
 
   val inMemoryTableScan: InMemoryTableScanExec = null
- /* With oap index and orc format, forOapOrcColumnarBatch is true. Otherwise, it's false.
+ /**
+  * With oap index and orc format, forOapOrcColumnarBatch is true. Otherwise, it's false.
   * If it's true, the code gen will use org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch which
   * is back ported from Spark 2.3 for OrcColumnarBatchReader.
-  **/
+  */
   private var forOapOrcColumnarBatch: Boolean = false
 
   override lazy val metrics = Map(
@@ -88,10 +89,11 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
     ctx.addMutableState("long", scanTimeTotalNs, s"$scanTimeTotalNs = 0;")
 
     val columnarBatchClz =
-      if (!forOapOrcColumnarBatch)
+      if (!forOapOrcColumnarBatch) {
         "org.apache.spark.sql.execution.vectorized.ColumnarBatch"
-      else
+      } else {
         "org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch"
+      }
     val batch = ctx.freshName("batch")
     ctx.addMutableState(columnarBatchClz, batch, s"$batch = null;")
 

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -160,7 +160,8 @@ case class FileSourceScanExec(
     requiredSchema: StructType,
     partitionFilters: Seq[Expression],
     dataFilters: Seq[Expression],
-    override val metastoreTableIdentifier: Option[TableIdentifier])
+    override val metastoreTableIdentifier: Option[TableIdentifier],
+    forOrcColumnarBatch: Boolean = false)
   extends DataSourceScanExec with ColumnarBatchScan  {
 
   val supportsBatch: Boolean = relation.fileFormat.supportBatch(
@@ -350,6 +351,7 @@ case class FileSourceScanExec(
 
   override protected def doProduce(ctx: CodegenContext): String = {
     if (supportsBatch) {
+      super.setForOrcColumnarBatch(forOrcColumnarBatch)
       return super.doProduce(ctx)
     }
     val numOutputRows = metricTerm(ctx, "numOutputRows")

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -85,8 +85,6 @@ object FileSourceStrategy extends Strategy with Logging {
 
       val selectedPartitions = _fsRelation.location.listFiles(partitionKeyFilters.toSeq, Nil)
 
-      // Below is used to indicate to read orc data with oap index accelerated.
-      var isOapOrcFileFormat = false
       val fsRelation: HadoopFsRelation = _fsRelation.fileFormat match {
         // TODO a better rule to check if we need to substitute the ParquetFileFormat
         // as OapFileFormat
@@ -132,11 +130,12 @@ object FileSourceStrategy extends Strategy with Logging {
               selectedPartitions.flatMap(p => p.files))
 
           if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
-            isOapOrcFileFormat = true
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+            // isOapOrcFileFormat is used to indicate to read orc data with oap index accelerated.
             val orcOptions: Map[String, String] =
               Map(SQLConf.ORC_FILTER_PUSHDOWN_ENABLED.key ->
                 _fsRelation.sparkSession.sessionState.conf.orcFilterPushDown.toString) ++
+               Map("isOapOrcFileFormat" -> "true")
                 _fsRelation.options
 
             _fsRelation.copy(fileFormat = oapFileFormat,
@@ -188,8 +187,7 @@ object FileSourceStrategy extends Strategy with Logging {
           outputSchema,
           partitionKeyFilters.toSeq,
           dataFilters,
-          table.map(_.identifier),
-          isOapOrcFileFormat)
+          table.map(_.identifier))
 
       val afterScanFilter = afterScanFilters.toSeq.reduceOption(expressions.And)
       val withFilter = afterScanFilter.map(execution.FilterExec(_, scan)).getOrElse(scan)

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.hive.orc.OrcFileFormat
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
 
@@ -84,6 +85,8 @@ object FileSourceStrategy extends Strategy with Logging {
 
       val selectedPartitions = _fsRelation.location.listFiles(partitionKeyFilters.toSeq, Nil)
 
+      // Below is used to indicate to read orc data with oap index accelerated.
+      var isOapOrcFileFormat = false
       val fsRelation: HadoopFsRelation = _fsRelation.fileFormat match {
         // TODO a better rule to check if we need to substitute the ParquetFileFormat
         // as OapFileFormat
@@ -114,6 +117,30 @@ object FileSourceStrategy extends Strategy with Logging {
 
             _fsRelation.copy(fileFormat = oapFileFormat,
               options = parquetOptions)(_fsRelation.sparkSession)
+
+          } else {
+            logInfo("hasAvailableIndex = false, will retain ParquetFileFormat.")
+            _fsRelation
+          }
+
+        case a: OrcFileFormat
+          if _fsRelation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) =>
+          val oapFileFormat = new OapFileFormat
+          oapFileFormat
+            .init(_fsRelation.sparkSession,
+              _fsRelation.options,
+              selectedPartitions.flatMap(p => p.files))
+
+          if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
+            isOapOrcFileFormat = true
+            logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+            val orcOptions: Map[String, String] =
+              Map(SQLConf.ORC_FILTER_PUSHDOWN_ENABLED.key ->
+                _fsRelation.sparkSession.sessionState.conf.orcFilterPushDown.toString) ++
+                _fsRelation.options
+
+            _fsRelation.copy(fileFormat = oapFileFormat,
+              options = orcOptions)(_fsRelation.sparkSession)
 
           } else {
             logInfo("hasAvailableIndex = false, will retain ParquetFileFormat.")
@@ -161,7 +188,8 @@ object FileSourceStrategy extends Strategy with Logging {
           outputSchema,
           partitionKeyFilters.toSeq,
           dataFilters,
-          table.map(_.identifier))
+          table.map(_.identifier),
+          isOapOrcFileFormat)
 
       val afterScanFilter = afterScanFilters.toSeq.reduceOption(expressions.And)
       val withFilter = afterScanFilter.map(execution.FilterExec(_, scan)).getOrElse(scan)

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -63,10 +63,11 @@ case class CreateIndexCommand(
 
     val (fileCatalog, schema, readerClassName, identifier, relation) = optimized match {
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id) =>
         (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, id, optimized)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _),
+          attributes, id) =>
         if (!sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED)) {
           throw new OapException(s"turn on ${
             OapConf.OAP_PARQUET_ENABLED.key} to allow index building on parquet files")
@@ -79,7 +80,7 @@ case class CreateIndexCommand(
         val logical = LogicalRelation(fsRelation, attributes, id)
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, id, logical)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: OrcFileFormat, _), attributes, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: OrcFileFormat, _), attributes, id) =>
         if (!sparkSession.conf.get(OapConf.OAP_ORC_ENABLED)) {
           throw new OapException(s"turn on ${
             OapConf.OAP_ORC_ENABLED.key} to allow index building on orc files")
@@ -327,7 +328,8 @@ case class RefreshIndexCommand(
           HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, _) =>
         (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, optimized)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _),
+          attributes, id) =>
         // Use ReadOnlyParquetFileFormat instead of ParquetFileFormat because of
         // ReadOnlyParquetFileFormat.isSplitable always return false
         val fsRelation = _fsRelation.copy(
@@ -336,7 +338,8 @@ case class RefreshIndexCommand(
         val logical = LogicalRelation(fsRelation, attributes, id)
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, logical)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: OrcFileFormat, _), attributes, id) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: OrcFileFormat, _),
+          attributes, id) =>
         // Use ReadOnlyOrcFileFormat because ReadOnlyOrcFileFormat.isSplitable is always false.
         val fsRelation = _fsRelation.copy(
           fileFormat = new ReadOnlyOrcFileFormat(),

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -31,10 +31,11 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
 
   def vectorTypes: Option[Seq[String]] = None
 
- /* With oap index and orc format, forOapOrcColumnarBatch is true. Otherwise, it's false.
+ /**
+  * With oap index and orc format, forOapOrcColumnarBatch is true. Otherwise, it's false.
   * If it's true, the code gen will use org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch which
   * is back ported from Spark 2.3 for OrcColumnarBatchReader.
-  **/
+  */
   private var forOapOrcColumnarBatch: Boolean = false
   protected def supportsBatch: Boolean = true
 

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -31,17 +31,16 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
 
   def vectorTypes: Option[Seq[String]] = None
 
- /* Without oap index, forOapOrcColumnarBatch is false.
-  * With oap index, forOapOrcColumnarBatch is true, and the code gen
-  * will use org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch, which
-  * is back ported and the same as that in Spark 2.3.
-  */
+ /* With oap index and orc format, forOapOrcColumnarBatch is true. Otherwise, it's false.
+  * If it's true, the code gen will use org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch which
+  * is back ported from Spark 2.3 for OrcColumnarBatchReader.
+  **/
   private var forOapOrcColumnarBatch: Boolean = false
   protected def supportsBatch: Boolean = true
 
   protected def needsUnsafeRowConversion: Boolean = true
 
-  def setForOrcColumnarBatch(forOapOrcColumnarBatch: Boolean) =
+  def setForOapOrcColumnarBatch(forOapOrcColumnarBatch: Boolean) =
     this.forOapOrcColumnarBatch = forOapOrcColumnarBatch
 
   override lazy val metrics = Map(

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -31,9 +31,18 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
 
   def vectorTypes: Option[Seq[String]] = None
 
+ /* Without oap index, forOapOrcColumnarBatch is false.
+  * With oap index, forOapOrcColumnarBatch is true, and the code gen
+  * will use org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch, which
+  * is back ported and the same as that in Spark 2.3.
+  */
+  private var forOapOrcColumnarBatch: Boolean = false
   protected def supportsBatch: Boolean = true
 
   protected def needsUnsafeRowConversion: Boolean = true
+
+  def setForOrcColumnarBatch(forOapOrcColumnarBatch: Boolean) =
+    this.forOapOrcColumnarBatch = forOapOrcColumnarBatch
 
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
@@ -87,12 +96,23 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
     val scanTimeMetric = metricTerm(ctx, "scanTime")
     val scanTimeTotalNs = ctx.addMutableState(ctx.JAVA_LONG, "scanTime") // init as scanTime = 0
 
-    val columnarBatchClz = classOf[ColumnarBatch].getName
+    val columnarBatchClz = 
+      if (!forOapOrcColumnarBatch) {
+        classOf[ColumnarBatch].getName
+      } else {
+        classOf[org.apache.spark.sql.vectorized.oap.orc.ColumnarBatch].getName
+      }
     val batch = ctx.addMutableState(columnarBatchClz, "batch")
 
     val idx = ctx.addMutableState(ctx.JAVA_INT, "batchIdx") // init as batchIdx = 0
-    val columnVectorClzs = vectorTypes.getOrElse(
-      Seq.fill(output.indices.size)(classOf[ColumnVector].getName))
+    val columnVectorClzs = 
+      if (!forOapOrcColumnarBatch) {
+        vectorTypes.getOrElse(Seq.fill(output.indices.size)(classOf[ColumnVector].getName))
+      } else {
+        vectorTypes.getOrElse(
+          Seq.fill(output.indices.size)(
+            classOf[org.apache.spark.sql.vectorized.oap.orc.ColumnVector].getName))
+      }
     val (colVars, columnAssigns) = columnVectorClzs.zipWithIndex.map {
       case (columnVectorClz, i) =>
         val name = ctx.addMutableState(columnVectorClz, s"colInstance$i")

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -163,7 +163,8 @@ case class FileSourceScanExec(
     requiredSchema: StructType,
     partitionFilters: Seq[Expression],
     dataFilters: Seq[Expression],
-    override val tableIdentifier: Option[TableIdentifier])
+    override val tableIdentifier: Option[TableIdentifier],
+    val forOrcColumnarBatch: Boolean = false)
   extends DataSourceScanExec with ColumnarBatchScan  {
 
   override val supportsBatch: Boolean = relation.fileFormat.supportBatch(
@@ -176,6 +177,10 @@ case class FileSourceScanExec(
       false
     }
   }
+
+  // Below is defined in ColumnarBatchScan.scala.
+  // If it's true, use this to read orc data with oap index accelerated.
+  super.setForOrcColumnarBatch(forOrcColumnarBatch)
 
   override def vectorTypes: Option[Seq[String]] =
     relation.fileFormat.vectorTypes(

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -84,8 +84,6 @@ object FileSourceStrategy extends Strategy with Logging {
 
       val selectedPartitions = _fsRelation.location.listFiles(partitionKeyFilters.toSeq, Nil)
 
-      // Below variable is used to indicate to read orc data with oap index accelerated.
-      var isOapOrcFileFormat = false
       val fsRelation: HadoopFsRelation = _fsRelation.fileFormat match {
         // TODO a better rule to check if we need to substitute the ParquetFileFormat
         // as OapFileFormat
@@ -132,11 +130,12 @@ object FileSourceStrategy extends Strategy with Logging {
               selectedPartitions.flatMap(p => p.files))
 
           if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
-            isOapOrcFileFormat = true
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+            // isOapOrcFileFormat is used to indicate to read orc data with oap index accelerated.
             val orcOptions: Map[String, String] =
               Map(SQLConf.ORC_FILTER_PUSHDOWN_ENABLED.key ->
                 _fsRelation.sparkSession.sessionState.conf.orcFilterPushDown.toString) ++
+                Map("isOapOrcFileFormat" -> "true") ++
                 _fsRelation.options
 
             _fsRelation.copy(fileFormat = oapFileFormat,
@@ -188,7 +187,7 @@ object FileSourceStrategy extends Strategy with Logging {
           outputSchema,
           partitionKeyFilters.toSeq,
           dataFilters,
-          table.map(_.identifier), isOapOrcFileFormat)
+          table.map(_.identifier))
 
       val afterScanFilter = afterScanFilters.toSeq.reduceOption(expressions.And)
       val withFilter = afterScanFilter.map(execution.FilterExec(_, scan)).getOrElse(scan)

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -63,10 +63,11 @@ case class CreateIndexCommand(
 
     val (fileCatalog, schema, readerClassName, identifier, relation) = optimized match {
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id, _) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, id, _) =>
         (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, id, optimized)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id, _) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _),
+          attributes, id, _) =>
         if (!sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED)) {
           throw new OapException(s"turn on ${
             OapConf.OAP_PARQUET_ENABLED.key} to allow index building on parquet files")
@@ -79,8 +80,8 @@ case class CreateIndexCommand(
         val logical = LogicalRelation(fsRelation, attributes, id, false)
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, id, logical)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format, _), attributes, id, _)
-        if (format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format, _), attributes, id, _)
+          if (format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
           format.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat]) =>
         if (!sparkSession.conf.get(OapConf.OAP_ORC_ENABLED)) {
           throw new OapException(s"turn on ${
@@ -337,7 +338,8 @@ case class RefreshIndexCommand(
           HadoopFsRelation(f, _, s, _, _: OapFileFormat, _), _, _, _) =>
         (f, s, OapFileFormat.OAP_DATA_FILE_CLASSNAME, optimized)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _), attributes, id, _) =>
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format: ParquetFileFormat, _),
+          attributes, id, _) =>
         // Use ReadOnlyParquetFileFormat instead of ParquetFileFormat because of
         // ReadOnlyParquetFileFormat.isSplitable always return false
         val fsRelation = _fsRelation.copy(
@@ -346,8 +348,8 @@ case class RefreshIndexCommand(
         val logical = LogicalRelation(fsRelation, attributes, id, false)
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, logical)
       case LogicalRelation(
-      _fsRelation @ HadoopFsRelation(f, _, s, _, format, _), attributes, id, _)
-        if (format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
+          _fsRelation @ HadoopFsRelation(f, _, s, _, format, _), attributes, id, _)
+          if (format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
           format.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat]) =>
         // ReadOnlyOrcFileFormat and ReadOnlyNativeOrcFileFormat don't support splitable.
         // ReadOnlyOrcFileFormat is for hive orc.

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -36,6 +36,8 @@ import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
+import org.apache.spark.sql.execution.datasources.orc.ReadOnlyOrcFileFormat
+import org.apache.spark.sql.execution.datasources.orc.ReadOnlyNativeOrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ReadOnlyParquetFileFormat}
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
@@ -76,6 +78,27 @@ case class CreateIndexCommand(
           options = _fsRelation.options)(_fsRelation.sparkSession)
         val logical = LogicalRelation(fsRelation, attributes, id, false)
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, id, logical)
+      case LogicalRelation(
+      _fsRelation @ HadoopFsRelation(f, _, s, _, format, _), attributes, id, _)
+        if (format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
+          format.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat]) =>
+        if (!sparkSession.conf.get(OapConf.OAP_ORC_ENABLED)) {
+          throw new OapException(s"turn on ${
+            OapConf.OAP_ORC_ENABLED.key} to allow index building on orc files")
+        }
+        // ReadOnlyOrcFileFormat and ReadOnlyNativeOrcFileFormat don't support splitable.
+        // ReadOnlyOrcFileFormat is for hive orc.
+        // ReadOnlyNativeOrcFileFormat is for native orc introduced in Spark 2.3.
+        val fsRelation = format match {
+          case a: org.apache.spark.sql.hive.orc.OrcFileFormat =>
+            _fsRelation.copy(fileFormat = new ReadOnlyOrcFileFormat(),
+              options = _fsRelation.options)(_fsRelation.sparkSession)
+          case a: org.apache.spark.sql.execution.datasources.orc.OrcFileFormat =>
+            _fsRelation.copy(fileFormat = new ReadOnlyNativeOrcFileFormat(),
+              options = _fsRelation.options)(_fsRelation.sparkSession)
+        }
+        val logical = LogicalRelation(fsRelation, attributes, id, false)
+        (f, s, OapFileFormat.ORC_DATA_FILE_CLASSNAME, id, logical)
       case other =>
         throw new OapException(s"We don't support index building for ${other.simpleString}")
     }
@@ -235,7 +258,9 @@ case class DropIndexCommand(
 
     relation match {
       case LogicalRelation(HadoopFsRelation(fileCatalog, _, _, _, format, _), _, identifier, _)
-          if format.isInstanceOf[OapFileFormat] || format.isInstanceOf[ParquetFileFormat] =>
+          if format.isInstanceOf[OapFileFormat] || format.isInstanceOf[ParquetFileFormat] ||
+            format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
+            format.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat] =>
         logInfo(s"Dropping index $indexName")
         val partitions = OapUtils.getPartitions(fileCatalog, partitionSpec)
         val targetDirs = partitions.filter(_.files.nonEmpty)
@@ -320,6 +345,23 @@ case class RefreshIndexCommand(
           options = _fsRelation.options)(_fsRelation.sparkSession)
         val logical = LogicalRelation(fsRelation, attributes, id, false)
         (f, s, OapFileFormat.PARQUET_DATA_FILE_CLASSNAME, logical)
+      case LogicalRelation(
+      _fsRelation @ HadoopFsRelation(f, _, s, _, format, _), attributes, id, _)
+        if (format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
+          format.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat]) =>
+        // ReadOnlyOrcFileFormat and ReadOnlyNativeOrcFileFormat don't support splitable.
+        // ReadOnlyOrcFileFormat is for hive orc.
+        // ReadOnlyNativeOrcFileFormat is for native orc introduced in Spark 2.3.
+        val fsRelation = format match {
+          case a: org.apache.spark.sql.hive.orc.OrcFileFormat =>
+            _fsRelation.copy(fileFormat = new ReadOnlyOrcFileFormat(),
+              options = _fsRelation.options)(_fsRelation.sparkSession)
+          case a: org.apache.spark.sql.execution.datasources.orc.OrcFileFormat =>
+            _fsRelation.copy(fileFormat = new ReadOnlyNativeOrcFileFormat(),
+              options = _fsRelation.options)(_fsRelation.sparkSession)
+        }
+        val logical = LogicalRelation(fsRelation, attributes, id, false)
+        (f, s, OapFileFormat.ORC_DATA_FILE_CLASSNAME, logical)
       case other =>
         throw new OapException(s"We don't support index refreshing for ${other.simpleString}")
     }

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyNativeOrcFileFormat.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyNativeOrcFileFormat.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.orc
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.Job
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
+import org.apache.spark.sql.types.StructType
+
+/**
+ * `ReadOnlyNativeOrcFileFormat` only supports read native orc operation and not support write.
+ * In oap we use it to create and refresh index because isSplitable method always returns false.
+ */
+class ReadOnlyNativeOrcFileFormat extends OrcFileFormat{
+  override def isSplitable(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      path: Path): Boolean = false
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory =
+    throw new UnsupportedOperationException(
+      "ReadOnlyNativeOrcFileFormat doesn't support write operation")
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -40,12 +40,16 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     sql(s"""CREATE TABLE oap_partition_table (a int, b int, c STRING)
             | USING parquet
             | PARTITIONED by (b, c)""".stripMargin)
+    sql(s"""CREATE TABLE oap_orc_table (a int, b int, c STRING)
+            | USING orc
+            | PARTITIONED by (b, c)""".stripMargin)
   }
 
   override def afterEach(): Unit = {
     sqlContext.dropTempTable("oap_test_1")
     sqlContext.dropTempTable("oap_test_2")
     sqlContext.sql("drop table oap_partition_table")
+    sqlContext.sql("drop table oap_orc_table")
   }
 
   test("write index for table read in from DS api") {
@@ -97,6 +101,26 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
           Row("oap_test_2", "index1", 0, "a", "D", "BTREE", true) ::
           Row("oap_test_2", "index1", 1, "b", "D", "BTREE", true) :: Nil)
     }
+  }
+
+  test("create and drop index with orc file format") {
+    val data: Seq[(Int, Int)] = (1 to 10).map { i => (i, i) }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+
+    sql(
+      """
+        |INSERT OVERWRITE TABLE oap_orc_table
+        |partition (b=1, c='c1')
+        |SELECT key from t where value < 4
+      """.stripMargin)
+
+    checkAnswer(sql("select * from oap_orc_table where a < 4"),
+      Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Nil)
+    // Turn on below index creation and query after the corresponding support
+    // in the following pull requests are merged.
+    // sql("create oindex index1 on oap_orc_table (a) partition (b=1, c='c1')")
+    // checkAnswer(sql("select * from oap_orc_table where a < 4"),
+    //  Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Nil)
   }
 
   test("create and drop index with partition specify") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapDDLSuite.scala
@@ -120,7 +120,8 @@ class OapDDLSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
     // in the following pull requests are merged.
     // sql("create oindex index1 on oap_orc_table (a) partition (b=1, c='c1')")
     // checkAnswer(sql("select * from oap_orc_table where a < 4"),
-    //  Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Nil)
+    //   Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Nil)
+    // sql("drop oindex index1 on oap_orc_table")
   }
 
   test("create and drop index with partition specify") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -40,11 +40,15 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
            | USING parquet
            | OPTIONS (path '$path2')""".stripMargin)
 
+    sql(s"""CREATE TEMPORARY VIEW orc_test_1 (a INT, b STRING)
+           | USING orc
+           | OPTIONS (path '$path2')""".stripMargin)
   }
 
   override def afterEach(): Unit = {
     sqlContext.dropTempTable("oap_test_1")
     sqlContext.dropTempTable("oap_parquet_test_1")
+    sqlContext.dropTempTable("orc_test_1")
   }
 
   test("index integrity") {
@@ -79,7 +83,7 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     }
   }
 
-  test("check sequence reading if parquet format") {
+  test("check sequence reading for oap, parquet and orc formats") {
     val data: Seq[(Int, String)] = (1 to 300).map { i =>
       if (i == 10) (1, s"this is test $i") else (i, s"this is test $i")
     }
@@ -107,6 +111,17 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
         Row(1, "this is test 1") ::
           Row(1, "this is test 10") ::
           Row(2, "this is test 2") :: Nil)
+    }
+
+    withIndex(TestIndex("orc_test_1", "index1")) {
+      sql("insert overwrite table orc_test_1 select * from t")
+      sql("create oindex index1 on orc_test_1 (a)")
+
+      // For orc format, the row Ids are sorted as well to reduce IO cost.
+      val parquetRslt = sql("select * from orc_test_1 where a > 0 and a < 3")
+      checkAnswer(parquetRslt, Row(1, "this is test 1") ::
+        Row(2, "this is test 2") ::
+        Row(1, "this is test 10") :: Nil)
     }
   }
 

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/orc/OapNativeOrcSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/orc/OapNativeOrcSuite.scala
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.orc
+
+import org.apache.hadoop.fs.Path
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.{QueryTest, Row, SaveMode}
+import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex, TestPartition}
+import org.apache.spark.util.Utils
+
+class OapNativeOrcSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
+  import testImplicits._
+
+  override def beforeEach(): Unit = {
+    val path1 = Utils.createTempDir().getAbsolutePath
+    val path2 = Utils.createTempDir().getAbsolutePath
+
+    sql(s"""CREATE TEMPORARY VIEW native_orc_test (a INT, b STRING)
+           | USING org.apache.spark.sql.execution.datasources.orc
+           | OPTIONS (path '$path1')""".stripMargin)
+    sql(s"""CREATE TEMPORARY VIEW orc_test (a INT, b STRING)
+           | USING orc
+           | OPTIONS (path '$path2')""".stripMargin)
+    sql(s"""CREATE TABLE native_orc_partition_table (a int, b int, c STRING)
+            | USING org.apache.spark.sql.execution.datasources.orc
+            | PARTITIONED by (b, c)""".stripMargin)
+    sql(s"""CREATE TEMPORARY VIEW orc_table_2 (a INT, b INT)
+           | USING orc
+           | OPTIONS (path '$path2')""".stripMargin)
+  }
+
+  override def afterEach(): Unit = {
+    sqlContext.dropTempTable("native_orc_test")
+    sqlContext.dropTempTable("orc_test")
+    sqlContext.sql("drop table native_orc_partition_table")
+    sqlContext.sql("drop table orc_table_2")
+  }
+
+  test("test native orc functionality with and without index ") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table native_orc_test select * from t")
+    checkAnswer(sql("select * from native_orc_test where a < 3"),
+      Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
+    // Test btree index.
+    sql("create oindex idx on native_orc_test (a)")
+    checkAnswer(sql("select * from native_orc_test where a < 3"),
+      Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
+    sql("drop oindex idx on native_orc_test")
+
+    // Test bitmap index.
+    sql("create oindex idx on native_orc_test (a) using BITMAP")
+    checkAnswer(sql("select * from native_orc_test where a == 4"),
+      Row(4, "this is test 4") :: Nil)
+    sql("drop oindex idx on native_orc_test")
+  }
+
+  test("test writing for hive orc and reading for native orc with and without index ") {
+    withSQLConf(SQLConf.ORC_IMPLEMENTATION.key -> "native") {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table orc_test select * from t")
+      checkAnswer(sql("select * from orc_test where a < 3"),
+        Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
+
+      sql("create oindex idx on orc_test (a)")
+      checkAnswer(sql("select * from orc_test where a < 3"),
+        Row(1, "this is test 1") :: Row(2, "this is test 2") :: Nil)
+      sql("drop oindex idx on orc_test")
+    }
+  }
+
+  test("create and drop index with partition specify with native orc") {
+    val data: Seq[(Int, Int)] = (1 to 10).map { i => (i, i) }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+
+    val path = new Path(sqlContext.conf.warehousePath)
+
+    sql(
+      """
+        |INSERT OVERWRITE TABLE native_orc_partition_table
+        |partition (b=1, c='c1')
+        |SELECT key from t where value < 4
+      """.stripMargin)
+
+    sql(
+      """
+        |INSERT INTO TABLE native_orc_partition_table
+        |partition (b=2, c='c2')
+        |SELECT key from t where value == 4
+      """.stripMargin)
+
+    withIndex(
+      TestIndex("native_orc_partition_table", "index1",
+        TestPartition("b", "1"), TestPartition("c", "c1"))) {
+      sql("create oindex index1 on native_orc_partition_table (a) partition (b=1, c='c1')")
+
+      checkAnswer(sql("select * from native_orc_partition_table where a < 4"),
+        Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Nil)
+
+      assert(path.getFileSystem(
+        configuration).globStatus(new Path(path,
+        "native_orc_partition_table/b=1/c=c1/*.index")).length != 0)
+      assert(path.getFileSystem(
+        configuration).globStatus(new Path(path,
+        "native_orc_partition_table/b=2/c=c2/*.index")).length == 0)
+    }
+
+    withIndex(
+      TestIndex("native_orc_partition_table", "index1",
+        TestPartition("b", "2"), TestPartition("c", "c2"))) {
+      sql("create oindex index1 on native_orc_partition_table (a) partition (b=2, c='c2')")
+
+      checkAnswer(sql("select * from native_orc_partition_table"),
+        Row(1, 1, "c1") :: Row(2, 1, "c1") :: Row(3, 1, "c1") :: Row(4, 2, "c2") :: Nil)
+      assert(path.getFileSystem(
+        configuration).globStatus(new Path(path,
+        "native_orc_partition_table/b=1/c=c1/*.index")).length == 0)
+      assert(path.getFileSystem(
+        configuration).globStatus(new Path(path,
+        "native_orc_partition_table/b=2/c=c2/*.index")).length != 0)
+    }
+  }
+
+  test("create duplicated name index with native orc") {
+    withSQLConf(SQLConf.ORC_IMPLEMENTATION.key -> "native") {
+      val data: Seq[(Int, String)] = (1 to 100).map { i => (i, s"this is test $i") }
+      val df = data.toDF("a", "b")
+      val pathDir = Utils.createTempDir().getAbsolutePath
+      df.write.format("orc").mode(SaveMode.Overwrite).save(pathDir)
+      val oapDf = spark.read.format("orc").load(pathDir)
+      oapDf.createOrReplaceTempView("t")
+
+      withIndex(TestIndex("t", "idxa")) {
+        sql("create oindex idxa on t (a)")
+        val path = new Path(pathDir)
+        val fs = path.getFileSystem(sparkContext.hadoopConfiguration)
+        val indexFiles1 = fs.listStatus(path).collect { case fileStatus if fileStatus.isFile &&
+          fileStatus.getPath.getName.endsWith(OapFileFormat.OAP_INDEX_EXTENSION) =>
+          fileStatus.getPath.getName
+        }
+
+        sql("create oindex if not exists idxa on t (a)")
+        val indexFiles2 = fs.listStatus(path).collect { case fileStatus if fileStatus.isFile &&
+          fileStatus.getPath.getName.endsWith(OapFileFormat.OAP_INDEX_EXTENSION) =>
+          fileStatus.getPath.getName
+        }
+        assert(indexFiles1 === indexFiles2)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The primary changes are below:
1. Add index creation, drop and refresh for Spark 2.1, 2.2 and 2.3
2. Enable to use oap.orc.ColumnarBatch for back ported OrcColumnarBatchReader w/ and w/o oap index
3. Add 27 unit tests for orc

In addtion, Spark 2.3 provides two orc file formats as below:
1. org.apache.spark.sql.hive.orc.OrcFileFormat is the traditional hive orc.
2. org.apache.spark.sql.execution.datasources.orc.OrcFileFormat is the new native orc.

Both of the above two formats are supported for index creation, drop and refresh in OAP for Spark 2.3.


## How was this patch tested?

All of oap unit tests passed for all the three spark profiles.
