### PR TITLE
 Introduce ParquetDataFiberReaderWriter for Spark-2.3

### DIFF
--- a/src/main/spark2.3/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionaryWrapper.java
+++ b/src/main/spark2.3/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionaryWrapper.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet;
+
+import org.apache.spark.sql.execution.vectorized.Dictionary;
+
+public class ParquetDictionaryWrapper implements Dictionary {
+  private org.apache.parquet.column.Dictionary dictionary;
+
+  public ParquetDictionaryWrapper(org.apache.parquet.column.Dictionary dictionary) {
+    this.dictionary = dictionary;
+  }
+
+  @Override
+  public int decodeToInt(int id) {
+    return dictionary.decodeToInt(id);
+  }
+
+  @Override
+  public long decodeToLong(int id) {
+    return dictionary.decodeToLong(id);
+  }
+
+  @Override
+  public float decodeToFloat(int id) {
+    return dictionary.decodeToFloat(id);
+  }
+
+  @Override
+  public double decodeToDouble(int id) {
+    return dictionary.decodeToDouble(id);
+  }
+
+  @Override
+  public byte[] decodeToBinary(int id) {
+    return dictionary.decodeToBinary(id).getBytes();
+  }
+
+  public int getMaxId() {
+    return dictionary.getMaxId();
+  }
+}

--- a/src/main/spark2.3/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/src/main/spark2.3/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -180,7 +180,7 @@ public class VectorizedColumnReader {
           // Column vector supports lazy decoding of dictionary values so just set the dictionary.
           // We can't do this if rowId != 0 AND the column doesn't have a dictionary (i.e. some
           // non-dictionary encoded values have already been added).
-          column.setDictionary(new ParquetDictionary(dictionary));
+          column.setDictionary(new ParquetDictionaryWrapper(dictionary));
         } else {
           decodeDictionaryIds(rowId, num, column, dictionaryIds);
         }

