### PR TITLE
Fix Java Files Import Order 

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -155,13 +155,11 @@
         </module>
         -->
         <!-- TODO: 11/09/15 disabled - order is currently wrong in many places -->
-        <!--
         <module name="ImportOrder">
             <property name="separated" value="true"/>
             <property name="ordered" value="true"/>
             <property name="groups" value="/^javax?\./,scala,*,org.apache.spark"/>
         </module>
-        -->
         <module name="MethodParamPad"/>
         <module name="AnnotationLocation">
             <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>

--- a/pom.xml
+++ b/pom.xml
@@ -434,8 +434,14 @@
           <failOnViolation>true</failOnViolation>
           <failOnWarning>false</failOnWarning>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
-          <sourceDirectory>src/main/scala</sourceDirectory>
-          <testSourceDirectory>src/test/scala</testSourceDirectory>
+          <sourceDirectories>
+            <directory>src/main/scala</directory>
+            <directory>src/main/spark2.3.2/scala</directory>
+          </sourceDirectories>
+          <testSourceDirectories>
+            <directory>src/test/scala</directory>
+            <directory>src/test/spark2.3.2/scala</directory>
+          </testSourceDirectories>
           <configLocation>scalastyle-config.xml</configLocation>
           <outputFile>target/scalastyle-output.xml</outputFile>
           <inputEncoding>UTF-8</inputEncoding>
@@ -589,12 +595,12 @@
           <failOnViolation>true</failOnViolation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <sourceDirectories>
-            <directory>${basedir}/src/main/java</directory>
-            <directory>${basedir}/src/main/scala</directory>
+            <directory>src/main/java</directory>
+            <directory>src/spark2.3.2/scala</directory>
           </sourceDirectories>
           <testSourceDirectories>
-            <directory>${basedir}/src/test/java</directory>
-            <directory>${basedir}/src/test/scala</directory>
+            <directory>src/test/java</directory>
+            <directory>src/test/spark2.3.2/java</directory>
           </testSourceDirectories>
           <configLocation>checkstyle.xml</configLocation>
           <outputFile>${basedir}/target/checkstyle-output.xml</outputFile>

--- a/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/IndexedVectorizedOapRecordReader.java
@@ -23,8 +23,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.parquet.hadoop.metadata.ParquetFooter;
 import org.apache.parquet.hadoop.OapParquetFileReader.RowGroupDataAndRowIds;
+import org.apache.parquet.hadoop.metadata.ParquetFooter;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 

--- a/src/main/java/org/apache/parquet/hadoop/InternalOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/InternalOapRecordReader.java
@@ -16,21 +16,18 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.apache.parquet.Log.DEBUG;
-import static org.apache.parquet.hadoop.ParquetInputFormat.STRICT_TYPE_CHECKING;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.hadoop.OapParquetFileReader.RowGroupDataAndRowIds;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.metadata.IndexedBlockMetaData;
-import org.apache.parquet.hadoop.OapParquetFileReader.RowGroupDataAndRowIds;
 import org.apache.parquet.hadoop.utils.Collections3;
 import org.apache.parquet.io.ColumnIOFactory;
 import org.apache.parquet.io.MessageColumnIO;
