### PR TITLE
Fix query failed when Some index file not exists(#1031)

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -339,6 +339,8 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
       false
     } else {
       if (analysisResults.forall(_._2 != StatsAnalysisResult.SKIP_INDEX)) {
+        // OAP#1031 we should filter FULL_SCAN when USE_INDEX scene
+        // because of FULL_SCAN may come from index file not exists in this partition.
         actualUsedScanners =
             analysisResults.filter(_._2 != StatsAnalysisResult.FULL_SCAN).map(_._1)
       }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -343,7 +343,7 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
         // because of FULL_SCAN may come from index file not exists in this partition and
         // FULL_SCAN Scanner needn't initialize index data.
         actualUsedScanners =
-            analysisResults.filter(_._2 != StatsAnalysisResult.FULL_SCAN).map(_._1)
+          analysisResults.filter(_._2 != StatsAnalysisResult.FULL_SCAN).map(_._1)
       }
       true
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -340,7 +340,8 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
     } else {
       if (analysisResults.forall(_._2 != StatsAnalysisResult.SKIP_INDEX)) {
         // OAP#1031 we should filter FULL_SCAN when USE_INDEX scene
-        // because of FULL_SCAN may come from index file not exists in this partition.
+        // because of FULL_SCAN may come from index file not exists in this partition and
+        // FULL_SCAN Scanner needn't initialize index data.
         actualUsedScanners =
             analysisResults.filter(_._2 != StatsAnalysisResult.FULL_SCAN).map(_._1)
       }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexScanner.scala
@@ -339,7 +339,8 @@ private[oap] class IndexScanners(val scanners: Seq[IndexScanner])
       false
     } else {
       if (analysisResults.forall(_._2 != StatsAnalysisResult.SKIP_INDEX)) {
-        actualUsedScanners = analysisResults.map(_._1)
+        actualUsedScanners =
+            analysisResults.filter(_._2 != StatsAnalysisResult.FULL_SCAN).map(_._1)
       }
       true
     }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
@@ -110,7 +110,7 @@ class OptimizedParquetFilterSuite extends QueryTest with SharedOapContext with B
     }
   }
 
-  test("index not exists") {
+  test("OAP#1031- query failed when Some index file not exists") {
     val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table parquet_test select * from t")
@@ -129,7 +129,7 @@ class OptimizedParquetFilterSuite extends QueryTest with SharedOapContext with B
         })
         files.foreach(f => fs.delete(f.getPath, true))
 
-        // push down indexScanners a and b , b not exists.
+        // push down indexScanners a and b , but b not exists.
         val df = sql("SELECT b FROM parquet_test WHERE b = 'this is test 1' and a = 1")
         checkAnswer(df, Row("this is test 1") :: Nil)
       }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.datasources.oap
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.hadoop.fs.{Path, PathFilter}
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a simple test case  to reproduce #1031  and fix it.

## How was this patch tested?
Add new test suite named "OAP#1031- query failed when Some index file not exists"