### PR TITLE
[BinaryCache-2] Add BinaryDataFiberId prepare for bianry cache

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -144,6 +144,12 @@ private[sql] class FiberCacheManager(
     logDebug(s"Getting Fiber: $fiber")
     cacheBackend.get(fiber)
   }
+
+  def getIfPresent(fiber: FiberId): FiberCache = {
+    logDebug(s"Getting Fiber: $fiber")
+    cacheBackend.getIfPresent(fiber)
+  }
+
   // only for unit test
   def setCompressionConf(dataEnable: Boolean = false,
       dataCompressCodec: String = "SNAPPY"): Unit = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -17,17 +17,27 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
+import org.apache.parquet.io.SeekableInputStream
+
 import org.apache.spark.sql.execution.datasources.oap.io.DataFile
+import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.unsafe.Platform
 
 private[oap] abstract class FiberId {}
 
-private[oap] case class DataFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) extends
-    FiberId {
+case class BinaryDataFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) extends
+  DataFiberId {
+
+  // TODO now we add these 3 fields to BinaryDataFiberId for `doCache` method, is there any way to
+  //  optimize it?
+  private var input: SeekableInputStream = _
+  private var offset: Long = _
+  private var length: Int = _
 
   override def hashCode(): Int = (file.path + columnIndex + rowGroupId).hashCode
 
   override def equals(obj: Any): Boolean = obj match {
-    case another: DataFiberId =>
+    case another: BinaryDataFiberId =>
       another.columnIndex == columnIndex &&
         another.rowGroupId == rowGroupId &&
         another.file.path.equals(file.path)
@@ -35,8 +45,58 @@ private[oap] case class DataFiberId(file: DataFile, columnIndex: Int, rowGroupId
   }
 
   override def toString: String = {
-    s"type: DataFiber rowGroup: $rowGroupId column: $columnIndex\n\tfile: ${file.path}"
+    s"type: BinaryDataFiber rowGroup: $rowGroupId column: $columnIndex\n\tfile: ${file.path}"
   }
+
+  // TODO Now we use SeekableInputStream, this class from Parquet, extend to Orc we need to
+  //  refactor this.
+  def withLoadCacheParameters(input: SeekableInputStream, offset: Long, length: Int): Unit = {
+    this.input = input
+    this.offset = offset
+    this.length = length
+  }
+
+  def cleanLoadCacheParameters(): Unit = {
+    input = null
+    offset = -1
+    length = 0
+  }
+
+  def doCache(): FiberCache = {
+    assert(input != null && offset >= 0 && length > 0,
+      "Illegal condition when load binary Fiber to cache.")
+    val data = new Array[Byte](length)
+    input.seek(offset)
+    input.readFully(data)
+    val fiber = OapRuntime.getOrCreate.memoryManager.getEmptyDataFiberCache(length)
+    Platform.copyMemory(data,
+      Platform.BYTE_ARRAY_OFFSET, null, fiber.getBaseOffset, length)
+    fiber
+  }
+}
+
+case class VectorDataFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) extends
+  DataFiberId {
+
+  override def hashCode(): Int = (file.path + columnIndex + rowGroupId).hashCode
+
+  override def equals(obj: Any): Boolean = obj match {
+    case another: VectorDataFiberId =>
+      another.columnIndex == columnIndex &&
+        another.rowGroupId == rowGroupId &&
+        another.file.path.equals(file.path)
+    case _ => false
+  }
+
+  override def toString: String = {
+    s"type: VectorDataFiber rowGroup: $rowGroupId column: $columnIndex\n\tfile: ${file.path}"
+  }
+}
+
+private[oap] abstract class DataFiberId extends FiberId {
+  def file: DataFile
+  def columnIndex: Int
+  def rowGroupId: Int
 }
 
 private[oap] case class BTreeFiberId(

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -69,7 +69,8 @@ trait OapCache {
 
   protected def cache(fiber: FiberId): FiberCache = {
     val cache = fiber match {
-      case DataFiberId(file, columnIndex, rowGroupId) => file.cache(rowGroupId, columnIndex)
+      case binary: BinaryDataFiberId => binary.doCache()
+      case VectorDataFiberId(file, columnIndex, rowGroupId) => file.cache(rowGroupId, columnIndex)
       case BTreeFiberId(getFiberData, _, _, _) => getFiberData.apply()
       case BitmapFiberId(getFiberData, _, _, _) => getFiberData.apply()
       case TestDataFiberId(getFiberData, _) => getFiberData.apply()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexedOrcCacheReader.java
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/IndexedOrcCacheReader.java
@@ -30,6 +30,7 @@ import org.apache.parquet.hadoop.metadata.IndexedStripeMeta;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntListIterator;
+import org.apache.spark.sql.execution.datasources.oap.filecache.VectorDataFiberId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,7 +154,11 @@ public class IndexedOrcCacheReader extends OrcCacheReader {
     for (int i = 0; i < requiredColumnIds.length; ++i) {
       long start = System.nanoTime();
       FiberCache fiberCache =
-              OapRuntime$.MODULE$.getOrCreate().fiberCacheManager().get(new DataFiberId(dataFile, requiredColumnIds[i], validStripes.get(curStripeIndex).stripeId));
+              OapRuntime$.MODULE$.getOrCreate().fiberCacheManager().get(
+                new VectorDataFiberId(
+                  dataFile,
+                  requiredColumnIds[i],
+                  validStripes.get(curStripeIndex).stripeId));
       long end = System.nanoTime();
       loadFiberTime += (end - start);
       dataFile.update(requiredColumnIds[i], fiberCache);

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -158,7 +158,7 @@ private[oap] case class OapDataFileV1(
       groupId =>
         val fiberCacheGroup = requiredIds.map { id =>
           val fiberCache = OapRuntime.getOrCreate.fiberCacheManager.get(
-            DataFiberId(this, id, groupId))
+            VectorDataFiberId(this, id, groupId))
           update(id, fiberCache)
           fiberCache
         }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcCacheReader.java
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcCacheReader.java
@@ -27,6 +27,7 @@ import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.datasources.oap.filecache.DataFiberId;
 import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache;
+import org.apache.spark.sql.execution.datasources.oap.filecache.VectorDataFiberId;
 import org.apache.spark.sql.execution.datasources.orc.OrcColumnVector;
 import org.apache.spark.sql.execution.datasources.orc.OrcColumnVectorAllocator;
 import org.apache.spark.sql.execution.vectorized.ColumnVectorUtils;
@@ -309,7 +310,8 @@ public class OrcCacheReader
     for (int i = 0; i < requiredColumnIds.length; ++i) {
       long start = System.nanoTime();
       FiberCache fiberCache =
-              OapRuntime$.MODULE$.getOrCreate().fiberCacheManager().get(new DataFiberId(dataFile, requiredColumnIds[i], currentStripe));
+              OapRuntime$.MODULE$.getOrCreate().fiberCacheManager().get(
+                      new VectorDataFiberId(dataFile, requiredColumnIds[i], currentStripe));
       long end = System.nanoTime();
       loadFiberTime += (end - start);
       dataFile.update(requiredColumnIds[i], fiberCache);

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/VectorizedCacheReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/VectorizedCacheReader.scala
@@ -160,7 +160,7 @@ class VectorizedCacheReader(
         } else {
           val start = System.nanoTime()
           val fiberCache: FiberCache =
-            OapRuntime.getOrCreate.fiberCacheManager.get(DataFiberId(dataFile, id, groupId))
+            OapRuntime.getOrCreate.fiberCacheManager.get(VectorDataFiberId(dataFile, id, groupId))
           val end = System.nanoTime()
           loadFiberTime += (end - start)
           dataFile.update(id, fiberCache)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/BinaryFiberIdSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/BinaryFiberIdSuite.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.oap.filecache
+
+import com.google.common.util.concurrent.ExecutionError
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.util.HadoopStreams
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.oap.io.TestDataFile
+import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.sql.test.oap.SharedOapContext
+import org.apache.spark.sql.types.StructType
+
+class BinaryFiberIdSuite extends SharedOapContext with Logging {
+
+  test("test binary fiber id write and read") {
+    withFileSystem(fs => withTempPath(path => {
+      // prepare data
+      val data = "test binary fiber id write and read".getBytes
+      val file = new Path(path.getAbsolutePath)
+      val output = fs.create(file)
+      output.write(data)
+      output.close()
+
+      val input = HadoopStreams.wrap(fs.open(file))
+      val dataFile = TestDataFile(file.getName, new StructType(), configuration)
+      val binaryDataFiberId = BinaryDataFiberId(dataFile, columnIndex = 0, rowGroupId = 0)
+      val cacheManager = OapRuntime.getOrCreate.fiberCacheManager
+
+      // Test input is null
+      binaryDataFiberId.withLoadCacheParameters(input = null, 0, 10)
+      val e1 = intercept[ExecutionError](cacheManager.get(binaryDataFiberId))
+      assert(e1.getMessage.contains("Illegal condition when load binary Fiber to cache."))
+      binaryDataFiberId.cleanLoadCacheParameters()
+
+      // Test offset < 0
+      binaryDataFiberId.withLoadCacheParameters(input, offset = -1, 10)
+      val e2 = intercept[ExecutionError](cacheManager.get(binaryDataFiberId))
+      assert(e2.getMessage.contains("Illegal condition when load binary Fiber to cache."))
+      binaryDataFiberId.cleanLoadCacheParameters()
+
+      // Test length <= 0
+      binaryDataFiberId.withLoadCacheParameters(input, offset = 0, length = 0)
+      val e3 = intercept[ExecutionError](cacheManager.get(binaryDataFiberId))
+      assert(e3.getMessage.contains("Illegal condition when load binary Fiber to cache."))
+      binaryDataFiberId.cleanLoadCacheParameters()
+
+      // Test normal case
+      binaryDataFiberId.withLoadCacheParameters(input, 0, 10)
+      val fiberCache = cacheManager.get(binaryDataFiberId)
+      input.close()
+      assert(fiberCache != null)
+      assert(fiberCache.size() == 10)
+      fiberCache.release()
+      binaryDataFiberId.cleanLoadCacheParameters()
+      assert(fiberCache.refCount == 0)
+      assert(cacheManager.getIfPresent(binaryDataFiberId) != null)
+      cacheManager.clearAllFibers()
+      assert(cacheManager.getIfPresent(binaryDataFiberId) == null)
+    }))
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/TestDataFile.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/TestDataFile.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+
+private[oap] case class TestDataFile(path: String, schema: StructType, configuration: Configuration)
+  extends DataFile {
+
+  override def iterator(
+      requiredIds: Array[Int],
+      filters: Seq[Filter]): OapCompletionIterator[Any] =
+    new OapCompletionIterator(Iterator.empty, {})
+
+  override def iteratorWithRowIds(
+      requiredIds: Array[Int],
+      rowIds: Array[Int],
+      filters: Seq[Filter]):
+  OapCompletionIterator[Any] = new OapCompletionIterator(Iterator.empty, {})
+
+  override def totalRows(): Long = 0
+
+  override def getDataFileMeta(): DataFileMeta =
+    throw new UnsupportedOperationException
+
+  override def cache(groupId: Int, fiberId: Int): FiberCache =
+    throw new UnsupportedOperationException
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `BinaryDataFiberId`  prepare for bianry cache and rename `DataFiberId` to `VectorDataFiberId`.

## How was this patch tested?

Add BinaryFiberIdSuite