### PR TITLE
Make OAP meta file support writing large schema which size exceeds 64k

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -288,7 +288,34 @@ private[oap] object IndexMeta {
   }
 }
 
-private[oap] case class Version(major: Byte, minor: Byte, revision: Byte)
+private[oap] case class Version(major: Byte, minor: Byte, revision: Byte) {
+  def -(that: Version) : Integer = {
+    val thisVer = this.major << 16 + this.minor << 8 + this.revision
+    val thatVer = that.major << 16 + that.minor << 8 + that.revision
+    thisVer - thatVer
+  }
+}
+
+private[oap] object  Version {
+  val versionSet = Set(Version(1, 0, 1), Version(1, 0, 1))
+
+  def isCompatible(version: Version): Boolean = {
+    versionSet.contains(version)
+  }
+
+  def latestVersion(): Version = {
+    Version(1, 0, 1)
+  }
+
+  def largeSchemaVersion(): Version = {
+    Version(1, 0, 1)
+  }
+
+  def allVersions(): Set[Version] = {
+    versionSet
+  }
+}
+
 
 private[oap] class FileHeader {
   import DataSourceMeta._
@@ -296,7 +323,7 @@ private[oap] class FileHeader {
   var recordCount: Long = _
   var dataFileCount: Long = _
   var indexCount: Long = _
-
+  var version: Version = _
   def write(out: FSDataOutputStream): Unit = {
     out.writeLong(recordCount)
     out.writeLong(dataFileCount)
@@ -311,14 +338,14 @@ private[oap] class FileHeader {
     recordCount = in.readLong()
     dataFileCount = in.readLong()
     indexCount = in.readLong()
-    val version = Version(in.readByte(), in.readByte(), in.readByte())
+    version = Version(in.readByte(), in.readByte(), in.readByte())
     val buffer = new Array[Byte](MAGIC_NUMBER.length)
     in.readFully(buffer)
     val magicNumber = new String(buffer, StandardCharsets.UTF_8)
     if (magicNumber != MAGIC_NUMBER) {
       throw new IOException("Not a valid Oap meta file.")
     }
-    if (version != VERSION) {
+    if (!Version.isCompatible(version)) {
       throw new IOException("The Oap meta file version is not compatible.")
     }
   }
@@ -326,11 +353,13 @@ private[oap] class FileHeader {
 
 private[oap] object FileHeader {
   def apply(): FileHeader = new FileHeader()
-  def apply(recordCount: Long, dataFileCount: Long, indexCount: Long): FileHeader = {
+  def apply(recordCount: Long, dataFileCount: Long,
+    indexCount: Long, version: Version): FileHeader = {
     val fileHeader = new FileHeader()
     fileHeader.recordCount = recordCount
     fileHeader.dataFileCount = dataFileCount
     fileHeader.indexCount = indexCount
+    fileHeader.version = version
     fileHeader
   }
 }
@@ -406,6 +435,7 @@ private[oap] class DataSourceMetaBuilder {
   val fileMetas = ArrayBuffer.empty[FileMeta]
   val indexMetas = ArrayBuffer.empty[IndexMeta]
   var schema: StructType = new StructType()
+  var version: Version = Version.latestVersion()
   // This won't contain version info, refer to [[DataSourceMeta]]
   var dataReaderClassName: String = OapFileFormat.OAP_DATA_FILE_CLASSNAME
 
@@ -436,20 +466,26 @@ private[oap] class DataSourceMetaBuilder {
     this
   }
 
+  def withNewVersion(schema: StructType): this.type = {
+    this.version = version
+    this
+  }
+
   def withNewDataReaderClassName(clsName: String): this.type = {
     this.dataReaderClassName = clsName
     this
   }
 
   def build(): DataSourceMeta = {
-    val fileHeader = FileHeader(fileMetas.map(_.recordCount).sum, fileMetas.size, indexMetas.size)
+    val fileHeader = FileHeader(fileMetas.map(_.recordCount).sum,
+      fileMetas.size, indexMetas.size, version)
     DataSourceMeta(fileMetas.toArray, indexMetas.toArray, schema, dataReaderClassName, fileHeader)
   }
 }
 
 private[oap] object DataSourceMeta extends Logging {
   final val MAGIC_NUMBER = "FIBER"
-  final val VERSION = Version(1, 0, 0)
+  final val VERSION = Version.latestVersion()
   final val FILE_HEAD_LEN = 32
 
   final val FILE_META_START_OFFSET = 0
@@ -503,11 +539,22 @@ private[oap] object DataSourceMeta extends Logging {
   private def readSchema(fileHeader: FileHeader, in: FSDataInputStream): StructType = {
     in.seek(FILE_META_START_OFFSET + FILE_META_LENGTH * fileHeader.dataFileCount +
       INDEX_META_LENGTH * fileHeader.indexCount)
-    StructType.fromString(in.readUTF())
+    val largeSchemaVersion = Version.largeSchemaVersion()
+    if (fileHeader.version - largeSchemaVersion < 0) {
+      StructType.fromString(in.readUTF())
+    } else {
+      val schemaLen = in.readInt()
+      val schemaBytes = new Array[Byte](schemaLen)
+      in.readFully(schemaBytes)
+      StructType.fromString(new String(schemaBytes, StandardCharsets.UTF_8))
+    }
   }
 
   private def writeSchema(schema: StructType, out: FSDataOutputStream): Unit = {
-    out.writeUTF(schema.json)
+    val bytes = schema.json.getBytes(StandardCharsets.UTF_8)
+    val length = bytes.length
+    out.writeInt(length)
+    out.write(bytes)
   }
 
   def writeString(value: String, totalSizeToWrite: Int, out: FSDataOutputStream): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -466,7 +466,7 @@ private[oap] class DataSourceMetaBuilder {
     this
   }
 
-  def withNewVersion(schema: StructType): this.type = {
+  def withNewVersion(version: Version): this.type = {
     this.version = version
     this
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.oap
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
+import java.nio.charset.StandardCharsets
 
 import scala.collection.mutable
 import scala.collection.parallel.ForkJoinTaskSupport
@@ -32,7 +33,7 @@ import org.scalatest.BeforeAndAfter
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
-import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.util.Utils
 
 class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
@@ -57,6 +58,12 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
   override def afterEach(): Unit = {}
 
   private def writeMetaFile(path: Path): Unit = {
+    val schema = new StructType()
+      .add("a", IntegerType).add("b", IntegerType).add("c", StringType)
+    writeMetaFile(path: Path, schema, Version.latestVersion())
+  }
+
+  private def writeMetaFile(path: Path, schema: StructType, version: Version): Unit = {
     val oapMeta = DataSourceMeta.newBuilder()
       .addFileMeta(FileMeta("OapFile1", 60, "file1"))
       .addFileMeta(FileMeta("OapFile2", 40, "file2"))
@@ -71,6 +78,7 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
         .appendEntry(BTreeIndexEntry(0, Ascending))))
       .withNewSchema(new StructType()
         .add("a", IntegerType).add("b", IntegerType).add("c", StringType))
+      .withNewSchema(schema)
       .withNewDataReaderClassName("NotExistedDataFileClassName")
       .build()
 
@@ -608,6 +616,34 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     } catch {
       case e: FileNotFoundException => fail(e.getMessage)
       case e: IOException => fail(e.getMessage)
+    }
+  }
+
+  test("test schema size larger than 65535") {
+    val fields = new Array[StructField](65536)
+    for (a <- 0 to 65535) {
+      fields(a) = new StructField(s"large_schema_column_$a", IntegerType)
+    }
+    val largeSchema = StructType(fields)
+    assert(largeSchema.json.getBytes(StandardCharsets.UTF_8).length > 65535)
+    val path = new Path(
+      new File(tmpDir.getAbsolutePath, "testOap.meta").getAbsolutePath)
+    writeMetaFile(path, largeSchema, Version.latestVersion())
+    val oapMeta = DataSourceMeta.initialize(path, new Configuration())
+    assert(oapMeta.schema == largeSchema)
+  }
+
+  test("test meta version compatibility") {
+    var testSchema = new StructType()
+    for (a <- 0 to 10) {
+      testSchema = testSchema.add(s"test_schema_column_$a", IntegerType)
+    }
+    for (version <- Version.allVersions()) {
+      val path = new Path(
+        new File(tmpDir.getAbsolutePath, s"version_$version.meta").getAbsolutePath)
+      writeMetaFile(path, testSchema, version)
+      val oapMeta = DataSourceMeta.initialize(path, new Configuration())
+      assert(oapMeta.schema == testSchema)
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMetaSuite.scala
@@ -76,9 +76,8 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
       .addIndexMeta(IndexMeta("index3", "15cc47fb3e0", BTreeIndex()
         .appendEntry(BTreeIndexEntry(1, Descending))
         .appendEntry(BTreeIndexEntry(0, Ascending))))
-      .withNewSchema(new StructType()
-        .add("a", IntegerType).add("b", IntegerType).add("c", StringType))
       .withNewSchema(schema)
+      .withNewVersion(version)
       .withNewDataReaderClassName("NotExistedDataFileClassName")
       .build()
 
@@ -626,8 +625,7 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
     }
     val largeSchema = StructType(fields)
     assert(largeSchema.json.getBytes(StandardCharsets.UTF_8).length > 65535)
-    val path = new Path(
-      new File(tmpDir.getAbsolutePath, "testOap.meta").getAbsolutePath)
+    val path = new Path(new File(tmpDir.getAbsolutePath, "testOap.meta").getAbsolutePath)
     writeMetaFile(path, largeSchema, Version.latestVersion())
     val oapMeta = DataSourceMeta.initialize(path, new Configuration())
     assert(oapMeta.schema == largeSchema)
@@ -639,8 +637,7 @@ class DataSourceMetaSuite extends SharedOapContext with BeforeAndAfter {
       testSchema = testSchema.add(s"test_schema_column_$a", IntegerType)
     }
     for (version <- Version.allVersions()) {
-      val path = new Path(
-        new File(tmpDir.getAbsolutePath, s"version_$version.meta").getAbsolutePath)
+      val path = new Path(new File(tmpDir.getAbsolutePath, s"test_$version.meta").getAbsolutePath)
       writeMetaFile(path, testSchema, version)
       val oapMeta = DataSourceMeta.initialize(path, new Configuration())
       assert(oapMeta.schema == testSchema)


### PR DESCRIPTION
## What changes were proposed in this pull request?

At present, OAP write schema into meta file by using DataOutputStream.writeUTF(String str) API which has the 64k limit, means when size of str exceeds 65535, writeUTF will throw a exception.

In this PR, we write the schema using length + content and also keep the backward compatibility by using  the  existing version field in meta file


## How was this patch tested?

add new UT

