### PR TITLE
Add a Config to control the index use of parquet

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, Partitio
 import org.apache.spark.sql.execution.datasources.oap.io.{DataFileContext, OapDataReaderV1, ParquetVectorizedContext}
 import org.apache.spark.sql.execution.datasources.oap.utils.FilterHelper
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{AtomicType, StructType}
 import org.apache.spark.util.SerializableConfiguration
@@ -60,7 +61,8 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
     // TODO we need to pass the extra data source meta information via the func parameter
     val (filterScanners, m) = meta match {
-      case Some(x) => (indexScanners(x, filters), x)
+      case Some(x) if sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLED) =>
+        (indexScanners(x, filters), x)
       case _ =>
         // TODO Now we need use a meta with PARQUET_DATA_FILE_CLASSNAME & dataSchema to init
         // ParquetDataFile, try to remove this condition.

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -294,6 +294,13 @@ object OapConf {
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_PARQUET_INDEX_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.index.enable")
+      .internal()
+      .doc("To indicate if enable parquet index, default true")
+      .booleanConf
+      .createWithDefault(true)
+
   val OAP_INDEX_DIRECTORY =
     SqlConfAdapter.buildConf("spark.sql.oap.index.directory")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new config `OAP_PARQUET_INDEX_ENABLED(spark.sql.oap.parquet.index.enable)` to control the index use of parquet， then we can use data cache independent even if index exists.

## How was this patch tested?

"disable index and use data cache independent"
