### PR TITLE
Sql query support parquet binary cache

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -268,6 +268,9 @@ private[sql] class FiberCacheManager(
 
   def cacheCount: Long = cacheBackend.cacheCount
 
+  // Get count of data cache, used by test suite
+  private[oap] def dataCacheCount: Long = cacheBackend.dataCacheCount
+
   // Used by test suite
   private[filecache] def pendingCount: Int = cacheBackend.pendingFiberCount
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -134,6 +134,7 @@ trait OapCache {
   def invalidateAll(fibers: Iterable[FiberId]): Unit
   def cacheSize: Long
   def cacheCount: Long
+  def dataCacheCount: Long
   def cacheStats: CacheStats
   def pendingFiberCount: Int
   def pendingFiberSize: Long
@@ -210,6 +211,8 @@ class SimpleOapCache extends OapCache with Logging {
   override def cacheStats: CacheStats = CacheStats()
 
   override def cacheCount: Long = 0
+
+  override def dataCacheCount: Long = 0
 
   override def pendingFiberCount: Int = cacheGuardian.pendingFiberCount
 
@@ -420,6 +423,14 @@ class GuavaOapCache(
       cacheInstance.size() + indexCacheInstance.size()
     } else {
       cacheInstance.size()
+    }
+
+  override def dataCacheCount: Long =
+    if (separationCache) {
+      cacheInstance.size()
+    } else {
+      cacheInstance.asMap().keySet().asScala
+        .count(fiber => fiber.isInstanceOf[DataFiberId] || fiber.isInstanceOf[TestDataFiberId])
     }
 
   override def pendingFiberCount: Int = cacheGuardian.pendingFiberCount


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make parquet binary cache work in query if conf entry `OapConf.OAP_PARQUET_BINARY_DATA_CACHE_ENABLED` set  true.

## How was this patch tested?
new uts added.
