### PR TITLE
lazy init inputstream with ParquetFileReader

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/LazyInitSeekableInputStream.java
+++ b/src/main/java/org/apache/parquet/hadoop/LazyInitSeekableInputStream.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.hadoop;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.util.HadoopStreams;
+import org.apache.parquet.io.SeekableInputStream;
+
+/**
+ * This input stream is not open until it is actually used, some rpc overhead can be saved in
+ * binary cache scenarios.
+ * Note that this input stream is not thread-safe.
+ */
+public class LazyInitSeekableInputStream extends SeekableInputStream {
+
+  private Path file;
+
+  private Configuration configuration;
+
+  private boolean inited;
+
+  private SeekableInputStream inputStream;
+
+  private LazyInitSeekableInputStream(Path file, Configuration configuration) {
+    this.file = file;
+    this.configuration = configuration;
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return input().getPos();
+  }
+
+  @Override
+  public void seek(long newPos) throws IOException {
+    input().seek(newPos);
+  }
+
+  @Override
+  public void readFully(byte[] bytes) throws IOException {
+    input().readFully(bytes);
+  }
+
+  @Override
+  public void readFully(byte[] bytes, int start, int len) throws IOException {
+    input().readFully(bytes, start, len);
+  }
+
+  @Override
+  public int read(ByteBuffer buf) throws IOException {
+    return input().read(buf);
+  }
+
+  @Override
+  public void readFully(ByteBuffer buf) throws IOException {
+    input().readFully(buf);
+  }
+
+  @Override
+  public int read() throws IOException {
+    return input().read();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (inputStream != null) {
+      inputStream.close();
+      inputStream = null;
+    }
+  }
+
+  private SeekableInputStream input() throws IOException {
+    if (!inited) {
+      inputStream = HadoopStreams.wrap(file.getFileSystem(configuration).open(file));
+      inited = true;
+    }
+    return inputStream;
+  }
+
+  public static SeekableInputStream wrap(Path file, Configuration configuration) {
+    return new LazyInitSeekableInputStream(file, configuration);
+  }
+}

--- a/src/main/java/org/apache/parquet/hadoop/util/LazyInitHadoopInputFile.java
+++ b/src/main/java/org/apache/parquet/hadoop/util/LazyInitHadoopInputFile.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.hadoop.util;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.LazyInitSeekableInputStream;
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
+
+public class LazyInitHadoopInputFile implements InputFile {
+
+  private final Configuration conf;
+  private FileStatus stat;
+
+  public static LazyInitHadoopInputFile fromPath(Path path, Configuration conf)
+      throws IOException {
+    return new LazyInitHadoopInputFile(path, conf);
+  }
+
+  private LazyInitHadoopInputFile(Path path, Configuration conf) throws IOException {
+    this.conf = conf;
+    this.stat = path.getFileSystem(conf).getFileStatus(path);
+  }
+
+  public Configuration getConfiguration() {
+    return conf;
+  }
+
+  @Override
+  public long getLength() {
+    return stat.getLen();
+  }
+
+  @Override
+  public SeekableInputStream newStream() {
+    return LazyInitSeekableInputStream.wrap(stat.getPath(), conf);
+  }
+
+  @Override
+  public String toString() {
+    return stat.getPath().toString();
+  }
+}

--- a/src/main/parquet1.10.1/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/src/main/parquet1.10.1/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -83,6 +83,7 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.HadoopReadOptions;
 import org.apache.parquet.hadoop.util.HiddenFileFilter;
+import org.apache.parquet.hadoop.util.LazyInitHadoopInputFile;
 import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.hadoop.util.counters.BenchmarkCounter;
 import org.apache.parquet.io.ParquetDecodingException;
@@ -670,7 +671,7 @@ public class ParquetFileReader implements Closeable {
   @Deprecated
   public ParquetFileReader(Configuration conf, Path file, ParquetMetadata footer) throws IOException {
     this.converter = new ParquetMetadataConverter(conf);
-    this.file = HadoopInputFile.fromPath(file, conf);
+    this.file = LazyInitHadoopInputFile.fromPath(file, conf);
     this.f = this.file.newStream();
     this.options = HadoopReadOptions.builder(conf).build();
     this.footer = footer;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Lazy init the input stream of parquet file reader to avoid unnecessary filesystem operation.

## How was this patch tested?
existing uts.