### PR TITLE
 Add a constant timestamps config for create oindex

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -108,7 +108,11 @@ case class CreateIndexCommand(
     // TODO currently we ignore empty partitions, so each partition may have different indexes,
     // this may impact index updating. It may also fail index existence check. Should put index
     // info at table level also.
-    val time = System.currentTimeMillis().toHexString
+    val time = if (sparkSession.conf.get(OapConf.OAP_INDEXER_USE_CONSTANT_TIMESTAMPS_ENABLED)) {
+      sparkSession.conf.get(OapConf.OAP_INDEXER_TIMESTAMPS_CONSTANT).toHexString
+    } else {
+      System.currentTimeMillis().toHexString
+    }
     val bAndP = partitions.filter(_.files.nonEmpty).map(p => {
       val metaBuilder = new DataSourceMetaBuilder()
       val parent = p.files.head.getPath.getParent

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -250,6 +250,21 @@ object OapConf {
       .intConf
       .createWithDefault(1)
 
+  val OAP_INDEXER_USE_CONSTANT_TIMESTAMPS_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.oindex.use.constant.timestamps")
+      .internal()
+      .doc("To indicate if enable/disable use constant timestamps when create oindex")
+      .booleanConf
+      .createWithDefault(false)
+
+  val OAP_INDEXER_TIMESTAMPS_CONSTANT =
+    SqlConfAdapter.buildConf("spark.sql.oap.oindex.timestamps.constant")
+      .internal()
+      .doc("If 'spark.sql.oap.oindex.use.constant.timestamps' is true, use this value to fill " +
+        "index meta timestamps")
+      .longConf
+      .createWithDefault(1555299314969L)
+
   val OAP_BTREE_ROW_LIST_PART_SIZE =
     SqlConfAdapter.buildConf("spark.sql.oap.btree.rowList.part.size")
       .internal()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.{DataSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
 import org.apache.spark.util.Utils
 
@@ -53,10 +54,15 @@ class OptimizedParquetFilterSuite extends QueryTest with SharedOapContext with B
     sql(s"""CREATE TEMPORARY VIEW parquet_test (a INT, b STRING)
            | USING parquet
            | OPTIONS (path '$path')""".stripMargin)
+
+    sql(s"""CREATE TABLE partitioned_parquet (a int, b STRING, c int)
+           | USING parquet
+           | PARTITIONED by (c)""".stripMargin)
   }
 
   override def afterEach(): Unit = {
     sqlContext.dropTempTable("parquet_test")
+    sql("DROP TABLE IF EXISTS partitioned_parquet")
   }
 
   test("enable data cache but no .oap.meta file") {
@@ -105,6 +111,39 @@ class OptimizedParquetFilterSuite extends QueryTest with SharedOapContext with B
             case _ => assert(false)
           }
         )
+      }
+    }
+  }
+
+  test("Index can be used when timestamps is constant on partitioned table") {
+    val data: Seq[(Int, String, Int)] = (1 to 300).map { i => (i, s"this is test $i", i % 2) }
+    data.toDF("key", "value1", "value2").createOrReplaceTempView("t")
+    sql(
+      """
+        |INSERT OVERWRITE TABLE partitioned_parquet
+        |partition (c=0)
+        |SELECT key, value1 from t where value2 = 0
+      """.stripMargin)
+    sql(
+      """
+        |INSERT OVERWRITE TABLE partitioned_parquet
+        |partition (c=1)
+        |SELECT key, value1 from t where value2 = 1
+      """.stripMargin)
+    withIndex(TestIndex("partitioned_parquet", "indexA")) {
+      withSQLConf(OapConf.OAP_INDEXER_USE_CONSTANT_TIMESTAMPS_ENABLED.key -> "true") {
+        // create index
+        sql("create oindex indexA on partitioned_parquet (a) partition(c = 0)")
+        sql("create oindex indexA on partitioned_parquet (a) partition(c = 1)")
+        val beforeQuery = OapRuntime.getOrCreate.fiberCacheManager.cacheStats.indexFiberCount
+        val df = sql("SELECT b FROM partitioned_parquet WHERE a = 1 or a = 2")
+        checkAnswer(df, Row("this is test 1") :: Row("this is test 2") :: Nil)
+        // After `INSERT TABLE` there are 4 files, there are 4 footer fiber need load,
+        // 2 files need load node pos fiber and rowIdList fiber, so after query increment is 8.
+        // If `OAP_INDEXER_USE_CONSTANT_TIMESTAMPS_ENABLED` if false, the indexFiberCount only 4
+        // because one of partition not use index.
+        val afterQuery = OapRuntime.getOrCreate.fiberCacheManager.cacheStats.indexFiberCount
+        assert(afterQuery == beforeQuery + 8)
       }
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFilterSuite.scala
@@ -115,7 +115,7 @@ class OptimizedParquetFilterSuite extends QueryTest with SharedOapContext with B
     }
   }
 
-  test("Index can be used when timestamps is constant on partitioned table") {
+  test("OAP#1038 Index can be used when timestamps is constant on partitioned table") {
     val data: Seq[(Int, String, Int)] = (1 to 300).map { i => (i, s"this is test $i", i % 2) }
     data.toDF("key", "value1", "value2").createOrReplaceTempView("t")
     sql(


### PR DESCRIPTION
## What changes were proposed in this pull request?

To solve the problem describe in #1038 , we create `.oap.meta` file  for each partition but only adopt one of them is a design issue, we need a different way to ensure meta consistency in the long run,  now it's just a workaround solution. 

## How was this patch tested?
`OAP#1038 Index can be used when timestamps is constant on partitioned table`
