### PR TITLE
Remove redundant configuration from OapConf

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
@@ -28,8 +28,8 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.oap.io.{DataFileContext, OapDataReaderV1, OrcDataFileContext}
-import org.apache.spark.sql.execution.datasources.orc.{OrcFilters, OrcFiltersAdapter, OrcUtils}
-import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.execution.datasources.orc.{OrcFiltersAdapter, OrcUtils}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{AtomicType, StructType}
 import org.apache.spark.util.SerializableConfiguration
@@ -49,7 +49,7 @@ private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
    */
   override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
     val conf = sparkSession.sessionState.conf
-    conf.getConf(OapConf.ORC_VECTORIZED_READER_ENABLED) &&
+    conf.getConf(SQLConf.ORC_VECTORIZED_READER_ENABLED) &&
       conf.wholeStageEnabled &&
       schema.length <= conf.wholeStageMaxNumFields &&
       schema.forall(_.dataType.isInstanceOf[AtomicType])
@@ -83,9 +83,9 @@ private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
         val requiredIds = requiredSchema.map(dataSchema.fields.indexOf(_)).toArray
 
         val enableOffHeapColumnVector =
-          sparkSession.sessionState.conf.getConf(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED)
+          sparkSession.sessionState.conf.getConf(SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED)
         val copyToSpark =
-          sparkSession.sessionState.conf.getConf(OapConf.ORC_COPY_BATCH_TO_SPARK)
+          sparkSession.sessionState.conf.getConf(SQLConf.ORC_COPY_BATCH_TO_SPARK)
         val isCaseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
 
         // Push down the filters to the orc record reader.

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -308,13 +308,4 @@ object OapConf {
         "is empty, it will store in the data file path")
       .stringConf
       .createWithDefault("")
-
-  val ORC_VECTORIZED_READER_ENABLED =
-    SqlConfAdapter.ORC_VECTORIZED_READER_ENABLED
-
-  val COLUMN_VECTOR_OFFHEAP_ENABLED =
-    SqlConfAdapter.COLUMN_VECTOR_OFFHEAP_ENABLED
-
-  val ORC_COPY_BATCH_TO_SPARK =
-    SqlConfAdapter.ORC_COPY_BATCH_TO_SPARK
 }

--- a/src/main/scala/org/apache/spark/sql/oap/adapter/SqlConfAdapter.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/adapter/SqlConfAdapter.scala
@@ -22,10 +22,4 @@ import org.apache.spark.sql.internal.SQLConf
 
 object SqlConfAdapter {
   def buildConf(key: String): ConfigBuilder = SQLConf.buildConf(key)
-
-  val ORC_VECTORIZED_READER_ENABLED = SQLConf.ORC_VECTORIZED_READER_ENABLED
-
-  val COLUMN_VECTOR_OFFHEAP_ENABLED = SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED
-
-  val ORC_COPY_BATCH_TO_SPARK = SQLConf.ORC_COPY_BATCH_TO_SPARK
 }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -1437,7 +1437,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering orc with off-heap column vector") {
-    spark.sqlContext.setConf(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key, "true")
+    spark.sqlContext.setConf(SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key, "true")
     val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
     data.toDF("key", "value").createOrReplaceTempView("t")
     sql("insert overwrite table orc_test select * from t")
@@ -1449,7 +1449,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
         Row(1, "this is test 1") :: Row(2, "this is test 2")
           :: Row(4, "this is test 4") :: Nil)
     }
-    spark.sqlContext.setConf(OapConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key, "false")
+    spark.sqlContext.setConf(SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key, "false")
   }
 
   test("OAP-764 BloomFilterStatisticsReader#analyse unexpected return SkipFile") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
`ORC_VECTORIZED_READER_ENABLE` | `COLUMN_VECTOR_OFFHEAP_ENABLED` | `ORC_COPY_BATCH_TO_SPARK` can use directly with `SQLConf` after Spark-2.3, remove it from `OapConf`

## How was this patch tested?
Exist Test.
