### PR TITLE
Using ExternalSorter for PartByValue and SampleBased Statistics

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -178,6 +178,9 @@ abstract class BTreeIndexRecordWriter(
           val bTreeNodeMetaData =
             serializeNode(nodeUniqueKeys, startPosInRowList, tempIdWriter, rowIdListBuffer)
           startPosInRowList += bTreeNodeMetaData.rowCount
+          // When enable statistics, partByValueStat and sampleBasedStat
+          // will calculated by using this oapExternalSorter iterator instead of
+          // loading all file data into an extra arraybuffer
           if (statisticsManager.isExternalSorterEnable) {
             statisticsManager.getPartByValueStat match {
               case Some(partByValueStat) =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -178,7 +178,7 @@ abstract class BTreeIndexRecordWriter(
           val bTreeNodeMetaData =
             serializeNode(nodeUniqueKeys, startPosInRowList, tempIdWriter, rowIdListBuffer)
           startPosInRowList += bTreeNodeMetaData.rowCount
-          // When enable statistics, partByValueStat and sampleBasedStat
+          // When enable statistics external sorter, partByValueStat and sampleBasedStat
           // will calculated by using this oapExternalSorter iterator instead of
           // loading all file data into an extra arraybuffer
           if (statisticsManager.isExternalSorterEnable) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -158,12 +158,12 @@ abstract class BTreeIndexRecordWriter(
         statisticsManager.getPartByValueStat match {
           case Some(partByValueStat) =>
             partByValueStat.initParams(treeSize)
-          case None => _
+          case None =>
         }
         statisticsManager.getSampleBasedStat match {
           case Some(sampleBasedStat) =>
             sampleBasedStat.initParams(recordCount - nullRecordCount)
-          case None => _
+          case None =>
         }
       }
 
@@ -182,12 +182,12 @@ abstract class BTreeIndexRecordWriter(
             statisticsManager.getPartByValueStat match {
               case Some(partByValueStat) =>
                 partByValueStat.buildPartMeta(nodeUniqueKeys, !sortedIter.hasNext)
-              case None => _
+              case None =>
             }
             statisticsManager.getSampleBasedStat match {
               case Some(sampleBasedStat) =>
                 sampleBasedStat.buildSampleArray(nodeUniqueKeys, !sortedIter.hasNext)
-              case None => _
+              case None =>
             }
           }
           bTreeNodeMetaData

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/BTreeIndexRecordWriter.scala
@@ -181,7 +181,7 @@ abstract class BTreeIndexRecordWriter(
           if (statisticsManager.isExternalSorterEnable) {
             statisticsManager.getPartByValueStat match {
               case Some(partByValueStat) =>
-                partByValueStat.buildPartMeta(nodeUniqueKeys, !sortedIter.hasNext)
+                partByValueStat.buildMetas(nodeUniqueKeys, !sortedIter.hasNext)
               case None =>
             }
             statisticsManager.getSampleBasedStat match {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -127,6 +127,7 @@ private[oap] class BloomFilterStatisticsWriter(
     projectors.foreach(p => bfIndex.addValue(p(key).getBytes))
   }
 
+  // this is the common part used by write and write2
   private def internalWrite(writer: OutputStream, offsetP: Int): Int = {
     var offset = offsetP
     // Bloom filter index file format:

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -158,8 +158,8 @@ private[oap] class BloomFilterStatisticsWriter(
     internalWrite(writer, offset)
   }
 
-  override def customWrite(writer: OutputStream): Int = {
-    val offset = super.customWrite(writer)
+  override def write2(writer: OutputStream): Int = {
+    val offset = super.write2(writer)
     internalWrite(writer, offset)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
@@ -33,7 +32,7 @@ import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.types._
 
 private[oap] class BloomFilterStatisticsReader(
-  schema: StructType) extends StatisticsReader(schema) with Logging {
+  schema: StructType) extends StatisticsReader(schema) {
   override val id: Int = StatisticsType.TYPE_BLOOM_FILTER
 
   protected var bfIndex: BloomFilter = _
@@ -99,10 +98,8 @@ private[oap] class BloomFilterStatisticsReader(
     }
 
     if (skipIndex) {
-      logInfo("Skip Index")
       StatsAnalysisResult.SKIP_INDEX
     } else {
-      logInfo("Use Index")
       StatsAnalysisResult.USE_INDEX
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -127,9 +127,8 @@ private[oap] class BloomFilterStatisticsWriter(
     projectors.foreach(p => bfIndex.addValue(p(key).getBytes))
   }
 
-  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
-    var offset = super.write(writer, sortedKeys)
-
+  private def internalWrite(writer: OutputStream, offsetP: Int): Int = {
+    var offset = offsetP
     // Bloom filter index file format:
     // numOfLong            4 Bytes, Int, record the total number of Longs in bit array
     // numOfHashFunction    4 Bytes, Int, record the total number of Hash Functions
@@ -149,5 +148,15 @@ private[oap] class BloomFilterStatisticsWriter(
       offset += 8
     })
     offset
+  }
+
+  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
+    val offset = super.write(writer, sortedKeys)
+    internalWrite(writer, offset)
+  }
+
+  override def write(writer: OutputStream, sortedIter: Iterator[Product2[Key, Seq[Int]]]): Int = {
+    val offset = super.write(writer, sortedIter)
+    internalWrite(writer, offset)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/BloomFilterStatistics.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
@@ -32,7 +33,7 @@ import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.types._
 
 private[oap] class BloomFilterStatisticsReader(
-  schema: StructType) extends StatisticsReader(schema) {
+  schema: StructType) extends StatisticsReader(schema) with Logging {
   override val id: Int = StatisticsType.TYPE_BLOOM_FILTER
 
   protected var bfIndex: BloomFilter = _
@@ -98,8 +99,10 @@ private[oap] class BloomFilterStatisticsReader(
     }
 
     if (skipIndex) {
+      logInfo("Skip Index")
       StatsAnalysisResult.SKIP_INDEX
     } else {
+      logInfo("Use Index")
       StatsAnalysisResult.USE_INDEX
     }
   }
@@ -155,8 +158,8 @@ private[oap] class BloomFilterStatisticsWriter(
     internalWrite(writer, offset)
   }
 
-  override def write(writer: OutputStream, sortedIter: Iterator[Product2[Key, Seq[Int]]]): Int = {
-    val offset = super.write(writer, sortedIter)
+  override def customWrite(writer: OutputStream): Int = {
+    val offset = super.customWrite(writer)
     internalWrite(writer, offset)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -133,8 +133,8 @@ private[oap] class MinMaxStatisticsWriter(
     internalWrite(writer, offset)
   }
 
-  override def customWrite(writer: OutputStream): Int = {
-    val offset = super.customWrite(writer)
+  override def write2(writer: OutputStream): Int = {
+    val offset = super.write2(writer)
     internalWrite(writer, offset)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -104,6 +104,7 @@ private[oap] class MinMaxStatisticsWriter(
     }
   }
 
+  // this is the common part used by write and write2
   private def internalWrite(writer: OutputStream, offsetP: Int): Int = {
     var offset = offsetP
     if (min != null) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -23,13 +23,15 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.types.StructType
 
-private[oap] class MinMaxStatisticsReader(schema: StructType) extends StatisticsReader(schema) {
+private[oap] class MinMaxStatisticsReader(schema: StructType) extends StatisticsReader(schema)
+  with Logging{
   override val id: Int = StatisticsType.TYPE_MIN_MAX
 
   protected var min: Key = _
@@ -53,6 +55,7 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
     if (min == null || max == null) {
+      logInfo("Use Index")
       return StatsAnalysisResult.USE_INDEX
     }
 
@@ -77,8 +80,10 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
       }
 
     if (startOutOfBound || endOutOfBound) {
+      logInfo("Skip Index")
       StatsAnalysisResult.SKIP_INDEX
     } else {
+      logInfo("Use Index")
       StatsAnalysisResult.USE_INDEX
     }
   }
@@ -128,8 +133,8 @@ private[oap] class MinMaxStatisticsWriter(
     internalWrite(writer, offset)
   }
 
-  override def write(writer: OutputStream, sortedIter: Iterator[Product2[Key, Seq[Int]]]): Int = {
-    val offset = super.write(writer, sortedIter)
+  override def customWrite(writer: OutputStream): Int = {
+    val offset = super.customWrite(writer)
     internalWrite(writer, offset)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -104,8 +104,8 @@ private[oap] class MinMaxStatisticsWriter(
     }
   }
 
-  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
-    var offset = super.write(writer, sortedKeys)
+  private def internalWrite(writer: OutputStream, offsetP: Int): Int = {
+    var offset = offsetP
     if (min != null) {
       val tempWriter = new ByteArrayOutputStream()
       nnkw.writeKey(tempWriter, min)
@@ -121,5 +121,15 @@ private[oap] class MinMaxStatisticsWriter(
       offset += IndexUtils.INT_SIZE
     }
     offset
+  }
+
+  override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
+    val offset = super.write(writer, sortedKeys)
+    internalWrite(writer, offset)
+  }
+
+  override def write(writer: OutputStream, sortedIter: Iterator[Product2[Key, Seq[Int]]]): Int = {
+    val offset = super.write(writer, sortedIter)
+    internalWrite(writer, offset)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/MinMaxStatistics.scala
@@ -23,15 +23,13 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.types.StructType
 
-private[oap] class MinMaxStatisticsReader(schema: StructType) extends StatisticsReader(schema)
-  with Logging{
+private[oap] class MinMaxStatisticsReader(schema: StructType) extends StatisticsReader(schema) {
   override val id: Int = StatisticsType.TYPE_MIN_MAX
 
   protected var min: Key = _
@@ -55,7 +53,6 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
     if (min == null || max == null) {
-      logInfo("Use Index")
       return StatsAnalysisResult.USE_INDEX
     }
 
@@ -80,10 +77,8 @@ private[oap] class MinMaxStatisticsReader(schema: StructType) extends Statistics
       }
 
     if (startOutOfBound || endOutOfBound) {
-      logInfo("Skip Index")
       StatsAnalysisResult.SKIP_INDEX
     } else {
-      logInfo("Use Index")
       StatsAnalysisResult.USE_INDEX
     }
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
@@ -45,7 +44,7 @@ import org.apache.spark.sql.types.StructType
 // (300,  "test#300")   299            300
 
 private[oap] class PartByValueStatisticsReader(schema: StructType)
-  extends StatisticsReader(schema) with Logging{
+  extends StatisticsReader(schema) {
   override val id: Int = StatisticsType.TYPE_PART_BY_VALUE
 
   @transient private lazy val ordering = GenerateOrdering.create(schema)
@@ -121,7 +120,6 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
 
       if (left == -1 || right == 0) {
         // interval.min > partition.max || interval.max < partition.min
-        logInfo("Skip Index")
         StatsAnalysisResult.SKIP_INDEX
       } else {
         var cover: Double =
@@ -137,25 +135,21 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
         }
 
         if (cover > wholeCount) {
-          logInfo("Full Index")
           StatsAnalysisResult.FULL_SCAN
         } else if (cover < 0) {
-          logInfo("Use Index")
           StatsAnalysisResult.USE_INDEX
         } else {
-          logInfo((cover / wholeCount).toString)
           StatsAnalysisResult(cover / wholeCount)
         }
       }
     } else {
-      logInfo("Use Index")
       StatsAnalysisResult.USE_INDEX
     }
   }
 }
 
 private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configuration)
-  extends StatisticsWriter(schema, conf) with Logging{
+  extends StatisticsWriter(schema, conf) {
   override val id: Int = StatisticsType.TYPE_PART_BY_VALUE
 
   private lazy val maxPartNum: Int = conf.getInt(
@@ -268,8 +262,7 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
     }
   }
 
-  def buildPartMeta(keyArray: Array[Product2[Key, Seq[Int]]], isLast: Boolean): Unit = {
-    logInfo("buildPartMetax")
+  def buildMetas(keyArray: Array[Product2[Key, Seq[Int]]], isLast: Boolean): Unit = {
     var kv: Product2[Key, Seq[Int]] = null
     if (keyArray != null && keyArray.size != 0) {
       keyArray.foreach(
@@ -288,8 +281,6 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
       if (isLast && ((this.keyCount - 1) > (this.idxNum - 1) * this.partSize)) {
         metas.append(PartedByValueMeta(this.idxNum, kv._1, this.keyCount - 1, this.curIdxCount))
       }
-
-      logInfo(s"metas size: ${metas.size}")
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -23,6 +23,8 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.{Aggregator, TaskContext}
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
@@ -30,6 +32,7 @@ import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.collection.OapExternalSorter
 
 // PartedByValueStatistics gives statistics with the value interval.
 // for example, in an array where all internal rows appear only once
@@ -44,7 +47,7 @@ import org.apache.spark.sql.types.StructType
 // (300,  "test#300")   299            300
 
 private[oap] class PartByValueStatisticsReader(schema: StructType)
-  extends StatisticsReader(schema) {
+  extends StatisticsReader(schema) with Logging{
   override val id: Int = StatisticsType.TYPE_PART_BY_VALUE
 
   @transient private lazy val ordering = GenerateOrdering.create(schema)
@@ -120,6 +123,7 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
 
       if (left == -1 || right == 0) {
         // interval.min > partition.max || interval.max < partition.min
+        logInfo("Skip Index")
         StatsAnalysisResult.SKIP_INDEX
       } else {
         var cover: Double =
@@ -135,14 +139,18 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
         }
 
         if (cover > wholeCount) {
+          logInfo("Full Index")
           StatsAnalysisResult.FULL_SCAN
         } else if (cover < 0) {
+          logInfo("Use Index")
           StatsAnalysisResult.USE_INDEX
         } else {
+          logInfo((cover / wholeCount).toString)
           StatsAnalysisResult(cover / wholeCount)
         }
       }
     } else {
+      logInfo("Use Index")
       StatsAnalysisResult.USE_INDEX
     }
   }
@@ -158,8 +166,53 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
 
   protected lazy val metas: ArrayBuffer[PartedByValueMeta] = new ArrayBuffer[PartedByValueMeta]()
 
+  protected var isExternalSorterEnable =
+    conf.getBoolean(OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.key,
+    OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.defaultValue.get)
+  protected val combiner: Int => Seq[Int] = Seq(_)
+  protected val merger: (Seq[Int], Int) => Seq[Int] = _ :+ _
+  protected val mergeCombiner: (Seq[Int], Seq[Int]) => Seq[Int] = _ ++ _
+  protected val aggregator =
+    new Aggregator[InternalRow, Int, Seq[Int]](combiner, merger, mergeCombiner)
+  protected var externalSorter = {
+    if (isExternalSorterEnable) {
+      val taskContext = TaskContext.get()
+      val sorter = new OapExternalSorter[InternalRow, Int, Seq[Int]](
+        taskContext, Some(aggregator), Some(ordering))
+      taskContext.addTaskCompletionListener(_ => sorter.stop())
+      sorter
+    } else {
+      null
+    }
+  }
+  private var recordCount: Int = 0
+
+  override def addOapKey(key: Key): Unit = {
+    if (isExternalSorterEnable) {
+      externalSorter.insert(key, recordCount)
+      recordCount += 1
+    }
+  }
+
+  private def internalWrite(writer: OutputStream, offsetP: Int): Int = {
+    var offset = offsetP
+    IndexUtils.writeInt(writer, metas.length)
+    offset += IndexUtils.INT_SIZE
+    val tempWriter = new ByteArrayOutputStream()
+    metas.foreach(meta => {
+      nnkw.writeKey(tempWriter, meta.row)
+      IndexUtils.writeInt(writer, meta.curMaxId)
+      IndexUtils.writeInt(writer, meta.accumulatorCnt)
+      IndexUtils.writeInt(writer, tempWriter.size())
+      offset += 12
+    })
+    writer.write(tempWriter.toByteArray)
+    offset += tempWriter.size
+    offset
+  }
+
   override def write(writer: OutputStream, sortedKeys: ArrayBuffer[Key]): Int = {
-    var offset = super.write(writer, sortedKeys)
+    val offset = super.write(writer, sortedKeys)
     val hashMap = new java.util.HashMap[Key, Int]()
     val uniqueKeys: ArrayBuffer[Key] = new ArrayBuffer[Key]()
 
@@ -187,65 +240,13 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
 
     buildPartMeta(uniqueKeys, hashMap)
 
-    // start writing
-    IndexUtils.writeInt(writer, metas.length)
-    offset += IndexUtils.INT_SIZE
-    val tempWriter = new ByteArrayOutputStream()
-    metas.foreach(meta => {
-      nnkw.writeKey(tempWriter, meta.row)
-      IndexUtils.writeInt(writer, meta.curMaxId)
-      IndexUtils.writeInt(writer, meta.accumulatorCnt)
-      IndexUtils.writeInt(writer, tempWriter.size())
-      offset += 12
-    })
-    writer.write(tempWriter.toByteArray)
-    offset += tempWriter.size
-    offset
+    internalWrite(writer, offset)
   }
 
-  override def write(writer: OutputStream, sortedIter: Iterator[Product2[Key, Seq[Int]]]): Int = {
-    var offset = super.write(writer, sortedIter)
-    val hashMap = new java.util.HashMap[Key, Int]()
-    val uniqueKeys: ArrayBuffer[Key] = new ArrayBuffer[Key]()
-
-    var prev: Key = null
-    var prevCnt: Int = 0
-
-    for (key <- sortedIter) {
-      if (prev == null) {
-        prev = key._1
-        prevCnt += 1
-      } else {
-        if (ordering.compare(prev, key._1) == 0) prevCnt += 1
-        else {
-          hashMap.put(prev, prevCnt)
-          uniqueKeys.append(prev)
-          prevCnt = 1
-          prev = key._1
-        }
-      }
-    }
-    if (prev != null) {
-      hashMap.put(prev, prevCnt)
-      uniqueKeys.append(prev)
-    }
-
-    buildPartMeta(uniqueKeys, hashMap)
-
-    // start writing
-    IndexUtils.writeInt(writer, metas.length)
-    offset += IndexUtils.INT_SIZE
-    val tempWriter = new ByteArrayOutputStream()
-    metas.foreach(meta => {
-      nnkw.writeKey(tempWriter, meta.row)
-      IndexUtils.writeInt(writer, meta.curMaxId)
-      IndexUtils.writeInt(writer, meta.accumulatorCnt)
-      IndexUtils.writeInt(writer, tempWriter.size())
-      offset += 12
-    })
-    writer.write(tempWriter.toByteArray)
-    offset += tempWriter.size
-    offset
+  override def customWrite(writer: OutputStream): Int = {
+    val offset = super.customWrite(writer)
+    buildPartMeta2()
+    internalWrite(writer, offset)
   }
 
   // TODO needs refactor, kept for easy debug
@@ -275,6 +276,44 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
         index += 1
       }
       metas.append(PartedByValueMeta(partNum, uniqueKeys.last, size - 1, count))
+    }
+  }
+
+  private def buildPartMeta2() = {
+    val sortedIter = externalSorter.iterator
+    val size = externalSorter.getDistinctCount
+    if (size > 0) {
+      val partNum = if (size > maxPartNum) maxPartNum else size
+      val perSize = size / partNum
+
+      var i = 0
+      var count = 0
+      var index = i * perSize
+      var prev: Key = null
+      var cur: Key = null
+      var key: Key = null
+      var begin = 0
+
+      while (sortedIter.hasNext) {
+        key = sortedIter.next()._1
+        if (cur == null) {
+          cur = key
+          begin += 1
+        } else {
+          if (ordering.compare(cur, key) != 0) {
+            prev = cur
+            cur = key
+            begin += 1
+          }
+        }
+        count += 1
+        if (begin > (index + 1)) {
+          metas.append(PartedByValueMeta(i, prev, index, (count - 1)))
+          i += 1
+          index = i * perSize
+        }
+      }
+      metas.append(PartedByValueMeta(partNum, cur, size - 1, count))
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -158,6 +158,7 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
 
   protected lazy val metas: ArrayBuffer[PartedByValueMeta] = new ArrayBuffer[PartedByValueMeta]()
 
+  // this is the common part used by write and write2
   private def internalWrite(writer: OutputStream, offsetP: Int): Int = {
     var offset = offsetP
     IndexUtils.writeInt(writer, metas.length)
@@ -262,6 +263,8 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
     }
   }
 
+  // This should provide the same function to get the metas as buildPartMeta().
+  // And this will be used when using the oapExternalSorter data
   def buildMetas(keyArray: Array[Product2[Key, Seq[Int]]], isLast: Boolean): Unit = {
     var kv: Product2[Key, Seq[Int]] = null
     if (keyArray != null && keyArray.size != 0) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/PartByValueStatistics.scala
@@ -155,7 +155,7 @@ private[oap] class PartByValueStatisticsReader(schema: StructType)
 }
 
 private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configuration)
-  extends StatisticsWriter(schema, conf) {
+  extends StatisticsWriter(schema, conf) with Logging{
   override val id: Int = StatisticsType.TYPE_PART_BY_VALUE
 
   private lazy val maxPartNum: Int = conf.getInt(
@@ -269,6 +269,7 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
   }
 
   def buildPartMeta(keyArray: Array[Product2[Key, Seq[Int]]], isLast: Boolean): Unit = {
+    logInfo("buildPartMetax")
     var kv: Product2[Key, Seq[Int]] = null
     if (keyArray != null && keyArray.size != 0) {
       keyArray.foreach(
@@ -287,6 +288,8 @@ private[oap] class PartByValueStatisticsWriter(schema: StructType, conf: Configu
       if (isLast && ((this.keyCount - 1) > (this.idxNum - 1) * this.partSize)) {
         metas.append(PartedByValueMeta(this.idxNum, kv._1, this.keyCount - 1, this.curIdxCount))
       }
+
+      logInfo(s"metas size: ${metas.size}")
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -88,6 +88,7 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
 
   protected var sampleArray: Array[Key] = _
 
+  // this is the common part used by write and write2
   private def internalWrite(writer: OutputStream, offsetP: Int, sizeP: Int): Int = {
     var offset = offsetP
     val size = sizeP
@@ -126,7 +127,7 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
     Random.shuffle(keys.indices.toList).take(size).map(keys(_)).toArray
 
   protected var randomHashSet: mutable.HashSet[Int] = mutable.HashSet.empty[Int]
-  protected var sampleArrayBuffer: ArrayBuffer[Key] = _
+  protected var sampleArrayBuffer: ArrayBuffer[Key] = ArrayBuffer.empty[Key]
   private var keyCount: Int = 0
 
   override def write2(writer: OutputStream): Int = {
@@ -147,7 +148,6 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
       Random.shuffle((0 to totalSorterRecordSize).indices.toList).take(size)
         .foreach(randomHashSet.add(_))
     }
-    sampleArrayBuffer = ArrayBuffer.empty[Key]
   }
 
   def buildSampleArray(keyArray: Array[Product2[Key, Seq[Int]]], isLast: Boolean): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -125,8 +125,8 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
   protected def takeSample(keys: ArrayBuffer[InternalRow], size: Int): Array[InternalRow] =
     Random.shuffle(keys.indices.toList).take(size).map(keys(_)).toArray
 
-  private var randomHashSet: mutable.HashSet[Int] = mutable.HashSet.empty[Int]
-  private var sampleArrayBuffer: ArrayBuffer[Key] = _
+  protected var randomHashSet: mutable.HashSet[Int] = mutable.HashSet.empty[Int]
+  protected var sampleArrayBuffer: ArrayBuffer[Key] = _
   private var keyCount: Int = 0
 
   override def write2(writer: OutputStream): Int = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/SampleBasedStatistics.scala
@@ -24,6 +24,8 @@ import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.{Aggregator, TaskContext}
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
@@ -31,9 +33,10 @@ import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
 import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.collection.OapExternalSorter
 
 private[oap] class SampleBasedStatisticsReader(
-    schema: StructType) extends StatisticsReader(schema) {
+    schema: StructType) extends StatisticsReader(schema) with Logging{
   override val id: Int = StatisticsType.TYPE_SAMPLE_BASE
 
   @transient private lazy val ordering = GenerateOrdering.create(schema)
@@ -41,6 +44,7 @@ private[oap] class SampleBasedStatisticsReader(
   protected var sampleArray: Array[Key] = _
 
   override def read(fiberCache: FiberCache, offset: Int): Int = {
+    logInfo(s"start to read sample")
     var readOffset = super.read(fiberCache, offset) + offset
 
     val size = fiberCache.getInt(readOffset)
@@ -48,19 +52,21 @@ private[oap] class SampleBasedStatisticsReader(
 
     // TODO use unsafe way to interact with sample array
     sampleArray = new Array[Key](size)
-
+    logInfo(s"read sampleArray size: ${sampleArray.size}")
     var rowOffset = 0
     for (i <- 0 until size) {
       sampleArray(i) = nnkr.readKey(
         fiberCache, readOffset + size * IndexUtils.INT_SIZE + rowOffset)._1
       rowOffset = fiberCache.getInt(readOffset + i * IndexUtils.INT_SIZE)
     }
+    logInfo(s"read rowOffset: ${rowOffset}")
     readOffset += (rowOffset + size * IndexUtils.INT_SIZE)
     readOffset - offset
   }
 
   override def analyse(intervalArray: ArrayBuffer[RangeInterval]): StatsAnalysisResult = {
     if (sampleArray == null || sampleArray.isEmpty) {
+      logInfo("Use Index")
       StatsAnalysisResult.USE_INDEX
     } else {
       var hitCnt = 0
@@ -70,13 +76,14 @@ private[oap] class SampleBasedStatisticsReader(
           hitCnt += 1
         }
       }
+      logInfo((hitCnt * 1.0 / sampleArray.length).toString)
       StatsAnalysisResult(hitCnt * 1.0 / sampleArray.length)
     }
   }
 }
 
 private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configuration)
-  extends StatisticsWriter(schema, conf) {
+  extends StatisticsWriter(schema, conf) with Logging{
   override val id: Int = StatisticsType.TYPE_SAMPLE_BASE
 
   lazy val sampleRate: Double = conf.getDouble(
@@ -87,6 +94,36 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
     OapConf.OAP_STATISTICS_SAMPLE_MIN_SIZE.defaultValue.get)
 
   protected var sampleArray: Array[Key] = _
+
+  protected var isExternalSorterEnable =
+    conf.getBoolean(OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.key,
+    OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.defaultValue.get)
+
+  @transient private lazy val ordering = GenerateOrdering.create(schema)
+  protected val combiner: Int => Seq[Int] = Seq(_)
+  protected val merger: (Seq[Int], Int) => Seq[Int] = _ :+ _
+  protected val mergeCombiner: (Seq[Int], Seq[Int]) => Seq[Int] = _ ++ _
+  protected val aggregator =
+    new Aggregator[InternalRow, Int, Seq[Int]](combiner, merger, mergeCombiner)
+  protected var externalSorter = {
+      if (isExternalSorterEnable) {
+      val taskContext = TaskContext.get()
+      val sorter = new OapExternalSorter[InternalRow, Int, Seq[Int]](
+        taskContext, Some(aggregator), Some(ordering))
+      taskContext.addTaskCompletionListener(_ => sorter.stop())
+      sorter
+    } else {
+      null
+    }
+  }
+  private var recordCount: Int = 0
+
+  override def addOapKey(key: Key): Unit = {
+    if (isExternalSorterEnable) {
+      externalSorter.insert(key, recordCount)
+      recordCount += 1
+    }
+  }
 
   private def internalWrite(writer: OutputStream, offsetP: Int, sizeP: Int): Int = {
     var offset = offsetP
@@ -125,24 +162,34 @@ private[oap] class SampleBasedStatisticsWriter(schema: StructType, conf: Configu
   protected def takeSample(keys: ArrayBuffer[InternalRow], size: Int): Array[InternalRow] =
     Random.shuffle(keys.indices.toList).take(size).map(keys(_)).toArray
 
-  override def write(writer: OutputStream, sortedIter: Iterator[Product2[Key, Seq[Int]]]): Int = {
-    val offset = super.write(writer, sortedIter)
-    val keySize = sortedIter.size
+  override def customWrite(writer: OutputStream): Int = {
+    val offset = super.customWrite(writer)
+    val sortedIter = externalSorter.iterator
+    val keySize = recordCount
     val size = math.max(
       (keySize * sampleRate).toInt, math.min(minSampleSize, keySize))
     sampleArray = takeSample(sortedIter, size, keySize)
-
-    internalWrite(writer, offset, size)
+    logInfo(s"write sampleArray size: ${sampleArray.size}")
+    internalWrite(writer, offset, sampleArray.size)
   }
 
   protected def takeSample(
     sortedIter: Iterator[Product2[Key, Seq[Int]]],
     size: Int,
     keySize: Int): Array[InternalRow] = {
-    val hashset: mutable.HashSet[Int] = mutable.HashSet.empty[Int]
-    while(hashset.size < size) {
-      hashset.add(Random.nextInt((keySize - 1)))
+    // use Hashset only when sample size is much smaller than keySize
+    if (size == (keySize * sampleRate).toInt) {
+      val hashset: mutable.HashSet[Int] = mutable.HashSet.empty[Int]
+      while (hashset.size <= size) {
+        hashset.add(Random.nextInt((keySize - 1)))
+      }
+      logInfo(s"use hashset: ${hashset.size}")
+      sortedIter.zipWithIndex.filter(v => hashset.contains(v._2)).map(_._1._1).toArray
+    } else {
+      val dataList = sortedIter.toList
+      logInfo(s"use dataList: ${dataList.size}")
+      Random.shuffle(dataList.indices.toList)
+        .take(size).map(dataList(_)._1).toArray
     }
-    sortedIter.zipWithIndex.filter(v => hashset.contains(v._2)).map(_._1._1).toArray
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -85,7 +85,7 @@ abstract class StatisticsWriter(schema: StructType, conf: Configuration) {
     4
   }
 
-  // this write2 methold is used when enable externalSorter
+  // this write2 is used when enable externalSorter
   def write2(writer: OutputStream): Int = {
     IndexUtils.writeInt(writer, id)
     4

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -84,6 +84,11 @@ abstract class StatisticsWriter(schema: StructType, conf: Configuration) {
     IndexUtils.writeInt(writer, id)
     4
   }
+
+  def write(writer: OutputStream, sortedIter: Iterator[Product2[Key, Seq[Int]]]): Int = {
+    IndexUtils.writeInt(writer, id)
+    4
+  }
 }
 
 // tool function for Statistics class

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -85,7 +85,8 @@ abstract class StatisticsWriter(schema: StructType, conf: Configuration) {
     4
   }
 
-  def customWrite(writer: OutputStream): Int = {
+  // this write2 methold is used when enable externalSorter
+  def write2(writer: OutputStream): Int = {
     IndexUtils.writeInt(writer, id)
     4
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/Statistics.scala
@@ -85,7 +85,7 @@ abstract class StatisticsWriter(schema: StructType, conf: Configuration) {
     4
   }
 
-  def write(writer: OutputStream, sortedIter: Iterator[Product2[Key, Seq[Int]]]): Int = {
+  def customWrite(writer: OutputStream): Int = {
     IndexUtils.writeInt(writer, id)
     4
   }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.datasources.oap.Key
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
@@ -128,7 +127,7 @@ class StatisticsWriteManager {
   private def sortKeys = content.sortWith((l, r) => ordering.compare(l, r) < 0)
 }
 
-object StatisticsManager extends Logging{
+object StatisticsManager {
   val STATISTICSMASK: Long = 0x20170524abcdefabL // a random mask for statistics begin
 
   val statisticsTypeMap: scala.collection.mutable.Map[OapIndexType, Array[String]] =
@@ -164,7 +163,6 @@ object StatisticsManager extends Logging{
       stats: Array[StatisticsReader],
       intervalArray: ArrayBuffer[RangeInterval],
       conf: Configuration): StatsAnalysisResult = {
-    logInfo("start statistic analyse")
     val fullScanThreshold = conf.getDouble(
       OapConf.OAP_FULL_SCAN_THRESHOLD.key, OapConf.OAP_FULL_SCAN_THRESHOLD.defaultValue.get)
     val analysisResults = stats.map(_.analyse(intervalArray))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -50,7 +50,7 @@ class StatisticsWriteManager {
 
   @transient private lazy val ordering = GenerateOrdering.create(schema)
 
-  private var _isExternalSorterEnable = false
+  private var _isExternalSorterEnable = true
 
   def isExternalSorterEnable: Boolean = _isExternalSorterEnable
   // When a task initialize statisticsWriteManager, we read all config from `conf`,

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -323,4 +323,11 @@ object OapConf {
         "is empty, it will store in the data file path")
       .stringConf
       .createWithDefault("")
+
+  val OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistic.externalsorter.enable")
+      .internal()
+      .doc("To indicate if to enable externalsorter for statistic calculation")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -329,5 +329,5 @@ object OapConf {
       .internal()
       .doc("To indicate if to enable externalsorter for statistic calculation")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to integrate PartByValue and SampleBased Statistics calculation into btree externalSorter iterator consumption. This will reduce memory consuming by not loading all file data into ArrayBuffer. Details please refer to #1052 

To disable this calculation, set `spark.sql.oap.index.statistic.externalsorter.enable` to `false`. This currently is only available for BTree index

Here is simple design doc
 https://docs.google.com/document/d/1tj91NNnTFrTfdIA4Q66P3lUGY7bCJAO2m8JFhIp8fNk/edit?usp=sharing

## How was this patch tested?
Added more PartByValue and SampleBased Statistics test