### PR TITLE
Fix index does not working on VMemcache

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -51,6 +51,10 @@ case class BinaryDataFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) 
 
   override def hashCode(): Int = (file.path + columnIndex + rowGroupId).hashCode
 
+  val fiberKey = s"${file.path}_${rowGroupId}_${columnIndex})"
+
+  override def toFiberKey(): String = fiberKey
+
   override def equals(obj: Any): Boolean = obj match {
     case another: BinaryDataFiberId =>
       another.columnIndex == columnIndex &&
@@ -96,6 +100,10 @@ case class OrcBinaryFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) e
   }
 
   override def hashCode(): Int = (file.path + columnIndex + rowGroupId).hashCode
+
+  val fiberKey = s"${file.path}_${rowGroupId}_${columnIndex})"
+
+  override def toFiberKey(): String = fiberKey
 
   override def equals(obj: Any): Boolean = obj match {
     case another: OrcBinaryFiberId =>
@@ -157,6 +165,10 @@ private[oap] case class BTreeFiberId(
 
   override def hashCode(): Int = (file + section + idx).hashCode
 
+  val fiberKey = s"${file}_${section}_${idx})"
+
+  override def toFiberKey(): String = fiberKey
+
   override def equals(obj: Any): Boolean = obj match {
     case another: BTreeFiberId =>
       another.section == section &&
@@ -179,6 +191,10 @@ private[oap] case class BitmapFiberId(
     loadUnitIdxOfSection: Int) extends FiberId {
 
   override def hashCode(): Int = (file + sectionIdxOfFile + loadUnitIdxOfSection).hashCode
+
+  val fiberKey = s"${file}_${sectionIdxOfFile}_${loadUnitIdxOfSection})"
+
+  override def toFiberKey(): String = fiberKey
 
   override def equals(obj: Any): Boolean = obj match {
     case another: BitmapFiberId =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix bug. Index cache does not working on vmemcache.

## How was this patch tested?

index btree testing
Generate 10G tpcds store_sales table.
create oindex store_sales_ss_customer_sk_index on store_sales (ss_customer_sk) using btree;
SELECT * FROM store_sales WHERE ss_customer_sk BETWEEN 10 AND 80;

paquet binary cache
set spark.sql.oap.parquet.binary.cache.enabled to true
result as the screenshot

<img width="917" alt="t" src="https://user-images.githubusercontent.com/7370904/76739466-32efd800-67a7-11ea-8368-e1685efcde81.PNG">
<img width="926" alt="jobs" src="https://user-images.githubusercontent.com/7370904/76739483-37b48c00-67a7-11ea-888c-56ad1798879f.PNG">
<img width="711" alt="conf" src="https://user-images.githubusercontent.com/7370904/76739485-38e5b900-67a7-11ea-9793-e2707b97e9ca.PNG">

orc binary cache
set spark.sql.oap.orc.binary.cache.enable to true and spark.sql.orc.copyBatchToSpark to true
result is same like parquet




