### PR TITLE
Correct index path for dataframe.createTempView("${path}/*.parquet")

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -217,8 +217,8 @@ private[oap] object IndexUtils {
 
     def getDirIfisFile(path: Path): Path = {
       val fs = path.getFileSystem(hadoopConf)
-       if (fs.isFile(path)) path.getParent
-       else path
+      if (fs.isFile(path)) path.getParent
+      else path
     }
 
     val paths = fileIndex.rootPaths

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -185,7 +185,7 @@ case class CreateIndexCommand(
     }
     // Generate the outPutPath based on OapConf.OAP_INDEX_DIRECTORY and the data path,
     // here the dataPath does not contain the partition path
-    val outPutPath = IndexUtils.getOutputPathBasedOnConf(fileCatalog, sparkSession.conf)
+    val outPutPath = IndexUtils.getOutputPathBasedOnConf(fileCatalog, sparkSession.conf, configuration)
     assert(outPutPath != null, "Expected exactly one path to be specified, but no value")
 
     val qualifiedOutputPath = {
@@ -445,7 +445,7 @@ case class RefreshIndexCommand(
 
       // Generate the outPutPath based on OapConf.OAP_INDEX_DIRECTORY and the data path,
       // here the dataPath does not contain the partition path
-      val outPutPath = IndexUtils.getOutputPathBasedOnConf(fileCatalog, sparkSession.conf)
+      val outPutPath = IndexUtils.getOutputPathBasedOnConf(fileCatalog, sparkSession.conf, configuration)
       assert(outPutPath != null, "Expected exactly one path to be specified, but no value")
 
       val qualifiedOutputPath = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/indexPlans.scala
@@ -185,7 +185,8 @@ case class CreateIndexCommand(
     }
     // Generate the outPutPath based on OapConf.OAP_INDEX_DIRECTORY and the data path,
     // here the dataPath does not contain the partition path
-    val outPutPath = IndexUtils.getOutputPathBasedOnConf(fileCatalog, sparkSession.conf, configuration)
+    val outPutPath = IndexUtils.getOutputPathBasedOnConf(
+      fileCatalog, sparkSession.conf, configuration)
     assert(outPutPath != null, "Expected exactly one path to be specified, but no value")
 
     val qualifiedOutputPath = {
@@ -445,7 +446,8 @@ case class RefreshIndexCommand(
 
       // Generate the outPutPath based on OapConf.OAP_INDEX_DIRECTORY and the data path,
       // here the dataPath does not contain the partition path
-      val outPutPath = IndexUtils.getOutputPathBasedOnConf(fileCatalog, sparkSession.conf, configuration)
+      val outPutPath = IndexUtils.getOutputPathBasedOnConf(
+        fileCatalog, sparkSession.conf, configuration)
       assert(outPutPath != null, "Expected exactly one path to be specified, but no value")
 
       val qualifiedOutputPath = {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexCreateSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexCreateSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.index
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.sql.test.oap.{SharedOapContext, TestIndex}
+import org.apache.spark.util.Utils
+
+class IndexCreateSuite extends QueryTest with SharedOapContext with BeforeAndAfterEach {
+  // TODO move Parquet TestSuite from FilterSuite
+  import testImplicits._
+
+  private var currentParquetPath: String = _
+  private var defaultEis: Boolean = true
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // In this suite we don't want to skip index even if the cost is higher.
+    defaultEis = sqlContext.conf.getConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION)
+    sqlContext.conf.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION, false)
+  }
+
+  override def afterAll(): Unit = {
+    sqlContext.conf.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION, defaultEis)
+    super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    val path = Utils.createTempDir().getAbsolutePath
+    currentParquetPath = path + "/test"
+  }
+
+  test("OAP#1061 Index path fault for path like /*.parquet") {
+    val dataDF =
+      (1 to 300).map { i => (i, s"this is test $i") }.toDF("a", "b")
+    dataDF.write.parquet(currentParquetPath);
+    spark.read.parquet(s"${currentParquetPath}/*.parquet")
+      .createOrReplaceTempView("parquet_test")
+    withIndex(TestIndex("parquet_test", "indexA")) {
+      // create index
+      sql("create oindex indexA on parquet_test (a)")
+      val beforeQuery = OapRuntime.getOrCreate.fiberCacheManager.cacheStats.indexFiberCount
+      val df = sql("SELECT b FROM parquet_test WHERE a = 1 or a = 2")
+      checkAnswer(df, Row("this is test 1") :: Row("this is test 2") :: Nil)
+      val afterQuery = OapRuntime.getOrCreate.fiberCacheManager.cacheStats.indexFiberCount
+      assert(afterQuery == beforeQuery + 4)
+    }
+    sqlContext.dropTempTable("parquet_test")
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtilsSuite.scala
@@ -333,31 +333,35 @@ class IndexUtilsSuite extends SparkFunSuite with SharedOapContext with Logging {
 
   test("test rootPaths empty") {
     val fileIndex = new InMemoryFileIndex(spark, Seq.empty, Map.empty, None)
+    val configuration = spark.sessionState.newHadoopConf()
     intercept[AssertionError] {
-      IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf)
+      IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf, configuration)
     }
   }
 
   test("test rootPaths length eq 1 no partitioned") {
+    val configuration = spark.sessionState.newHadoopConf()
     val tablePath = new Path("/table")
     val rootPaths = Seq(tablePath)
     val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, None)
-    val ret = IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf)
+    val ret = IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf, configuration)
     assert(ret.equals(tablePath))
   }
 
   test("test rootPaths length eq 1 partitioned") {
+    val configuration = spark.sessionState.newHadoopConf()
     val tablePath = new Path("/table")
     val partitionSchema = new StructType()
       .add(StructField("a", StringType))
       .add(StructField("b", StringType))
     val rootPaths = Seq(tablePath)
     val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, Some(partitionSchema))
-    val ret = IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf)
+    val ret = IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf, configuration)
     assert(ret.equals(tablePath))
   }
 
   test("test rootPaths length more than 1") {
+    val configuration = spark.sessionState.newHadoopConf()
     val part1 = new Path("/table/a=1/b=1")
     val part2 = new Path("/table/a=1/b=2")
     val tablePath = new Path("/table")
@@ -366,18 +370,19 @@ class IndexUtilsSuite extends SparkFunSuite with SharedOapContext with Logging {
       .add(StructField("b", StringType))
     val rootPaths = Seq(part1, part2)
     val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, Some(partitionSchema))
-    val ret = IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf)
+    val ret = IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf, configuration)
     assert(ret.equals(tablePath))
   }
 
   test("test rootPaths length eq 1 but partitioned") {
+    val configuration = spark.sessionState.newHadoopConf()
     val part1 = new Path("/table/a=1/b=1")
     val partitionSchema = new StructType()
       .add(StructField("a", StringType))
       .add(StructField("b", StringType))
     val rootPaths = Seq(part1)
     val fileIndex = new InMemoryFileIndex(spark, rootPaths, Map.empty, Some(partitionSchema))
-    val ret = IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf)
+    val ret = IndexUtils.getOutputPathBasedOnConf(fileIndex, spark.conf, configuration)
     assert(ret.equals(part1))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Please reference to #1061, this fix is to correct the index path when using Temp View


## How was this patch tested?
Added a suite to test this scenario