### PR TITLE
Correctly update vars in OapEnv

### DIFF
--- a/src/main/spark2.1/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
@@ -68,7 +68,7 @@ private[spark] object OapEnv extends Logging {
 
       SparkSQLEnv.sparkContext = sparkContext
       SparkSQLEnv.sqlContext = sqlContext
-      this.sparkSession = sparkSession
+      this.sparkSession = sqlContext.sparkSession
 
       sparkContext.ui.foreach(new OapTab(_))
       initialized = true

--- a/src/main/spark2.2/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
@@ -71,7 +71,7 @@ private[spark] object OapEnv extends Logging {
 
       SparkSQLEnv.sparkContext = sparkContext
       SparkSQLEnv.sqlContext = sqlContext
-      this.sparkSession = sparkSession
+      this.sparkSession = sqlContext.sparkSession
 
       sparkContext.ui.foreach(new OapTab(_))
       initialized = true

--- a/src/main/spark2.3/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/hive/thriftserver/OapEnv.scala
@@ -71,7 +71,7 @@ private[spark] object OapEnv extends Logging {
 
       SparkSQLEnv.sparkContext = sparkContext
       SparkSQLEnv.sqlContext = sqlContext
-      this.sparkSession = sparkSession
+      this.sparkSession = sqlContext.sparkSession
 
       sparkContext.ui.foreach(new OapTab(_))
       initialized = true


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix #893 , `sparkSession` in `OapEnv` was wrongly updated.

Existing UT in `OapRuntimeSuite` didn't cover this because SparkSession for testing is separated from non-testing one.

## How was this patch tested?

Manual test.