### PR TITLE
Chanage some api used by oap with spark2.1 from java8 to java7.#938

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberSensor.scala
@@ -50,8 +50,11 @@ private[sql] class FiberSensor extends Logging {
 
   private[filecache] def updateRecordingMap(fromHost: String, commingStatus: FiberCacheStatus) =
     synchronized {
-    val currentHostsForFile = fileToHosts.getOrDefault(
-      commingStatus.file, new ArrayBuffer[HostFiberCache](0))
+    val currentHostsForFile = if (fileToHosts.containsKey(commingStatus.file)) {
+      fileToHosts.get(commingStatus.file)
+    } else {
+      new ArrayBuffer[HostFiberCache](0)
+    }
     val (_, theRest) = currentHostsForFile.partition(_.host == fromHost)
     val newHostsForFile = (HostFiberCache(fromHost, commingStatus) +: theRest)
       .sorted.takeRight(FiberSensor.MAX_HOSTS_MAINTAINED)
@@ -112,8 +115,12 @@ private[sql] class FiberSensor extends Logging {
    * @return
    */
   def getHosts(filePath: String): Seq[String] = {
-    fileToHosts.getOrDefault(filePath, new ArrayBuffer[HostFiberCache](0))
-      .sorted.takeRight(FiberSensor.NUM_GET_HOSTS).reverse.map(_.host)
+    val hosts = if (fileToHosts.containsKey(filePath)) {
+      fileToHosts.get(filePath)
+    } else {
+      new ArrayBuffer[HostFiberCache](0)
+    }
+    hosts.sorted.takeRight(FiberSensor.NUM_GET_HOSTS).reverse.map(_.host)
   }
 }
 

--- a/src/main/spark2.1/scala/org/apache/spark/sql/oap/ui/FiberCacheManagerPage.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/oap/ui/FiberCacheManagerPage.scala
@@ -55,7 +55,11 @@ private[spark] object FiberCacheManagerPage {
     val memUsed = status.memUsed
     val maxMem = status.maxMem
     val cacheStats =
-      OapRuntime.getOrCreate.fiberSensor.executorToCacheManager.getOrDefault(execId, CacheStats())
+      if (OapRuntime.getOrCreate.fiberSensor.executorToCacheManager.containsKey(execId)) {
+      OapRuntime.getOrCreate.fiberSensor.executorToCacheManager.get(execId)
+    } else {
+      CacheStats()
+    }
 
 
     new FiberCacheManagerSummary(

--- a/src/main/spark2.1/scala/org/apache/spark/sql/oap/ui/FiberCacheManagerPage.scala
+++ b/src/main/spark2.1/scala/org/apache/spark/sql/oap/ui/FiberCacheManagerPage.scala
@@ -56,10 +56,10 @@ private[spark] object FiberCacheManagerPage {
     val maxMem = status.maxMem
     val cacheStats =
       if (OapRuntime.getOrCreate.fiberSensor.executorToCacheManager.containsKey(execId)) {
-      OapRuntime.getOrCreate.fiberSensor.executorToCacheManager.get(execId)
-    } else {
-      CacheStats()
-    }
+        OapRuntime.getOrCreate.fiberSensor.executorToCacheManager.get(execId)
+      } else {
+        CacheStats()
+      }
 
 
     new FiberCacheManagerSummary(


### PR DESCRIPTION
## What changes were proposed in this pull request?

To slove #938,  oap with spark2.1 should build by java 7.

## How was this patch tested?

Existing unit test case passed.