### PR TITLE
Avoid use jdk8 api in common code part #887

### DIFF
--- a/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1235,9 +1235,10 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       long right = getLong(rbase, roffset + i);
       if (left != right) {
         if (IS_LITTLE_ENDIAN) {
-          return Long.compareUnsigned(Long.reverseBytes(left), Long.reverseBytes(right));
+          return Long.compare(Long.reverseBytes(left) + Long.MIN_VALUE,
+            Long.reverseBytes(right)+ Long.MIN_VALUE);
         } else {
-          return Long.compareUnsigned(left, right);
+          return Long.compare(left + Long.MIN_VALUE , right + Long.MIN_VALUE);
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As #887 said , `Long.compareUnsigned`  api add since jdk 1.8,  will affect compile with jdk-1.7 and run with jre-1.7, this pr refer to `Long.compareUnsigned` api code as follow:
```
public static int compareUnsigned(long x, long y) {
        return compare(x + MIN_VALUE, y + MIN_VALUE);
}
```

## How was this patch tested?
