### PR TITLE
Support Persistent Memory destroy method and fiberCacheManager.resetAll()

### DIFF
--- a/src/main/java/org/apache/spark/unsafe/PersistentMemoryPlatform.java
+++ b/src/main/java/org/apache/spark/unsafe/PersistentMemoryPlatform.java
@@ -36,6 +36,10 @@ public class PersistentMemoryPlatform {
     NativeLibraryLoader.load(LIBNAME);
   }
 
+  public static void resetInitFlag() {
+    initialized = false;
+  }
+
   /**
    * Initialize the persistent memory.
    * @param path The initial path which should be a directory.
@@ -84,4 +88,6 @@ public class PersistentMemoryPlatform {
    * Free the memory by address.
    */
   public static native void freeMemory(long address);
+
+  public static native void destroyKind();
 }

--- a/src/main/native/org_apache_spark_unsafe_PersistentMemoryPlatform.cpp
+++ b/src/main/native/org_apache_spark_unsafe_PersistentMemoryPlatform.cpp
@@ -26,6 +26,7 @@
 
 using memkind = struct memkind;
 memkind *pmemkind = NULL;
+struct memkind_config *pmemkind_config;
 
 // copied form openjdk: http://hg.openjdk.java.net/jdk8/jdk8/hotspot/file/87ee5ee27509/src/share/vm/prims/unsafe.cpp
 inline void* addr_from_java(jlong addr) {
@@ -55,7 +56,11 @@ JNIEXPORT void JNICALL Java_org_apache_spark_unsafe_PersistentMemoryPlatform_ini
   const char* str = env->GetStringUTFChars(path, NULL);
   size_t sz = (size_t)size;
   // Initialize persistent memory
-  int error = memkind_create_pmem(str, sz, &pmemkind);
+  memkind_config = memkind_config_new();
+  memkind_config_set_path(pmemkind_config, str);
+  memkind_config_set_size(pmemkind_config, sz);
+  memkind_config_set_memory_usage_policy(pmemkind_config, MEMKIND_MEM_USAGE_POLICY_CONSERVATIVE);
+  int error = memkind_create_pmem_with_config(pmemkind_config, &pmemkind);
   if (error) {
     jclass exceptionCls = env->FindClass("java/lang/Exception");
     env->ThrowNew(exceptionCls,

--- a/src/main/native/org_apache_spark_unsafe_PersistentMemoryPlatform.cpp
+++ b/src/main/native/org_apache_spark_unsafe_PersistentMemoryPlatform.cpp
@@ -56,7 +56,7 @@ JNIEXPORT void JNICALL Java_org_apache_spark_unsafe_PersistentMemoryPlatform_ini
   const char* str = env->GetStringUTFChars(path, NULL);
   size_t sz = (size_t)size;
   // Initialize persistent memory
-  memkind_config = memkind_config_new();
+  pmemkind_config = memkind_config_new();
   memkind_config_set_path(pmemkind_config, str);
   memkind_config_set_size(pmemkind_config, sz);
   memkind_config_set_memory_usage_policy(pmemkind_config, MEMKIND_MEM_USAGE_POLICY_CONSERVATIVE);

--- a/src/main/native/org_apache_spark_unsafe_PersistentMemoryPlatform.h
+++ b/src/main/native/org_apache_spark_unsafe_PersistentMemoryPlatform.h
@@ -56,6 +56,14 @@ JNIEXPORT jlong JNICALL Java_org_apache_spark_unsafe_PersistentMemoryPlatform_ge
 JNIEXPORT void JNICALL Java_org_apache_spark_unsafe_PersistentMemoryPlatform_freeMemory
   (JNIEnv *, jclass, jlong);
 
+/*
+ * Class:     org_apache_spark_unsafe_PersistentMemoryPlatform
+ * Method:    destroyKind
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_org_apache_spark_unsafe_PersistentMemoryPlatform_destroyKind
+  (JNIEnv *, jclass);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/scala/org/apache/spark/sql/execution/OapSparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/OapSparkSqlParser.scala
@@ -77,6 +77,10 @@ class OapSparkSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
   }
 
+  override def visitOapDropCache(ctx: OapDropCacheContext): LogicalPlan = withOrigin(ctx) {
+    DropCacheCommand("drop cache")
+  }
+
   override def visitIndexCols(ctx: IndexColsContext): Array[IndexColumn] = withOrigin(ctx) {
     ctx.indexCol.toArray(new Array[IndexColContext](ctx.indexCol.size)).map(visitIndexCol)
   }

--- a/src/main/scala/org/apache/spark/sql/execution/OapSparkSqlParser.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/OapSparkSqlParser.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.datasources.oap.index._
 import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
+import org.apache.spark.sql.oap.rpc.CacheBehaviorEnum
 
 /**
  * Concrete parser for Spark SQL statements.
@@ -77,8 +78,8 @@ class OapSparkSqlAstBuilder(conf: SQLConf) extends SparkSqlAstBuilder(conf) {
       Option(ctx.partitionSpec).map(visitNonOptionalPartitionSpec))
   }
 
-  override def visitOapDropCache(ctx: OapDropCacheContext): LogicalPlan = withOrigin(ctx) {
-    DropCacheCommand("drop cache")
+  override def visitOapResetCache(ctx: OapResetCacheContext): LogicalPlan = withOrigin(ctx) {
+    OapCacheCommand(CacheBehaviorEnum.RESET)
   }
 
   override def visitIndexCols(ctx: IndexColsContext): Array[IndexColumn] = withOrigin(ctx) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -179,7 +179,7 @@ private[sql] class FiberCacheManager(
   }
 
   // Used by test suite
-  private[oap] def clearAllFibers(): Unit = cacheBackend.cleanUp
+  def clearAllFibers(): Unit = cacheBackend.cleanUp
 
   // TODO: test case, consider data eviction, try not use DataFileMeta which my be costly
   private[sql] def status(): String = {

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -128,24 +128,27 @@ object OapConf {
   val OAP_DATAFIBER_USE_FIBERCACHE_RATIO =
     SqlConfAdapter.buildConf("spark.sql.oap.dataCache.use.fiberCache.ratio")
       .internal()
-      .doc("Define the ratio of data cache use fiber cache ratio. " +
-        "This is not available under mix mode")
+      .doc("Define the ratio of data cache use fiber cache ratio " +
+        "when enable cache separation for single physical storage. " +
+        "This is not available under mix mode because the index and data " +
+        "will be stored in different physical storage")
       .doubleConf
       .createWithDefault(0.8)
 
   val OAP_INDEX_DATA_SEPARATION_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.index.data.cache.separation.enable")
       .internal()
-      .doc("This is to enable index and data cache separation feature for offheap and pm, " +
-        "not for MixMemoryManager")
+      .doc("This is to enable index data cache separation feature including mix memory manager")
       .booleanConf
       .createWithDefault(false)
 
   val OAP_FIBERCACHE_MEMORY_MANAGER =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.memory.manager")
       .internal()
-      .doc("Sets the implement of memory manager, it only supports offheap(DRAM OFF_HEAP) and " +
-        "(PM) Intel Optane DC persistent memory currently.")
+      .doc("Sets the implement of memory manager, it currently supports offheap(DRAM OFF_HEAP), " +
+        "pm(Intel Optane DC persistent memory) and mix(A combination of offheap and pm)." +
+        "To enable mix mode, you need to set " +
+        "spark.sql.oap.index.data.cache.separation.enable to true")
       .stringConf
       .createWithDefault("offheap")
 

--- a/src/main/scala/org/apache/spark/sql/oap/rpc/OapMessages.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/rpc/OapMessages.scala
@@ -20,6 +20,11 @@ package org.apache.spark.sql.oap.rpc
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.storage.BlockManagerId
 
+object CacheBehaviorEnum extends Enumeration {
+  type CacheBehaviorEnum = Value
+  val RESET = Value
+}
+
 private[spark] object OapMessages {
 
   sealed trait OapMessage extends Serializable
@@ -34,7 +39,8 @@ private[spark] object OapMessages {
 
   /* Master to slave messages */
   case class CacheDrop(indexName: String) extends ToOapRpcManagerSlave
-  case class CacheDropCache(name: String) extends ToOapRpcManagerSlave
+  case class OapCacheControlMsg(behavior: CacheBehaviorEnum.CacheBehaviorEnum)
+    extends ToOapRpcManagerSlave
 
   /* Slave to master messages */
   case class RegisterOapRpcManager(

--- a/src/main/scala/org/apache/spark/sql/oap/rpc/OapMessages.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/rpc/OapMessages.scala
@@ -34,6 +34,7 @@ private[spark] object OapMessages {
 
   /* Master to slave messages */
   case class CacheDrop(indexName: String) extends ToOapRpcManagerSlave
+  case class CacheDropCache(name: String) extends ToOapRpcManagerSlave
 
   /* Slave to master messages */
   case class RegisterOapRpcManager(

--- a/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
@@ -110,6 +110,7 @@ private[spark] class OapRpcManagerSlaveEndpoint(
 
   private def handleOapMessage(message: OapMessage): Unit = message match {
     case CacheDrop(indexName) => fiberCacheManager.releaseIndexCache(indexName)
+    case CacheDropCache(name) => fiberCacheManager.clearAllFibers()
     case _ =>
   }
 }

--- a/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
+++ b/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
@@ -110,7 +110,11 @@ private[spark] class OapRpcManagerSlaveEndpoint(
 
   private def handleOapMessage(message: OapMessage): Unit = message match {
     case CacheDrop(indexName) => fiberCacheManager.releaseIndexCache(indexName)
-    case CacheDropCache(name) => fiberCacheManager.clearAllFibers()
+    case OapCacheControlMsg(behavior) =>
+      behavior match {
+        case CacheBehaviorEnum.RESET =>
+          fiberCacheManager.resetAll()
+      }
     case _ =>
   }
 }

--- a/src/main/spark2.3.2/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/spark2.3.2/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -175,6 +175,7 @@ statement
         partitionSpec?                                                 #oapDropIndex
     | DISABLE SINDEX IDENTIFIER                                        #oapDisableIndex
     | ENABLE SINDEX IDENTIFIER                                         #oapEnableIndex
+    | DROP OAP CACHE                                                   #oapDropCache
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
@@ -1013,6 +1014,8 @@ OPTION: 'OPTION';
 ANTI: 'ANTI';
 LOCAL: 'LOCAL';
 INPATH: 'INPATH';
+OAP: 'OAP';
+
 
 CHECK: 'CHECK';
 SINDEX: 'SINDEX' | 'OINDEX';

--- a/src/main/spark2.3.2/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/spark2.3.2/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -175,7 +175,7 @@ statement
         partitionSpec?                                                 #oapDropIndex
     | DISABLE SINDEX IDENTIFIER                                        #oapDisableIndex
     | ENABLE SINDEX IDENTIFIER                                         #oapEnableIndex
-    | DROP OAP CACHE                                                   #oapDropCache
+    | RESET OAP CACHE                                                  #oapResetCache
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
@@ -1015,7 +1015,6 @@ ANTI: 'ANTI';
 LOCAL: 'LOCAL';
 INPATH: 'INPATH';
 OAP: 'OAP';
-
 
 CHECK: 'CHECK';
 SINDEX: 'SINDEX' | 'OINDEX';

--- a/src/main/spark2.3.2/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/src/main/spark2.3.2/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -175,7 +175,7 @@ statement
         partitionSpec?                                                 #oapDropIndex
     | DISABLE SINDEX IDENTIFIER                                        #oapDisableIndex
     | ENABLE SINDEX IDENTIFIER                                         #oapEnableIndex
-    | RESET OAP CACHE                                                  #oapResetCache
+    | RESET FIBER CACHE                                                #oapResetCache
     | SHOW SINDEX (FROM | IN) tableIdentifier                          #oapShowIndex
     | CHECK SINDEX ON tableIdentifier partitionSpec?                   #oapCheckIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
@@ -1014,7 +1014,7 @@ OPTION: 'OPTION';
 ANTI: 'ANTI';
 LOCAL: 'LOCAL';
 INPATH: 'INPATH';
-OAP: 'OAP';
+FIBER: 'FIBER';
 
 CHECK: 'CHECK';
 SINDEX: 'SINDEX' | 'OINDEX';


### PR DESCRIPTION
## What changes were proposed in this pull request?
Due to memkind memory allocate issue. This patch will allow user to reinitialize persistent memory cache pool.

Added destoryKind() method in JNI to destory memkind persistent memory pool. Added a resetAll method in fiberCacheManager to reinitialize persistent memory. Added sql grammer "RESET FIBER CACHE" to call fiberCacheManager.resetAll to reset PM cache pool.

## How was this patch tested?
ET

