### PR TITLE
Config orc version in diff profile  #939

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
     <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
-      <version>1.5.2</version>
+      <version>${orc.version}</version>
       <classifier>nohive</classifier>
       <scope>compile</scope>
       <exclusions>
@@ -334,7 +334,7 @@
     <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-mapreduce</artifactId>
-      <version>1.5.2</version>
+      <version>${orc.version}</version>
       <classifier>nohive</classifier>
       <scope>compile</scope>
       <exclusions>
@@ -633,6 +633,7 @@
         <!--for a bug fix, upgrade 1.8.1 to 1.8.2-->
         <parquet.version>1.8.2</parquet.version>
         <jetty.version>9.2.16.v20160414</jetty.version>
+        <orc.version>1.4.4</orc.version>
       </properties>
       <build>
         <plugins>
@@ -711,6 +712,7 @@
         <scalacheck.version>1.12.5</scalacheck.version>
         <parquet.version>1.8.2</parquet.version>
         <jetty.version>9.3.11.v20160721</jetty.version>
+        <orc.version>1.5.2</orc.version>
       </properties>
       <build>
         <plugins>
@@ -789,6 +791,7 @@
         <scalacheck.version>1.13.5</scalacheck.version>
         <parquet.version>1.8.3</parquet.version>
         <jetty.version>9.3.24.v20180605</jetty.version>
+        <orc.version>1.5.2</orc.version>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
## What changes were proposed in this pull request?

To slove #939, let oap with spark-2.1 profile can build by Java 7.

## How was this patch tested?
Manual test