### PR TITLE
Don't call analyzeStatistics if intervalArray contains PrefixMatch IndexScanner

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -133,13 +133,11 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
           OapConf.OAP_EXECUTOR_INDEX_SELECTION_STATISTICS_POLICY.defaultValue.get)
 
       // Policy 4: statistics tells the scan cost
-      if (statsPolicyEnable) {
+      if (statsPolicyEnable && !intervalArray.exists(_.isPrefixMatch)) {
         if (intervalArray.isEmpty) {
           StatsAnalysisResult.SKIP_INDEX
-        } else if (!intervalArray.exists(_.isPrefixMatch)) {
-          analyzeStatistics(indexPath, conf)
         } else {
-          StatsAnalysisResult.USE_INDEX
+          analyzeStatistics(indexPath, conf)
         }
       } else {
         StatsAnalysisResult.USE_INDEX

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -136,8 +136,10 @@ private[oap] abstract class IndexScanner(idxMeta: IndexMeta)
       if (statsPolicyEnable) {
         if (intervalArray.isEmpty) {
           StatsAnalysisResult.SKIP_INDEX
-        } else {
+        } else if (!intervalArray.exists(_.isPrefixMatch)) {
           analyzeStatistics(indexPath, conf)
+        } else {
+          StatsAnalysisResult.USE_INDEX
         }
       } else {
         StatsAnalysisResult.USE_INDEX

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -81,23 +81,18 @@ private[oap] class BloomFilterStatisticsReader(
      *    2.2 interval.start != interval.end (not equal or DUMMY_KEY). Just return false
      */
     val skipIndex = !intervalArray.exists { interval =>
-      // If this interval is a PrefixMatch, don't use bf checkExist.
-      if (interval.isPrefixMatch) {
-        true
-      } else {
-        val numFields = math.min(interval.start.numFields, interval.end.numFields)
-        if (schema.length > 1) {
-          if (numFields == schema.length && ordering.compare(interval.start, interval.end) == 0) {
-            bfIndex.checkExist(converter(interval.start).getBytes)
-          } else {
-            bfIndex.checkExist(partialConverter(interval.start).getBytes)
-          }
+      val numFields = math.min(interval.start.numFields, interval.end.numFields)
+      if (schema.length > 1) {
+        if (numFields == schema.length && ordering.compare(interval.start, interval.end) == 0) {
+          bfIndex.checkExist(converter(interval.start).getBytes)
         } else {
-          if (numFields == 1 && ordering.compare(interval.start, interval.end) == 0) {
-            bfIndex.checkExist(converter(interval.start).getBytes)
-          } else {
-            true
-          }
+          bfIndex.checkExist(partialConverter(interval.start).getBytes)
+        }
+      } else {
+        if (numFields == 1 && ordering.compare(interval.start, interval.end) == 0) {
+          bfIndex.checkExist(converter(interval.start).getBytes)
+        } else {
+          true
         }
       }
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -52,8 +52,6 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
   }
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
-    if (intervalArray.exists(_.isPrefixMatch)) return StatsAnalysisResult.USE_INDEX
-
     if (min == null || max == null) {
       return StatsAnalysisResult.USE_INDEX
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -109,7 +109,7 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
   }
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
-    if (metas.nonEmpty && !intervalArray.exists(_.isPrefixMatch)) {
+    if (metas.nonEmpty) {
       val wholeCount = metas.last.accumulatorCnt
 
       val start = intervalArray.head


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Refer to #981, unified processing isPrefixMatch queries, only enter the analysis process when  `statsPolicyEnable` && `!intervalArray.exists(_.isPrefixMatch)` is true

- revert code change of `BloomFilterStatisticsReader` (#975)

- revert code change of `MinMaxStatisticsReader` and `PartByValueStatisticsReader` (#980)


## How was this patch tested?

existing test.

