### PR TITLE
Support read parquet use data cache no meta file for spark-2.3

### DIFF
--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -25,9 +25,11 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OptimizedOrcFileFormat, OptimizedParquetFileFormat}
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.datasources.orc.ReadOnlyOrcFileFormat
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ReadOnlyParquetFileFormat}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.types.AtomicType
 
 /**
  * A strategy for planning scans over collections of files that might be partitioned or bucketed
@@ -82,27 +84,80 @@ object FileSourceStrategy extends Strategy with Logging {
         ExpressionSet(normalizedFilters.filter(_.references.subsetOf(partitionSet)))
       logInfo(s"Pruning directories with: ${partitionKeyFilters.mkString(",")}")
 
+      val dataColumns =
+        l.resolve(_fsRelation.dataSchema, _fsRelation.sparkSession.sessionState.analyzer.resolver)
+
+      // Partition keys are not available in the statistics of the files.
+      val dataFilters = normalizedFilters.filter(_.references.intersect(partitionSet).isEmpty)
+
+      // Predicates with both partition keys and attributes need to be evaluated after the scan.
+      val afterScanFilters = filterSet -- partitionKeyFilters.filter(_.references.nonEmpty)
+      logInfo(s"Post-Scan Filters: ${afterScanFilters.mkString(",")}")
+
+      val filterAttributes = AttributeSet(afterScanFilters)
+      val requiredExpressions: Seq[NamedExpression] = filterAttributes.toSeq ++ projects
+      val requiredAttributes = AttributeSet(requiredExpressions)
+
+      val readDataColumns =
+        dataColumns
+          .filter(requiredAttributes.contains)
+          .filterNot(partitionColumns.contains)
+      val outputSchema = readDataColumns.toStructType
+      logInfo(s"Output Data Schema: ${outputSchema.simpleString(5)}")
+
+      val outputAttributes = readDataColumns ++ partitionColumns
+
       val selectedPartitions = _fsRelation.location.listFiles(partitionKeyFilters.toSeq, Nil)
 
       val fsRelation: HadoopFsRelation = _fsRelation.fileFormat match {
-        // TODO a better rule to check if we need to substitute the ParquetFileFormat
-        // as OapFileFormat
-        // add spark.sql.oap.parquet.enable config
-        // if config true turn to OapFileFormat
-        // else turn to ParquetFileFormat
-        case a: ParquetFileFormat
+        case _: ReadOnlyParquetFileFormat =>
+          logInfo("index operation for parquet, retain ReadOnlyParquetFileFormat.")
+          _fsRelation
+        case _: ReadOnlyOrcFileFormat =>
+          logInfo("index operation for orc, retain ReadOnlyOrcFileFormat.")
+          _fsRelation
+        // There are two scenarios will use OptimizedParquetFileFormat:
+        // 1. canUseCache: OAP_PARQUET_ENABLED is true and OAP_PARQUET_DATA_CACHE_ENABLED is true
+        //    and PARQUET_VECTORIZED_READER_ENABLED is true and WHOLESTAGE_CODEGEN_ENABLED is
+        //    true and all fields in outputSchema are AtomicType.
+        // 2. canUseIndex: OAP_PARQUET_ENABLED is true and hasAvailableIndex.
+        // Other scenarios still use ParquetFileFormat.
+        case _: ParquetFileFormat
           if _fsRelation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) =>
+
           val optimizedParquetFileFormat = new OptimizedParquetFileFormat
           optimizedParquetFileFormat
             .init(_fsRelation.sparkSession,
               _fsRelation.options,
               selectedPartitions.flatMap(p => p.files))
 
-          if (optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)) {
-            logInfo("hasAvailableIndex = true, will replace with OapFileFormat.")
+          def canUseCache: Boolean = {
+            val runtimeConf = _fsRelation.sparkSession.conf
+            val ret = runtimeConf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED) &&
+              runtimeConf.get(SQLConf.PARQUET_VECTORIZED_READER_ENABLED) &&
+              runtimeConf.get(SQLConf.WHOLESTAGE_CODEGEN_ENABLED) &&
+              outputSchema.forall(_.dataType.isInstanceOf[AtomicType])
+            if (ret) {
+              logInfo("data cache enable and suitable for use , " +
+                "will replace with OptimizedParquetFileFormat.")
+            }
+            ret
+          }
+
+          def canUseIndex: Boolean = {
+            val ret = optimizedParquetFileFormat.hasAvailableIndex(normalizedFilters)
+            if (ret) {
+              logInfo("hasAvailableIndex = true, " +
+                "will replace with OptimizedParquetFileFormat.")
+            }
+            ret
+          }
+
+          if (canUseCache || canUseIndex) {
             _fsRelation.copy(fileFormat = optimizedParquetFileFormat)(_fsRelation.sparkSession)
           } else {
-            logInfo("hasAvailableIndex = false, will retain ParquetFileFormat.")
+            logInfo("hasAvailableIndex = false and data cache disable, will retain " +
+              "ParquetFileFormat.")
             _fsRelation
           }
 
@@ -142,29 +197,6 @@ object FileSourceStrategy extends Strategy with Logging {
         case _: FileFormat =>
           _fsRelation
       }
-
-      val dataColumns =
-        l.resolve(fsRelation.dataSchema, fsRelation.sparkSession.sessionState.analyzer.resolver)
-
-      // Partition keys are not available in the statistics of the files.
-      val dataFilters = normalizedFilters.filter(_.references.intersect(partitionSet).isEmpty)
-
-      // Predicates with both partition keys and attributes need to be evaluated after the scan.
-      val afterScanFilters = filterSet -- partitionKeyFilters.filter(_.references.nonEmpty)
-      logInfo(s"Post-Scan Filters: ${afterScanFilters.mkString(",")}")
-
-      val filterAttributes = AttributeSet(afterScanFilters)
-      val requiredExpressions: Seq[NamedExpression] = filterAttributes.toSeq ++ projects
-      val requiredAttributes = AttributeSet(requiredExpressions)
-
-      val readDataColumns =
-        dataColumns
-          .filter(requiredAttributes.contains)
-          .filterNot(partitionColumns.contains)
-      val outputSchema = readDataColumns.toStructType
-      logInfo(s"Output Data Schema: ${outputSchema.simpleString(5)}")
-
-      val outputAttributes = readDataColumns ++ partitionColumns
 
       val scan =
         FileSourceScanExec(

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -59,68 +59,67 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
       options: Map[String, String],
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
     // TODO we need to pass the extra data source meta information via the func parameter
-    meta match {
-      case Some(m) =>
-        logDebug(s"Building OapDataReader with "
-          + m.dataReaderClassName.substring(m.dataReaderClassName.lastIndexOf(".") + 1)
-          + " ...")
+    val (filterScanners, m) = meta match {
+      case Some(x) => (indexScanners(x, filters), x)
+      case _ =>
+        // TODO Now we need use a meta with PARQUET_DATA_FILE_CLASSNAME & dataSchema to init
+        // ParquetDataFile, try to remove this condition.
+        val emptyMeta = new DataSourceMetaBuilder()
+          .withNewDataReaderClassName(OapFileFormat.PARQUET_DATA_FILE_CLASSNAME)
+          .withNewSchema(dataSchema).build()
+        (None, emptyMeta)
+    }
 
-        val filterScanners = indexScanners(m, filters)
-        // TODO refactor this.
-        hitIndexColumns = filterScanners match {
-          case Some(s) =>
-            s.scanners.flatMap { scanner =>
-              scanner.keyNames.map(n => n -> scanner.meta.indexType)
-            }.toMap
-          case _ => Map.empty
-        }
+    // TODO Not very easy to use, refactor this.
+    hitIndexColumns = filterScanners match {
+      case Some(s) =>
+        s.scanners.flatMap { scanner =>
+          scanner.keyNames.map(n => n -> scanner.meta.indexType)
+        }.toMap
+      case _ => Map.empty
+    }
 
-        val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
-        val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
+    val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
+    val pushed = FilterHelper.tryToPushFilters(sparkSession, requiredSchema, filters)
 
-        val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
-        // TODO why add `sparkSession.sessionState.conf.wholeStageEnabled` condition
-        val enableVectorizedReader: Boolean =
-          sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
-            sparkSession.sessionState.conf.wholeStageEnabled &&
-            resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
-        val returningBatch = supportBatch(sparkSession, resultSchema)
+    val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
+    // TODO why add `sparkSession.sessionState.conf.wholeStageEnabled` condition
+    val enableVectorizedReader: Boolean =
+      sparkSession.sessionState.conf.parquetVectorizedReaderEnabled &&
+        sparkSession.sessionState.conf.wholeStageEnabled &&
+        resultSchema.forall(_.dataType.isInstanceOf[AtomicType])
+    val returningBatch = supportBatch(sparkSession, resultSchema)
 
-        hadoopConf.set(
-          SQLConf.SESSION_LOCAL_TIMEZONE.key,
-          sparkSession.sessionState.conf.sessionLocalTimeZone)
+    hadoopConf.set(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key,
+      sparkSession.sessionState.conf.sessionLocalTimeZone)
 
-        // Sets flags for `ParquetToSparkSchemaConverter`
-        hadoopConf.setBoolean(
-          SQLConf.PARQUET_BINARY_AS_STRING.key,
-          sparkSession.sessionState.conf.isParquetBinaryAsString)
-        hadoopConf.setBoolean(
-          SQLConf.PARQUET_INT96_AS_TIMESTAMP.key,
-          sparkSession.sessionState.conf.isParquetINT96AsTimestamp)
-        val broadcastedHadoopConf =
-          sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+    // Sets flags for `ParquetToSparkSchemaConverter`
+    hadoopConf.setBoolean(
+      SQLConf.PARQUET_BINARY_AS_STRING.key,
+      sparkSession.sessionState.conf.isParquetBinaryAsString)
+    hadoopConf.setBoolean(
+      SQLConf.PARQUET_INT96_AS_TIMESTAMP.key,
+      sparkSession.sessionState.conf.isParquetINT96AsTimestamp)
+    val broadcastedHadoopConf =
+      sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
-        (file: PartitionedFile) => {
-          assert(file.partitionValues.numFields == partitionSchema.size)
-          val conf = broadcastedHadoopConf.value.value
-          // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
-          // Otherwise context is none.
-          val context: Option[DataFileContext] = if (enableVectorizedReader) {
-            Some(ParquetVectorizedContext(partitionSchema,
-              file.partitionValues, returningBatch))
-          } else {
-            None
-          }
-
-          val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
-            filterScanners, requiredIds, pushed, oapMetrics, conf, enableVectorizedReader, options,
-            filters, context)
-          reader.read(file)
-        }
-      case None => (_: PartitionedFile) => {
-        // TODO For parquet should refer to ParquetFileFormat
-        Iterator.empty
+    (file: PartitionedFile) => {
+      assert(file.partitionValues.numFields == partitionSchema.size)
+      val conf = broadcastedHadoopConf.value.value
+      // For parquet, if enableVectorizedReader is true, init ParquetVectorizedContext.
+      // Otherwise context is none.
+      val context: Option[DataFileContext] = if (enableVectorizedReader) {
+        Some(ParquetVectorizedContext(partitionSchema,
+          file.partitionValues, returningBatch))
+      } else {
+        None
       }
+
+      val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
+        filterScanners, requiredIds, pushed, oapMetrics, conf, enableVectorizedReader, options,
+        filters, context)
+      reader.read(file)
     }
   }
 }

--- a/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
+++ b/src/test/spark2.3/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.{DataSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.HadoopFsRelation
+import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.util.Utils
+
+class OptimizedParquetFilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
+  // TODO move Parquet TestSuite from FilterSuite
+  import testImplicits._
+
+  private var currentPath: String = _
+  private var defaultEis: Boolean = true
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // In this suite we don't want to skip index even if the cost is higher.
+    defaultEis = sqlContext.conf.getConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)
+    sqlContext.conf.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION, false)
+  }
+
+  override def afterAll(): Unit = {
+    sqlContext.conf.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION, defaultEis)
+    super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    val path = Utils.createTempDir().getAbsolutePath
+    currentPath = path
+    sql(s"""CREATE TEMPORARY VIEW parquet_test (a INT, b STRING)
+           | USING parquet
+           | OPTIONS (path '$path')""".stripMargin)
+  }
+
+  override def afterEach(): Unit = {
+    sqlContext.dropTempTable("parquet_test")
+  }
+
+  test("enable data cache but no .oap.meta file") {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
+
+    withSQLConf(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key -> "true") {
+      val df = sql("SELECT b FROM parquet_test WHERE b = 'this is test 1'")
+      checkAnswer(df, Row("this is test 1") :: Nil)
+      val plans = new ArrayBuffer[SparkPlan]
+      df.queryExecution.executedPlan.foreach(node => plans.append(node))
+      val dataSources = plans.filter(p => p.isInstanceOf[DataSourceScanExec])
+      assert(dataSources.nonEmpty)
+      dataSources.foreach(p =>
+        p.asInstanceOf[DataSourceScanExec].relation match {
+          case h: HadoopFsRelation =>
+            assert(h.fileFormat.isInstanceOf[OapFileFormat])
+          case _ => assert(false)
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
What changes were proposed in this pull request?
Same as # #925 & #931 , Support read parquet use data cache no meta file for spark-2.3 profile

How was this patch tested?
Add a new test case to test enable data cache but no .oap.meta file

mvn test -Pspark-2.3 pass

not affect spark-2.1 profile & spark-2.2 profile