### PR TITLE
[Orc-Binary-Cache-02] Derive subclasses for implementing ORC Binary Cache

### DIFF
--- a/src/main/java/org/apache/orc/impl/ColumnDiskRangeList.java
+++ b/src/main/java/org/apache/orc/impl/ColumnDiskRangeList.java
@@ -1,0 +1,52 @@
+package org.apache.orc.impl;
+
+import org.apache.orc.storage.common.io.DiskRangeList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ColumnDiskRangeList extends DiskRangeList {
+
+  private static final Logger LOG =
+          LoggerFactory.getLogger(ColumnDiskRangeList.class);
+
+
+  final int columnId;
+  final int currentStripe;
+
+  public ColumnDiskRangeList(int columnId, int currentStripe, long offset, long end) {
+    super(offset, end);
+    this.columnId = columnId;
+    this.currentStripe = currentStripe;
+  }
+
+  public static class CreateColumnRangeHelper {
+    private DiskRangeList tail = null;
+    private DiskRangeList head;
+
+    public CreateColumnRangeHelper() {
+    }
+
+    public DiskRangeList getTail() {
+      return this.tail;
+    }
+
+    public void add(int columnId, int currentStripe, long offset, long end) {
+      DiskRangeList node = new ColumnDiskRangeList(columnId, currentStripe, offset, end);
+      if (this.tail == null) {
+        this.head = this.tail = node;
+      } else {
+        this.tail = this.tail.insertAfter(node);
+      }
+    }
+
+    public DiskRangeList get() {
+      return this.head;
+    }
+
+    public DiskRangeList extract() {
+      DiskRangeList result = this.head;
+      this.head = null;
+      return result;
+    }
+  }
+}

--- a/src/main/java/org/apache/orc/impl/ColumnDiskRangeList.java
+++ b/src/main/java/org/apache/orc/impl/ColumnDiskRangeList.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.orc.impl;
 
 import org.apache.orc.storage.common.io.DiskRangeList;

--- a/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderBinaryCacheImpl.java
+++ b/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderBinaryCacheImpl.java
@@ -1,0 +1,115 @@
+package org.apache.orc.impl;
+
+import org.apache.orc.*;
+import org.apache.orc.storage.common.io.DiskRangeList;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RecordReaderBinaryCacheImpl extends RecordReaderImpl {
+
+  public RecordReaderBinaryCacheImpl(ReaderImpl fileReader,
+                                     Reader.Options options) throws IOException {
+    super(fileReader, options);
+  }
+
+  /**
+   * Read the current stripe into memory.
+   *
+   * @throws IOException
+   */
+  protected void readStripe() throws IOException {
+    StripeInformation stripe = beginReadStripe();
+
+    if (rowInStripe < rowCountInStripe) {
+      readPartialDataStreams(stripe);
+      reader.startStripe(streams, stripeFooter);
+      // if we skipped the first row group, move the pointers forward
+      if (rowInStripe != 0) {
+        seekToRowEntry(reader, (int) (rowInStripe / rowIndexStride));
+      }
+    }
+  }
+
+  private void readPartialDataStreams(StripeInformation stripe) throws IOException {
+    List<OrcProto.Stream> streamList = stripeFooter.getStreamsList();
+    DiskRangeList toRead = planReadColumnData(streamList, fileIncluded);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("chunks = " + RecordReaderBinaryCacheUtils.stringifyDiskRanges(toRead));
+    }
+    bufferChunks = ((RecordReaderBinaryCacheUtils.BinaryCacheDataReader)dataReader)
+            .readFileColumnData(toRead, stripe.getOffset(), false);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("merge = " + RecordReaderBinaryCacheUtils.stringifyDiskRanges(bufferChunks));
+    }
+    createStreams(streamList, bufferChunks, fileIncluded,
+            dataReader.getCompressionCodec(), bufferSize, streams);
+  }
+
+
+  /**
+   * Plan the ranges of the file that we need to read, given the list of
+   * columns in one stripe.
+   *
+   * @param streamList        the list of streams available
+   * @param includedColumns   which columns are needed
+   * @return the list of disk ranges that will be loaded
+   */
+  private DiskRangeList planReadColumnData(
+          List<OrcProto.Stream> streamList,
+          boolean[] includedColumns) {
+    long offset = 0;
+    Map<Integer, RecordReaderBinaryCacheImpl.ColumnDiskRange> columnDiskRangeMap = new HashMap<Integer, RecordReaderBinaryCacheImpl.ColumnDiskRange>();
+    ColumnDiskRangeList.CreateColumnRangeHelper list =
+            new ColumnDiskRangeList.CreateColumnRangeHelper();
+    for (OrcProto.Stream stream : streamList) {
+      long length = stream.getLength();
+      int column = stream.getColumn();
+      OrcProto.Stream.Kind streamKind = stream.getKind();
+      // since stream kind is optional, first check if it exists
+      if (stream.hasKind() &&
+              (StreamName.getArea(streamKind) == StreamName.Area.DATA) &&
+              (column < includedColumns.length && includedColumns[column])) {
+
+        if (columnDiskRangeMap.containsKey(column)) {
+          columnDiskRangeMap.get(column).length += length;
+        } else {
+          columnDiskRangeMap.put(column, new RecordReaderBinaryCacheImpl.ColumnDiskRange(offset, length));
+        }
+      }
+      offset += length;
+    }
+    for (int columnId=1; columnId<includedColumns.length; ++columnId) {
+      if (includedColumns[columnId]) {
+        list.add(columnId, currentStripe, columnDiskRangeMap.get(columnId).offset,
+                columnDiskRangeMap.get(columnId).offset + columnDiskRangeMap.get(columnId).length);
+      }
+    }
+    return list.extract();
+  }
+
+  public class ColumnDiskRange {
+    private long offset;
+    private long length;
+
+    ColumnDiskRange(long offset, long length) {
+      this.offset = offset;
+      this.length = length;
+    }
+
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (other instanceof ColumnDiskRange) {
+        ColumnDiskRange otherColumnDiskRange = (ColumnDiskRange)other;
+        return otherColumnDiskRange.offset == this.offset &&
+                otherColumnDiskRange.length == this.length;
+      }
+      return false;
+    }
+  }
+
+}

