### PR TITLE
fix the core dump issue caused by the wrong address in readBinaryToColumnVector method of ParquetDataFaultFiberReader

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFaultFiberReader.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFaultFiberReader.scala
@@ -82,7 +82,7 @@ class ParquetDataFaultFiberReader(fiberCache: FiberCache, dataType: DataType, to
         column.getArrayLengths, Platform.INT_ARRAY_OFFSET, num * 4L)
       Platform.copyMemory(
         originalColumn.getArrayOffsets,
-        Platform.INT_ARRAY_OFFSET + total * 4L + start * 4L,
+        Platform.INT_ARRAY_OFFSET + start * 4L,
         column.getArrayOffsets, Platform.INT_ARRAY_OFFSET, num * 4L)
 
       var lastIndex = num - 1
@@ -106,8 +106,9 @@ class ParquetDataFaultFiberReader(fiberCache: FiberCache, dataType: DataType, to
           column.getArrayOffset(firstIndex) + column.getArrayLength(lastIndex)
 
         val data = new Array[Byte](length)
-        Platform.copyMemory(originalColumn.getByteData,
-          Platform.BYTE_ARRAY_OFFSET + total * 8L + startOffset,
+        val child = originalColumn.getChild(0).asInstanceOf[OnHeapColumnVector]
+        Platform.copyMemory(child.getByteData,
+          Platform.BYTE_ARRAY_OFFSET + startOffset,
           data, Platform.BYTE_ARRAY_OFFSET, data.length)
         column.getChild(0).asInstanceOf[OnHeapColumnVector].setByteData(data)
       }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/BinaryTypeDataFiberReaderWriterSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/BinaryTypeDataFiberReaderWriterSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.oap.io
 
 import org.apache.parquet.io.api.Binary
 
+import org.apache.spark.sql.execution.datasources.oap.filecache.CacheEnum
 import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
 import org.apache.spark.sql.execution.vectorized.{Dictionary, OnHeapColumnVector}
 import org.apache.spark.sql.types.BinaryType
@@ -32,6 +33,33 @@ class BinaryTypeDataFiberReaderWriterSuite extends DataFiberReaderWriterSuite {
     BinaryDictionary(Array(Binary.fromString("oap"),
     Binary.fromString("parquet"),
     Binary.fromString("orc"))))
+
+  test("no dic no nulls in ParquetDataFaultFiberReader") {
+    // write data
+    val column = new OnHeapColumnVector(total, BinaryType)
+    (0 until total).foreach(i => column.putByteArray(i, i.toString.getBytes))
+    fiberCache = ParquetDataFiberWriter.dumpToCache(column, total)
+    fiberCache.setMemBlockCacheType(CacheEnum.FAIL)
+    fiberCache.column = column
+
+    // init reader
+    val address = fiberCache.getBaseOffset
+    val faultReader = ParquetDataFaultFiberReader(fiberCache, BinaryType, total)
+
+    // read use batch api
+    val ret1 = new OnHeapColumnVector(total, BinaryType)
+    faultReader.readBatch(start, num, ret1)
+    (0 until num).foreach(i => {
+      assert(ret1.getBinary(i).sameElements((i + start).toString.getBytes))
+    })
+
+    // read use random access api
+    val ret2 = new OnHeapColumnVector(total, BinaryType)
+    faultReader.readBatch(rowIdList, ret2)
+    ints.indices.foreach(i => {
+      assert(ret2.getBinary(i).sameElements(ints(i).toString.getBytes))
+    })
+  }
 
   test("no dic no nulls") {
     // write data


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the core dump issue when read data from disk after allocating memory failed in in readBinaryToColumnVector method of ParquetDataFaultFiberReader


## How was this patch tested?
manual BONC test

