### PR TITLE
improve the robustness of sync free

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -96,6 +96,39 @@ case class FiberCache(fiberData: MemoryBlockHolder) extends Logging {
     _refCount.decrementAndGet()
   }
 
+  def tryDisposeWithoutWait(): Boolean = {
+    require(fiberId != null, "FiberId shouldn't be null for this FiberCache")
+    val startTime = System.currentTimeMillis()
+    val writeLockOp = OapRuntime.get.map(_.fiberLockManager.getFiberLock(fiberId).writeLock())
+    writeLockOp match {
+      case None => return true // already stopped OapRuntime
+      case Some(writeLock) =>
+        // Give caller a chance to deal with the long wait case.
+        while (System.currentTimeMillis() - startTime <= DISPOSE_TIMEOUT) {
+          if (refCount != 0) {
+            // LRU access (get and occupy) done, but fiber was still occupied by at least one
+            // reader, so it needs to sleep some time to see if the reader done.
+            // Otherwise, it becomes a polling loop.
+            // TODO: use lock/sync-obj to leverage the concurrency APIs instead of explicit sleep.
+            return false
+          } else {
+            if (writeLock.tryLock(200, TimeUnit.MILLISECONDS)) {
+              try {
+                if (refCount == 0) {
+                  realDispose()
+                  return true
+                }
+              } finally {
+                writeLock.unlock()
+              }
+            }
+          }
+        }
+    }
+    logWarning(s"Fiber Cache Dispose waiting detected for $fiberId")
+    false
+  }
+
   def tryDispose(): Boolean = {
     require(fiberId != null, "FiberId shouldn't be null for this FiberCache")
     val startTime = System.currentTimeMillis()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -98,29 +98,25 @@ case class FiberCache(fiberData: MemoryBlockHolder) extends Logging {
 
   def tryDisposeWithoutWait(): Boolean = {
     require(fiberId != null, "FiberId shouldn't be null for this FiberCache")
-    val startTime = System.currentTimeMillis()
     val writeLockOp = OapRuntime.get.map(_.fiberLockManager.getFiberLock(fiberId).writeLock())
     writeLockOp match {
       case None => return true // already stopped OapRuntime
       case Some(writeLock) =>
-        // Give caller a chance to deal with the long wait case.
-        while (System.currentTimeMillis() - startTime <= DISPOSE_TIMEOUT) {
-          if (refCount != 0) {
-            // LRU access (get and occupy) done, but fiber was still occupied by at least one
-            // reader, so it needs to sleep some time to see if the reader done.
-            // Otherwise, it becomes a polling loop.
-            // TODO: use lock/sync-obj to leverage the concurrency APIs instead of explicit sleep.
-            return false
-          } else {
-            if (writeLock.tryLock(200, TimeUnit.MILLISECONDS)) {
-              try {
-                if (refCount == 0) {
-                  realDispose()
-                  return true
-                }
-              } finally {
-                writeLock.unlock()
+        if (refCount != 0) {
+          // LRU access (get and occupy) done, but fiber was still occupied by at least one
+          // reader, so it needs to sleep some time to see if the reader done.
+          // Otherwise, it becomes a polling loop.
+          // TODO: use lock/sync-obj to leverage the concurrency APIs instead of explicit sleep.
+          return false
+        } else {
+          if (writeLock.tryLock(200, TimeUnit.MILLISECONDS)) {
+            try {
+              if (refCount == 0) {
+                realDispose()
+                return true
               }
+            } finally {
+              writeLock.unlock()
             }
           }
         }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -149,14 +149,14 @@ class GuavaOapCache(
   private val removalListener = new RemovalListener[FiberId, FiberCache] {
     override def onRemoval(notification: RemovalNotification[FiberId, FiberCache]): Unit = {
       logDebug(s"Put fiber into removal list. Fiber: ${notification.getKey}")
-      if (notification.getValue.refCount == 0) {
-        // if the refCount ==0, directly free and not put in 'removalPendingQueue'
-        // to wait the single thread to release. And if release failed,
-        // still put it in 'removalPendingQueue'
-        if (!notification.getValue.tryDispose()) {
-          cacheGuardian.addRemovalFiber(notification.getKey, notification.getValue)
-        }
-      } else {
+
+      // if the refCount ==0, directly free and not put in 'removalPendingQueue'
+      // to wait the single thread to release. And if release failed,
+      // still put it in 'removalPendingQueue'
+      if (!notification.getValue.tryDisposeWithoutWait()) {
+        cacheGuardian.addRemovalFiber(notification.getKey, notification.getValue)
+      }
+      else {
         cacheGuardian.addRemovalFiber(notification.getKey, notification.getValue)
       }
       _cacheSize.addAndGet(-notification.getValue.size())

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -156,9 +156,6 @@ class GuavaOapCache(
       if (!notification.getValue.tryDisposeWithoutWait()) {
         cacheGuardian.addRemovalFiber(notification.getKey, notification.getValue)
       }
-      else {
-        cacheGuardian.addRemovalFiber(notification.getKey, notification.getValue)
-      }
       _cacheSize.addAndGet(-notification.getValue.size())
       decFiberCountAndSize(notification.getKey, 1, notification.getValue.size())
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When sync the fiber and the refCount is not 0,  it may cause the other thread to read the removing fiber if we wait `Thread.sleep(100)`.  This PR will directly return when the refCount is to 0 and not wait.


## How was this patch tested?
Manual test in TPC-DS
