### PR TITLE
Fix index cache not working on vmemcache

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -157,6 +157,10 @@ private[oap] case class BTreeFiberId(
 
   override def hashCode(): Int = (file + section + idx).hashCode
 
+  val fiberKey = s"${file}_${section}_${idx})"
+
+  override def toFiberKey(): String = fiberKey
+
   override def equals(obj: Any): Boolean = obj match {
     case another: BTreeFiberId =>
       another.section == section &&
@@ -179,6 +183,10 @@ private[oap] case class BitmapFiberId(
     loadUnitIdxOfSection: Int) extends FiberId {
 
   override def hashCode(): Int = (file + sectionIdxOfFile + loadUnitIdxOfSection).hashCode
+
+  val fiberKey = s"${file}_${sectionIdxOfFile}_${loadUnitIdxOfSection})"
+
+  override def toFiberKey(): String = fiberKey
 
   override def equals(obj: Any): Boolean = obj match {
     case another: BitmapFiberId =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix bug. Index cache does not working on vmemcache. 

## How was this patch tested?
Generate 10G tpcds store_sales table. 
create oindex store_sales_ss_customer_sk_index on store_sales (ss_customer_sk) using btree; 
SELECT * FROM store_sales WHERE ss_customer_sk BETWEEN 10 AND 80; 
