### PR TITLE
Separate index and cache functionality for OAP FileFormat

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValuesBytes.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/ColumnValuesBytes.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap
+
+import java.nio.{ByteBuffer, ByteOrder}
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+class ColumnValuesBytes(defaultSize: Int, dataType: DataType, bytesData: Array[Byte])
+  extends ColumnValues(defaultSize, dataType, null) {
+  require(dataType.isInstanceOf[AtomicType], s"Only atomic type accepted for now, got $dataType.")
+
+  // for any FiberData, the first `(defaultSize - 1) >> 6 + 1` longs will be the bitmask
+  // num of bytes needed to hold defaultSize elements is then `((defaultSize - 1) >> 6 << 3) + 8`
+  private val dataOffset = ((defaultSize - 1) >> 6 << 3) + 8
+
+  var byteBufferWraper = ByteBuffer.wrap(bytesData).order(ByteOrder.LITTLE_ENDIAN)
+
+  override def isNullAt(idx: Int): Boolean = {
+    val bitmask = 1L << (idx & 0x3f)   // mod 64 and shift
+    (byteBufferWraper.getLong(idx >> 6 << 3) & bitmask) == 0  // div by 64 and mask
+  }
+
+  private def genericGet(idx: Int): Any = dataType match {
+    case BinaryType => getBinaryValue(idx)
+    case BooleanType => getBooleanValue(idx)
+    case ByteType => getByteValue(idx)
+    case DateType => getDateValue(idx)
+    case DoubleType => getDoubleValue(idx)
+    case FloatType => getFloatValue(idx)
+    case IntegerType => getIntValue(idx)
+    case LongType => getLongValue(idx)
+    case ShortType => getShortValue(idx)
+    case StringType => getStringValue(idx)
+    case _: ArrayType => throw new NotImplementedError(s"Array")
+    case CalendarIntervalType => throw new NotImplementedError(s"CalendarInterval")
+    case _: DecimalType => throw new NotImplementedError(s"Decimal")
+    case _: MapType => throw new NotImplementedError(s"Map")
+    case _: StructType => throw new NotImplementedError(s"Struct")
+    case TimestampType => throw new NotImplementedError(s"Timestamp")
+    case other => throw new NotImplementedError(s"$other")
+  }
+
+  private def getAs[T](idx: Int): T = genericGet(idx).asInstanceOf[T]
+  override def get(idx: Int): AnyRef = getAs(idx)
+
+  override def getBooleanValue(idx: Int): Boolean = {
+    bytesData(dataOffset + idx * BooleanType.defaultSize) == 1
+  }
+  override def getByteValue(idx: Int): Byte = {
+    byteBufferWraper.get(dataOffset + idx * ByteType.defaultSize)
+  }
+  override def getDateValue(idx: Int): Int = {
+    byteBufferWraper.getInt(dataOffset + idx * IntegerType.defaultSize)
+  }
+  override def getDoubleValue(idx: Int): Double = {
+    byteBufferWraper.getDouble(dataOffset + idx * DoubleType.defaultSize)
+  }
+  override def getIntValue(idx: Int): Int = {
+    byteBufferWraper.getInt(dataOffset + idx * IntegerType.defaultSize)
+  }
+  override def getLongValue(idx: Int): Long = {
+    byteBufferWraper.getLong(dataOffset + idx * LongType.defaultSize)
+  }
+  override def getShortValue(idx: Int): Short = {
+    byteBufferWraper.getShort(dataOffset + idx * ShortType.defaultSize)
+  }
+  override def getFloatValue(idx: Int): Float = {
+    byteBufferWraper.getFloat(dataOffset + idx * FloatType.defaultSize)
+  }
+
+  override def getStringValue(idx: Int): UTF8String = {
+    //  The byte data format like:
+    //    value #1 length (int)
+    //    value #1 offset, (0 - based to the start of this Fiber Group)
+    //    value #2 length
+    //    value #2 offset, (0 - based to the start of this Fiber Group)
+    //    …
+    //    …
+    //    value #N length
+    //    value #N offset, (0 - based to the start of this Fiber Group)
+    //    value #1
+    //    value #2
+    //    …
+    //    value #N
+    val length = getIntValue(idx * 2)
+    val offset = getIntValue(idx * 2 + 1)
+
+    UTF8String.fromBytes(bytesData, offset, length)
+  }
+
+  override def getBinaryValue(idx: Int): Array[Byte] = {
+    //  The byte data format like:
+    //    value #1 length (int)
+    //    value #1 offset, (0 - based to the start of this Fiber Group)
+    //    value #2 length
+    //    value #2 offset, (0 - based to the start of this Fiber Group)
+    //    …
+    //    …
+    //    value #N length
+    //    value #N offset, (0 - based to the start of this Fiber Group)
+    //    value #1
+    //    value #2
+    //    …
+    //    value #N
+    val length = getIntValue(idx * 2)
+    val offset = getIntValue(idx * 2 + 1)
+
+    val array = new Array[Byte](length)
+    System.arraycopy(bytesData, offset, array, 0, length)
+    array
+  }
+}
+
+

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -28,6 +28,7 @@ import org.apache.parquet.column.values.dictionary.PlainValuesDictionary.{PlainB
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.oap._
 import org.apache.spark.sql.execution.datasources.oap.filecache._
+import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
@@ -41,6 +42,10 @@ private[oap] case class OapDataFileV1(
     path: String,
     schema: StructType,
     configuration: Configuration) extends OapDataFile {
+
+  private val oapDataCacheEnable =
+    configuration.getBoolean(OapConf.OAP_OAPFILEFORMAT_DATA_CACHE_ENABLED.key,
+      OapConf.OAP_OAPFILEFORMAT_DATA_CACHE_ENABLED.defaultValue.get)
 
   private val dictionaries = new Array[Dictionary](schema.length)
   private val codecFactory = new CodecFactory(configuration)
@@ -139,6 +144,53 @@ private[oap] case class OapDataFileV1(
     OapRuntime.getOrCreate.memoryManager.toDataFiberCache(data)
   }
 
+  def getFiberBytes(groupId: Int, fiberId: Int): Array[Byte] = {
+    val groupMeta = meta.rowGroupsMeta(groupId)
+    val decompressor: BytesDecompressor = codecFactory.getDecompressor(meta.codec)
+
+    // get the fiber data start position
+    // TODO: update the meta to store the fiber start pos
+    var i = 0
+    var fiberStart = groupMeta.start
+    while (i < fiberId) {
+      fiberStart += groupMeta.fiberLens(i)
+      i += 1
+    }
+    val len = groupMeta.fiberLens(fiberId)
+    val uncompressedLen = groupMeta.fiberUncompressedLens(fiberId)
+    val encoding = meta.columnsMeta(fiberId).encoding
+
+    val bytes = new Array[Byte](len)
+
+    val is = meta.fin
+    // TODO: replace by FSDataInputStream.readFully(position, buffer) which is thread safe
+    is.synchronized {
+      is.seek(fiberStart)
+      is.readFully(bytes)
+    }
+
+    val dataType = schema(fiberId).dataType
+    val dictionary = getDictionary(fiberId)
+    val fiberParser =
+      if (dictionary != null) {
+        DictionaryBasedDataFiberParser(encoding, meta, dictionary, dataType)
+      } else {
+        DataFiberParser(encoding, meta, dataType)
+      }
+
+    val rowCount =
+      if (groupId == meta.groupCount - 1) {
+        meta.rowCountInLastGroup
+      } else {
+        meta.rowCountInEachGroup
+      }
+
+    // We have to read Array[Byte] from file and decode/decompress it before putToFiberCache
+    // TODO: Try to finish this in off-heap memory
+    val data = fiberParser.parse(decompressor.decompress(bytes, uncompressedLen), rowCount)
+    data
+  }
+
   private def buildIterator(
       conf: Configuration,
       requiredIds: Array[Int],
@@ -154,29 +206,62 @@ private[oap] case class OapDataFileV1(
       groupIds.iterator.filterNot(isSkippedByRowGroup(filters, _))
     }
 
-    val iterator = groupIdsNonSkipped.flatMap {
-      groupId =>
-        val fiberCacheGroup = requiredIds.map { id =>
-          val fiberCache = OapRuntime.getOrCreate.fiberCacheManager.get(
-            DataFiberId(this, id, groupId))
-          update(id, fiberCache)
-          fiberCache
-        }
+    var iterator: Iterator[Key] = null
+    if(oapDataCacheEnable) {
+      iterator = groupIdsNonSkipped.flatMap {
+        groupId =>
+          val fiberCacheGroup = requiredIds.map { id =>
+            val fiberCache = OapRuntime.getOrCreate.fiberCacheManager.get(
+              DataFiberId(this, id, groupId))
+            update(id, fiberCache)
+            fiberCache
+          }
 
-        val columns = fiberCacheGroup.zip(requiredIds).map { case (fiberCache, id) =>
-          new ColumnValues(meta.rowCountInEachGroup, schema(id).dataType, fiberCache)
-        }
+          val columns = fiberCacheGroup.zip(requiredIds).map { case (fiberCache, id) =>
+            new ColumnValues(meta.rowCountInEachGroup, schema(id).dataType, fiberCache)
+          }
 
-        val rowCount =
-          if (groupId < meta.groupCount - 1) meta.rowCountInEachGroup else meta.rowCountInLastGroup
-        rows.reset(rowCount, columns)
+          val rowCount =
+            if (groupId < meta.groupCount - 1) meta.rowCountInEachGroup
+            else meta.rowCountInLastGroup
+          rows.reset(rowCount, columns)
 
-        groupIdToRowIds match {
-          case Some(map) =>
-            map(groupId).iterator.map(rowId => rows.moveToRow(rowId % meta.rowCountInEachGroup))
-          case None => rows.toIterator
-        }
+          groupIdToRowIds match {
+            case Some(map) =>
+              map(groupId).iterator.map(rowId => rows.moveToRow(rowId % meta.rowCountInEachGroup))
+            case None => rows.toIterator
+          }
+      }
     }
+    else {
+      iterator = groupIdsNonSkipped.flatMap {
+        groupId =>
+          val fiberDataGroup = requiredIds.map { id =>
+            val fiberBytes = getFiberBytes(groupId, id)
+//            update(id, fiberCache)
+            fiberBytes
+          }
+
+          val columns = fiberDataGroup.zip(requiredIds).map { case (fiberData, id) =>
+            val columnValues: ColumnValues = new ColumnValuesBytes(meta.rowCountInEachGroup,
+              schema(id).dataType, fiberData)
+//            columnValues.getIntValue(1)
+            columnValues
+          }
+
+          val rowCount =
+            if (groupId < meta.groupCount - 1) meta.rowCountInEachGroup
+            else meta.rowCountInLastGroup
+          rows.reset(rowCount, columns)
+
+          groupIdToRowIds match {
+            case Some(map) =>
+              map(groupId).iterator.map(rowId => rows.moveToRow(rowId % meta.rowCountInEachGroup))
+            case None => rows.toIterator
+          }
+      }
+    }
+
     new OapCompletionIterator[InternalRow](iterator, inUseFiberCache.indices.foreach(release)) {
       override def close(): Unit = {
         // To ensure if any exception happens, caches are still released after calling close()

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -309,6 +309,13 @@ object OapConf {
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_OAPFILEFORMAT_DATA_CACHE_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.oapfileformat.data.cache.enable")
+      .internal()
+      .doc("To indicate if enable parquet data cache, default false")
+      .booleanConf
+      .createWithDefault(false)
+
   val OAP_ORC_DATA_CACHE_ENABLED =
     SqlConfAdapter.buildConf("spark.sql.oap.orc.data.cache.enable")
       .internal()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapSuite.scala
@@ -68,6 +68,13 @@ class OapSuite extends QueryTest with SharedOapContext with BeforeAndAfter {
   override def afterEach(): Unit = {}
 
   test("reading oap file") {
+    sqlContext.conf.setConf(OapConf.OAP_OAPFILEFORMAT_DATA_CACHE_ENABLED, true)
+    verifyFrame(sqlContext.read.format("oap").load(path.getAbsolutePath))
+  }
+
+  test("reading oap file without cache") {
+    // scalastyle:off println
+    println("without cache")
     verifyFrame(sqlContext.read.format("oap").load(path.getAbsolutePath))
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

About OAP FileFormat, Separate index and cache functionality for better testing index and improving.

Now, have implemented basic separation

Later, will refactor some classes, add more unit tests.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

