### PR TITLE
Introduce OptimizedParquetFileFormat and OptimizedOrcFileFormat

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -147,10 +147,8 @@ private[sql] class OapFileFormat extends FileFormat
     }
     val conf = sparkSession.sessionState.conf
     // TODO modify conditions after oap support batch return
-    ((readerClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME) &&
-      conf.parquetVectorizedReaderEnabled) ||
-      (readerClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME) &&
-      conf.getConf(OapConf.ORC_VECTORIZED_READER_ENABLED))) &&
+    readerClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME) &&
+      conf.getConf(OapConf.ORC_VECTORIZED_READER_ENABLED) &&
       conf.wholeStageEnabled &&
       schema.length <= conf.wholeStageMaxNumFields &&
       schema.forall(_.dataType.isInstanceOf[AtomicType])

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -317,6 +317,7 @@ private[sql] class OapFileFormat extends FileFormat
 
   protected def indexScanners(m: DataSourceMeta, filters: Seq[Filter]): Option[IndexScanners] = {
 
+    // Check whether this filter conforms to certain patterns that could benefit from index
     def canTriggerIndex(filter: Filter): Boolean = {
       var attr: String = null
       def checkAttribute(filter: Filter): Boolean = filter match {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -22,25 +22,21 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 import org.apache.hadoop.util.StringUtils
-import org.apache.orc.OrcFile
-import org.apache.orc.mapreduce.OrcInputFormat
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.oap.index.{IndexContext, IndexScanners, ScannerBuilder}
 import org.apache.spark.sql.execution.datasources.oap.io._
 import org.apache.spark.sql.execution.datasources.oap.io.OapDataFileProperties.DataFileVersion
-import org.apache.spark.sql.execution.datasources.oap.utils.{FilterHelper, OapUtils}
-import org.apache.spark.sql.execution.datasources.orc.OrcFilters
-import org.apache.spark.sql.execution.datasources.orc.OrcUtils
+import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types.{AtomicType, StructType}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 private[sql] class OapFileFormat extends FileFormat
@@ -138,21 +134,7 @@ private[sql] class OapFileFormat extends FileFormat
   /**
    * Returns whether the reader will return the rows as batch or not.
    */
-  override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
-    // TODO remove readerClassName after oap support batch return
-    val readerClassName = meta match {
-      case Some(m) =>
-        m.dataReaderClassName
-      case _ => ""
-    }
-    val conf = sparkSession.sessionState.conf
-    // TODO modify conditions after oap support batch return
-    readerClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME) &&
-      conf.getConf(OapConf.ORC_VECTORIZED_READER_ENABLED) &&
-      conf.wholeStageEnabled &&
-      schema.length <= conf.wholeStageMaxNumFields &&
-      schema.forall(_.dataType.isInstanceOf[AtomicType])
-  }
+  override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = false
 
   override def isSplitable(
       sparkSession: SparkSession,
@@ -184,29 +166,7 @@ private[sql] class OapFileFormat extends FileFormat
         }
 
         val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
-        val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
-        // Refer to ParquetFileFormat, use resultSchema to decide if this query support
-        // Vectorized Read and returningBatch. Also it depends on WHOLE_STAGE_CODE_GEN,
-        // as the essential unsafe projection is done by that.
-        val isParquet = m.dataReaderClassName.equals(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME)
-        val isOrc = m.dataReaderClassName.equals(OapFileFormat.ORC_DATA_FILE_CLASSNAME)
-        val enableOffHeapColumnVector =
-          sparkSession.sessionState.conf.getConf(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED)
-        val copyToSpark =
-          sparkSession.sessionState.conf.getConf(OapConf.ORC_COPY_BATCH_TO_SPARK)
-        val isCaseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
-
-        // Push down the filters to the orc record reader.
-        if (isOrc && sparkSession.sessionState.conf.orcFilterPushDown) {
-          OrcFilters.createFilter(dataSchema,
-            filters).foreach { f =>
-            OrcInputFormat.setSearchArgument(hadoopConf, f, dataSchema.fieldNames)
-          }
-        }
-
-        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
-        val returningBatch = supportBatch(sparkSession, resultSchema)
         val broadcastedHadoopConf =
           sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
@@ -217,70 +177,21 @@ private[sql] class OapFileFormat extends FileFormat
           val path = new Path(StringUtils.unEscapeString(file.filePath))
           val fs = path.getFileSystem(broadcastedHadoopConf.value.value)
 
-          val version = if (isParquet || isOrc) {
-            // Currently both Parquet and Orc are using OapDataReaderV1.
-            DataFileVersion.OAP_DATAFILE_V1
-          } else {
-            // Below is for Oap format file.
-            OapDataReader.readVersion(fs.open(path), fs.getFileStatus(path).getLen)
-          }
-
-          var orcWithEmptyColIds = false
-          // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
-          // Otherwise context is none.
-          // For Orc, the context is used by both vectorized readers and map reduce readers.
-          // See the comments in DataFile.scala.
-          var context: Option[DataFileContext] = None
-          if (isParquet) {
-            returningBatch match {
-              case true =>
-                context = Some(ParquetVectorizedContext(partitionSchema,
-                  file.partitionValues, returningBatch))
-              case false =>
-                context = None
-            }
-          } else if (isOrc) {
-            val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-            val reader = OrcFile.createReader(path, readerOptions)
-            val requestedColIdsOrEmptyFile = OrcUtils.requestedColumnIds(
-              isCaseSensitive, dataSchema, requiredSchema, reader, conf)
-            if (!requestedColIdsOrEmptyFile.isEmpty) {
-              val requestedColIds = requestedColIdsOrEmptyFile.get
-              assert(requestedColIds.length == requiredSchema.length,
-                "[BUG] requested column IDs do not match required schema")
-              context = Some(OrcDataFileContext(partitionSchema, file.partitionValues,
-                returningBatch, requiredSchema, dataSchema, enableOffHeapColumnVector,
-                  copyToSpark, requestedColIds))
-            } else {
-              orcWithEmptyColIds = true
-              context = None
-            }
-          } else {
-            context = None
-          }
-
-          if (orcWithEmptyColIds) {
-            // For the case of Orc with empty required column Ids.
-            Iterator.empty
-          } else {
-            version match {
-              case DataFileVersion.OAP_DATAFILE_V1 =>
-                val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
-                  filterScanners, requiredIds, pushed, oapMetrics, conf, returningBatch, options,
-                  filters, context)
-                reader.read(file)
-              // Actually it shouldn't get to this line, because unsupported version will cause
-              // exception thrown in readVersion call
-              case _ =>
-                throw new OapException("Unexpected data file version")
-                Iterator.empty
-            }
+          OapDataReader.readVersion(fs.open(path), fs.getFileStatus(path).getLen) match {
+            case DataFileVersion.OAP_DATAFILE_V1 =>
+              val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
+                filterScanners, requiredIds, None, oapMetrics, conf, false, options,
+                filters, None)
+              reader.read(file)
+            // Actually it shouldn't get to this line, because unsupported version will cause
+            // exception thrown in readVersion call
+            case _ =>
+              throw new OapException("Unexpected data file version")
+              Iterator.empty
           }
         }
       case None => (_: PartitionedFile) => {
         // TODO need to think about when there is no oap.meta file at all
-        // TODO Parquet should refer to ParquetFileFormat in OptimizedParquetFileFormat
-        // TODO Orc should refer to OrcFileFormat in OptimizedOrcFileFormat
         Iterator.empty
       }
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -281,6 +281,8 @@ private[sql] class OapFileFormat extends FileFormat
         }
       case None => (_: PartitionedFile) => {
         // TODO need to think about when there is no oap.meta file at all
+        // TODO Parquet should refer to ParquetFileFormat in OptimizedParquetFileFormat
+        // TODO Orc should refer to OrcFileFormat in OptimizedOrcFileFormat
         Iterator.empty
       }
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -315,43 +315,39 @@ private[sql] class OapFileFormat extends FileFormat
     }
   }
 