--- a/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderBinaryCacheUtils.java
+++ b/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderBinaryCacheUtils.java
@@ -1,0 +1,94 @@
+package org.apache.orc.impl;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.orc.DataReader;
+import org.apache.orc.storage.common.io.DiskRangeList;
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache;
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCacheManager;
+import org.apache.spark.sql.execution.datasources.oap.filecache.OrcBinaryFiberId;
+import org.apache.spark.sql.execution.datasources.oap.io.DataFile;
+import org.apache.spark.sql.execution.datasources.oap.io.OrcDataFile;
+import org.apache.spark.sql.oap.OapRuntime$;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.Platform;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class RecordReaderBinaryCacheUtils extends RecordReaderUtils {
+
+  protected static class BinaryCacheDataReader extends DefaultDataReader {
+    private BinaryCacheDataReader(DataReaderProperties properties) {
+      super(properties);
+    }
+
+    public DiskRangeList readFileColumnData(
+            DiskRangeList range, long baseOffset, boolean doForceDirect) throws IOException {
+      return RecordReaderBinaryCacheUtils.readColumnRanges(file, path, baseOffset, range, doForceDirect);
+    }
+  }
+
+  public static DataReader createBinaryCacheDataReader(DataReaderProperties properties) {
+    return new BinaryCacheDataReader(properties);
+  }
+
+  /**
+   * Read the list of ranges from the file.
+   * @param file the file to read
+   * @param base the base of the stripe
+   * @param range the disk ranges within the stripe to read
+   * @return the bytes read for each disk range, which is the same length as
+   *    ranges
+   * @throws IOException
+   */
+  static DiskRangeList readColumnRanges(FSDataInputStream file,
+                                        Path path,
+                                        long base,
+                                        DiskRangeList range,
+                                        boolean doForceDirect) throws IOException {
+    if (range == null) return null;
+    DiskRangeList prev = range.prev;
+    if (prev == null) {
+      prev = new DiskRangeList.MutateHelper(range);
+    }
+    while (range != null) {
+      if (range.hasData()) {
+        range = range.next;
+        continue;
+      }
+      int len = (int) (range.getEnd() - range.getOffset());
+      long off = range.getOffset();
+      // Don't use HDFS ByteBuffer API because it has no readFully, and is buggy and pointless.
+
+      byte[] buffer = new byte[len];
+
+      DataFile dataFile = new OrcDataFile(path.toUri().toString(),
+              new StructType(), new Configuration());
+      FiberCacheManager cacheManager = OapRuntime$.MODULE$.getOrCreate().fiberCacheManager();
+      FiberCache fiberCache = null;
+      OrcBinaryFiberId fiberId = null;
+      ColumnDiskRangeList columnRange = (ColumnDiskRangeList)range;
+      fiberId = new OrcBinaryFiberId(dataFile, columnRange.columnId, columnRange.currentStripe);
+      fiberId.withLoadCacheParameters(file, base + off, len);
+      fiberCache = cacheManager.get(fiberId);
+      long fiberOffset = fiberCache.getBaseOffset();
+      Platform.copyMemory(null, fiberOffset, buffer, Platform.BYTE_ARRAY_OFFSET, len);
+
+      ByteBuffer bb = null;
+      if (doForceDirect) {
+        bb = ByteBuffer.allocateDirect(len);
+        bb.put(buffer);
+        bb.position(0);
+        bb.limit(len);
+      } else {
+        bb = ByteBuffer.wrap(buffer);
+      }
+      range = range.replaceSelfWith(new BufferChunk(bb, range.getOffset()));
+      range = range.next;
+    }
+    return prev.next;
+  }
+
+}

