### PR TITLE
decouple BinaryFiberId from parquet seekable input stream

### DIFF
--- a/src/main/java/org/apache/parquet/hadoop/ParquetCacheableFileReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/ParquetCacheableFileReader.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
@@ -161,7 +162,7 @@ public class ParquetCacheableFileReader extends ParquetFileReader {
       try {
         byte[] data = new byte[length];
         fiberId = new BinaryDataFiberId(dataFile, columnIndex, rowGroupId);
-        fiberId.withLoadCacheParameters(f, offset, length);
+        fiberId.withLoadCacheParameters(new FSDataInputStream(f), offset, length);
         fiberCache = cacheManager.get(fiberId);
         long fiberOffset = fiberCache.getBaseOffset();
         Platform.copyMemory(null, fiberOffset, data, Platform.BYTE_ARRAY_OFFSET, length);

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -62,7 +62,8 @@ case class BinaryDataFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) 
     assert(input != null && offset >= 0 && length > 0,
       "Illegal condition when load binary Fiber to cache.")
     val data = new Array[Byte](length)
-    input.readFully(offset, data)
+    input.seek(offset)
+    input.readFully(data)
     val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length)
     Platform.copyMemory(data,
       Platform.BYTE_ARRAY_OFFSET, null, fiber.getBaseOffset, length)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/BinaryFiberIdSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/BinaryFiberIdSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 
 import com.google.common.util.concurrent.ExecutionError
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.util.HadoopStreams
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.oap.io.TestDataFile
@@ -39,7 +38,7 @@ class BinaryFiberIdSuite extends SharedOapContext with Logging {
       output.write(data)
       output.close()
 
-      val input = HadoopStreams.wrap(fs.open(file))
+      val input = fs.open(file)
       val dataFile = TestDataFile(file.getName, new StructType(), configuration)
       val binaryDataFiberId = BinaryDataFiberId(dataFile, columnIndex = 0, rowGroupId = 0)
       val cacheManager = OapRuntime.getOrCreate.fiberCacheManager


### PR DESCRIPTION
## What changes were proposed in this pull request?
decouple BinaryFiberId from parquet seekable input stream， make it more general. This pr fix https://github.com/Intel-bigdata/OAP/issues/1129

modify input stream type of BinaryFiberId as FsDataInputStream;
make LazyInitSeekableInputStream implements Seekable and PositionedReadable so that it can be wrappped as FsDataInputStream;

## How was this patch tested?
existing ut.
