### PR TITLE
Fix Min-Max & PartByValue misjudged if interval is isPrefixMatch #978

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -52,6 +52,8 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
   }
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
+    if (intervalArray.exists(_.isPrefixMatch)) return StatsAnalysisResult.USE_INDEX
+
     if (min == null || max == null) {
       return StatsAnalysisResult.USE_INDEX
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -109,7 +109,7 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
   }
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
-    if (metas.nonEmpty) {
+    if (metas.nonEmpty && !intervalArray.exists(_.isPrefixMatch)) {
       val wholeCount = metas.last.accumulatorCnt
 
       val start = intervalArray.head

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -157,7 +157,8 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     }
   }
 
-  test("OAP-978 Misjudged by MinMaxStatisticsReader about like query") {
+  test("OAP-978 Misjudged by " +
+    "MinMaxStatisticsReader & PartByValueStatisticsReader startswith using index.") {
     val data: Seq[(Int, String)] =
       scala.util.Random.shuffle(30 to 90).map(i => (i, s"this$i is test"))
     data.toDF("key", "value").createOrReplaceTempView("t")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapIndexQuerySuite.scala
@@ -157,6 +157,19 @@ class OapIndexQuerySuite extends QueryTest with SharedOapContext with BeforeAndA
     }
   }
 
+  test("OAP-978 Misjudged by MinMaxStatisticsReader about like query") {
+    val data: Seq[(Int, String)] =
+      scala.util.Random.shuffle(30 to 90).map(i => (i, s"this$i is test"))
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test_1 select * from t")
+    withIndex(TestIndex("oap_test_1", "index1")) {
+      sql("create oindex index1 on oap_test_1 (b) using btree")
+      val ret = sql("SELECT a FROM oap_test_1 WHERE b like 'this3%'")
+      checkAnswer(ret, Row(30) :: Row(31) :: Row(32) :: Row(33) :: Row(34) :: Row(35) :: Row(36)
+        :: Row(37) :: Row(38) :: Row(39) :: Nil)
+    }
+  }
+
   test("startswith using multi-dimension index") {
     val data: Seq[(Int, String)] =
       scala.util.Random.shuffle(1 to 30).map(i => (i, s"this$i is test"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a bug fix for startWith query condition as #978 said, shouldn't use min-max and part-by-value statistics to judge `SKIP_INDEX` when `intervalArray.exists(_.isPrefixMatch)`.

## How was this patch tested?
Add test suite named `OAP-978 Misjudged by MinMaxStatisticsReader about like query`, before this pr, test case failed.

