### PR TITLE
Use org.spark_project.jetty instead of org.eclipse.jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
     <basedir>./</basedir>
-    <jetty.version>9.2.16.v20160414</jetty.version>
     <exec.maven.version>1.6.0</exec.maven.version>
   </properties>
 
@@ -604,6 +603,7 @@
         <scalacheck.version>1.12.5</scalacheck.version>
         <!--for a bug fix, upgrade 1.8.1 to 1.8.2-->
         <parquet.version>1.8.2</parquet.version>
+        <jetty.version>9.2.16.v20160414</jetty.version>
       </properties>
       <build>
         <plugins>
@@ -681,6 +681,7 @@
         <scalatest.version>2.2.6</scalatest.version>
         <scalacheck.version>1.12.5</scalacheck.version>
         <parquet.version>1.8.2</parquet.version>
+        <jetty.version>9.3.11.v20160721</jetty.version>
       </properties>
       <build>
         <plugins>
@@ -758,6 +759,7 @@
         <scalatest.version>3.0.3</scalatest.version>
         <scalacheck.version>1.13.5</scalacheck.version>
         <parquet.version>1.8.3</parquet.version>
+        <jetty.version>9.3.24.v20180605</jetty.version>
       </properties>
       <build>
         <plugins>

--- a/src/main/spark2.2/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
@@ -22,10 +22,10 @@ import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.{Context, Response}
 
-import org.eclipse.jetty.server.handler.ContextHandler
-import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.glassfish.jersey.server.ServerProperties
 import org.glassfish.jersey.servlet.ServletContainer
+import org.spark_project.jetty.server.handler.ContextHandler
+import org.spark_project.jetty.servlet.{ServletContextHandler, ServletHolder}
 
 import org.apache.spark.SecurityManager
 import org.apache.spark.ui.SparkUI


### PR DESCRIPTION
## What changes were proposed in this pull request?

To slove #904 , need use `org.spark_project.jetty` package code not `org.eclipse.jetty` package code, and  oap dep different spark version need different jetty version.

## How was this patch tested?
Manual test 