### PR TITLE
[FOLLOWUP]Move OapSparkSqlParser to oap package #1005

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/OapSparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/OapSparkSqlParser.scala
@@ -17,25 +17,12 @@
 
 package org.apache.spark.sql.execution
 
-import java.util.Locale
-
-import scala.collection.JavaConverters._
-
-import org.antlr.v4.runtime.{ParserRuleContext, Token}
-import org.antlr.v4.runtime.tree.TerminalNode
-
-import org.apache.spark.sql.{SaveMode, SparkSession}
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.catalog._
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.parser._
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.oap.index._
-import org.apache.spark.sql.internal.{HiveSerDe, SQLConf, VariableSubstitution}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
 
 /**
  * Concrete parser for Spark SQL statements.


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. spark2.3.2 use to store code introduce from spark, so move `OapSparkSqlParser` out to oap package.

2. clean up unused import 


## How was this patch tested?

existing test

