### PR TITLE
Support inSet() for Spark-Sql optimized Compatibility (#930)

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -391,6 +391,8 @@ private[oap] case class DataSourceMeta(
         checkInMetaSet(attrRef)
       case In(attrRef: AttributeReference, _) =>
         checkInMetaSet(attrRef)
+      case InSet(attrRef: AttributeReference, _) =>
+        checkInMetaSet(attrRef)
       case IsNull(attrRef: AttributeReference) =>
         checkInMetaSet(attrRef)
       case _ => false

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -426,6 +426,9 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
       val lte = Seq(LessThanOrEqual(AttributeReference("a", IntegerType)(), Literal(1)))
       val gte = Seq(GreaterThanOrEqual(AttributeReference("a", IntegerType)(), Literal(1)))
       val gte1 = Seq(GreaterThanOrEqual(Literal(1), AttributeReference("a", IntegerType)()))
+      val inSet = Seq(InSet(AttributeReference("a", IntegerType)(),
+        Set(Literal(1), Literal(2), Literal(3), Literal(4), Literal(5), Literal(6),
+          Literal(7), Literal(8), Literal(9), Literal(10), Literal(11))))
       val or1 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
         EqualTo(AttributeReference("a", IntegerType)(), Literal(1))))
       val or2 = Seq(Or(GreaterThan(AttributeReference("a", IntegerType)(), Literal(15)),
@@ -512,6 +515,7 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
       assert(lte.exists(meta.isSupportedByIndex(_, None)))
       assert(gte.exists(meta.isSupportedByIndex(_, None)))
       assert(gte1.exists(meta.isSupportedByIndex(_, None)))
+      assert(inSet.exists(meta.isSupportedByIndex(_, None)))
       assert(!eq2.exists(meta.isSupportedByIndex(_, None)))
       assert(or1.exists(meta.isSupportedByIndex(_, None)))
       assert(or2.exists(meta.isSupportedByIndex(_, None)))

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -1335,7 +1335,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("get columns hit index") {
-    val rowRDD = spark.sparkContext.parallelize(1 to 100).map(i =>
+    val rowRDD = spark.sparkContext.parallelize(1 to 100, 3).map(i =>
       Seq(i, s"this is row $i")).map(Row.fromSeq)
     val schema =
       StructType(
@@ -1367,14 +1367,8 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("OAP-930 test columns hit index when in optimized to inset") {
-    val rowRDD = spark.sparkContext.parallelize(0 to 100, 3).map(i =>
-      Seq(i, s"this is row $i")).map(Row.fromSeq)
-    val schema =
-      StructType(
-        StructField("a", IntegerType) ::
-          StructField("b", StringType) :: Nil)
-    val df = spark.createDataFrame(rowRDD, schema)
-    df.createOrReplaceTempView("t")
+    val data: Seq[(Int, String)] = (0 to 100).map { i => (i, s"this is row $i") }
+    data.toDF("a", "b").createOrReplaceTempView("t")
 
     sql("insert overwrite table parquet_test select * from t")
     withIndex(TestIndex("parquet_test", "idx1")) {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -1377,7 +1377,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
       val intSeq = 0 to sqlContext.conf.optimizerInSetConversionThreshold
       val df = sql(s"SELECT * from parquet_test WHERE a in(" +
         s"${intSeq.map(_.toString).mkString(",")})")
-      val rowList = intSeq.map(i => Row(i, s"this is row $i")) ++ Nil
+      val rowList = intSeq.map(i => Row(i, s"this is row $i"))
       checkAnswer(df, rowList)
       val ret = getColumnsHitIndex(df.queryExecution.sparkPlan)
       assert(ret.keySet.size == 1 && ret.contains("a"))


### PR DESCRIPTION
Change-Id: If087643747525b73834b31b663bf83ac178137e6

## What changes were proposed in this pull request?

When the number of in() elements exceeds spark.sql.optimizer.inSetConversionThreshold (default as 10)，In() expression will be optimized to Inset(), oap has not covered this condition. Ths patch is to fix this miss


## How was this patch tested?

mvn test pass (-Pspark-2.1 default)

