### PR TITLE
Fix bug when there is no NOT NULL keys, BitmapReader.getKeyIdx may th…

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BitmapReader.scala
@@ -83,6 +83,9 @@ private[oap] case class BitmapReader(
 
   protected def getKeyIdx(keySeq: Seq[InternalRow], range: RangeInterval): (Int, Int) = {
     val keyLength = keySeq.length
+    if (keyLength == 0) {
+      return (-1, -1)
+    }
     val startIdx = if (range.start == IndexScanner.DUMMY_KEY_START) {
       // If no starting key, assume to start from the first key.
       0

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexSuite.scala
@@ -217,7 +217,7 @@ class BitMapIndexSuite extends QueryTest with SharedOapContext with BeforeAndAft
     assert(message.contains("BitMapIndexType only supports one single column"))
   }
 
-  test("BitMap index for full null value on parquet data file") {
+  test("OAP#1037: BitMap index for full null value on parquet data file") {
     val data: Seq[(Int, String)] = (0 to 200).map {i => (i, null)}
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table parquet_test select * from t")
@@ -230,7 +230,7 @@ class BitMapIndexSuite extends QueryTest with SharedOapContext with BeforeAndAft
     sql("drop oindex index_bf on parquet_test")
   }
 
-  test("BitMap index for full null value on oap data file") {
+  test("OAP#1037: BitMap index for full null value on oap data file") {
     val data: Seq[(Int, String)] = (0 to 200).map {i => (i, null)}
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table oap_test select * from t")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/BitMapIndexSuite.scala
@@ -216,4 +216,30 @@ class BitMapIndexSuite extends QueryTest with SharedOapContext with BeforeAndAft
     }.getMessage
     assert(message.contains("BitMapIndexType only supports one single column"))
   }
+
+  test("BitMap index for full null value on parquet data file") {
+    val data: Seq[(Int, String)] = (0 to 200).map {i => (i, null)}
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table parquet_test select * from t")
+    sql("create oindex index_bf on parquet_test (b) USING BITMAP")
+
+    val nullResult: Seq[(Int, String)] = Nil
+    checkAnswer(sql("SELECT * FROM parquet_test WHERE b = 'hello'"),
+      nullResult.toDF("key", "value"))
+
+    sql("drop oindex index_bf on parquet_test")
+  }
+
+  test("BitMap index for full null value on oap data file") {
+    val data: Seq[(Int, String)] = (0 to 200).map {i => (i, null)}
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql("insert overwrite table oap_test select * from t")
+    sql("create oindex index_bf on oap_test (b) USING BITMAP")
+
+    val nullResult: Seq[(Int, String)] = Nil
+    checkAnswer(sql("SELECT * FROM oap_test WHERE b = 'hello'"),
+      nullResult.toDF("key", "value"))
+
+    sql("drop oindex index_bf on oap_test")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there is no NOT NULL keys, the `keySeq` is empy,  BitmapReader.getKeyIdx may throw exception since it will access `keySeq.head` or `keySeq.last`

## How was this patch tested?
test manually

