### PR TITLE
Make RequestedColIds work in ORC Binary Cache and ORC Index. Fix #1154

### DIFF
--- a/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderBinaryCacheImpl.java
+++ b/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderBinaryCacheImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.orc.impl;
 
 import org.apache.orc.*;
@@ -81,6 +98,7 @@ public class RecordReaderBinaryCacheImpl extends RecordReaderImpl {
       }
       offset += length;
     }
+    // Start from index 1, because includedColumns[0] is invalid in ORC.
     for (int columnId=1; columnId<includedColumns.length; ++columnId) {
       if (includedColumns[columnId]) {
         list.add(columnId, currentStripe, columnDiskRangeMap.get(columnId).offset,

--- a/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderBinaryCacheUtils.java
+++ b/src/main/orc-1.5.5-nohive/java/org/apache/orc/impl/RecordReaderBinaryCacheUtils.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
@@ -25,7 +42,7 @@ public class RecordReaderBinaryCacheUtils extends RecordReaderUtils {
     }
 
     public DiskRangeList readFileColumnData(
-            DiskRangeList range, long baseOffset, boolean doForceDirect) throws IOException {
+            DiskRangeList range, long baseOffset, boolean doForceDirect) {
       return RecordReaderBinaryCacheUtils.readColumnRanges(file, path, baseOffset, range, doForceDirect);
     }
   }
@@ -47,7 +64,7 @@ public class RecordReaderBinaryCacheUtils extends RecordReaderUtils {
                                         Path path,
                                         long base,
                                         DiskRangeList range,
-                                        boolean doForceDirect) throws IOException {
+                                        boolean doForceDirect) {
     if (range == null) return null;
     DiskRangeList prev = range.prev;
     if (prev == null) {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
@@ -115,17 +115,12 @@ private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
       // For Orc, the context is used by both vectorized readers and map reduce readers.
       // See the comments in DataFile.scala.
       val context: Option[DataFileContext] = {
-        val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-        val reader = OrcFile.createReader(path, readerOptions)
-        val requestedColIdsOrEmptyFile = OrcUtils.requestedColumnIds(
-          isCaseSensitive, dataSchema, requiredSchema, reader, conf)
-        if (requestedColIdsOrEmptyFile.isDefined) {
-          val requestedColIds = requestedColIdsOrEmptyFile.get
-          assert(requestedColIds.length == requiredSchema.length,
+        if (requiredIds.length != 0) {
+          assert(requiredIds.length == requiredSchema.length,
             "[BUG] requested column IDs do not match required schema")
           Some(OrcDataFileContext(partitionSchema, file.partitionValues,
             returningBatch, requiredSchema, dataSchema, enableOffHeapColumnVector,
-            copyToSpark, requestedColIds))
+            copyToSpark, requiredIds))
         } else {
           orcWithEmptyColIds = true
           None

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -111,7 +111,7 @@ case class OrcBinaryFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) e
 
   def doCache(): FiberCache = {
     assert(input != null && offset >= 0 && length > 0,
-      "Illegal condition when load Parquet Chunk Fiber to cache.")
+      "Illegal condition when load ORCColumn Fiber to cache.")
     val data = new Array[Byte](length)
     input.readFully((offset), data, 0, data.length);
     val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
@@ -67,14 +67,14 @@ private[oap] case class OrcDataFile(
     configuration: Configuration) extends DataFile {
 
   private var context: OrcDataFileContext = _
-  private val filePath: Path = new Path(path)
-  private val orcDataCacheEnable =
+  private lazy val filePath: Path = new Path(path)
+  private lazy val orcDataCacheEnable =
     configuration.getBoolean(OapConf.OAP_ORC_DATA_CACHE_ENABLED.key,
       OapConf.OAP_ORC_DATA_CACHE_ENABLED.defaultValue.get)
-  val meta =
+  lazy val meta =
     OapRuntime.getOrCreate.dataFileMetaCacheManager.get(this).asInstanceOf[OrcDataFileMeta]
 //  meta.getOrcFileReader()
-  private val fileReader: Reader = {
+  private lazy val fileReader: Reader = {
     import scala.collection.JavaConverters._
 //    val meta =
 //      OapRuntime.getOrCreate.dataFileMetaCacheManager.get(this).asInstanceOf[OrcDataFileMeta]
@@ -83,14 +83,15 @@ private[oap] case class OrcDataFile(
 
 //  recordReader = reader.rows(options)
 
-  val reader: Reader = OrcFile.createReader(meta.path, OrcFile.readerOptions(meta.configuration)
+  lazy val reader: Reader = OrcFile.createReader(meta.path,
+    OrcFile.readerOptions(meta.configuration)
     .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(meta.configuration)).filesystem(meta.fs))
-  val options: Reader.Options = OrcInputFormat.buildOptions(meta.configuration,
+  lazy val options: Reader.Options = OrcInputFormat.buildOptions(meta.configuration,
     reader, 0, meta.length)
 
   var recordReader: RecordReaderCacheImpl = _
 
-  private val inUseFiberCache = new Array[FiberCache](schema.length)
+  private lazy val inUseFiberCache = new Array[FiberCache](schema.length)
 
   private def release(idx: Int): Unit = Option(inUseFiberCache(idx)).foreach { fiberCache =>
     fiberCache.release()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
@@ -166,7 +166,10 @@ private[oap] case class OrcDataFile(
 
   private def initVectorizedReader(c: OrcDataFileContext,
       reader: OrcColumnarBatchReader) = {
-    reader.initialize(filePath, configuration)
+    val taskConf = new Configuration(configuration)
+    taskConf.set(OrcConf.INCLUDE_COLUMNS.getAttribute,
+      c.requestedColIds.filter(_ != -1).sorted.mkString(","))
+    reader.initialize(filePath, taskConf)
     reader.initBatch(fileReader.getSchema, c.requestedColIds, c.requiredSchema.fields,
       c.partitionColumns, c.partitionValues)
     val iterator = new FileRecordReaderIterator(reader)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make RequestedColIds work in ORC Binary Cache and ORC Index. Fix #1154


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

