### PR TITLE
[FOLLOWUP]fix Index meta version compatibility bugs#1040

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/DataSourceMeta.scala
@@ -297,7 +297,7 @@ private[oap] case class Version(major: Byte, minor: Byte, revision: Byte) {
 }
 
 private[oap] object  Version {
-  val versionSet = Set(Version(1, 0, 1), Version(1, 0, 1))
+  val versionSet = Set(Version(1, 0, 0), Version(1, 0, 1))
 
   def isCompatible(version: Version): Boolean = {
     versionSet.contains(version)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In DataSourceMeta, we use a Set(versionSet) to record all meta versions, current code as follows:
DataSourceMeta.scala:300
val versionSet = Set(Version(1, 0, 1), Version(1, 0, 1))

there is a typo/bug in the above code， which doesn't contain Version(1, 0, 0).

the correct code should be :
val versionSet = Set(Version(1, 0, 0), Version(1, 0, 1))


## How was this patch tested?

existing unit tests