### PR TITLE
Use independent OAP cache pool for DRAM

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -111,24 +111,14 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
   private lazy val memoryManager = sparkEnv.memoryManager
 
   private lazy val oapMemory = {
-    assert(memoryManager.maxOffHeapStorageMemory > 0, "Oap can't run without offHeap memory")
-    val useOffHeapRatio = sparkEnv.conf.getDouble(
-      OapConf.OAP_FIBERCACHE_USE_OFFHEAP_RATIO.key,
-      OapConf.OAP_FIBERCACHE_USE_OFFHEAP_RATIO.defaultValue.get)
-    logInfo(s"Oap use ${useOffHeapRatio * 100}% of 'spark.memory.offHeap.size' for fiber cache.")
-    assert(useOffHeapRatio > 0 && useOffHeapRatio <1,
-      "OapConf 'spark.sql.oap.fiberCache.use.offheap.ratio' must more than 0 and less than 1.")
-    (memoryManager.maxOffHeapStorageMemory * useOffHeapRatio).toLong
+    val offHeapSizeStr = sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE).trim
+    val offHeapSize = Utils.byteStringAsBytes(offHeapSizeStr)
+    offHeapSize.toLong
   }
 
   // TODO: a config to control max memory size
   private val _memorySize = {
-    if (memoryManager.acquireStorageMemory(
-      MemoryManager.DUMMY_BLOCK_ID, oapMemory, MemoryMode.OFF_HEAP)) {
       oapMemory
-    } else {
-      throw new OapException(s"Can't acquire memory from spark Memory Manager. Size (${oapMemory})")
-    }
   }
 
   // TODO: Atomic is really needed?

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -179,6 +179,13 @@ object OapConf {
       .stringConf
       .createWithDefault("offheap")
 
+  val OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.offheap.memory.size")
+      .internal()
+      .doc("Used to set available memory size for fiberCache for each executor.")
+      .stringConf
+      .createWithDefault("100m")
+
   val OAP_MIX_DATA_MEMORY_MANAGER =
     SqlConfAdapter.buildConf("spark.sql.oap.mix.data.memory.manager")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make the OAP DRAM cache independent of Spark OffHeap for better cache management and avoiding Spark Executor launch issues


## How was this patch tested?

unit tests, integration tests


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

