### PR TITLE
Use a sparksession to lazy init conf of OapSparkSqlParser

### DIFF
--- a/src/main/scala/org/apache/spark/sql/OapExtensions.scala
+++ b/src/main/scala/org/apache/spark/sql/OapExtensions.scala
@@ -29,6 +29,6 @@ class OapExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectPlannerStrategy(_ => OapGroupAggregateStrategy)
     extensions.injectPlannerStrategy(_ => OapFileSourceStrategy)
     // Oap Custom SqlParser.
-    extensions.injectParser((_, _) => new OapSparkSqlParser)
+    extensions.injectParser((session, _) => new OapSparkSqlParser(session))
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/OapSparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/OapSparkSqlParser.scala
@@ -27,8 +27,8 @@ import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
 /**
  * Concrete parser for Spark SQL statements.
  */
- class OapSparkSqlParser extends AbstractSqlParser {
-  lazy val conf = SparkSession.getActiveSession.get.sessionState.conf
+ class OapSparkSqlParser(session: SparkSession) extends AbstractSqlParser {
+  lazy val conf = session.sessionState.conf
   lazy val astBuilder = new OapSparkSqlAstBuilder(conf)
 
   private lazy val substitutor = new VariableSubstitution(conf)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previous usage can work relied on every thread call `SparkSession.setActiveSession` api manually in a multithreaded scenario.

## How was this patch tested?

exiting test