@@ -42,6 +39,9 @@ import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.parquet.schema.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.parquet.Log.DEBUG;
+import static org.apache.parquet.hadoop.ParquetInputFormat.STRICT_TYPE_CHECKING;
 
 public class InternalOapRecordReader<T> {
 

--- a/src/main/java/org/apache/parquet/hadoop/MrOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/MrOapRecordReader.java
@@ -18,8 +18,6 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
-
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -27,6 +25,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.api.RecordReader;
 import org.apache.parquet.hadoop.metadata.ParquetFooter;
+
+import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
 
 public class MrOapRecordReader<T> implements RecordReader<T> {
 

--- a/src/main/java/org/apache/parquet/hadoop/OapParquetFileReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/OapParquetFileReader.java
@@ -16,8 +16,6 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
@@ -33,6 +31,8 @@ import org.apache.parquet.hadoop.metadata.ParquetFooter;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.parquet.schema.MessageType;
+
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 
 public class OapParquetFileReader implements Closeable {
 

--- a/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
+++ b/src/main/java/org/apache/parquet/hadoop/SpecificOapRecordReaderBase.java
@@ -16,8 +16,6 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
-
 import java.io.IOException;
 import java.util.Map;
 
@@ -30,6 +28,8 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.utils.Collections3;
 import org.apache.parquet.schema.MessageType;
+
+import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
 
 import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportWrapper;
 import org.apache.spark.sql.types.StructType;

--- a/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/VectorizedOapRecordReader.java
@@ -27,6 +27,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.hadoop.metadata.ParquetFooter;
 import org.apache.parquet.schema.Type;
+
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.datasources.parquet.SkippableVectorizedColumnReader;

--- a/src/main/java/org/apache/parquet/io/RecordReaderFactory.java
+++ b/src/main/java/org/apache/parquet/io/RecordReaderFactory.java
@@ -18,12 +18,12 @@
  */
 package org.apache.parquet.io;
 
+import java.util.List;
+
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
-
-import java.util.List;
 
 import static org.apache.parquet.Preconditions.checkNotNull;
 

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/IndexedOrcMapreduceRecordReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/IndexedOrcMapreduceRecordReader.java
@@ -17,11 +17,11 @@
  */
 package org.apache.spark.sql.execution.datasources.oap.orc;
 
+import java.io.IOException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.WritableComparable;
-
-import java.io.IOException;
 
 /**
  * This record reader has rowIds in order to seek to specific rows to skip unused data.

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
@@ -42,8 +42,8 @@ import org.apache.spark.sql.execution.vectorized.ColumnVectorUtils;
 import org.apache.spark.sql.execution.vectorized.OffHeapColumnVector;
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
-import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 /**
  * This class is a copy of OrcColumnarBatchReader with minor changes to be able to

--- a/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcMapreduceRecordReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcMapreduceRecordReader.java
@@ -17,10 +17,12 @@
  */
 package org.apache.spark.sql.execution.datasources.oap.orc;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -32,9 +34,7 @@ import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.mapred.OrcMapredRecordReader;
 import org.apache.orc.mapred.OrcStruct;
-
-import java.io.IOException;
-import java.util.List;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 
 /**
  * This record reader is a copy of OrcMapreduceRecordReader with minor changes

--- a/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnVectorAllocator.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnVectorAllocator.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.orc;
 
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
+
 import org.apache.spark.sql.types.DataType;
 
 public final class OrcColumnVectorAllocator {

--- a/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SkippableVectorizedColumnReader.java
+++ b/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SkippableVectorizedColumnReader.java
@@ -27,14 +27,14 @@ import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.ValuesReader;
-
 import org.apache.parquet.schema.OriginalType;
+
+import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
+
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.DecimalType;
-
-import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
 
 /**
  * Add skip values ability to VectorizedColumnReader, skip method refer to

--- a/src/main/java/org/apache/spark/unsafe/PersistentMemoryPlatform.java
+++ b/src/main/java/org/apache/spark/unsafe/PersistentMemoryPlatform.java
@@ -20,6 +20,7 @@ package org.apache.spark.unsafe;
 import java.io.File;
 
 import com.google.common.base.Preconditions;
+
 import org.apache.spark.util.NativeLibraryLoader;
 
 /**

--- a/src/main/spark2.3.2/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/src/main/spark2.3.2/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1629,13 +1629,13 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
   }
 
   /**
-    * Create an index. Create a [[CreateIndexCommand]] command.
-    *
-    * {{{
-    *   CREATE OINDEX [IF NOT EXISTS] indexName ON tableName (col1 [ASC | DESC], col2, ...)
-    *   [USING (BTREE | BITMAP)] [PARTITION (partcol1=val1, partcol2=val2 ...)]
-    * }}}
-    */
+   * Create an index. Create a [[CreateIndexCommand]] command.
+   *
+   * {{{
+   *   CREATE OINDEX [IF NOT EXISTS] indexName ON tableName (col1 [ASC | DESC], col2, ...)
+   *   [USING (BTREE | BITMAP)] [PARTITION (partcol1=val1, partcol2=val2 ...)]
+   * }}}
+   */
   override def visitOapCreateIndex(ctx: OapCreateIndexContext): LogicalPlan =
     withOrigin(ctx) {
       CreateIndexCommand(
@@ -1647,12 +1647,12 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
     }
 
   /**
-    * Drop an index. Create a [[DropIndexCommand]] command.
-    *
-    * {{{
-    *   DROP OINDEX [IF EXISTS] indexName on tableName [PARTITION (partcol1=val1, partcol2=val2 ...)]
-    * }}}
-    */
+   * Drop an index. Create a [[DropIndexCommand]] command.
+   *
+   * {{{
+   *   DROP OINDEX [IF EXISTS] indexName on tableName [PARTITION (partcol1=val1, partcol2=val2 ...)]
+   * }}}
+   */
   override def visitOapDropIndex(ctx: OapDropIndexContext): LogicalPlan = withOrigin(ctx) {
     DropIndexCommand(
       ctx.IDENTIFIER.getText,

--- a/src/main/spark2.3.2/scala/org/apache/spark/sql/execution/datasources/OutputWriter.scala
+++ b/src/main/spark2.3.2/scala/org/apache/spark/sql/execution/datasources/OutputWriter.scala
@@ -49,10 +49,10 @@ abstract class OutputWriterFactory extends Serializable {
       context: TaskAttemptContext): OutputWriter
 
   /**
-    * This API called from the driver when all of the write task finished, and give the data
-    * source extensions to pass back the data writing task status, etc. writing the global
-    * meta information.
-    */
+   * This API called from the driver when all of the write task finished, and give the data
+   * source extensions to pass back the data writing task status, etc. writing the global
+   * meta information.
+   */
   def commitJob(taskResults: Array[WriteResult]): Unit = { }
 }
 
@@ -77,9 +77,9 @@ abstract class OutputWriter {
   def close(): Unit
 
   /**
-    * This is to collect data for meta when OAP writing or index writing.
-    * Can be replaced with datasource v2 api from Spark 2.3
-    */
+   * This is to collect data for meta when OAP writing or index writing.
+   * Can be replaced with datasource v2 api from Spark 2.3
+   */
   def writeStatus(): WriteResult = { }
 
   protected[sql] def setPartitionString(ps: String): Unit = {

--- a/src/main/spark2.3.2/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
+++ b/src/main/spark2.3.2/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
@@ -19,16 +19,15 @@ package org.apache.spark.status.api.v1
 import java.io.OutputStream
 import java.util.{List => JList}
 import java.util.zip.ZipOutputStream
-
 import javax.ws.rs.{GET, Path, PathParam, Produces, QueryParam}
 import javax.ws.rs.core.{MediaType, Response, StreamingOutput}
 
 import scala.util.control.NonFatal
+
 import org.apache.spark.JobExecutionStatus
 import org.apache.spark.sql.execution.datasources.oap.filecache.CacheStats
 import org.apache.spark.sql.oap.OapRuntime
-import org.apache.spark.sql.oap.ui.{FiberCacheManagerPage, FiberCacheManagerSummary}
-import org.apache.spark.ui.SparkUI
+import org.apache.spark.sql.oap.ui.FiberCacheManagerSummary
 
 @Produces(Array(MediaType.APPLICATION_JSON))
 private[v1] class AbstractApplicationResource extends BaseAppResource {
@@ -62,8 +61,8 @@ private[v1] class AbstractApplicationResource extends BaseAppResource {
     seqExecutorSummary.map(
       executorSummary =>
         {
-          val cacheStats =
-            OapRuntime.getOrCreate.fiberSensor.getExecutorToCacheManager.getOrDefault(executorSummary.id, CacheStats())
+          val cacheStats = OapRuntime.getOrCreate.fiberSensor.getExecutorToCacheManager.
+            getOrDefault(executorSummary.id, CacheStats())
 
           new FiberCacheManagerSummary(
             executorSummary.id,


### PR DESCRIPTION
## What changes were proposed in this pull request?

- enable `ImportOrder` rule in  check-style.xml and fix by `mvn checkstyle:check` cmd

- add `spark2.3.2/scala` dir to  `scalastyle-maven-plugin` config and fix problems.

## How was this patch tested?
N/a