-  /**
-   * Check whether this filter conforms to certain patterns that could benefit from index
-   * @param filter
-   * @return
-   */
-  protected def canTriggerIndex(filter: Filter): Boolean = {
-    var attr: String = null
-    def checkAttribute(filter: Filter): Boolean = filter match {
-      case Or(left, right) =>
-        checkAttribute(left) && checkAttribute(right)
-      case And(left, right) =>
-        checkAttribute(left) && checkAttribute(right)
-      case EqualTo(attribute, _) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case LessThan(attribute, _) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case LessThanOrEqual(attribute, _) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case GreaterThan(attribute, _) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case GreaterThanOrEqual(attribute, _) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case In(attribute, _) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case IsNull(attribute) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case IsNotNull(attribute) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case StringStartsWith(attribute, _) =>
-        if (attr ==  null || attr == attribute) {attr = attribute; true} else false
-      case _ => false
+  protected def indexScanners(m: DataSourceMeta, filters: Seq[Filter]): Option[IndexScanners] = {
+
+    def canTriggerIndex(filter: Filter): Boolean = {
+      var attr: String = null
+      def checkAttribute(filter: Filter): Boolean = filter match {
+        case Or(left, right) =>
+          checkAttribute(left) && checkAttribute(right)
+        case And(left, right) =>
+          checkAttribute(left) && checkAttribute(right)
+        case EqualTo(attribute, _) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case LessThan(attribute, _) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case LessThanOrEqual(attribute, _) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case GreaterThan(attribute, _) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case GreaterThanOrEqual(attribute, _) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case In(attribute, _) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case IsNull(attribute) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case IsNotNull(attribute) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case StringStartsWith(attribute, _) =>
+          if (attr ==  null || attr == attribute) {attr = attribute; true} else false
+        case _ => false
+      }
+
+      checkAttribute(filter)
     }
 
-    checkAttribute(filter)
-  }
-
-  protected def indexScanners(m: DataSourceMeta, filters: Seq[Filter]): Option[IndexScanners] = {
     val ic = new IndexContext(m)
 
     if (m.indexMetas.nonEmpty) { // check and use index

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
@@ -82,10 +82,6 @@ private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
 
         val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
 
-        // Refer to ParquetFileFormat, use resultSchema to decide if this query support
-        // Vectorized Read and returningBatch. Also it depends on WHOLE_STAGE_CODE_GEN,
-        // as the essential unsafe projection is done by that.
-
         val enableOffHeapColumnVector =
           sparkSession.sessionState.conf.getConf(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED)
         val copyToSpark =
@@ -113,8 +109,6 @@ private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
           val fs = path.getFileSystem(broadcastedHadoopConf.value.value)
 
           var orcWithEmptyColIds = false
-          // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
-          // Otherwise context is none.
           // For Orc, the context is used by both vectorized readers and map reduce readers.
           // See the comments in DataFile.scala.
           val context: Option[DataFileContext] = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
@@ -45,8 +45,8 @@ private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
       "only support read operation")
 
   /**
-    * Returns whether the reader will return the rows as batch or not.
-    */
+   * Returns whether the reader will return the rows as batch or not.
+   */
   override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
     val conf = sparkSession.sessionState.conf
     conf.getConf(OapConf.ORC_VECTORIZED_READER_ENABLED) &&

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
@@ -140,8 +140,7 @@ private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
           }
         }
       case None => (_: PartitionedFile) => {
-        // TODO need to think about when there is no oap.meta file at all
-        // TODO For parquet should refer to ParquetFileFormat
+        // TODO Orc should refer to OrcFileFormat in OptimizedOrcFileFormat
         Iterator.empty
       }
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.util.StringUtils
+import org.apache.orc.OrcFile
+import org.apache.orc.mapreduce.OrcInputFormat
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.oap.io.{DataFileContext, OapDataReaderV1, OrcDataFileContext}
+import org.apache.spark.sql.execution.datasources.orc.{OrcFilters, OrcUtils}
+import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.{AtomicType, StructType}
+import org.apache.spark.util.SerializableConfiguration
+
+private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory =
+    throw new UnsupportedOperationException("OptimizedOrcFileFormat " +
+      "only support read operation")
+
+  /**
+    * Returns whether the reader will return the rows as batch or not.
+    */
+  override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
+    val conf = sparkSession.sessionState.conf
+    conf.getConf(OapConf.ORC_VECTORIZED_READER_ENABLED) &&
+      conf.wholeStageEnabled &&
+      schema.length <= conf.wholeStageMaxNumFields &&
+      schema.forall(_.dataType.isInstanceOf[AtomicType])
+  }
+
+  override def buildReaderWithPartitionValues(
+     sparkSession: SparkSession,
+     dataSchema: StructType,
+     partitionSchema: StructType,
+     requiredSchema: StructType,
+     filters: Seq[Filter],
+     options: Map[String, String],
+     hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+    // TODO we need to pass the extra data source meta information via the func parameter
+    meta match {
+      case Some(m) =>
+        logDebug(s"Building OapDataReader with "
+          + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
+          + " ...")
+
+        val filterScanners = indexScanners(m, filters)
+        // TODO refactor this.
+        hitIndexColumns = filterScanners match {
+          case Some(s) =>
+            s.scanners.flatMap { scanner =>
+              scanner.keyNames.map(n => n -> scanner.meta.indexType)
+            }.toMap
+          case _ => Map.empty
+        }
+
+        val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
+
+        // Refer to ParquetFileFormat, use resultSchema to decide if this query support
+        // Vectorized Read and returningBatch. Also it depends on WHOLE_STAGE_CODE_GEN,
+        // as the essential unsafe projection is done by that.
+
+        val enableOffHeapColumnVector =
+          sparkSession.sessionState.conf.getConf(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED)
+        val copyToSpark =
+          sparkSession.sessionState.conf.getConf(OapConf.ORC_COPY_BATCH_TO_SPARK)
+        val isCaseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
+
+        // Push down the filters to the orc record reader.
+        if (sparkSession.sessionState.conf.orcFilterPushDown) {
+          OrcFilters.createFilter(dataSchema,
+            filters).foreach { f =>
+            OrcInputFormat.setSearchArgument(hadoopConf, f, dataSchema.fieldNames)
+          }
+        }
+
+        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+        val returningBatch = supportBatch(sparkSession, resultSchema)
+        val broadcastedHadoopConf =
+          sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+        (file: PartitionedFile) => {
+          assert(file.partitionValues.numFields == partitionSchema.size)
+          val conf = broadcastedHadoopConf.value.value
+
+          val path = new Path(StringUtils.unEscapeString(file.filePath))
+          val fs = path.getFileSystem(broadcastedHadoopConf.value.value)
+
+          var orcWithEmptyColIds = false
+          // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
+          // Otherwise context is none.
+          // For Orc, the context is used by both vectorized readers and map reduce readers.
+          // See the comments in DataFile.scala.
+          val context: Option[DataFileContext] = {
+            val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
+            val reader = OrcFile.createReader(path, readerOptions)
+            val requestedColIdsOrEmptyFile = OrcUtils.requestedColumnIds(
+              isCaseSensitive, dataSchema, requiredSchema, reader, conf)
+            if (requestedColIdsOrEmptyFile.isDefined) {
+              val requestedColIds = requestedColIdsOrEmptyFile.get
+              assert(requestedColIds.length == requiredSchema.length,
+                "[BUG] requested column IDs do not match required schema")
+              Some(OrcDataFileContext(partitionSchema, file.partitionValues,
+                returningBatch, requiredSchema, dataSchema, enableOffHeapColumnVector,
+                copyToSpark, requestedColIds))
+            } else {
+              orcWithEmptyColIds = true
+              None
+            }
+          }
+
+          if (orcWithEmptyColIds) {
+            // For the case of Orc with empty required column Ids.
+            Iterator.empty
+          } else {
+            val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
+              filterScanners, requiredIds, None, oapMetrics, conf, returningBatch, options,
+              filters, context)
+            reader.read(file)
+          }
+        }
+      case None => (_: PartitionedFile) => {
+        // TODO need to think about when there is no oap.meta file at all
+        // TODO For parquet should refer to ParquetFileFormat
+        Iterator.empty
+      }
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{AtomicType, StructType}
 import org.apache.spark.util.SerializableConfiguration
 
-class OptimizedParquetFileFormat extends OapFileFormat {
+private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
 
   override def prepareWrite(
       sparkSession: SparkSession,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -78,7 +78,7 @@ class OptimizedParquetFileFormat extends OapFileFormat {
         val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
         val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
-        // TODO why add `sparkSession.sessionState.conf.wholeStageEnabled` condition ?
+        // TODO why add `sparkSession.sessionState.conf.wholeStageEnabled` condition
         val enableVectorizedReader: Boolean =
           sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
             sparkSession.sessionState.conf.wholeStageEnabled &&

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -105,7 +105,6 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
           reader.read(file)
         }
       case None => (_: PartitionedFile) => {
-        // TODO need to think about when there is no oap.meta file at all
         // TODO For parquet should refer to ParquetFileFormat
         Iterator.empty
       }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.Job
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.oap.io.{DataFileContext, OapDataReaderV1, ParquetVectorizedContext}
+import org.apache.spark.sql.execution.datasources.oap.utils.FilterHelper
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.{AtomicType, StructType}
+import org.apache.spark.util.SerializableConfiguration
+
+class OptimizedParquetFileFormat extends OapFileFormat {
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory =
+    throw new UnsupportedOperationException("OptimizedParquetFileFormat " +
+      "only support read operation")
+
+  /**
+   * Returns whether the reader will return the rows as batch or not.
+   */
+  override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
+    val conf = sparkSession.sessionState.conf
+    conf.parquetVectorizedReaderEnabled && conf.wholeStageEnabled &&
+      schema.length <= conf.wholeStageMaxNumFields &&
+      schema.forall(_.dataType.isInstanceOf[AtomicType])
+  }
+
+  override def buildReaderWithPartitionValues(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+    // TODO we need to pass the extra data source meta information via the func parameter
+    meta match {
+      case Some(m) =>
+        logDebug(s"Building OapDataReader with "
+          + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
+          + " ...")
+
+        val filterScanners = indexScanners(m, filters)
+        // TODO refactor this.
+        hitIndexColumns = filterScanners match {
+          case Some(s) =>
+            s.scanners.flatMap { scanner =>
+              scanner.keyNames.map(n => n -> scanner.meta.indexType)
+            }.toMap
+          case _ => Map.empty
+        }
+
+        val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
+        val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
+
+        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+        val returningBatch = supportBatch(sparkSession, resultSchema)
+        val broadcastedHadoopConf =
+          sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+        (file: PartitionedFile) => {
+          assert(file.partitionValues.numFields == partitionSchema.size)
+          val conf = broadcastedHadoopConf.value.value
+
+          // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
+          // Otherwise context is none.
+          val context: Option[DataFileContext] = if (returningBatch) {
+            Some(ParquetVectorizedContext(partitionSchema,
+              file.partitionValues, returningBatch))
+          } else {
+            None
+          }
+
+          val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
+            filterScanners, requiredIds, pushed, oapMetrics, conf, returningBatch, options,
+            filters, context)
+          reader.read(file)
+        }
+      case None => (_: PartitionedFile) => {
+        // TODO need to think about when there is no oap.meta file at all
+        // TODO For parquet should refer to ParquetFileFormat
+        Iterator.empty
+      }
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -90,7 +90,6 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
         (file: PartitionedFile) => {
           assert(file.partitionValues.numFields == partitionSchema.size)
           val conf = broadcastedHadoopConf.value.value
-
           // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
           // Otherwise context is none.
           val context: Option[DataFileContext] = if (enableVectorizedReader) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -78,8 +78,10 @@ class OptimizedParquetFileFormat extends OapFileFormat {
         val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
         val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+        // TODO why add `sparkSession.sessionState.conf.wholeStageEnabled` condition ?
         val enableVectorizedReader: Boolean =
           sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
+            sparkSession.sessionState.conf.wholeStageEnabled &&
             resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
         val returningBatch = supportBatch(sparkSession, resultSchema)
         val broadcastedHadoopConf =

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OptimizedParquetFileFormat}
+import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OptimizedOrcFileFormat, OptimizedParquetFileFormat}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.hive.orc.OrcFileFormat
 import org.apache.spark.sql.internal.SQLConf
@@ -121,7 +121,7 @@ object FileSourceStrategy extends Strategy with Logging {
 
         case a: OrcFileFormat
           if _fsRelation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) =>
-          val oapFileFormat = new OapFileFormat
+          val oapFileFormat = new OptimizedOrcFileFormat
           oapFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -94,13 +94,13 @@ object FileSourceStrategy extends Strategy with Logging {
         // else turn to ParquetFileFormat
         case a: ParquetFileFormat
           if _fsRelation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) =>
-          val oapFileFormat = new OptimizedParquetFileFormat
-          oapFileFormat
+          val optimizedParquetFileFormat = new OptimizedParquetFileFormat
+          optimizedParquetFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,
               selectedPartitions.flatMap(p => p.files))
 
-          if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
+          if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
             val parquetOptions: Map[String, String] =
               Map(SQLConf.PARQUET_BINARY_AS_STRING.key ->
@@ -111,7 +111,7 @@ object FileSourceStrategy extends Strategy with Logging {
                   _fsRelation.sparkSession.sessionState.conf.writeLegacyParquetFormat.toString) ++
                 _fsRelation.options
 
-            _fsRelation.copy(fileFormat = oapFileFormat,
+            _fsRelation.copy(fileFormat = optimizedParquetFileFormat,
               options = parquetOptions)(_fsRelation.sparkSession)
 
           } else {
@@ -121,13 +121,13 @@ object FileSourceStrategy extends Strategy with Logging {
 
         case a: OrcFileFormat
           if _fsRelation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) =>
-          val oapFileFormat = new OptimizedOrcFileFormat
-          oapFileFormat
+          val optimizedOrcFileFormat = new OptimizedOrcFileFormat
+          optimizedOrcFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,
               selectedPartitions.flatMap(p => p.files))
 
-          if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
+          if (optimizedOrcFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
             // isOapOrcFileFormat is used to indicate to read orc data with oap index accelerated.
             val orcOptions: Map[String, String] =
@@ -136,7 +136,7 @@ object FileSourceStrategy extends Strategy with Logging {
                 Map("isOapOrcFileFormat" -> "true") ++
                 _fsRelation.options
 
-            _fsRelation.copy(fileFormat = oapFileFormat,
+            _fsRelation.copy(fileFormat = optimizedOrcFileFormat,
               options = orcOptions)(_fsRelation.sparkSession)
 
           } else {

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -102,6 +102,7 @@ object FileSourceStrategy extends Strategy with Logging {
 
           if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+            // TODO move append options process to OptimizedParquetFileFormat
             val parquetOptions: Map[String, String] =
               Map(SQLConf.PARQUET_BINARY_AS_STRING.key ->
                 _fsRelation.sparkSession.sessionState.conf.isParquetBinaryAsString.toString,

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
+import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OptimizedParquetFileFormat}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.hive.orc.OrcFileFormat
 import org.apache.spark.sql.internal.SQLConf
@@ -94,7 +94,7 @@ object FileSourceStrategy extends Strategy with Logging {
         // else turn to ParquetFileFormat
         case a: ParquetFileFormat
           if _fsRelation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) =>
-          val oapFileFormat = new OapFileFormat
+          val oapFileFormat = new OptimizedParquetFileFormat
           oapFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,

--- a/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.Job
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.oap.io.{DataFileContext, OapDataReaderV1, ParquetVectorizedContext}
+import org.apache.spark.sql.execution.datasources.oap.utils.FilterHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.{AtomicType, StructType}
+import org.apache.spark.util.SerializableConfiguration
+
+private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory =
+    throw new UnsupportedOperationException("OptimizedParquetFileFormat " +
+      "only support read operation")
+
+  /**
+   * Returns whether the reader will return the rows as batch or not.
+   */
+  override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
+    val conf = sparkSession.sessionState.conf
+    conf.parquetVectorizedReaderEnabled && conf.wholeStageEnabled &&
+      schema.length <= conf.wholeStageMaxNumFields &&
+      schema.forall(_.dataType.isInstanceOf[AtomicType])
+  }
+
+  override def buildReaderWithPartitionValues(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+    // TODO we need to pass the extra data source meta information via the func parameter
+    meta match {
+      case Some(m) =>
+        logDebug(s"Building OapDataReader with "
+          + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
+          + " ...")
+
+        val filterScanners = indexScanners(m, filters)
+        // TODO refactor this.
+        hitIndexColumns = filterScanners match {
+          case Some(s) =>
+            s.scanners.flatMap { scanner =>
+              scanner.keyNames.map(n => n -> scanner.meta.indexType)
+            }.toMap
+          case _ => Map.empty
+        }
+
+        val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
+        val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
+
+        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+        // TODO why add `sparkSession.sessionState.conf.wholeStageEnabled` condition
+        val enableVectorizedReader: Boolean =
+          sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
+            sparkSession.sessionState.conf.wholeStageEnabled &&
+            resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
+        val returningBatch = supportBatch(sparkSession, resultSchema)
+
+        // Sets flags for `CatalystSchemaConverter`
+        hadoopConf.setBoolean(
+          SQLConf.PARQUET_BINARY_AS_STRING.key,
+          sparkSession.sessionState.conf.isParquetBinaryAsString)
+        hadoopConf.setBoolean(
+          SQLConf.PARQUET_INT96_AS_TIMESTAMP.key,
+          sparkSession.sessionState.conf.isParquetINT96AsTimestamp)
+
+        val broadcastedHadoopConf =
+          sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+        (file: PartitionedFile) => {
+          assert(file.partitionValues.numFields == partitionSchema.size)
+          val conf = broadcastedHadoopConf.value.value
+          // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
+          // Otherwise context is none.
+          val context: Option[DataFileContext] = if (enableVectorizedReader) {
+            Some(ParquetVectorizedContext(partitionSchema,
+              file.partitionValues, returningBatch))
+          } else {
+            None
+          }
+
+          val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
+            filterScanners, requiredIds, pushed, oapMetrics, conf, enableVectorizedReader, options,
+            filters, context)
+          reader.read(file)
+        }
+      case None => (_: PartitionedFile) => {
+        // TODO For parquet should refer to ParquetFileFormat
+        Iterator.empty
+      }
+    }
+  }
+}

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -101,22 +101,7 @@ object FileSourceStrategy extends Strategy with Logging {
 
           if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
-            // TODO move append options process to OptimizedParquetFileFormat
-            val parquetOptions: Map[String, String] =
-              Map(SQLConf.PARQUET_BINARY_AS_STRING.key ->
-                _fsRelation.sparkSession.sessionState.conf.isParquetBinaryAsString.toString,
-                SQLConf.PARQUET_INT96_AS_TIMESTAMP.key ->
-                  _fsRelation.sparkSession.sessionState.conf.isParquetINT96AsTimestamp.toString,
-                SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key ->
-                  _fsRelation.sparkSession.sessionState.conf.writeLegacyParquetFormat.toString,
-                SQLConf.PARQUET_INT64_AS_TIMESTAMP_MILLIS.key ->
-                  _fsRelation.sparkSession.sessionState.conf
-                    .isParquetINT64AsTimestampMillis.toString) ++
-                _fsRelation.options
-
-            _fsRelation.copy(fileFormat = optimizedParquetFileFormat,
-              options = parquetOptions)(_fsRelation.sparkSession)
-
+            _fsRelation.copy(fileFormat = optimizedParquetFileFormat)(_fsRelation.sparkSession)
           } else {
             logInfo("hasAvailableIndex = false, will retain ParquetFileFormat.")
             _fsRelation

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
+import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OptimizedOrcFileFormat, OptimizedParquetFileFormat}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.hive.orc.OrcFileFormat
 import org.apache.spark.sql.internal.SQLConf
@@ -93,13 +93,13 @@ object FileSourceStrategy extends Strategy with Logging {
         // else turn to ParquetFileFormat
         case a: ParquetFileFormat
           if _fsRelation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) =>
-          val oapFileFormat = new OapFileFormat
-          oapFileFormat
+          val optimizedParquetFileFormat = new OptimizedParquetFileFormat
+          optimizedParquetFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,
               selectedPartitions.flatMap(p => p.files))
 
-          if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
+          if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
             val parquetOptions: Map[String, String] =
               Map(SQLConf.PARQUET_BINARY_AS_STRING.key ->
@@ -113,7 +113,7 @@ object FileSourceStrategy extends Strategy with Logging {
                     .isParquetINT64AsTimestampMillis.toString) ++
                 _fsRelation.options
 
-            _fsRelation.copy(fileFormat = oapFileFormat,
+            _fsRelation.copy(fileFormat = optimizedParquetFileFormat,
               options = parquetOptions)(_fsRelation.sparkSession)
 
           } else {
@@ -123,13 +123,13 @@ object FileSourceStrategy extends Strategy with Logging {
 
         case a: OrcFileFormat
           if _fsRelation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) =>
-          val oapFileFormat = new OapFileFormat
-          oapFileFormat
+          val optimizedOrcFileFormat = new OptimizedOrcFileFormat
+          optimizedOrcFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,
               selectedPartitions.flatMap(p => p.files))
 
-          if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
+          if (optimizedOrcFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
             // isOapOrcFileFormat is used to indicate to read orc data with oap index accelerated.
             val orcOptions: Map[String, String] =
@@ -138,7 +138,7 @@ object FileSourceStrategy extends Strategy with Logging {
                Map("isOapOrcFileFormat" -> "true")
                 _fsRelation.options
 
-            _fsRelation.copy(fileFormat = oapFileFormat,
+            _fsRelation.copy(fileFormat = optimizedOrcFileFormat,
               options = orcOptions)(_fsRelation.sparkSession)
 
           } else {

--- a/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.2/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -101,6 +101,7 @@ object FileSourceStrategy extends Strategy with Logging {
 
           if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+            // TODO move append options process to OptimizedParquetFileFormat
             val parquetOptions: Map[String, String] =
               Map(SQLConf.PARQUET_BINARY_AS_STRING.key ->
                 _fsRelation.sparkSession.sessionState.conf.isParquetBinaryAsString.toString,

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.oap.OapFileFormat
+import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OptimizedOrcFileFormat, OptimizedParquetFileFormat}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
@@ -92,13 +92,13 @@ object FileSourceStrategy extends Strategy with Logging {
         // else turn to ParquetFileFormat
         case a: ParquetFileFormat
           if _fsRelation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) =>
-          val oapFileFormat = new OapFileFormat
-          oapFileFormat
+          val optimizedParquetFileFormat = new OptimizedParquetFileFormat
+          optimizedParquetFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,
               selectedPartitions.flatMap(p => p.files))
 
-          if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
+          if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
             val parquetOptions: Map[String, String] =
               Map(SQLConf.PARQUET_BINARY_AS_STRING.key ->
@@ -112,7 +112,7 @@ object FileSourceStrategy extends Strategy with Logging {
                     .isParquetINT64AsTimestampMillis.toString) ++
                 _fsRelation.options
 
-            _fsRelation.copy(fileFormat = oapFileFormat,
+            _fsRelation.copy(fileFormat = optimizedParquetFileFormat,
               options = parquetOptions)(_fsRelation.sparkSession)
 
           } else {
@@ -123,13 +123,13 @@ object FileSourceStrategy extends Strategy with Logging {
         case a if (_fsRelation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) &&
           (a.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
             a.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat])) =>
-          val oapFileFormat = new OapFileFormat
-          oapFileFormat
+          val optimizedOrcFileFormat = new OptimizedOrcFileFormat
+          optimizedOrcFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,
               selectedPartitions.flatMap(p => p.files))
 
-          if (oapFileFormat.hasAvailableIndex(normalizedFilters)) {
+          if (optimizedOrcFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
             // isOapOrcFileFormat is used to indicate to read orc data with oap index accelerated.
             val orcOptions: Map[String, String] =
@@ -138,7 +138,7 @@ object FileSourceStrategy extends Strategy with Logging {
                 Map("isOapOrcFileFormat" -> "true") ++
                 _fsRelation.options
 
-            _fsRelation.copy(fileFormat = oapFileFormat,
+            _fsRelation.copy(fileFormat = optimizedOrcFileFormat,
               options = orcOptions)(_fsRelation.sparkSession)
 
           } else {

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -100,22 +100,7 @@ object FileSourceStrategy extends Strategy with Logging {
 
           if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
-            // TODO move append options process to OptimizedParquetFileFormat
-            val parquetOptions: Map[String, String] =
-              Map(SQLConf.PARQUET_BINARY_AS_STRING.key ->
-                _fsRelation.sparkSession.sessionState.conf.isParquetBinaryAsString.toString,
-                SQLConf.PARQUET_INT96_AS_TIMESTAMP.key ->
-                  _fsRelation.sparkSession.sessionState.conf.isParquetINT96AsTimestamp.toString,
-                SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key ->
-                  _fsRelation.sparkSession.sessionState.conf.writeLegacyParquetFormat.toString,
-                SQLConf.PARQUET_INT64_AS_TIMESTAMP_MILLIS.key ->
-                  _fsRelation.sparkSession.sessionState.conf
-                    .isParquetINT64AsTimestampMillis.toString) ++
-                _fsRelation.options
-
-            _fsRelation.copy(fileFormat = optimizedParquetFileFormat,
-              options = parquetOptions)(_fsRelation.sparkSession)
-
+            _fsRelation.copy(fileFormat = optimizedParquetFileFormat)(_fsRelation.sparkSession)
           } else {
             logInfo("hasAvailableIndex = false, will retain ParquetFileFormat.")
             _fsRelation

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -100,6 +100,7 @@ object FileSourceStrategy extends Strategy with Logging {
 
           if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
             logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+            // TODO move append options process to OptimizedParquetFileFormat
             val parquetOptions: Map[String, String] =
               Map(SQLConf.PARQUET_BINARY_AS_STRING.key ->
                 _fsRelation.sparkSession.sessionState.conf.isParquetBinaryAsString.toString,

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.Job
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.oap.io.{DataFileContext, OapDataReaderV1, ParquetVectorizedContext}
+import org.apache.spark.sql.execution.datasources.oap.utils.FilterHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.{AtomicType, StructType}
+import org.apache.spark.util.SerializableConfiguration
+
+private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory =
+    throw new UnsupportedOperationException("OptimizedParquetFileFormat " +
+      "only support read operation")
+
+  /**
+   * Returns whether the reader will return the rows as batch or not.
+   */
+  override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
+    val conf = sparkSession.sessionState.conf
+    conf.parquetVectorizedReaderEnabled && conf.wholeStageEnabled &&
+      schema.length <= conf.wholeStageMaxNumFields &&
+      schema.forall(_.dataType.isInstanceOf[AtomicType])
+  }
+
+  override def buildReaderWithPartitionValues(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+    // TODO we need to pass the extra data source meta information via the func parameter
+    meta match {
+      case Some(m) =>
+        logDebug(s"Building OapDataReader with "
+          + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
+          + " ...")
+
+        val filterScanners = indexScanners(m, filters)
+        // TODO refactor this.
+        hitIndexColumns = filterScanners match {
+          case Some(s) =>
+            s.scanners.flatMap { scanner =>
+              scanner.keyNames.map(n => n -> scanner.meta.indexType)
+            }.toMap
+          case _ => Map.empty
+        }
+
+        val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
+        val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
+
+        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+        // TODO why add `sparkSession.sessionState.conf.wholeStageEnabled` condition
+        val enableVectorizedReader: Boolean =
+          sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
+            sparkSession.sessionState.conf.wholeStageEnabled &&
+            resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
+        val returningBatch = supportBatch(sparkSession, resultSchema)
+
+        hadoopConf.set(
+          SQLConf.SESSION_LOCAL_TIMEZONE.key,
+          sparkSession.sessionState.conf.sessionLocalTimeZone)
+
+        // Sets flags for `ParquetToSparkSchemaConverter`
+        hadoopConf.setBoolean(
+          SQLConf.PARQUET_BINARY_AS_STRING.key,
+          sparkSession.sessionState.conf.isParquetBinaryAsString)
+        hadoopConf.setBoolean(
+          SQLConf.PARQUET_INT96_AS_TIMESTAMP.key,
+          sparkSession.sessionState.conf.isParquetINT96AsTimestamp)
+        val broadcastedHadoopConf =
+          sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+        (file: PartitionedFile) => {
+          assert(file.partitionValues.numFields == partitionSchema.size)
+          val conf = broadcastedHadoopConf.value.value
+          // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
+          // Otherwise context is none.
+          val context: Option[DataFileContext] = if (enableVectorizedReader) {
+            Some(ParquetVectorizedContext(partitionSchema,
+              file.partitionValues, returningBatch))
+          } else {
+            None
+          }
+
+          val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
+            filterScanners, requiredIds, pushed, oapMetrics, conf, enableVectorizedReader, options,
+            filters, context)
+          reader.read(file)
+        }
+      case None => (_: PartitionedFile) => {
+        // TODO For parquet should refer to ParquetFileFormat
+        Iterator.empty
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

As #883 said,  extract Parquet code to `OptimizedParquetFileFormat`, Orc code to `OptimizedOrcFileFormat`, they extends `OapFileFormat`.

Move parquet custom config from `FileSourceStrategy` to `OptimizedParquetFileFormat `.

## How was this patch tested?
mvn test -Pspark-2.1 pass
mvn test -Pspark-2.2 pass
mvn test -Pspark-2.3 pass