### PR TITLE
Fix BloomFilter misjudged if interval is isPrefixMatch

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -81,18 +81,23 @@ private[oap] class BloomFilterStatisticsReader(
      *    2.2 interval.start != interval.end (not equal or DUMMY_KEY). Just return false
      */
     val skipIndex = !intervalArray.exists { interval =>
-      val numFields = math.min(interval.start.numFields, interval.end.numFields)
-      if (schema.length > 1) {
-        if (numFields == schema.length && ordering.compare(interval.start, interval.end) == 0) {
-          bfIndex.checkExist(converter(interval.start).getBytes)
-        } else {
-          bfIndex.checkExist(partialConverter(interval.start).getBytes)
-        }
+      // If this interval is a PrefixMatch, don't use bf checkExist.
+      if (interval.isPrefixMatch) {
+        true
       } else {
-        if (numFields == 1 && ordering.compare(interval.start, interval.end) == 0) {
-          bfIndex.checkExist(converter(interval.start).getBytes)
+        val numFields = math.min(interval.start.numFields, interval.end.numFields)
+        if (schema.length > 1) {
+          if (numFields == schema.length && ordering.compare(interval.start, interval.end) == 0) {
+            bfIndex.checkExist(converter(interval.start).getBytes)
+          } else {
+            bfIndex.checkExist(partialConverter(interval.start).getBytes)
+          }
         } else {
-          true
+          if (numFields == 1 && ordering.compare(interval.start, interval.end) == 0) {
+            bfIndex.checkExist(converter(interval.start).getBytes)
+          } else {
+            true
+          }
         }
       }
     }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -71,7 +71,7 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
 
     val testRowId = groupSize - 1
     val data: Seq[(Int, String)] = (0 until groupSize * 3)
-                                    .map { i => (i, s"this is test $i") }
+      .map { i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_test_1 select * from t")
 
@@ -146,7 +146,6 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
   }
 
   test("startswith using index") {
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, false)
     val data: Seq[(Int, String)] =
       scala.util.Random.shuffle(1 to 30).map(i => (i, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
@@ -156,11 +155,9 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
         Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     }
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
   }
 
   test("startswith using multi-dimension index") {
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, false)
     val data: Seq[(Int, String)] =
       scala.util.Random.shuffle(1 to 30).map(i => (i, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
@@ -170,11 +167,9 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
         Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     }
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
   }
 
   test("startswith using multi-dimension index - multi-filters") {
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, false)
     val data: Seq[(Int, String)] =
       scala.util.Random.shuffle(1 to 30).map(i => (i % 7, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")
@@ -184,11 +179,9 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       checkAnswer(sql("SELECT * FROM oap_test_1 WHERE a = 3 and b like 'this3%'"),
         Row(3, "this3 is test") :: Nil)
     }
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
   }
 
   test("startswith using multi-dimension index 2") {
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, false)
     val data: Seq[(Int, String)] = Seq(
       15, 29, 26, 4, 28, 17, 16, 11, 12, 27, 22, 6, 10, 18, 19, 20, 30, 21, 14, 25, 1, 2,
       13, 23, 7, 24, 3, 8, 5, 9).map(i => (i, s"this$i is test"))
@@ -199,6 +192,5 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
       checkAnswer(sql("SELECT * FROM oap_test_1 WHERE b like 'this3%'"),
         Row(3, "this3 is test") :: Row(30, "this30 is test") :: Nil)
     }
-    sqlContext.conf.setConf(OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY, true)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This is a bug fix for `startWith` query condition, I found that if test case in` OapIndexQuerySuite` set `OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY` to true, query result will not correct because BloomFilterStatistics do misjudged for PrefixMatch query, so add branch when `interval.isPrefixMatch` to fix this problem.

## How was this patch tested?
Let `OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY`  use true and ` OapIndexQuerySuite` test pass.


