### PR TITLE
fix guava version to 14.0.1 which is consistent with spark2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,8 +360,14 @@
         </exclusion>
       </exclusions>
     </dependency>
-  </dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>14.0.1</version>
+      <scope>provided</scope>
+    </dependency>
 
+  </dependencies>
   <build>
     <plugins>
      <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix guava version to 14.0.1 which is consistent with spark2.3.2


## How was this patch tested?
 Tested with spark 2.3.2

