### PR TITLE
Clean pom and Update README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
 - sudo make install
 - cd ${TRAVIS_BUILD_DIR}
 script:
-- mvn clean -q -Pspark-2.3 -Ppersistent-memory test
+- mvn clean -q -Ppersistent-memory test

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 OAP - Optimized Analytics Package (previously known as Spinach) is designed to accelerate Ad-hoc query. OAP defines a new parquet-like columnar storage data format and offering a fine-grained hierarchical cache mechanism in the unit of “Fiber” in memory. What’s more, OAP has extended the Spark SQL DDL to allow user to define the customized indices based on relation.
 ## Building
-By defaut, it builds for Spark 2.1.0. To specify the Spark version, please use profile spark-2.1 , spark-2.2 or spark-2.3.
+
 ```
 mvn clean -q -Ppersistent-memory -DskipTests package
-mvn clean -q -Pspark-2.2 -Ppersistent-memory -DskipTests package
-mvn clean -q -Pspark-2.3 -Ppersistent-memory -DskipTests package
 ```
+Profile `persistent-memory` is Optional.
 ## Prerequisites
-You should have [Apache Spark](http://spark.apache.org/) of version 2.1.0, 2.2.0 or 2.3.0 installed in your cluster. Refer to Apache Spark's [documents](http://spark.apache.org/docs/2.1.0/) for details.
+You should have [Apache Spark](http://spark.apache.org/) of version 2.3.2 installed in your cluster
+. Refer to Apache Spark's [documents](http://spark.apache.org/docs/2.3.2/) for details.
 ## Use OAP with Spark
 1. Build OAP find `oap-<version>-with-<spark-version>.jar` in `target/`
 2. Deploy `oap-<version>-with-<spark-version>.jar` to master machine.
@@ -46,7 +46,7 @@ For a more detailed examples with performance compare, you can refer to [this pa
 
 To run all the tests, use
 ```
-mvn clean -q -Pspark-2.3 -Ppersistent-memory test
+mvn clean -q -Ppersistent-memory test
 ```
 To run any specific test suite, for example `OapDDLSuite`, use
 ```
@@ -71,7 +71,6 @@ Parquet is the most popular and recommended data format in Spark open-source com
 * Orc Data Adaptor
 Orc is another popular data format. We also designed the compatible layer to allow user to create index directly on top of Orc data. With the Orc reader we implemented, query over indexed Orc data is also accelerated.
 * Compatible with multiple versions of spark
-OAP is currently compatible with spark2.1, spark2.2 or spark 2.3.
 
 ## Configurations and Performance Tuning
 

--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
               <javacArg>${java.version}</javacArg>
               <javacArg>-target</javacArg>
               <javacArg>${java.version}</javacArg>
-              <javacArg>-Xlint:all,-serial,-pathgit</javacArg>
+              <javacArg>-Xlint:all,-serial,-path</javacArg>
             </javacArgs>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,16 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
     <basedir>./</basedir>
+    <spark.internal.version>2.3.2</spark.internal.version>
+    <scala.version>2.11.8</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <java.version>1.8</java.version>
+    <antlr.version>4.7</antlr.version>
+    <scalatest.version>3.0.3</scalatest.version>
+    <scalacheck.version>1.13.5</scalacheck.version>
+    <parquet.version>1.8.3</parquet.version>
+    <jetty.version>9.3.24.v20180605</jetty.version>
+    <orc.version>1.5.2</orc.version>
     <exec.maven.version>1.6.0</exec.maven.version>
   </properties>
 
@@ -181,13 +191,11 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -195,19 +203,16 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-mllib_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -215,13 +220,11 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -229,13 +232,11 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -243,19 +244,16 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-unsafe_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-unsafe_${scala.binary.version}</artifactId>
-      <!--<version>${spark.version}</version>-->
       <version>${spark.internal.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -612,90 +610,58 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4-maven-plugin</artifactId>
+        <version>${antlr.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>antlr4</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <visitor>true</visitor>
+          <sourceDirectory>src/main/spark2.3.2/antlr4</sourceDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/main/spark2.3.2/java</source>
+                <source>src/main/spark2.3.2/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/test/spark2.3/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
-    <profile>
-      <id>spark-2.3</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <spark.version>2.3.2</spark.version>
-        <spark.internal.version>2.3.2</spark.internal.version>
-        <scala.version>2.11.8</scala.version>
-        <scala.binary.version>2.11</scala.binary.version>
-        <java.version>1.8</java.version>
-        <antlr.version>4.7</antlr.version>
-        <scalatest.version>3.0.3</scalatest.version>
-        <scalacheck.version>1.13.5</scalacheck.version>
-        <parquet.version>1.8.3</parquet.version>
-        <jetty.version>9.3.24.v20180605</jetty.version>
-        <orc.version>1.5.2</orc.version>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-maven-plugin</artifactId>
-            <version>${antlr.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>antlr4</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <visitor>true</visitor>
-              <sourceDirectory>src/main/spark2.3.2/antlr4</sourceDirectory>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>src/main/spark2.3.2</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.0.0</version>
-            <executions>
-              <execution>
-                <id>add-source</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>add-source</goal>
-                </goals>
-                <configuration>
-                  <sources>
-                    <source>src/main/spark2.3.2/java</source>
-                    <source>src/main/spark2.3.2/scala</source>
-                  </sources>
-                </configuration>
-              </execution>
-              <execution>
-                <id>add-test-source</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>add-test-source</goal>
-                </goals>
-                <configuration>
-                  <sources>
-                    <source>src/test/spark2.3/scala</source>
-                  </sources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>persistent-memory</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <scalacheck.version>1.13.5</scalacheck.version>
     <parquet.version>1.8.3</parquet.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
+    <!--diff: Spark-2.3.2 use orc 1.4.4 -->
     <orc.version>1.5.2</orc.version>
     <exec.maven.version>1.6.0</exec.maven.version>
   </properties>
@@ -185,7 +186,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-      <version>2.6.5</version>
+      <version>2.6.7.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -495,15 +496,14 @@
             <jvmArgs>
               <jvmArg>-Xms1024m</jvmArg>
               <jvmArg>-Xmx1024m</jvmArg>
-              <jvmArg>-XX:PermSize=2g</jvmArg>
-              <jvmArg>-XX:MaxPermSize=5g</jvmArg>
+              <jvmArg>-XX:ReservedCodeCacheSize=512m</jvmArg>
             </jvmArgs>
             <javacArgs>
               <javacArg>-source</javacArg>
               <javacArg>${java.version}</javacArg>
               <javacArg>-target</javacArg>
               <javacArg>${java.version}</javacArg>
-              <javacArg>-Xlint:all,-serial,-path</javacArg>
+              <javacArg>-Xlint:all,-serial,-pathgit</javacArg>
             </javacArgs>
           </configuration>
         </plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Clean spark-2.3 profile from pom.xml

- Update travis.yml build script

- Update README.md

- Java8 nerver use '-XX:PermSize' and '-XX:MaxPermSize' 

- Spark-2.3.2 use `com.fasterxml.jackson.module:jackson-module-scala_2.11:2.6.7.1`

## How was this patch tested?

existing test

