### PR TITLE
[Branch-0.5] Fix Inheritance hierarchy of  ReadOnlyOrcFileFormat in spark-2.3 #965

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyOrcFileFormat.scala
@@ -21,13 +21,14 @@ import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+import org.apache.spark.sql.hive.orc.{OrcFileFormat => HiveOrcFileFormat}
 import org.apache.spark.sql.types.StructType
 
 /**
  * `ReadOnlyOrcFileFormat` only support read orc operation and not support write,
  * in oap we use it to create and refresh index because of isSplitable method always return false.
  */
-class ReadOnlyOrcFileFormat extends org.apache.spark.sql.hive.orc.OrcFileFormat {
+class ReadOnlyOrcFileFormat extends HiveOrcFileFormat {
   override def isSplitable(
       sparkSession: SparkSession,
       options: Map[String, String],

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyOrcFileFormat.scala
@@ -21,14 +21,13 @@ import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory
-import org.apache.spark.sql.hive.orc.OrcFileFormat
 import org.apache.spark.sql.types.StructType
 
 /**
  * `ReadOnlyOrcFileFormat` only support read orc operation and not support write,
  * in oap we use it to create and refresh index because of isSplitable method always return false.
  */
-class ReadOnlyOrcFileFormat extends OrcFileFormat{
+class ReadOnlyOrcFileFormat extends org.apache.spark.sql.hive.orc.OrcFileFormat {
   override def isSplitable(
       sparkSession: SparkSession,
       options: Map[String, String],

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -114,7 +114,8 @@ object FileSourceStrategy extends Strategy with Logging {
           logInfo("index operation for parquet, retain ReadOnlyParquetFileFormat.")
           _fsRelation
         case _: ReadOnlyOrcFileFormat | _: ReadOnlyNativeOrcFileFormat =>
-          logInfo("index operation for orc, retain ReadOnlyOrcFileFormat.")
+          logInfo("index operation for orc, retain ReadOnlyOrcFileFormat or " +
+            "ReadOnlyNativeOrcFileFormat.")
           _fsRelation
         // There are two scenarios will use OptimizedParquetFileFormat:
         // 1. canUseCache: OAP_PARQUET_ENABLED is true and OAP_PARQUET_DATA_CACHE_ENABLED is true

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OptimizedOrcFileFormat, OptimizedParquetFileFormat}
-import org.apache.spark.sql.execution.datasources.orc.ReadOnlyOrcFileFormat
+import org.apache.spark.sql.execution.datasources.orc.{ReadOnlyNativeOrcFileFormat, ReadOnlyOrcFileFormat}
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ReadOnlyParquetFileFormat}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
@@ -113,7 +113,7 @@ object FileSourceStrategy extends Strategy with Logging {
         case _: ReadOnlyParquetFileFormat =>
           logInfo("index operation for parquet, retain ReadOnlyParquetFileFormat.")
           _fsRelation
-        case _: ReadOnlyOrcFileFormat =>
+        case _: ReadOnlyOrcFileFormat | _: ReadOnlyNativeOrcFileFormat =>
           logInfo("index operation for orc, retain ReadOnlyOrcFileFormat.")
           _fsRelation
         // There are two scenarios will use OptimizedParquetFileFormat:

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyNativeOrcFileFormat.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyNativeOrcFileFormat.scala
@@ -21,14 +21,13 @@ import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory
-import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.types.StructType
 
 /**
  * `ReadOnlyNativeOrcFileFormat` only supports read native orc operation and not support write.
  * In oap we use it to create and refresh index because isSplitable method always returns false.
  */
-class ReadOnlyNativeOrcFileFormat extends OrcFileFormat{
+class ReadOnlyNativeOrcFileFormat extends OrcFileFormat {
   override def isSplitable(
       sparkSession: SparkSession,
       options: Map[String, String],

--- a/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyNativeOrcFileFormat.scala
+++ b/src/main/spark2.3/scala/org/apache/spark/sql/execution/datasources/orc/ReadOnlyNativeOrcFileFormat.scala
@@ -21,13 +21,14 @@ import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.types.StructType
 
 /**
  * `ReadOnlyNativeOrcFileFormat` only supports read native orc operation and not support write.
  * In oap we use it to create and refresh index because isSplitable method always returns false.
  */
-class ReadOnlyNativeOrcFileFormat extends OrcFileFormat {
+class ReadOnlyNativeOrcFileFormat extends OrcFileFormat{
   override def isSplitable(
       sparkSession: SparkSession,
       options: Map[String, String],


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Solve compile waring of `ReadOnlyOrcFileFormat` : ```imported `OrcFileFormat' is permanently hidden by definition of object OrcFileFormat in package orc```
 
- Add match case `ReadOnlyNativeOrcFileFormat` in  `FileSourceStrategy`

## How was this patch tested?

existing test