--- a/src/main/spark2.3/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/src/main/spark2.3/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -498,6 +499,60 @@ public final class OnHeapColumnVector extends WritableColumnVector {
     arrayOffsets[rowId] = result;
     arrayLengths[rowId] = length;
     return result;
+  }
+
+  public byte[] getNulls() {
+    return nulls;
+  }
+
+  public byte[] getByteData() {
+    return byteData;
+  }
+
+  public short[] getShortData() {
+    return shortData;
+  }
+
+  public int[] getIntData() {
+    return intData;
+  }
+
+  public long[] getLongData() {
+    return longData;
+  }
+
+  public float[] getFloatData() {
+    return floatData;
+  }
+
+  public double[] getDoubleData() {
+    return doubleData;
+  }
+
+  public int[] getArrayLengths() {
+    return arrayLengths;
+  }
+
+  public int[] getArrayOffsets() {
+    return arrayOffsets;
+  }
+
+  public void setByteData(byte[] byteData) {
+    this.byteData = byteData;
+  }
+
+  public Dictionary getDictionary() {
+    return this.dictionary;
+  }
+
+  public int dictionaryLength() {
+    if(dictionary ==  null) {
+      return 0;
+    } else if (dictionary instanceof  ParquetDictionaryWrapper) {
+      return ((ParquetDictionaryWrapper)dictionary).getMaxId() + 1;
+    } else {
+      throw new UnsupportedOperationException("this api only use by oap");
+    }
   }
 
   // Spilt this function out since it is the slow path.

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberReaderWriter.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberReaderWriter.scala
@@ -1,0 +1,815 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.parquet.column.{Dictionary, Encoding}
+import org.apache.parquet.io.api.Binary
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
+import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.Platform
+
+/**
+ * ParquetDataFiberWriter is a util use to write OnHeapColumnVector data to data fiber.
+ * Data Fiber write as follow format:
+ * ParquetDataFiberHeader: (noNulls:boolean:1 bit, allNulls:boolean:1 bit, dicLength:int:4 bit)
+ * NullsData: (noNulls:false, allNulls: false) will store nulls to data fiber as bytes array
+ * Values: store value data except (noNulls:false, allNulls: true) by dataType,
+ * Dic encode data store as int array.
+ * Dictionary: if dicLength > 0 will store dic data by dataType.
+ */
+object ParquetDataFiberWriter extends Logging {
+
+  def dumpToCache(column: OnHeapColumnVector, total: Int): FiberCache = {
+    val header = ParquetDataFiberHeader(column, total)
+    logDebug(s"will dump column to data fiber dataType = ${column.dataType()}, " +
+      s"total = $total, header is $header")
+    header match {
+      case ParquetDataFiberHeader(true, false, 0) =>
+        val length = fiberLength(column, total, 0 )
+        logDebug(s"will apply $length bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(length)
+        val nativeAddress = header.writeToCache(fiber.getBaseOffset)
+        dumpDataToFiber(nativeAddress, column, total)
+        fiber
+      case ParquetDataFiberHeader(true, false, dicLength) =>
+        val length = fiberLength(column, total, 0, dicLength)
+        logDebug(s"will apply $length bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(length)
+        val nativeAddress = header.writeToCache(fiber.getBaseOffset)
+        dumpDataAndDicToFiber(nativeAddress, column, total, dicLength)
+        fiber
+      case ParquetDataFiberHeader(false, true, _) =>
+        logDebug(s"will apply ${ParquetDataFiberHeader.defaultSize} " +
+          s"bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(ParquetDataFiberHeader.defaultSize)
+        header.writeToCache(fiber.getBaseOffset)
+        fiber
+      case ParquetDataFiberHeader(false, false, 0) =>
+        val length = fiberLength(column, total, 1)
+        logDebug(s"will apply $length bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(length)
+        val nativeAddress =
+          dumpNullsToFiber(header.writeToCache(fiber.getBaseOffset), column, total)
+        dumpDataToFiber(nativeAddress, column, total)
+        fiber
+      case ParquetDataFiberHeader(false, false, dicLength) =>
+        val length = fiberLength(column, total, 1, dicLength)
+        logDebug(s"will apply $length bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(length)
+        val nativeAddress =
+          dumpNullsToFiber(header.writeToCache(fiber.getBaseOffset), column, total)
+        dumpDataAndDicToFiber(nativeAddress, column, total, dicLength)
+        fiber
+      case ParquetDataFiberHeader(true, true, _) =>
+        throw new OapException("impossible header status (true, true, _).")
+      case other => throw new OapException(s"impossible header status $other.")
+    }
+  }
+
+  /**
+   * Write nulls data to data fiber.
+   */
+  private def dumpNullsToFiber(
+      nativeAddress: Long, column: OnHeapColumnVector, total: Int): Long = {
+    Platform.copyMemory(column.getNulls,
+      Platform.BYTE_ARRAY_OFFSET, null, nativeAddress, total)
+    nativeAddress + total
+  }
+
+  /**
+   * noNulls is true, nulls are all 0, not dump nulls to cache,
+   * allNulls is false, need dump to cache,
+   * dicLength is 0, needn't calculate dictionary part.
+   */
+  private def dumpDataToFiber(nativeAddress: Long, column: OnHeapColumnVector, total: Int): Unit = {
+    column.dataType match {
+      case ByteType | BooleanType =>
+        Platform.copyMemory(column.getByteData,
+          Platform.BYTE_ARRAY_OFFSET, null, nativeAddress, total)
+      case ShortType =>
+        Platform.copyMemory(column.getShortData,
+          Platform.SHORT_ARRAY_OFFSET, null, nativeAddress, total * 2)
+      case IntegerType | DateType =>
+        Platform.copyMemory(column.getIntData,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4)
+      case FloatType =>
+        Platform.copyMemory(column.getFloatData,
+          Platform.FLOAT_ARRAY_OFFSET, null, nativeAddress, total * 4)
+      case LongType | TimestampType =>
+        Platform.copyMemory(column.getLongData,
+          Platform.LONG_ARRAY_OFFSET, null, nativeAddress, total * 8)
+      case DoubleType =>
+        Platform.copyMemory(column.getDoubleData,
+          Platform.DOUBLE_ARRAY_OFFSET, null, nativeAddress, total * 8)
+      case StringType | BinaryType =>
+        Platform.copyMemory(column.getArrayLengths,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4)
+        Platform.copyMemory(column.getArrayOffsets,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress + total * 4, total * 4)
+        val child = column.getChild(0).asInstanceOf[OnHeapColumnVector]
+        Platform.copyMemory(child.getByteData,
+          Platform.BYTE_ARRAY_OFFSET, null, nativeAddress + total * 8,
+          child.getElementsAppended)
+      case other if DecimalType.is32BitDecimalType(other) =>
+        Platform.copyMemory(column.getIntData,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4)
+      case other if DecimalType.is64BitDecimalType(other) =>
+        Platform.copyMemory(column.getLongData,
+          Platform.LONG_ARRAY_OFFSET, null, nativeAddress, total * 8)
+      case other if DecimalType.isByteArrayDecimalType(other) =>
+        Platform.copyMemory(column.getArrayLengths,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4)
+        Platform.copyMemory(column.getArrayOffsets,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress + total * 4, total * 4)
+        val child = column.getChild(0).asInstanceOf[OnHeapColumnVector]
+        Platform.copyMemory(child.getByteData,
+          Platform.BYTE_ARRAY_OFFSET, null, nativeAddress + total * 8,
+          child.getElementsAppended)
+      case other => throw new OapException(s"$other data type is not support data cache.")
+    }
+  }
+
+  /**
+   * Write dictionaryIds(int array) and Dictionary data to data fiber.
+   */
+  private def dumpDataAndDicToFiber(
+      nativeAddress: Long, column: OnHeapColumnVector, total: Int, dicLength: Int): Unit = {
+    // dump dictionaryIds to data fiber, it's a int array.
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    Platform.copyMemory(dictionaryIds.getIntData,
+      Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4)
+    var dicNativeAddress = nativeAddress + total * 4
+    val dictionary = column.getDictionary
+    // dump dictionary to data fiber case by dataType.
+    column.dataType() match {
+      case ByteType | ShortType | IntegerType | DateType =>
+        val intDictionaryContent = new Array[Int](dicLength)
+        (0 until dicLength).foreach(id => intDictionaryContent(id) = dictionary.decodeToInt(id))
+        Platform.copyMemory(intDictionaryContent, Platform.INT_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 4)
+      case FloatType =>
+        val floatDictionaryContent = new Array[Float](dicLength)
+        (0 until dicLength).foreach(id => floatDictionaryContent(id) = dictionary.decodeToFloat(id))
+        Platform.copyMemory(floatDictionaryContent, Platform.FLOAT_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 4)
+      case LongType | TimestampType =>
+        val longDictionaryContent = new Array[Long](dicLength)
+        (0 until dicLength).foreach(id => longDictionaryContent(id) = dictionary.decodeToLong(id))
+        Platform.copyMemory(longDictionaryContent, Platform.LONG_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 8)
+      case DoubleType =>
+        val doubleDictionaryContent = new Array[Double](dicLength)
+        (0 until dicLength).foreach(id =>
+          doubleDictionaryContent(id) = dictionary.decodeToDouble(id))
+        Platform.copyMemory(doubleDictionaryContent, Platform.DOUBLE_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 8);
+      case StringType | BinaryType =>
+        var bytesNativeAddress = dicNativeAddress + 4 * dicLength
+        (0 until dicLength).foreach( id => {
+          val binary = dictionary.decodeToBinary(id)
+          val length = binary.length
+          Platform.putInt(null, dicNativeAddress, length)
+          dicNativeAddress += 4
+          Platform.copyMemory(binary,
+            Platform.BYTE_ARRAY_OFFSET, null, bytesNativeAddress, length)
+          bytesNativeAddress += length
+        })
+      case other if DecimalType.is32BitDecimalType(other) =>
+        val intDictionaryContent = new Array[Int](dicLength)
+        (0 until dicLength).foreach(id => intDictionaryContent(id) = dictionary.decodeToInt(id))
+        Platform.copyMemory(intDictionaryContent, Platform.INT_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 4)
+      case other if DecimalType.is64BitDecimalType(other) =>
+        val longDictionaryContent = new Array[Long](dicLength)
+        (0 until dicLength).foreach(id => longDictionaryContent(id) = dictionary.decodeToLong(id))
+        Platform.copyMemory(longDictionaryContent, Platform.LONG_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 8)
+      case other if DecimalType.isByteArrayDecimalType(other) =>
+        var bytesNativeAddress = dicNativeAddress + 4 * dicLength
+        (0 until dicLength).foreach( id => {
+          val binary = dictionary.decodeToBinary(id)
+          val length = binary.length
+          Platform.putInt(null, dicNativeAddress, length)
+          dicNativeAddress += 4
+          Platform.copyMemory(binary,
+            Platform.BYTE_ARRAY_OFFSET, null, bytesNativeAddress, length)
+          bytesNativeAddress += length
+        })
+      case other => throw new OapException(s"$other data type is not support dictionary.")
+    }
+  }
+
+  /**
+   * noNulls is true, nulls are all 0, not dump nulls to cache, nullsLength is 0,
+   * allNulls is false, need dump to cache,
+   * dicLength is 0, needn't calculate dictionary part.
+   */
+  private def fiberLength(column: OnHeapColumnVector, total: Int, nullUnitLength: Int): Long =
+    if (isFixedLengthDataType(column.dataType())) {
+      logDebug(s"dataType ${column.dataType()} is fixed length. ")
+      // Fixed length data type fiber length.
+      ParquetDataFiberHeader.defaultSize +
+        nullUnitLength * total + column.dataType().defaultSize * total
+    } else {
+      logDebug(s"dataType ${column.dataType()} is not fixed length. ")
+      // lengthData and offsetData will be set and data will be put in child if type is Array.
+      // lengthData: 4 bytes, offsetData: 4 bytes, nulls: 1 byte,
+      // child.data: childColumns[0].elementsAppended bytes.
+      ParquetDataFiberHeader.defaultSize + nullUnitLength * total + total * 8 +
+        column.getChild(0).getElementsAppended
+    }
+
+  /**
+   * noNulls is true, nulls are all 0, not dump nulls to cache, nullsLength is 0,
+   * allNulls is false, need dump to cache,
+   * dicLength is not, need calculate dictionary part and dictionaryIds is a int array.
+   */
+  private def fiberLength(
+      column: OnHeapColumnVector, total: Int, nullUnitLength: Int, dicLength: Int): Long = {
+    val dicPartSize = column.dataType() match {
+      case ByteType | ShortType | IntegerType | DateType => dicLength * 4
+      case FloatType => dicLength * 4
+      case LongType | TimestampType => dicLength * 8
+      case DoubleType => dicLength * 8
+      case StringType | BinaryType =>
+        val dictionary = column.getDictionary
+        (0 until dicLength).map(id => dictionary.decodeToBinary(id).length + 4).sum
+      // if DecimalType.is32BitDecimalType(other) as int data type
+      case other if DecimalType.is32BitDecimalType(other) => dicLength * 4
+      // if DecimalType.is64BitDecimalType(other) as long data type
+      case other if DecimalType.is64BitDecimalType(other) => dicLength * 8
+      // if DecimalType.isByteArrayDecimalType(other) as binary data type
+      case other if DecimalType.isByteArrayDecimalType(other) =>
+        val dictionary = column.getDictionary
+        (0 until dicLength).map(id => dictionary.decodeToBinary(id).length + 4).sum
+      case other => throw new OapException(s"$other data type is not support dictionary.")
+    }
+    ParquetDataFiberHeader.defaultSize + nullUnitLength * total + 4 * total + dicPartSize
+  }
+
+  private def isFixedLengthDataType(dataType: DataType): Boolean = dataType match {
+    case StringType | BinaryType => false
+    case ByteType | BooleanType | ShortType |
+         IntegerType | DateType | FloatType |
+         LongType | DoubleType | TimestampType => true
+    // if DecimalType.is32BitDecimalType(other) as int data type,
+    // if DecimalType.is64BitDecimalType(other) as long data type,
+    // so they are fixed length
+    case other if DecimalType.is32BitDecimalType(other) ||
+      DecimalType.is64BitDecimalType(other) => true
+    // if DecimalType.isByteArrayDecimalType(other) as binary data type,
+    // so it's not fixed length
+    case other if DecimalType.isByteArrayDecimalType(other) => false
+    case other => throw new OapException(s"$other data type is not implemented for cache.")
+  }
+
+  private def emptyDataFiber(fiberLength: Long): FiberCache =
+    OapRuntime.getOrCreate.memoryManager.getEmptyDataFiberCache(fiberLength)
+}
+
+/**
+ * ParquetDataFiberReader use to read data to ColumnVector.
+ * @param address data fiber address.
+ * @param dataType data type of data fiber.
+ * @param total total row count of data fiber.
+ */
+class ParquetDataFiberReader private(address: Long, dataType: DataType, total: Int) extends
+  Logging {
+
+  private var header: ParquetDataFiberHeader = _
+
+  private var dictionary: org.apache.spark.sql.execution.vectorized.Dictionary = _
+
+  /**
+   * Read num values to OnHeapColumnVector from data fiber by start position.
+   * @param start data fiber start rowId position.
+   * @param num need read values num.
+   * @param column target OnHeapColumnVector.
+   */
+  def readBatch(
+      start: Int, num: Int, column: OnHeapColumnVector): Unit = if (dictionary != null) {
+    // Use dictionary encode, value store in dictionaryIds, it's a int array.
+    column.setDictionary(dictionary)
+    val dictionaryIds = column.reserveDictionaryIds(num).asInstanceOf[OnHeapColumnVector]
+    header match {
+      case ParquetDataFiberHeader(true, false, _) =>
+        val dataNativeAddress = address + ParquetDataFiberHeader.defaultSize
+        Platform.copyMemory(null,
+          dataNativeAddress + start * 4,
+          dictionaryIds.getIntData, Platform.INT_ARRAY_OFFSET, num * 4)
+      case ParquetDataFiberHeader(false, false, _) =>
+        val nullsNativeAddress = address + ParquetDataFiberHeader.defaultSize
+        Platform.copyMemory(null,
+          nullsNativeAddress + start, column.getNulls, Platform.BYTE_ARRAY_OFFSET, num)
+        val dataNativeAddress = nullsNativeAddress + 1 * total
+        Platform.copyMemory(null,
+          dataNativeAddress + start * 4,
+          dictionaryIds.getIntData, Platform.INT_ARRAY_OFFSET, num * 4)
+      case ParquetDataFiberHeader(false, true, _) =>
+        // can to this branch ?
+        column.putNulls(0, num)
+      case ParquetDataFiberHeader(true, true, _) =>
+        throw new OapException("error header status (true, true, _)")
+      case other => throw new OapException(s"impossible header status $other.")
+    }
+  } else {
+    column.setDictionary(null)
+    header match {
+      case ParquetDataFiberHeader(true, false, _) =>
+        val dataNativeAddress = address + ParquetDataFiberHeader.defaultSize
+        readBatch(dataNativeAddress, start, num, column)
+      case ParquetDataFiberHeader(false, false, _) =>
+        val nullsNativeAddress = address + ParquetDataFiberHeader.defaultSize
+        Platform.copyMemory(null,
+          nullsNativeAddress + start, column.getNulls, Platform.BYTE_ARRAY_OFFSET, num)
+        val dataNativeAddress = nullsNativeAddress + 1 * total
+        readBatch(dataNativeAddress, start, num, column)
+      case ParquetDataFiberHeader(false, true, _) =>
+        column.putNulls(0, num)
+      case ParquetDataFiberHeader(true, true, _) =>
+        throw new OapException("error header status (true, true, _)")
+      case other => throw new OapException(s"impossible header status $other.")
+    }
+  }
+
+  /**
+   * Read a OnHeapColumnVector by rowIdList, suitable for rowIdList length is small,
+   * read value one by one.
+   * @param rowIdList need rowId List
+   * @param column target OnHeapColumnVector
+   */
+  def readBatch(rowIdList: IntList, column: OnHeapColumnVector): Unit = if (dictionary != null) {
+    // Use dictionary encode, value store in dictionaryIds, it's a int array.
+    column.setDictionary(dictionary)
+    val num = rowIdList.size()
+    val dictionaryIds = column.reserveDictionaryIds(num).asInstanceOf[OnHeapColumnVector]
+    header match {
+      case ParquetDataFiberHeader(true, false, _) =>
+        val dataNativeAddress = address + ParquetDataFiberHeader.defaultSize
+        val intData = dictionaryIds.getIntData
+        (0 until num).foreach(idx => {
+          intData(idx) = Platform.getInt(null,
+            dataNativeAddress + rowIdList.getInt(idx) * 4)
+        })
+      case ParquetDataFiberHeader(false, false, _) =>
+        val nullsNativeAddress = address + ParquetDataFiberHeader.defaultSize
+        val nulls = column.getNulls
+        val intData = dictionaryIds.getIntData
+        (0 until num).foreach(idx => {
+          nulls(idx) = Platform.getByte(null, nullsNativeAddress + rowIdList.getInt(idx))
+        })
+        val dataNativeAddress = nullsNativeAddress + 1 * total
+        (0 until num).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            intData(idx) = Platform.getInt(null,
+              dataNativeAddress + rowIdList.getInt(idx) * 4)
+          }
+        })
+      case ParquetDataFiberHeader(false, true, _) =>
+        column.putNulls(0, num)
+      case ParquetDataFiberHeader(true, true, _) =>
+        throw new OapException("error header status (true, true, _)")
+      case other => throw new OapException(s"impossible header status $other.")
+    }
+  } else {
+    column.setDictionary(null)
+    val num = rowIdList.size()
+    header match {
+      case ParquetDataFiberHeader(true, false, _) =>
+        val dataNativeAddress = address + ParquetDataFiberHeader.defaultSize
+        readBatch(dataNativeAddress, rowIdList, column)
+      case ParquetDataFiberHeader(false, false, _) =>
+        val nullsNativeAddress = address + ParquetDataFiberHeader.defaultSize
+        val nulls = column.getNulls
+        (0 until num).foreach(idx => {
+          nulls(idx) = Platform.getByte(null, nullsNativeAddress + rowIdList.getInt(idx))
+        })
+        val dataNativeAddress = nullsNativeAddress + 1 * total
+        readBatch(dataNativeAddress, rowIdList, column)
+      case ParquetDataFiberHeader(false, true, _) =>
+        column.putNulls(0, num)
+      case ParquetDataFiberHeader(true, true, _) =>
+        throw new OapException("error header status (true, true, _)")
+      case other => throw new OapException(s"impossible header status $other.")
+    }
+  }
+
+  /**
+   * Read ParquetDataFiberHeader and dictionary from data fiber.
+   */
+  private def readRowGroupMetas(): Unit = {
+    header = ParquetDataFiberHeader(address)
+    header match {
+      case ParquetDataFiberHeader(_, _, 0) =>
+        dictionary = null
+      case ParquetDataFiberHeader(false, true, _) =>
+        dictionary = null
+      case ParquetDataFiberHeader(true, false, dicLength) =>
+        val dicNativeAddress = address + ParquetDataFiberHeader.defaultSize + 4 * total
+        dictionary =
+          new ParquetDictionaryWrapper(readDictionary(dataType, dicLength, dicNativeAddress))
+      case ParquetDataFiberHeader(false, false, dicLength) =>
+        val dicNativeAddress = address + ParquetDataFiberHeader.defaultSize + 1 * total + 4 * total
+        dictionary =
+          new ParquetDictionaryWrapper(readDictionary(dataType, dicLength, dicNativeAddress))
+      case ParquetDataFiberHeader(true, true, _) =>
+        throw new OapException("error header status (true, true, _)")
+      case other => throw new OapException(s"impossible header status $other.")
+    }
+  }
+
+  /**
+   * Read num values to OnHeapColumnVector from data fiber by start position,
+   * not Dictionary encode.
+   */
+  private def readBatch(
+      dataNativeAddress: Long, start: Int, num: Int, column: OnHeapColumnVector): Unit = {
+
+    def readBinaryToColumnVector(): Unit = {
+      Platform.copyMemory(null,
+        dataNativeAddress + start * 4,
+        column.getArrayLengths, Platform.INT_ARRAY_OFFSET, num * 4)
+      Platform.copyMemory(
+        null,
+        dataNativeAddress + total * 4 + start * 4,
+        column.getArrayOffsets, Platform.INT_ARRAY_OFFSET, num * 4)
+
+      var lastIndex = num - 1
+      while (lastIndex >= 0 && column.isNullAt(lastIndex)) {
+        lastIndex -= 1
+      }
+      var firstIndex = 0
+      while (firstIndex < num && column.isNullAt(firstIndex)) {
+        firstIndex += 1
+      }
+      if (firstIndex < num && lastIndex >= 0) {
+        val arrayOffsets: Array[Int] = column.getArrayOffsets
+        val startOffset = arrayOffsets(firstIndex)
+        for (idx <- firstIndex to lastIndex) {
+          if (!column.isNullAt(idx)) {
+            arrayOffsets(idx) -= startOffset
+          }
+        }
+
+        val length = column.getArrayOffset(lastIndex) -
+          column.getArrayOffset(firstIndex) + column.getArrayLength(lastIndex)
+
+        val data = new Array[Byte](length)
+        Platform.copyMemory(null,
+          dataNativeAddress + total * 8 + startOffset,
+          data, Platform.BYTE_ARRAY_OFFSET, data.length)
+        column.getChild(0).asInstanceOf[OnHeapColumnVector].setByteData(data)
+      }
+    }
+
+    dataType match {
+      case ByteType | BooleanType =>
+        Platform.copyMemory(null,
+          dataNativeAddress + start, column.getByteData, Platform.BYTE_ARRAY_OFFSET, num)
+      case ShortType =>
+        Platform.copyMemory(null,
+          dataNativeAddress + start * 2,
+          column.getShortData, Platform.SHORT_ARRAY_OFFSET, num * 2)
+      case IntegerType | DateType =>
+        Platform.copyMemory(null,
+          dataNativeAddress + start * 4,
+          column.getIntData, Platform.INT_ARRAY_OFFSET, num * 4)
+      case FloatType =>
+        Platform.copyMemory(null,
+          dataNativeAddress + start * 4,
+          column.getFloatData, Platform.FLOAT_ARRAY_OFFSET, num * 4)
+      case LongType | TimestampType =>
+        Platform.copyMemory(null,
+          dataNativeAddress + start * 8,
+          column.getLongData, Platform.LONG_ARRAY_OFFSET, num * 8)
+      case DoubleType =>
+        Platform.copyMemory(
+          null, dataNativeAddress + start * 8,
+          column.getDoubleData, Platform.DOUBLE_ARRAY_OFFSET, num * 8)
+      case BinaryType | StringType => readBinaryToColumnVector()
+      // if DecimalType.is32BitDecimalType(other) as int data type.
+      case other if DecimalType.is32BitDecimalType(other) =>
+        Platform.copyMemory(null,
+          dataNativeAddress + start * 4,
+          column.getIntData, Platform.INT_ARRAY_OFFSET, num * 4)
+      // if DecimalType.is64BitDecimalType(other) as long data type.
+      case other if DecimalType.is64BitDecimalType(other) =>
+        Platform.copyMemory(null,
+          dataNativeAddress + start * 8,
+          column.getLongData, Platform.LONG_ARRAY_OFFSET, num * 8)
+      // if DecimalType.isByteArrayDecimalType(other) as binary data type.
+      case other if DecimalType.isByteArrayDecimalType(other) => readBinaryToColumnVector()
+      case other => throw new OapException(s"impossible data type $other.")
+    }
+  }
+
+  /**
+   * Read a OnHeapColumnVector by rowIdList, suitable for rowIdList length is small,
+   * read value one by one, not Dictionary encode.
+   */
+  private def readBatch(
+      dataNativeAddress: Long, rowIdList: IntList, column: OnHeapColumnVector): Unit = {
+
+    def readBinaryToColumnVector(): Unit = {
+      val arrayLengths = column.getArrayLengths
+      val arrayOffsets = column.getArrayOffsets
+      val offsetsStart = total * 4
+      val dataStart = total * 8
+      var offset = 0
+      val childColumn = column.getChild(0).asInstanceOf[OnHeapColumnVector]
+      (0 until rowIdList.size()).foreach(idx => {
+        if (!column.isNullAt(idx)) {
+          val rowId = rowIdList.getInt(idx)
+          val length = Platform.getInt(null, dataNativeAddress + rowId * 4)
+          val start = Platform.getInt(null, dataNativeAddress + offsetsStart + rowId * 4)
+          val data = new Array[Byte](length)
+          Platform.copyMemory(null, dataNativeAddress + dataStart + start, data,
+            Platform.BYTE_ARRAY_OFFSET, length)
+          arrayOffsets(idx) = offset
+          arrayLengths(idx) = length
+          childColumn.appendBytes(length, data, 0)
+          offset += length
+        }
+      })
+    }
+
+    dataType match {
+      case ByteType | BooleanType =>
+        val bytes = column.getByteData
+        (0 until rowIdList.size()).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            bytes(idx) = Platform.getByte(null, dataNativeAddress + rowIdList.getInt(idx))
+          }
+        })
+      case ShortType =>
+        val shorts = column.getShortData
+        (0 until rowIdList.size()).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            shorts(idx) = Platform.getShort(null,
+              dataNativeAddress + rowIdList.getInt(idx) * 2)
+          }
+        })
+      case IntegerType | DateType =>
+        val ints = column.getIntData
+        (0 until rowIdList.size()).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            ints(idx) = Platform.getInt(null, dataNativeAddress + rowIdList.getInt(idx) * 4)
+          }
+        })
+      case FloatType =>
+        val floats = column.getFloatData
+        (0 until rowIdList.size()).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            floats(idx) = Platform.getFloat(null,
+              dataNativeAddress + rowIdList.getInt(idx) * 4)
+          }
+        })
+      case LongType | TimestampType =>
+        val longs = column.getLongData
+        (0 until rowIdList.size()).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            longs(idx) = Platform.getLong(null,
+              dataNativeAddress + rowIdList.getInt(idx) * 8)
+          }
+        })
+      case DoubleType =>
+        val doubles = column.getDoubleData
+        (0 until rowIdList.size()).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            doubles(idx) = Platform.getDouble(null,
+              dataNativeAddress + rowIdList.getInt(idx) * 8)
+          }
+        })
+      case BinaryType | StringType => readBinaryToColumnVector()
+      // if DecimalType.is32BitDecimalType(other) as int data type.
+      case other if DecimalType.is32BitDecimalType(other) =>
+        val ints = column.getIntData
+        (0 until rowIdList.size()).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            ints(idx) = Platform.getInt(null,
+              dataNativeAddress + rowIdList.getInt(idx) * 4)
+          }
+        })
+      // if DecimalType.is64BitDecimalType(other) as long data type.
+      case other if DecimalType.is64BitDecimalType(other) =>
+        val longs = column.getLongData
+        (0 until rowIdList.size()).foreach(idx => {
+          if (!column.isNullAt(idx)) {
+            longs(idx) = Platform.getLong(null,
+              dataNativeAddress + rowIdList.getInt(idx) * 8)
+          }
+        })
+      // if DecimalType.isByteArrayDecimalType(other) as binary data type.
+      case other if DecimalType.isByteArrayDecimalType(other) => readBinaryToColumnVector()
+      case other => throw new OapException(s"impossible data type $other.")
+    }
+  }
+
+  /**
+   * Read a `dicLength` size Parquet Dictionary from data fiber.
+   */
+  private def readDictionary(
+      dataType: DataType, dicLength: Int, dicNativeAddress: Long): Dictionary = {
+
+    def readBinaryDictionary: Dictionary = {
+      val binaryDictionaryContent = new Array[Binary](dicLength)
+      val lengthsArray = new Array[Int](dicLength)
+      Platform.copyMemory(null, dicNativeAddress,
+        lengthsArray, Platform.INT_ARRAY_OFFSET, dicLength * 4)
+      val dictionaryBytesLength = lengthsArray.sum
+      val dictionaryBytes = new Array[Byte](dictionaryBytesLength)
+      Platform.copyMemory(null,
+        dicNativeAddress + dicLength * 4,
+        dictionaryBytes, Platform.BYTE_ARRAY_OFFSET, dictionaryBytesLength)
+      var offset = 0
+      for (i <- binaryDictionaryContent.indices) {
+        val length = lengthsArray(i)
+        binaryDictionaryContent(i) =
+          Binary.fromConstantByteArray(dictionaryBytes, offset, length)
+        offset += length
+      }
+      BinaryDictionary(binaryDictionaryContent)
+    }
+
+    dataType match {
+      // ByteType, ShortType, IntegerType, DateType Dictionary read as Int type array.
+      case ByteType | ShortType | IntegerType | DateType =>
+        val intDictionaryContent = new Array[Int](dicLength)
+        Platform.copyMemory(null,
+          dicNativeAddress, intDictionaryContent, Platform.INT_ARRAY_OFFSET, dicLength * 4)
+        IntegerDictionary(intDictionaryContent)
+      // FloatType Dictionary read as Float type array.
+      case FloatType =>
+        val floatDictionaryContent = new Array[Float](dicLength)
+        Platform.copyMemory(null,
+          dicNativeAddress, floatDictionaryContent, Platform.FLOAT_ARRAY_OFFSET, dicLength * 4)
+        FloatDictionary(floatDictionaryContent)
+      // LongType Dictionary read as Long type array.
+      case LongType | TimestampType =>
+        val longDictionaryContent = new Array[Long](dicLength)
+        Platform.copyMemory(null,
+          dicNativeAddress, longDictionaryContent, Platform.LONG_ARRAY_OFFSET, dicLength * 8)
+        LongDictionary(longDictionaryContent)
+      // DoubleType Dictionary read as Double type array.
+      case DoubleType =>
+        val doubleDictionaryContent = new Array[Double](dicLength)
+        Platform.copyMemory(null,
+          dicNativeAddress, doubleDictionaryContent, Platform.DOUBLE_ARRAY_OFFSET, dicLength * 8)
+        DoubleDictionary(doubleDictionaryContent)
+      // StringType, BinaryType Dictionary read as a Int array and Byte array,
+      // we use int array record offset and length of Byte array and use a shared backend
+      // Byte array to construct all Binary.
+      case StringType | BinaryType => readBinaryDictionary
+      // if DecimalType.is32BitDecimalType(other) as int data type.
+      case other if DecimalType.is32BitDecimalType(other) =>
+        val intDictionaryContent = new Array[Int](dicLength)
+        Platform.copyMemory(null,
+          dicNativeAddress, intDictionaryContent, Platform.INT_ARRAY_OFFSET, dicLength * 4)
+        IntegerDictionary(intDictionaryContent)
+      // if DecimalType.is64BitDecimalType(other) as long data type.
+      case other if DecimalType.is64BitDecimalType(other) =>
+        val longDictionaryContent = new Array[Long](dicLength)
+        Platform.copyMemory(null,
+          dicNativeAddress, longDictionaryContent, Platform.LONG_ARRAY_OFFSET, dicLength * 8)
+        LongDictionary(longDictionaryContent)
+      // if DecimalType.isByteArrayDecimalType(other) as binary data type.
+      case other if DecimalType.isByteArrayDecimalType(other) => readBinaryDictionary
+      case other => throw new OapException(s"$other data type is not support dictionary.")
+    }
+  }
+}
+
+object ParquetDataFiberReader {
+  def apply(address: Long, dataType: DataType, total: Int): ParquetDataFiberReader = {
+    val reader = new ParquetDataFiberReader(address, dataType, total)
+    reader.readRowGroupMetas()
+    reader
+  }
+}
+
+/**
+ * Wrap a Int Array to a Parquet Dictionary.
+ */
+case class IntegerDictionary(dictionaryContent: Array[Int])
+  extends Dictionary(Encoding.PLAIN) {
+
+  override def decodeToInt(id: Int): Int = dictionaryContent(id)
+
+  override def getMaxId: Int = dictionaryContent.length - 1
+}
+
+/**
+ * Wrap a Float Array to a Parquet Dictionary.
+ */
+case class FloatDictionary(dictionaryContent: Array[Float])
+  extends Dictionary(Encoding.PLAIN) {
+
+  override def decodeToFloat(id: Int): Float = dictionaryContent(id)
+
+  override def getMaxId: Int = dictionaryContent.length - 1
+}
+
+/**
+ * Wrap a Long Array to a Parquet Dictionary.
+ */
+case class LongDictionary(dictionaryContent: Array[Long])
+  extends Dictionary(Encoding.PLAIN) {
+
+  override def decodeToLong(id: Int): Long = dictionaryContent(id)
+
+  override def getMaxId: Int = dictionaryContent.length - 1
+}
+
+/**
+ * Wrap a Double Array to a Parquet Dictionary.
+ */
+case class DoubleDictionary(dictionaryContent: Array[Double])
+  extends Dictionary(Encoding.PLAIN) {
+
+  override def decodeToDouble(id: Int): Double = dictionaryContent(id)
+
+  override def getMaxId: Int = dictionaryContent.length - 1
+}
+
+/**
+ * Wrap a Binary Array to a Parquet Dictionary.
+ */
+case class BinaryDictionary(dictionaryContent: Array[Binary])
+  extends Dictionary(Encoding.PLAIN) {
+
+  override def decodeToBinary(id: Int): Binary = dictionaryContent(id)
+
+  override def getMaxId: Int = dictionaryContent.length - 1
+}
+
+/**
+ * Define a `ParquetDataFiberHeader` to record data fiber status.
+ * @param noNulls status represent no null value in this data fiber.
+ * @param allNulls status represent all value are null in this data fiber.
+ * @param dicLength dictionary length of this data fiber, if 0 represent there is no dictionary.
+ */
+case class ParquetDataFiberHeader(noNulls: Boolean, allNulls: Boolean, dicLength: Int) {
+
+  /**
+   * Write ParquetDataFiberHeader to Fiber
+   * @param address dataFiber address offset
+   * @return dataFiber address offset
+   */
+  def writeToCache(address: Long): Long = {
+    Platform.putBoolean(null, address, noNulls)
+    Platform.putBoolean(null, address + 1, allNulls)
+    Platform.putInt(null, address + 2, dicLength)
+    address + ParquetDataFiberHeader.defaultSize
+  }
+}
+
+/**
+ * Use to construct ParquetDataFiberHeader instance.
+ */
+object ParquetDataFiberHeader {
+
+  def apply(vector: OnHeapColumnVector, total: Int): ParquetDataFiberHeader = {
+    val numNulls = vector.numNulls
+    val allNulls = numNulls == total
+    val noNulls = numNulls == 0
+    val dicLength = vector.dictionaryLength
+    new ParquetDataFiberHeader(noNulls, allNulls, dicLength)
+  }
+
+  def apply(nativeAddress: Long): ParquetDataFiberHeader = {
+    val noNulls = Platform.getBoolean(null, nativeAddress)
+    val allNulls = Platform.getBoolean(null, nativeAddress + 1)
+    val dicLength = Platform.getInt(null, nativeAddress + 2)
+    new ParquetDataFiberHeader(noNulls, allNulls, dicLength)
+  }
+
+  /**
+   * allNulls: Boolean: 1
+   * noNulls: Boolean: 1
+   * dicLength: Int: 4
+   * @return 1 + 1 + 4
+   */
+  def defaultSize: Int = 6
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/filecache/TestFiberCache.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/filecache/TestFiberCache.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.filecache
+
+import org.apache.spark.sql.oap.OapRuntime
+
+class TestFiberCache(fiberCache: FiberCache)
+  extends FiberCache(fiberData = MemoryBlockHolder(null, fiberCache.getBaseOffset,
+      fiberCache.size(), fiberCache.getOccupiedSize())) {
+
+  def free(): Unit = {
+    if (!disposed) {
+      OapRuntime.get.foreach(_.memoryManager.free(fiberData))
+    }
+    disposed = true
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/BinaryTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/BinaryTypeDataFiberReaderWriterSuite.scala
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.parquet.io.api.Binary
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
+import org.apache.spark.sql.types.BinaryType
+
+class BinaryTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
+
+
+
+  // binary type use BinaryDictionary
+  protected val dictionary: Dictionary = new ParquetDictionaryWrapper(
+    BinaryDictionary(Array(Binary.fromString("oap"),
+    Binary.fromString("parquet"),
+    Binary.fromString("orc"))))
+
+  test("no dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, BinaryType)
+    (0 until total).foreach(i => column.putByteArray(i, i.toString.getBytes))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, BinaryType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      assert(ret1.getBinary(i).sameElements((i + start).toString.getBytes))
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      assert(ret2.getBinary(i).sameElements(ints(i).toString.getBytes))
+    })
+  }
+
+  test("with dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, BinaryType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => dictionaryIds.putInt(i, i % column.dictionaryLength ))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, BinaryType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      val idx = (i + start) % column.dictionaryLength
+      assert(ret1.getBinary(i).sameElements(dictionary.decodeToBinary(idx)))
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      val idx = ints(i) % column.dictionaryLength
+      assert(ret2.getBinary(i).sameElements(dictionary.decodeToBinary(idx)))
+    })
+  }
+
+  test("no dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, BinaryType)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, BinaryType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("with dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, BinaryType)
+    column.reserveDictionaryIds(total)
+    column.setDictionary(dictionary)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, BinaryType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("no dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, BinaryType)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else column.putByteArray(i, i.toString.getBytes)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, BinaryType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getBinary(i).sameElements((i + start).toString.getBytes))
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getBinary(i).sameElements(ints(i).toString.getBytes))
+    })
+  }
+
+  test("with dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, BinaryType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else dictionaryIds.putInt(i, i % column.dictionaryLength)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, BinaryType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else {
+        val idx = (i + start) % column.dictionaryLength
+        assert(ret1.getBinary(i).sameElements(dictionary.decodeToBinary(idx)))
+      }
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BinaryType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else {
+        val idx = ints(i) % column.dictionaryLength
+        assert(ret2.getBinary(i).sameElements(dictionary.decodeToBinary(idx)))
+      }
+    })
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/BooleanTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/BooleanTypeDataFiberReaderWriterSuite.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
+import org.apache.spark.sql.types.BooleanType
+
+/**
+ * Boolean Type not support dic encode.
+ */
+class BooleanTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
+
+  protected def dictionary: Dictionary =
+    throw new UnsupportedOperationException("Boolean Type not support dic encode")
+
+  test("no dic no nulls") {
+    val column = new OnHeapColumnVector(total, BooleanType)
+    (0 until total).foreach(i => column.putBoolean(i, i % 2 == 0))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    val address = fiberCache.getBaseOffset
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BooleanType)
+    val reader = ParquetDataFiberReader(address, BooleanType, total)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.getBoolean(i) == (((i + start) % 2) == 0)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BooleanType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.getBoolean(i) == ((ints(i) % 2) == 0)))
+  }
+
+  test("no dic all nulls") {
+    val column = new OnHeapColumnVector(total, BooleanType)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    val address = fiberCache.getBaseOffset
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BooleanType)
+    val reader = ParquetDataFiberReader(address, BooleanType, total)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BooleanType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("no dic") {
+    val column = new OnHeapColumnVector(total, BooleanType)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else column.putBoolean(i, i % 2 == 0)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    val address = fiberCache.getBaseOffset
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BooleanType)
+    val reader = ParquetDataFiberReader(address, BooleanType, total)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getBoolean(i) == (((i + start) % 2) == 0))
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BooleanType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getBoolean(i) == ((ints(i) % 2) == 0))
+    })
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ByteTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ByteTypeDataFiberReaderWriterSuite.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
+import org.apache.spark.sql.types.ByteType
+
+class ByteTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
+
+  // byte data use IntegerDictionary
+  protected val dictionary: Dictionary = new ParquetDictionaryWrapper(
+    IntegerDictionary(Array(0, 1, 2)))
+
+  test("no dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, ByteType)
+    (0 until total).foreach(i => column.putByte(i, i.toByte))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ByteType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.getByte(i) == (i + start).toByte))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.getByte(i) == ints(i).toByte))
+  }
+
+  test("with dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, ByteType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => dictionaryIds.putInt(i, i % column.dictionaryLength ))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ByteType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i =>
+      assert(ret1.getByte(i) == ((i + start) % column.dictionaryLength).toByte))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i =>
+      assert(ret2.getByte(i) == (ints(i) % column.dictionaryLength).toByte))
+  }
+
+  test("no dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, ByteType)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ByteType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("with dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, ByteType)
+    column.reserveDictionaryIds(total)
+    column.setDictionary(dictionary)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ByteType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("no dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, ByteType)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else column.putByte(i, i.toByte)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ByteType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getByte(i) == (i + start).toByte)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getByte(i) == ints(i).toByte)
+    })
+  }
+
+  test("with dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, ByteType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else dictionaryIds.putInt(i, i % column.dictionaryLength)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ByteType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getByte(i) == ((i + start) % column.dictionaryLength).toByte)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ByteType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getByte(i) == (ints(i) % column.dictionaryLength).toByte)
+    })
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFiberReaderWriterSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntArrayList
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, TestFiberCache}
+import org.apache.spark.sql.execution.vectorized.Dictionary
+import org.apache.spark.sql.test.oap.SharedOapContext
+
+abstract class DataFiberReaderWriterSuite extends SparkFunSuite with SharedOapContext
+  with BeforeAndAfterEach with Logging {
+
+  protected val total: Int = 10000
+  protected val start: Int = 4096
+  protected val num: Int = 4096
+  protected val ints: Array[Int] = Array[Int](1, 667, 9999)
+  protected val rowIdList = {
+    val ret = new IntArrayList(3)
+    ints.foreach(ret.add)
+    ret
+  }
+
+  protected var fiberCache: FiberCache = _
+
+  protected override def afterEach(): Unit = {
+    if (fiberCache !== null) {
+      new TestFiberCache(fiberCache).free()
+      fiberCache = null
+    }
+  }
+
+  protected def dictionary: Dictionary
+
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/DoubleTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/DoubleTypeDataFiberReaderWriterSuite.scala
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
+import org.apache.spark.sql.types.DoubleType
+
+class DoubleTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
+
+  // double type use DoubleDictionary
+  protected val dictionary: Dictionary = new ParquetDictionaryWrapper(
+    DoubleDictionary(Array(0L, 1L, 2L)))
+
+  test("no dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, DoubleType)
+    (0 until total).foreach(i => column.putDouble(i, i))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, DoubleType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.getDouble(i) == (i + start).toDouble))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.getDouble(i) == ints(i).toDouble))
+  }
+
+  test("with dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => dictionaryIds.putInt(i, i % column.dictionaryLength ))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, DoubleType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i =>
+      assert(ret1.getDouble(i) == ((i + start) % column.dictionaryLength).toDouble))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i =>
+      assert(ret2.getDouble(i) == (ints(i) % column.dictionaryLength).toDouble))
+  }
+
+  test("no dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, DoubleType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("with dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    column.reserveDictionaryIds(total)
+    column.setDictionary(dictionary)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, DoubleType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("no dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else column.putDouble(i, i)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, DoubleType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getDouble(i) == (i + start).toDouble)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getDouble(i) == ints(i).toDouble)
+    })
+  }
+
+  test("with dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else dictionaryIds.putInt(i, i % column.dictionaryLength)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, DoubleType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getDouble(i) == ((i + start) % column.dictionaryLength).toDouble)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, DoubleType)
+      .asInstanceOf[OnHeapColumnVector]
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getDouble(i) == (ints(i) % column.dictionaryLength).toDouble)
+    })
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/FloatTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/FloatTypeDataFiberReaderWriterSuite.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
+import org.apache.spark.sql.types.FloatType
+
+class FloatTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
+
+  // float type use FloatDictionary
+  protected val dictionary: Dictionary = new ParquetDictionaryWrapper(
+    FloatDictionary(Array(0F, 1F, 2F)))
+
+  test("no dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, FloatType)
+    (0 until total).foreach(i => column.putFloat(i, i))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, FloatType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.getFloat(i) == (i + start).toFloat))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.getFloat(i) == ints(i).toFloat))
+  }
+
+  test("with dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, FloatType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => dictionaryIds.putInt(i, i % column.dictionaryLength ))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, FloatType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i =>
+      assert(ret1.getFloat(i) == ((i + start) % column.dictionaryLength).toFloat))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i =>
+      assert(ret2.getFloat(i) == (ints(i) % column.dictionaryLength).toFloat))
+  }
+
+  test("no dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, FloatType)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, FloatType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("with dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, FloatType)
+    column.reserveDictionaryIds(total)
+    column.setDictionary(dictionary)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, FloatType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("no dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, FloatType)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else column.putFloat(i, i)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, FloatType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getFloat(i) == (i + start).toFloat)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getFloat(i) == ints(i).toFloat)
+    })
+  }
+
+  test("with dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, FloatType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else dictionaryIds.putInt(i, i % column.dictionaryLength)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, FloatType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getFloat(i) == ((i + start) % column.dictionaryLength).toFloat)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, FloatType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getFloat(i) == (ints(i) % column.dictionaryLength).toFloat)
+    })
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/IntegerTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/IntegerTypeDataFiberReaderWriterSuite.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
+import org.apache.spark.sql.types.IntegerType
+
+class IntegerTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
+
+  // int type use IntegerDictionary
+  protected val dictionary: Dictionary = new ParquetDictionaryWrapper(
+    IntegerDictionary(Array(0, 1, 2)))
+
+  test("no dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, IntegerType)
+    (0 until total).foreach(i => column.putInt(i, i))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, IntegerType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.getInt(i) == (i + start)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.getInt(i) == ints(i)))
+  }
+
+  test("with dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, IntegerType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => dictionaryIds.putInt(i, i % column.dictionaryLength ))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, IntegerType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i =>
+      assert(ret1.getShort(i) == ((i + start) % column.dictionaryLength)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i =>
+      assert(ret2.getShort(i) == (ints(i) % column.dictionaryLength)))
+  }
+
+  test("no dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, IntegerType)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, IntegerType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("with dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, IntegerType)
+    column.reserveDictionaryIds(total)
+    column.setDictionary(dictionary)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, IntegerType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("no dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, IntegerType)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else column.putInt(i, i)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, IntegerType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getInt(i) == (i + start))
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getInt(i) == ints(i))
+    })
+  }
+
+  test("with dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, IntegerType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else dictionaryIds.putInt(i, i % column.dictionaryLength)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, IntegerType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getShort(i) == ((i + start) % column.dictionaryLength))
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, IntegerType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getShort(i) == (ints(i) % column.dictionaryLength))
+    })
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/LongTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/LongTypeDataFiberReaderWriterSuite.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
+import org.apache.spark.sql.types.LongType
+
+class LongTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
+
+  // long type use LongDictionary
+  protected val dictionary: Dictionary = new ParquetDictionaryWrapper(
+    LongDictionary(Array(0L, 1L, 2L)))
+
+  test("no dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, LongType)
+    (0 until total).foreach(i => column.putLong(i, i))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, LongType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.getLong(i) == (i + start).toLong))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.getLong(i) == ints(i).toLong))
+  }
+
+  test("with dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, LongType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => dictionaryIds.putInt(i, i % column.dictionaryLength ))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, LongType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i =>
+      assert(ret1.getLong(i) == ((i + start) % column.dictionaryLength).toLong))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i =>
+      assert(ret2.getLong(i) == (ints(i) % column.dictionaryLength).toLong))
+  }
+
+  test("no dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, LongType)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, LongType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("with dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, LongType)
+    column.reserveDictionaryIds(total)
+    column.setDictionary(dictionary)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, LongType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("no dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, LongType)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else column.putLong(i, i)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, LongType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getLong(i) == (i + start).toLong)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getLong(i) == ints(i).toLong)
+    })
+  }
+
+  test("with dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, LongType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else dictionaryIds.putInt(i, i % column.dictionaryLength)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, LongType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getLong(i) == ((i + start) % column.dictionaryLength).toLong)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, LongType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getLong(i) == (ints(i) % column.dictionaryLength).toLong)
+    })
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberHeaderSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberHeaderSuite.scala
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
+import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.types.IntegerType
+
+class ParquetDataFiberHeaderSuite extends SparkFunSuite with SharedOapContext
+  with BeforeAndAfterEach with Logging {
+
+  test("construct no dic no nulls") {
+    val total = 10
+    val column = new OnHeapColumnVector(12, IntegerType)
+    val data = (0 until 10).toArray
+    column.putInts(0, total, data, 0)
+    val header = ParquetDataFiberHeader(column, total)
+    assert(header.noNulls)
+    assert(!header.allNulls)
+    assert(header.dicLength == 0)
+
+    val fiberCache = OapRuntime.getOrCreate.memoryManager
+      .getEmptyDataFiberCache(ParquetDataFiberHeader.defaultSize)
+    val address = fiberCache.getBaseOffset
+    header.writeToCache(address)
+    val headerLoadFromCache = ParquetDataFiberHeader(address)
+    assert(headerLoadFromCache.noNulls)
+    assert(!headerLoadFromCache.allNulls)
+    assert(headerLoadFromCache.dicLength == 0)
+  }
+
+  test("construct with dic no nulls") {
+    val total = 10
+    val column = new OnHeapColumnVector(12, IntegerType)
+    val dictionary = IntegerDictionary(Array(3, 7, 9))
+    column.setDictionary(new ParquetDictionaryWrapper(dictionary))
+    val dictionaryIds = column.reserveDictionaryIds(total).asInstanceOf[OnHeapColumnVector]
+
+    (0 until 10).foreach(i => {
+      dictionaryIds.putInt(i, i % 3)
+    })
+
+    val header = ParquetDataFiberHeader(column, total)
+    assert(header.noNulls)
+    assert(!header.allNulls)
+    assert(header.dicLength == 3)
+
+    val fiberCache = OapRuntime.getOrCreate.memoryManager
+      .getEmptyDataFiberCache(ParquetDataFiberHeader.defaultSize)
+    val address = fiberCache.getBaseOffset
+    header.writeToCache(address)
+    val headerLoadFromCache = ParquetDataFiberHeader(address)
+    assert(headerLoadFromCache.noNulls)
+    assert(!headerLoadFromCache.allNulls)
+    assert(headerLoadFromCache.dicLength == 3)
+  }
+
+  test("construct no dic all nulls") {
+    val total = 10
+    val column = new OnHeapColumnVector(12, IntegerType)
+      .asInstanceOf[OnHeapColumnVector]
+    column.putNulls(0, total)
+    val header = ParquetDataFiberHeader(column, total)
+    assert(!header.noNulls)
+    assert(header.allNulls)
+    assert(header.dicLength == 0)
+
+    val fiberCache = OapRuntime.getOrCreate.memoryManager
+      .getEmptyDataFiberCache(ParquetDataFiberHeader.defaultSize)
+    val address = fiberCache.getBaseOffset
+    header.writeToCache(address)
+    val headerLoadFromCache = ParquetDataFiberHeader(address)
+    assert(!headerLoadFromCache.noNulls)
+    assert(headerLoadFromCache.allNulls)
+    assert(headerLoadFromCache.dicLength == 0)
+  }
+
+  test("construct with dic all nulls") {
+    val total = 10
+    val column = new OnHeapColumnVector(12, IntegerType)
+    val dictionary = IntegerDictionary(Array(3, 7, 9))
+    column.setDictionary(new ParquetDictionaryWrapper(dictionary))
+    val dictionaryIds = column.reserveDictionaryIds(total).asInstanceOf[OnHeapColumnVector]
+    column.putNulls(0, total)
+
+    val header = ParquetDataFiberHeader(column, total)
+    assert(!header.noNulls)
+    assert(header.allNulls)
+    assert(header.dicLength == 3)
+
+    val fiberCache = OapRuntime.getOrCreate.memoryManager
+      .getEmptyDataFiberCache(ParquetDataFiberHeader.defaultSize)
+    val address = fiberCache.getBaseOffset
+    header.writeToCache(address)
+    val headerLoadFromCache = ParquetDataFiberHeader(address)
+    assert(!headerLoadFromCache.noNulls)
+    assert(headerLoadFromCache.allNulls)
+    assert(headerLoadFromCache.dicLength == 3)
+  }
+
+  test("construct no dic") {
+    val total = 10
+    val column = new OnHeapColumnVector(12, IntegerType)
+    (0 until 10).foreach(i => {
+      if (i % 2 == 0) column.putInt(i, i)
+      else column.putNull(i)
+    })
+    val header = ParquetDataFiberHeader(column, total)
+    assert(!header.noNulls)
+    assert(!header.allNulls)
+    assert(header.dicLength == 0)
+
+    val fiberCache = OapRuntime.getOrCreate.memoryManager
+      .getEmptyDataFiberCache(ParquetDataFiberHeader.defaultSize)
+    val address = fiberCache.getBaseOffset
+    header.writeToCache(address)
+    val headerLoadFromCache = ParquetDataFiberHeader(address)
+    assert(!headerLoadFromCache.noNulls)
+    assert(!headerLoadFromCache.allNulls)
+    assert(headerLoadFromCache.dicLength == 0)
+  }
+
+  test("construct with dic") {
+    val total = 10
+    val column = new OnHeapColumnVector(12, IntegerType)
+    val dictionary = IntegerDictionary(Array(3, 7, 9))
+    column.setDictionary(new ParquetDictionaryWrapper(dictionary))
+    val dictionaryIds = column.reserveDictionaryIds(total).asInstanceOf[OnHeapColumnVector]
+
+    (0 until 10).foreach(i => {
+      if (i % 5 != 0) dictionaryIds.putInt(i, i % 3)
+      else column.putNull(i)
+    })
+
+    val header = ParquetDataFiberHeader(column, total)
+    assert(!header.noNulls)
+    assert(!header.allNulls)
+    assert(header.dicLength == 3)
+
+    val fiberCache = OapRuntime.getOrCreate.memoryManager
+      .getEmptyDataFiberCache(ParquetDataFiberHeader.defaultSize)
+    val address = fiberCache.getBaseOffset
+    header.writeToCache(address)
+    val headerLoadFromCache = ParquetDataFiberHeader(address)
+    assert(!headerLoadFromCache.noNulls)
+    assert(!headerLoadFromCache.allNulls)
+    assert(headerLoadFromCache.dicLength == 3)
+  }
+}

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ShortTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/io/ShortTypeDataFiberReaderWriterSuite.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
+import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
+import org.apache.spark.sql.types.ShortType
+
+class ShortTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
+
+  // short type use IntegerDictionary
+  protected val dictionary: Dictionary = new ParquetDictionaryWrapper(
+    IntegerDictionary(Array(0, 1, 2)))
+
+  test("no dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, ShortType)
+    (0 until total).foreach(i => column.putShort(i, i.toShort))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ShortType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.getShort(i) == (i + start).toShort))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.getShort(i) == ints(i).toShort))
+  }
+
+  test("with dic no nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, ShortType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => dictionaryIds.putInt(i, i % column.dictionaryLength ))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ShortType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i =>
+      assert(ret1.getShort(i) == ((i + start) % column.dictionaryLength).toShort))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i =>
+      assert(ret2.getShort(i) == (ints(i) % column.dictionaryLength).toShort))
+  }
+
+  test("no dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, ShortType)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ShortType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("with dic all nulls") {
+    // write data
+    val column = new OnHeapColumnVector(total, ShortType)
+    column.reserveDictionaryIds(total)
+    column.setDictionary(dictionary)
+    column.putNulls(0, total)
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ShortType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => assert(ret1.isNullAt(i)))
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => assert(ret2.isNullAt(i)))
+  }
+
+  test("no dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, ShortType)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else column.putShort(i, i.toShort)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ShortType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getShort(i) == (i + start).toShort)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getShort(i) == ints(i).toShort)
+    })
+  }
+
+  test("with dic") {
+    // write data
+    val column = new OnHeapColumnVector(total, ShortType)
+    column.reserveDictionaryIds(total)
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    column.setDictionary(dictionary)
+    (0 until total).foreach(i => {
+      if (i % 3 == 0) column.putNull(i)
+      else dictionaryIds.putInt(i, i % column.dictionaryLength)
+    })
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val reader = ParquetDataFiberReader(address, ShortType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret1.isNullAt(i))
+      else assert(ret1.getShort(i) == ((i + start) % column.dictionaryLength).toShort)
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, ShortType)
+    reader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      if ((i + start) % 3 == 0) assert(ret2.isNullAt(i))
+      else assert(ret2.getShort(i) == (ints(i) % column.dictionaryLength).toShort)
+    })
+  }
+}


### PR DESCRIPTION
What changes were proposed in this pull request?

- refer to #914 & #919 , Introduce ParquetDataFiberReaderWriter for Spark-2.3

- spark-2.3 add a new interface named `org.apache.spark.sql.execution.vectorized.Dictionary` and OnHeapColumnVector use it instead of `org.apache.parquet.column.Dictionary`, we need to know `maxId` of `org.apache.parquet.column.Dictionary` when dump Dictionary to data fiber, so add a new class named `ParquetDictionaryWrapper` to impl `getMaxId` api.

- change `VectorizedColumnReader` use `ParquetDictionaryWrapper` insread of `ParquetDictionary`

How was this patch tested?
Add *TypeDataFiberReaderWriterSuite & ParquetDataFiberHeaderSuite to test ParquetDataFiberReaderWriter