--- a/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -73,30 +73,30 @@ public class RecordReaderImpl implements RecordReader {
   private final long firstRow;
   private final List<StripeInformation> stripes =
       new ArrayList<StripeInformation>();
-  private OrcProto.StripeFooter stripeFooter;
+  protected OrcProto.StripeFooter stripeFooter;
   private final long totalRowCount;
   protected final TypeDescription schema;
-  private final List<OrcProto.Type> types;
-  private final int bufferSize;
+  protected final List<OrcProto.Type> types;
+  protected final int bufferSize;
   private final SchemaEvolution evolution;
   // the file included columns indexed by the file's column ids.
-  private final boolean[] fileIncluded;
-  private final long rowIndexStride;
-  private long rowInStripe = 0;
-  private int currentStripe = -1;
+  protected final boolean[] fileIncluded;
+  protected final long rowIndexStride;
+  protected long rowInStripe = 0;
+  protected int currentStripe = -1;
   private long rowBaseInStripe = 0;
-  private long rowCountInStripe = 0;
-  private final Map<StreamName, InStream> streams =
+  protected long rowCountInStripe = 0;
+  protected final Map<StreamName, InStream> streams =
       new HashMap<StreamName, InStream>();
   DiskRangeList bufferChunks = null;
-  private final TreeReaderFactory.TreeReader reader;
+  protected final TreeReaderFactory.TreeReader reader;
   private final OrcProto.RowIndex[] indexes;
   private final OrcProto.BloomFilterIndex[] bloomFilterIndices;
   private final OrcProto.Stream.Kind[] bloomFilterKind;
   private final SargApplier sargApp;
   // an array about which row groups aren't skipped
-  private boolean[] includedRowGroups = null;
-  private final DataReader dataReader;
+  protected boolean[] includedRowGroups = null;
+  protected DataReader dataReader;
   private final boolean ignoreNonUtf8BloomFilter;
   private final OrcFile.WriterVersion writerVersion;
   private final int maxDiskRangeChunkLimit;
@@ -1044,7 +1044,7 @@ public class RecordReaderImpl implements RecordReader {
    *
    * @throws IOException
    */
-  private void readStripe() throws IOException {
+  protected void readStripe() throws IOException {
     StripeInformation stripe = beginReadStripe();
     includedRowGroups = pickRowGroups();
 
@@ -1081,7 +1081,7 @@ public class RecordReaderImpl implements RecordReader {
     return true;
   }
 
-  private StripeInformation beginReadStripe() throws IOException {
+  protected StripeInformation beginReadStripe() throws IOException {
     StripeInformation stripe = stripes.get(currentStripe);
     stripeFooter = readStripeFooter(stripe);
     clearStreams();
@@ -1383,7 +1383,7 @@ public class RecordReaderImpl implements RecordReader {
         bloomFilterKind, bloomFilterIndex);
   }
 
-  private void seekToRowEntry(TreeReaderFactory.TreeReader reader, int rowEntry)
+  protected void seekToRowEntry(TreeReaderFactory.TreeReader reader, int rowEntry)
       throws IOException {
     PositionProvider[] index = new PositionProvider[indexes.length];
     for (int i = 0; i < indexes.length; ++i) {

--- a/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -143,12 +143,12 @@ public class RecordReaderUtils {
     return result.get();
   }
 
-  private static class DefaultDataReader implements DataReader {
-    private FSDataInputStream file = null;
+  protected static class DefaultDataReader implements DataReader {
+    protected FSDataInputStream file = null;
     private ByteBufferAllocatorPool pool;
     private HadoopShims.ZeroCopyReaderShim zcr = null;
     private final FileSystem fs;
-    private final Path path;
+    protected final Path path;
     private final boolean useZeroCopy;
     private CompressionCodec codec;
     private final int bufferSize;
@@ -156,7 +156,7 @@ public class RecordReaderUtils {
     private CompressionKind compressionKind;
     private final int maxDiskRangeChunkLimit;
 
-    private DefaultDataReader(DataReaderProperties properties) {
+    protected DefaultDataReader(DataReaderProperties properties) {
       this.fs = properties.getFileSystem();
       this.path = properties.getPath();
       this.useZeroCopy = properties.getZeroCopy();

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -102,7 +102,7 @@ case class OrcBinaryFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) e
   }
 
   override def toString: String = {
-    s"type: ParquetChunkFiber rowGroup: $rowGroupId column: $columnIndex\n\tfile: ${file.path}"
+    s"type: ORCColumn rowGroup: $rowGroupId column: $columnIndex\n\tfile: ${file.path}"
   }
 
   def doCache(): FiberCache = {
@@ -110,12 +110,10 @@ case class OrcBinaryFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) e
       "Illegal condition when load Parquet Chunk Fiber to cache.")
     val data = new Array[Byte](length)
     input.seek(offset)
-    //    input.readFully(data)
     input.readFully((offset), data, 0, data.length);
     val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length)
     Platform.copyMemory(data,
       Platform.BYTE_ARRAY_OFFSET, null, fiber.getBaseOffset, length)
-    //    BenchmarkCounter.incrementBytesRead(length)
     fiber
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.oap.filecache
 
+import org.apache.hadoop.fs.FSDataInputStream
 import org.apache.parquet.io.SeekableInputStream
 
 import org.apache.spark.sql.execution.datasources.oap.io.DataFile
@@ -67,6 +68,54 @@ case class BinaryDataFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) 
     val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length)
     Platform.copyMemory(data,
       Platform.BYTE_ARRAY_OFFSET, null, fiber.getBaseOffset, length)
+    fiber
+  }
+}
+
+case class OrcBinaryFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) extends
+  DataFiberId {
+
+  private var input: FSDataInputStream = _
+  private var offset: Long = _
+  private var length: Int = _
+
+  def withLoadCacheParameters(input: FSDataInputStream, offset: Long, length: Int): Unit = {
+    this.input = input
+    this.offset = offset
+    this.length = length
+  }
+
+  def cleanLoadCacheParameters(): Unit = {
+    input = null
+    offset = -1
+    length = 0
+  }
+
+  override def hashCode(): Int = (file.path + columnIndex + rowGroupId).hashCode
+
+  override def equals(obj: Any): Boolean = obj match {
+    case another: OrcBinaryFiberId =>
+      another.columnIndex == columnIndex &&
+        another.rowGroupId == rowGroupId &&
+        another.file.path.equals(file.path)
+    case _ => false
+  }
+
+  override def toString: String = {
+    s"type: ParquetChunkFiber rowGroup: $rowGroupId column: $columnIndex\n\tfile: ${file.path}"
+  }
+
+  def doCache(): FiberCache = {
+    assert(input != null && offset >= 0 && length > 0,
+      "Illegal condition when load Parquet Chunk Fiber to cache.")
+    val data = new Array[Byte](length)
+    input.seek(offset)
+    //    input.readFully(data)
+    input.readFully((offset), data, 0, data.length);
+    val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length)
+    Platform.copyMemory(data,
+      Platform.BYTE_ARRAY_OFFSET, null, fiber.getBaseOffset, length)
+    //    BenchmarkCounter.incrementBytesRead(length)
     fiber
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -109,7 +109,6 @@ case class OrcBinaryFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) e
     assert(input != null && offset >= 0 && length > 0,
       "Illegal condition when load Parquet Chunk Fiber to cache.")
     val data = new Array[Byte](length)
-    input.seek(offset)
     input.readFully((offset), data, 0, data.length);
     val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length)
     Platform.copyMemory(data,


### PR DESCRIPTION
## What changes were proposed in this pull request?

After #1144 , this PR derives subclasses from RecordReaderImpl.java and RecordReaderUtils.java for implementing ORC Binary Cache.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

