### PR TITLE
DataSourceRegister keep pace with spark-2.3.x

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -2,7 +2,10 @@ org.apache.spark.sql.execution.datasources.oap.OapFileFormat
 org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider
 org.apache.spark.sql.execution.datasources.json.JsonFileFormat
+org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 org.apache.spark.sql.execution.datasources.text.TextFileFormat
 org.apache.spark.sql.execution.streaming.ConsoleSinkProvider
 org.apache.spark.sql.execution.streaming.TextSocketSourceProvider
+org.apache.spark.sql.execution.streaming.RateSourceProvider
+org.apache.spark.sql.execution.streaming.sources.RateSourceProviderV2


### PR DESCRIPTION
## What changes were proposed in this pull request?

`resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister` File should keep pace with spark-2.3.x


## How was this patch tested?

N/A
