### PR TITLE
index/data cache seperation with different cache backend

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
@@ -29,7 +29,8 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
   extends Logging {
   private val _separateMemory = checkSeparateMemory()
   private val (memoryManager, indexMemoryManager) = init()
-  private val (_dataCacheMemory, _indexCacheMemory, _cacheGuardianMemory) = calculateSizes()
+  private val (_dataCacheMemory, _indexCacheMemory,
+              _dataCacheGuardianMemory, _indexCacheGuardianMemory) = calculateSizes()
 
   private def checkSeparateMemory(): Boolean = {
     val separateCache = sparkEnv.conf.getBoolean(
@@ -48,11 +49,11 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
       case _ => false
     }
   }
-  private def calculateSizes(): (Long, Long, Long) = {
+  private def calculateSizes(): (Long, Long, Long, Long) = {
     // TO DO: make the 0.9 : 0.1 ration configurable
     if (_separateMemory) {
       ((memoryManager.memorySize * 0.9).toLong, (indexMemoryManager.memorySize * 0.9).toLong,
-        (memoryManager.memorySize * 0.1).toLong + (indexMemoryManager.memorySize * 0.1).toLong)
+        (memoryManager.memorySize * 0.1).toLong, (indexMemoryManager.memorySize * 0.1).toLong)
     } else {
       val cacheRatio = sparkEnv.conf.getDouble(
         OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key,
@@ -63,7 +64,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
       val memorySize = memoryManager.memorySize
       ((memorySize * 0.9 * cacheRatio).toLong,
         (memorySize * 0.9 * (1 - cacheRatio)).toLong,
-        (memorySize * 0.1).toLong)
+        (memorySize * 0.1).toLong, 0)
     }
   }
 
@@ -121,7 +122,8 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
 
   def dataCacheMemory: Long = _dataCacheMemory
   def indexCacheMemory: Long = _indexCacheMemory
-  def cacheGuardianMemory: Long = _cacheGuardianMemory
+  def dataCacheGuardianMemory: Long = _dataCacheGuardianMemory
+  def indexCacheGuardianMemory: Long = _indexCacheGuardianMemory
   def separateMemory: Boolean = _separateMemory
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
@@ -29,8 +29,8 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
   extends Logging {
   private val _separateMemory = checkSeparateMemory()
   private val (memoryManager, indexMemoryManager) = init()
-  private val (_dataCacheMemory, _indexCacheMemory,
-              _dataCacheGuardianMemory, _indexCacheGuardianMemory) = calculateSizes()
+  private val (_dataCacheMemorySize, _indexCacheMemorySize,
+              _dataCacheGuardianMemorySize, _indexCacheGuardianMemorySize) = calculateSizes()
 
   private def checkSeparateMemory(): Boolean = {
     val memoryManagerOpt =
@@ -119,10 +119,10 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
     }
   }
 
-  def dataCacheMemory: Long = _dataCacheMemory
-  def indexCacheMemory: Long = _indexCacheMemory
-  def dataCacheGuardianMemory: Long = _dataCacheGuardianMemory
-  def indexCacheGuardianMemory: Long = _indexCacheGuardianMemory
+  def dataCacheMemorySize: Long = _dataCacheMemorySize
+  def indexCacheMemorySize: Long = _indexCacheMemorySize
+  def dataCacheGuardianMemorySize: Long = _dataCacheGuardianMemorySize
+  def indexCacheGuardianMemorySize: Long = _indexCacheGuardianMemorySize
   def separateMemory: Boolean = _separateMemory
 }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
@@ -33,18 +33,17 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
               _dataCacheGuardianMemory, _indexCacheGuardianMemory) = calculateSizes()
 
   private def checkSeparateMemory(): Boolean = {
-    val separateCache = sparkEnv.conf.getBoolean(
-      OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
-      OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
-    )
     val memoryManagerOpt =
       sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
+    val cacheName =
+      sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_STRATEGY.key, "guava").toLowerCase
+
     memoryManagerOpt match {
-      case "mix" => if (separateCache) {
+      case ("mix") => if (cacheName.equals("mix")) {
         true
       } else {
         throw new UnsupportedOperationException("In order to enable mix memory manager," +
-          "you need to set to spark.sql.oap.index.data.cache.separation.enable to true")
+          "you need also to set to spark.oap.cache.strategy to mix")
       }
       case _ => false
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.internal.oap.OapConf
  */
 private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
   extends Logging {
-  private val separateMemory = checkSeparateMemory()
+  private val _separateMemory = checkSeparateMemory()
   private val (memoryManager, indexMemoryManager) = init()
   private val (_dataCacheMemory, _indexCacheMemory, _cacheGuardianMemory) = calculateSizes()
 
@@ -50,7 +50,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
   }
   private def calculateSizes(): (Long, Long, Long) = {
     // TO DO: make the 0.9 : 0.1 ration configurable
-    if (separateMemory) {
+    if (_separateMemory) {
       ((memoryManager.memorySize * 0.9).toLong, (indexMemoryManager.memorySize * 0.9).toLong,
         (memoryManager.memorySize * 0.1).toLong + (indexMemoryManager.memorySize * 0.1).toLong)
     } else {
@@ -68,7 +68,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
   }
 
   private def init(): (MemoryManager, MemoryManager) = {
-    if (separateMemory) {
+    if (_separateMemory) {
       val dataManager = MemoryManager(sparkEnv, OapConf.OAP_MIX_DATA_MEMORY_MANAGER)
       val indexManager = MemoryManager(sparkEnv, OapConf.OAP_MIX_INDEX_MEMORY_MANAGER)
       if (indexManager.getClass.equals(dataManager.getClass)) {
@@ -88,7 +88,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
   }
 
   def allocateIndexMemory(size: Long): MemoryBlockHolder = {
-    if (separateMemory) {
+    if (_separateMemory) {
       indexMemoryManager.allocate(size)
     } else {
       memoryManager.allocate(size)
@@ -100,7 +100,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
   }
 
   def freeIndexMemory(block: MemoryBlockHolder): Unit = {
-    if (separateMemory) {
+    if (_separateMemory) {
       indexMemoryManager.free(block)
     } else {
       memoryManager.free(block)
@@ -114,7 +114,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
 
   def stop(): Unit = {
     memoryManager.stop()
-    if (separateMemory) {
+    if (_separateMemory) {
       indexMemoryManager.stop()
     }
   }
@@ -122,6 +122,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
   def dataCacheMemory: Long = _dataCacheMemory
   def indexCacheMemory: Long = _indexCacheMemory
   def cacheGuardianMemory: Long = _cacheGuardianMemory
+  def separateMemory: Boolean = _separateMemory
 }
 
 private[sql] object CacheMemoryAllocator {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -56,10 +56,10 @@ private[sql] class FiberCacheManager(
   private val cacheAllocator: CacheMemoryAllocator = CacheMemoryAllocator(sparkEnv)
   private val fiberLockManager = new FiberLockManager()
 
-  var dataCacheMemory: Long = cacheAllocator.dataCacheMemory
-  var indexCacheMemory: Long = cacheAllocator.indexCacheMemory
-  def dataCacheGuardianMemory: Long = cacheAllocator.dataCacheGuardianMemory
-  def indexCacheGuardianMemory: Long = cacheAllocator.indexCacheGuardianMemory
+  var dataCacheMemorySize: Long = cacheAllocator.dataCacheMemorySize
+  var indexCacheMemorySize: Long = cacheAllocator.indexCacheMemorySize
+  def dataCacheGuardianMemorySize: Long = cacheAllocator.dataCacheGuardianMemorySize
+  def indexCacheGuardianMemorySize: Long = cacheAllocator.indexCacheGuardianMemorySize
 
   def dataCacheCompressEnable: Boolean = _dataCacheCompressEnable
   def dataCacheCompressionCodec: String = _dataCacheCompressionCodec
@@ -70,16 +70,16 @@ private[sql] class FiberCacheManager(
 
   private val cacheBackend: OapCache = {
     if (!inMixMode) {
-      dataCacheMemory = dataCacheMemory + indexCacheMemory
+      dataCacheMemorySize = dataCacheMemorySize + indexCacheMemorySize
     }
 
     val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
     if (cacheName.equals(GUAVA_CACHE)) {
-      new GuavaOapCache(dataCacheMemory, dataCacheGuardianMemory, FiberType.DATA)
+      new GuavaOapCache(dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
     } else if (cacheName.equals(SIMPLE_CACHE)) {
       new SimpleOapCache()
     } else if (cacheName.equals(NO_EVICT_CACHE)) {
-      new NonEvictPMCache(dataCacheMemory, dataCacheGuardianMemory, FiberType.DATA)
+      new NonEvictPMCache(dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
     } else if (cacheName.equals(VMEM_CACHE)) {
       new VMemCache(FiberType.DATA)
     } else if (cacheName.equals(MIX_CACHE)) {
@@ -87,8 +87,8 @@ private[sql] class FiberCacheManager(
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
       )
-      new MixCache(dataCacheMemory, indexCacheMemory, dataCacheGuardianMemory,
-        indexCacheGuardianMemory, separateCache, sparkEnv)
+      new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
+        indexCacheGuardianMemorySize, separateCache, sparkEnv)
     } else {
       throw new OapException(s"Unsupported cache strategy $cacheName")
     }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -28,7 +28,9 @@ import com.google.common.cache._
 
 import org.apache.spark.{SparkEnv, SparkException}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.filecache.FiberType.FiberType
 import org.apache.spark.sql.execution.datasources.oap.utils.PersistentMemoryConfigUtils
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
@@ -202,6 +204,31 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logg
   }
 }
 
+private[filecache] object OapCache {
+
+  def apply(sparkEnv: SparkEnv, cacheMemory: Long,
+            cacheGuardianMemory: Long, fiberType: FiberType): OapCache = {
+    apply(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY, cacheMemory, cacheGuardianMemory, fiberType)
+  }
+
+  def apply(sparkEnv: SparkEnv, configEntry: ConfigEntry[String],
+            cacheMemory: Long, cacheGuardianMemory: Long, fiberType: FiberType): OapCache = {
+    val conf = sparkEnv.conf
+    val oapCacheOpt = conf.get(
+      configEntry.key,
+      configEntry.defaultValue.get).toLowerCase
+    oapCacheOpt match {
+      case "guava" => new GuavaOapCache(cacheMemory, cacheGuardianMemory, fiberType)
+      case "vmem" => new VMemCache(fiberType)
+      case "simple" => new SimpleOapCache()
+      case "noevict" => new NonEvictPMCache(cacheMemory, cacheGuardianMemory, fiberType)
+      case _ => throw new UnsupportedOperationException(
+        s"The cache backend: ${oapCacheOpt} is not supported now")
+    }
+
+  }
+}
+
 trait OapCache {
   val dataFiberSize: AtomicLong = new AtomicLong(0)
   val indexFiberSize: AtomicLong = new AtomicLong(0)
@@ -263,7 +290,8 @@ trait OapCache {
 }
 
 class NonEvictPMCache(pmSize: Long,
-                      cacheGuardianMemory: Long) extends OapCache with Logging {
+                      cacheGuardianMemory: Long,
+                      fiberType: FiberType) extends OapCache with Logging {
   // We don't bother the memory use of Simple Cache
   private val cacheGuardian = new MultiThreadCacheGuardian(Int.MaxValue)
   private val _cacheSize: AtomicLong = new AtomicLong(0)
@@ -382,7 +410,7 @@ class SimpleOapCache extends OapCache with Logging {
   override def getCacheGuardian: CacheGuardian = cacheGuardian
 }
 
-class VMemCache extends OapCache with Logging {
+class VMemCache(fiberType: FiberType) extends OapCache with Logging {
   private def emptyDataFiber(fiberLength: Long): FiberCache =
     OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(fiberLength)
 
@@ -510,23 +538,45 @@ class VMemCache extends OapCache with Logging {
     cacheTotalSize = status(2)
     logDebug(s"Current status is evict:$cacheEvictCount," +
       s" count:$cacheTotalCount, size:$cacheTotalSize")
-    CacheStats(
-      cacheTotalCount, // dataFiberCount
-      cacheTotalSize, // dataFiberSize JNIGet
-      0, // indexFiberCount
-      0, // indexFiberSize
-      cacheGuardian.pendingFiberCount, // pendingFiberCount
-      cacheGuardian.pendingFiberSize, // pendingFiberSize
-      cacheHitCount.get(), // dataFiberHitCount
-      cacheMissCount.get(), // dataFiberMissCount
-      cacheHitCount.get(), // dataFiberLoadCount
-      cacheTotalGetTime.get(), // dataTotalLoadTime
-      cacheEvictCount, // dataEvictionCount
-      0, // indexFiberHitCount
-      0, // indexFiberMissCount
-      0, // indexFiberLoadCount
-      0, // indexFiberLoadTime
-      0) // indexEvictionCount JNIGet
+
+    if (fiberType == FiberType.INDEX) {
+      CacheStats(
+        0, // dataFiberCount
+        0, // dataFiberSize JNIGet
+        cacheTotalCount, // indexFiberCount
+        cacheTotalSize, // indexFiberSize
+        cacheGuardian.pendingFiberCount, // pendingFiberCount
+        cacheGuardian.pendingFiberSize, // pendingFiberSize
+        0L,
+        0L,
+        0L,
+        0L,
+        0L,
+        cacheHitCount.get(), // indexFiberHitCount
+        cacheMissCount.get(), // indexFiberMissCount
+        cacheHitCount.get(), // indexFiberLoadCount
+        cacheTotalGetTime.get(), // indexTotalLoadTime
+        cacheEvictCount // indexEvictionCount
+      )
+    } else {
+      CacheStats(
+        cacheTotalCount, // dataFiberCount
+        cacheTotalSize, // dataFiberSize JNIGet
+        0, // indexFiberCount
+        0, // indexFiberSize
+        cacheGuardian.pendingFiberCount, // pendingFiberCount
+        cacheGuardian.pendingFiberSize, // pendingFiberSize
+        cacheHitCount.get(), // dataFiberHitCount
+        cacheMissCount.get(), // dataFiberMissCount
+        cacheHitCount.get(), // dataFiberLoadCount
+        cacheTotalGetTime.get(), // dataTotalLoadTime
+        cacheEvictCount, // dataEvictionCount
+        0, // indexFiberHitCount
+        0, // indexFiberMissCount
+        0, // indexFiberLoadCount
+        0, // indexFiberLoadTime
+        0) // indexEvictionCount JNIGet
+    }
   }
 
   override def cacheCount: Long = 0
@@ -547,19 +597,16 @@ class VMemCache extends OapCache with Logging {
 }
 
 class GuavaOapCache(
-    dataCacheMemory: Long,
-    indexCacheMemory: Long,
+    cacheMemory: Long,
     cacheGuardianMemory: Long,
-    var separationCache: Boolean)
+    fiberType: FiberType)
     extends OapCache with Logging {
 
   // TODO: CacheGuardian can also track cache statistics periodically
   private val cacheGuardian = new CacheGuardian(cacheGuardianMemory)
   cacheGuardian.start()
 
-  private val DATA_MAX_WEIGHT = dataCacheMemory
-  private val INDEX_MAX_WEIGHT = indexCacheMemory
-  private val TOTAL_MAX_WEIGHT = INDEX_MAX_WEIGHT + DATA_MAX_WEIGHT
+  private val MAX_WEIGHT = cacheMemory
   private val CONCURRENCY_LEVEL = 4
 
   // Total cached size for debug purpose, not include pending fiber
@@ -587,150 +634,87 @@ class GuavaOapCache(
     }
   }
 
-  private var cacheInstance = if (separationCache) {
-    initLoadingCache(DATA_MAX_WEIGHT)
-  } else {
-    initLoadingCache(TOTAL_MAX_WEIGHT)
-  }
-
-  // this is only used when enable index and data cache separation
-  private var indexCacheInstance = if (separationCache) {
-    initLoadingCache(INDEX_MAX_WEIGHT)
-  } else {
-    null
-  }
-
-  private def initLoadingCache(weight: Long) = {
-    CacheBuilder.newBuilder()
-      .recordStats()
-      .removalListener(removalListener)
-      .maximumWeight(weight)
-      .weigher(weigher)
-      .concurrencyLevel(CONCURRENCY_LEVEL)
-      .build[FiberId, FiberCache](new CacheLoader[FiberId, FiberCache] {
+  private val cacheInstance = CacheBuilder.newBuilder()
+    .recordStats()
+    .removalListener(removalListener)
+    .maximumWeight(MAX_WEIGHT)
+    .weigher(weigher)
+    .concurrencyLevel(CONCURRENCY_LEVEL)
+    .build[FiberId, FiberCache](new CacheLoader[FiberId, FiberCache] {
       override def load(key: FiberId): FiberCache = {
         val startLoadingTime = System.currentTimeMillis()
         val fiberCache = cache(key)
         incFiberCountAndSize(key, 1, fiberCache.size())
         logDebug(
-          "Load missed index fiber took %s. Fiber: %s. length: %s".format(
+          "Load missed fiber took %s. Fiber: %s. length: %s".format(
             Utils.getUsedTimeMs(startLoadingTime), key, fiberCache.size()))
         _cacheSize.addAndGet(fiberCache.size())
         fiberCache
       }
     })
-  }
+
 
   override def get(fiber: FiberId): FiberCache = {
     val readLock = OapRuntime.getOrCreate.fiberCacheManager.getFiberLock(fiber).readLock()
     readLock.lock()
     try {
-        if (separationCache) {
-          if (fiber.isInstanceOf[DataFiberId] || fiber.isInstanceOf[TestDataFiberId]) {
-            val fiberCache = cacheInstance.get(fiber)
-            // Avoid loading a fiber larger than DATA_MAX_WEIGHT / CONCURRENCY_LEVEL
-            assert(fiberCache.size() <= DATA_MAX_WEIGHT / CONCURRENCY_LEVEL,
-              s"Failed to cache fiber(${Utils.bytesToString(fiberCache.size())}) " +
-                s"with cache's MAX_WEIGHT" +
-                s"(${Utils.bytesToString(DATA_MAX_WEIGHT.toLong)}) " +
-                s"/ $CONCURRENCY_LEVEL")
-            fiberCache.occupy()
-            fiberCache
-          } else if (
-            fiber.isInstanceOf[BTreeFiberId] ||
-              fiber.isInstanceOf[BitmapFiberId] ||
-              fiber.isInstanceOf[TestIndexFiberId]) {
-            val fiberCache = indexCacheInstance.get(fiber)
-            // Avoid loading a fiber larger than INDEX_MAX_WEIGHT / CONCURRENCY_LEVEL
-            assert(fiberCache.size() <= INDEX_MAX_WEIGHT / CONCURRENCY_LEVEL,
-              s"Failed to cache fiber(${Utils.bytesToString(fiberCache.size())}) " +
-                s"with cache's MAX_WEIGHT" +
-                s"(${Utils.bytesToString(INDEX_MAX_WEIGHT)}) " +
-                s"/ $CONCURRENCY_LEVEL")
-            fiberCache.occupy()
-            fiberCache
-          } else throw new OapException(s"not support fiber type $fiber")
-        } else {
-          val fiberCache = cacheInstance.get(fiber)
-          // Avoid loading a fiber larger than MAX_WEIGHT / CONCURRENCY_LEVEL
-          assert(fiberCache.size() <= TOTAL_MAX_WEIGHT / CONCURRENCY_LEVEL,
-            s"Failed to cache fiber(${Utils.bytesToString(fiberCache.size())}) " +
-              s"with cache's MAX_WEIGHT" +
-              s"(${Utils.bytesToString(TOTAL_MAX_WEIGHT)}) / $CONCURRENCY_LEVEL")
-          fiberCache.occupy()
-          fiberCache
-        }
+      val fiberCache = cacheInstance.get(fiber)
+      // Avoid loading a fiber larger than MAX_WEIGHT / CONCURRENCY_LEVEL
+      assert(fiberCache.size() <= MAX_WEIGHT / CONCURRENCY_LEVEL,
+        s"Failed to cache fiber(${Utils.bytesToString(fiberCache.size())}) " +
+          s"with cache's MAX_WEIGHT" +
+          s"(${Utils.bytesToString(MAX_WEIGHT)}) / $CONCURRENCY_LEVEL")
+      fiberCache.occupy()
+      fiberCache
     } finally {
       readLock.unlock()
     }
   }
 
-  override def getIfPresent(fiber: FiberId): FiberCache =
-    if (separationCache &&
-        (fiber.isInstanceOf[BTreeFiberId] ||
-         fiber.isInstanceOf[BitmapFiberId] ||
-         fiber.isInstanceOf[TestIndexFiberId])) {
-        indexCacheInstance.getIfPresent(fiber)
-    } else {
-      cacheInstance.getIfPresent(fiber)
-    }
+  override def getIfPresent(fiber: FiberId): FiberCache = cacheInstance.getIfPresent(fiber)
 
-  override def getFibers: Set[FiberId] =
-    if (separationCache) {
-      cacheInstance.asMap().keySet().asScala.toSet ++
-        indexCacheInstance.asMap().keySet().asScala.toSet
-    } else {
-      cacheInstance.asMap().keySet().asScala.toSet
-    }
+  override def getFibers: Set[FiberId] = {
+    cacheInstance.asMap().keySet().asScala.toSet
+  }
 
-  override def invalidate(fiber: FiberId): Unit =
-    if (separationCache &&
-        (fiber.isInstanceOf[BTreeFiberId] ||
-         fiber.isInstanceOf[BitmapFiberId] ||
-         fiber.isInstanceOf[TestIndexFiberId])) {
-      indexCacheInstance.invalidate(fiber)
-    } else {
-      cacheInstance.invalidate(fiber)
-    }
+  override def invalidate(fiber: FiberId): Unit = {
+    cacheInstance.invalidate(fiber)
+  }
 
   override def invalidateAll(fibers: Iterable[FiberId]): Unit = {
-    fibers.foreach(invalidate)
+    cacheInstance.invalidateAll(fibers.asJava)
   }
 
   override def cacheSize: Long = _cacheSize.get()
 
   override def cacheStats: CacheStats = {
-    if (separationCache) {
-      val dataStats = cacheInstance.stats()
-      val indexStats = indexCacheInstance.stats()
+    val stats = cacheInstance.stats()
+    if (fiberType == FiberType.INDEX) {
       CacheStats(
         dataFiberCount.get(), dataFiberSize.get(),
         indexFiberCount.get(), indexFiberSize.get(),
         pendingFiberCount, cacheGuardian.pendingFiberSize,
-        dataStats.hitCount(),
-        dataStats.missCount(),
-        dataStats.loadCount(),
-        dataStats.totalLoadTime(),
-        dataStats.evictionCount(),
-        indexStats.hitCount(),
-        indexStats.missCount(),
-        indexStats.loadCount(),
-        indexStats.totalLoadTime(),
-        indexStats.evictionCount()
+        0L,
+        0L,
+        0L,
+        0L,
+        0L,
+        stats.hitCount(),
+        stats.missCount(),
+        stats.loadCount(),
+        stats.totalLoadTime(),
+        stats.evictionCount()
       )
     } else {
-      // when disable index and data cache separation
-      // we can't independently retrieve index and data cache
-      val cacheStats = cacheInstance.stats()
       CacheStats(
         dataFiberCount.get(), dataFiberSize.get(),
         indexFiberCount.get(), indexFiberSize.get(),
         pendingFiberCount, cacheGuardian.pendingFiberSize,
-        cacheStats.hitCount(),
-        cacheStats.missCount(),
-        cacheStats.loadCount(),
-        cacheStats.totalLoadTime(),
-        cacheStats.evictionCount(),
+        stats.hitCount(),
+        stats.missCount(),
+        stats.loadCount(),
+        stats.totalLoadTime(),
+        stats.evictionCount(),
         0L,
         0L,
         0L,
@@ -740,20 +724,7 @@ class GuavaOapCache(
     }
   }
 
-  override def cacheCount: Long =
-    if (separationCache) {
-      cacheInstance.size() + indexCacheInstance.size()
-    } else {
-      cacheInstance.size()
-    }
-
-  override def dataCacheCount: Long =
-    if (separationCache) {
-      cacheInstance.size()
-    } else {
-      cacheInstance.asMap().keySet().asScala
-        .count(fiber => fiber.isInstanceOf[DataFiberId] || fiber.isInstanceOf[TestDataFiberId])
-    }
+  override def cacheCount: Long = cacheInstance.size()
 
   override def pendingFiberCount: Int = cacheGuardian.pendingFiberCount
 
@@ -766,15 +737,10 @@ class GuavaOapCache(
   override def cleanUp(): Unit = {
     super.cleanUp()
     cacheInstance.cleanUp()
-    if (separationCache) {
-      indexCacheInstance.cleanUp()
-    }
   }
 
-  // This is only for test purpose
-  private[filecache] def enableCacheSeparation(): Unit = {
-    this.separationCache = true
-    cacheInstance = initLoadingCache(DATA_MAX_WEIGHT)
-    indexCacheInstance = initLoadingCache(INDEX_MAX_WEIGHT)
+  override def dataCacheCount: Long = {
+    cacheInstance.asMap().keySet().asScala
+      .count(fiber => fiber.isInstanceOf[DataFiberId] || fiber.isInstanceOf[TestDataFiberId])
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -541,9 +541,8 @@ class VMemCache(fiberType: FiberType) extends OapCache with Logging {
 
     if (fiberType == FiberType.INDEX) {
       CacheStats(
-        0, 0, // For index cache, the data fiber metrics should always be zero
-        cacheTotalCount, // indexFiberCount
-        cacheTotalSize, // indexFiberSize
+        0, 0,
+        cacheTotalCount, cacheTotalSize,
         cacheGuardian.pendingFiberCount, // pendingFiberCount
         cacheGuardian.pendingFiberSize, // pendingFiberSize
         0, 0, 0, 0, 0, // For index cache, the data fiber metrics should always be zero
@@ -555,9 +554,8 @@ class VMemCache(fiberType: FiberType) extends OapCache with Logging {
       )
     } else {
       CacheStats(
-        cacheTotalCount, // dataFiberCount
-        cacheTotalSize, // dataFiberSize JNIGet
-        0, 0, // For data cache, the index fiber metrics should always be zero
+        cacheTotalCount, cacheTotalSize,
+        0, 0,
         cacheGuardian.pendingFiberCount, // pendingFiberCount
         cacheGuardian.pendingFiberSize, // pendingFiberSize
         cacheHitCount.get(), // dataFiberHitCount
@@ -672,7 +670,7 @@ class GuavaOapCache(
   }
 
   override def invalidateAll(fibers: Iterable[FiberId]): Unit = {
-    cacheInstance.invalidateAll(fibers.asJava)
+    fibers.foreach(invalidate)
   }
 
   override def cacheSize: Long = _cacheSize.get()
@@ -681,7 +679,7 @@ class GuavaOapCache(
     val stats = cacheInstance.stats()
     if (fiberType == FiberType.INDEX) {
       CacheStats(
-        0, 0, // For index cache, the data fiber metrics should always be zero
+        dataFiberCount.get(), dataFiberSize.get(),
         indexFiberCount.get(), indexFiberSize.get(),
         pendingFiberCount, cacheGuardian.pendingFiberSize,
         0, 0, 0, 0, 0, // For index cache, the data fiber metrics should always be zero
@@ -694,7 +692,7 @@ class GuavaOapCache(
     } else {
       CacheStats(
         dataFiberCount.get(), dataFiberSize.get(),
-        0, 0, // For data cache, the index fiber metrics should always be zero
+        indexFiberCount.get(), indexFiberSize.get(),
         pendingFiberCount, cacheGuardian.pendingFiberSize,
         stats.hitCount(),
         stats.missCount(),

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -139,7 +139,8 @@ object OapConf {
   val OAP_INDEX_DATA_SEPARATION_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.index.data.cache.separation.enable")
       .internal()
-      .doc("This is to enable index data cache separation feature including mix memory manager")
+      .doc("This is to enable index data cache separation feature including mix memory manager" +
+        "and mix cache backend")
       .booleanConf
       .createWithDefault(false)
 
@@ -169,6 +170,16 @@ object OapConf {
       .stringConf
       .createWithDefault("offheap")
 
+  val OAP_FIBERCACHE_STRATEGY =
+    SqlConfAdapter.buildConf("spark.oap.cache.strategy")
+      .internal()
+      .doc("Sets the implement of cache strategy, it currently supports guava(Guava Cache), " +
+        "vmem(VMemCache), simple, noevict." +
+        "To enable mix mode, you need to set " +
+        "spark.sql.oap.index.data.cache.separation.enable to true")
+      .stringConf
+      .createWithDefault("guava")
+
   val OAP_MIX_INDEX_MEMORY_MANAGER =
     SqlConfAdapter.buildConf("spark.sql.oap.mix.index.memory.manager")
       .internal()
@@ -195,6 +206,20 @@ object OapConf {
         "It should be different from spark.sql.oap.mix.index.memory.manager")
       .stringConf
       .createWithDefault("pm")
+
+  val OAP_MIX_INDEX_CACHE_BACKEND =
+    SqlConfAdapter.buildConf("spark.sql.oap.mix.index.cache.backend")
+      .internal()
+      .doc("Sets the implement of index cache backend in mix mode.")
+      .stringConf
+      .createWithDefault("guava")
+
+  val OAP_MIX_DATA_CACHE_BACKEND =
+    SqlConfAdapter.buildConf("spark.sql.oap.mix.data.cache.backend")
+      .internal()
+      .doc("Sets the implement of data memory manager in mix mode.")
+      .stringConf
+      .createWithDefault("guava")
 
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.config.file")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -47,7 +47,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
   private def totalMemorySize = dataCacheMemorySize + indexCacheMemorySize
 
   test("unit test") {
-    val memorySizeInMB = (totalMemorySize / mbSize).toInt
+    val memorySizeInMB = (dataCacheMemorySize / mbSize).toInt
     val origStats = fiberCacheManager.cacheStats
     newFiberGroup
     (1 to memorySizeInMB * 2).foreach { i =>
@@ -72,7 +72,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
   }
 
   test("remove a fiber is in use") {
-    val memorySizeInMB = (totalMemorySize / mbSize).toInt
+    val memorySizeInMB = (dataCacheMemorySize / mbSize).toInt
     val dataInUse = generateData(mbSize)
     val fiberInUse = TestDataFiberId(
         () => fiberCacheManager.toDataFiberCache(dataInUse), s"test fiber #${newFiberGroup}.0")
@@ -97,7 +97,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
     newFiberGroup
     class FiberTestRunner(i: Int) extends Thread {
       override def run(): Unit = {
-        val memorySizeInMB = (totalMemorySize / mbSize).toInt
+        val memorySizeInMB = (dataCacheMemorySize / mbSize).toInt
         val data = generateData(memorySizeInMB / 4 * mbSize)
         val fiber = TestDataFiberId(
           () => fiberCacheManager.toDataFiberCache(data), s"test fiber #$fiberGroupId.$i")
@@ -116,7 +116,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
   }
 
   test("add a very large fiber") {
-    val memorySizeInMB = (totalMemorySize / mbSize).toInt
+    val memorySizeInMB = (dataCacheMemorySize / mbSize).toInt
     val ASSERT_MESSAGE_REGEX =
       ("""assertion failed: Failed to cache fiber\(\d+\.\d [TGMK]?B\) """ +
         """with cache's MAX_WEIGHT\(\d+\.\d [TGMK]?B\) / 4""").r
@@ -153,7 +153,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
   test("cache guardian remove pending fibers") {
     newFiberGroup
     Thread.sleep(1000) // Wait some time for CacheGuardian to remove pending fibers
-    val memorySizeInMB = (totalMemorySize / mbSize).toInt
+    val memorySizeInMB = (dataCacheMemorySize / mbSize).toInt
     val fibers = (1 to memorySizeInMB * 2).map { i =>
       val data = generateData(mbSize)
       TestDataFiberId(() => fiberCacheManager.toDataFiberCache(data),
@@ -208,7 +208,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
 
   // request fibers exceed max memory at the same time
   test("get different fiber simultaneously") {
-    val memorySizeInMB = (totalMemorySize / mbSize).toInt
+    val memorySizeInMB = (dataCacheMemorySize / mbSize).toInt
     val pool = Executors.newCachedThreadPool()
     val runners = (1 to 6).map { i =>
       val data = generateData(memorySizeInMB / 5 * mbSize)
@@ -305,7 +305,7 @@ class FiberCacheManagerSuite extends SharedOapContext {
   }
 
   test("LRU blocks memory free") {
-    val memorySizeInMB = (totalMemorySize / mbSize).toInt
+    val memorySizeInMB = (dataCacheMemorySize / mbSize).toInt
     val dataInUse = generateData(mbSize)
     val fiberInUse = TestDataFiberId(
       () => fiberCacheManager.toDataFiberCache(dataInUse), s"test fiber #${newFiberGroup}.0")

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -42,8 +42,8 @@ class FiberCacheManagerSuite extends SharedOapContext {
 
   private def fiberCacheManager = OapRuntime.getOrCreate.fiberCacheManager
 
-  private def dataCacheMemorySize = fiberCacheManager.dataCacheMemory
-  private def indexCacheMemorySize = fiberCacheManager.indexCacheMemory
+  private def dataCacheMemorySize = fiberCacheManager.dataCacheMemorySize
+  private def indexCacheMemorySize = fiberCacheManager.indexCacheMemorySize
   private def totalMemorySize = dataCacheMemorySize + indexCacheMemorySize
 
   test("unit test") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
@@ -43,12 +43,7 @@ class IndexDataCacheSeparationSuite extends SharedOapContext with BeforeAndAfter
   }
 
   oapSparkConf.set("spark.sql.oap.index.data.cache.separation.enable", "true")
-  oapSparkConf.set("spark.sql.oap.fiberCache.memory.manager", "mix")
   oapSparkConf.set("spark.oap.cache.strategy", "mix")
-  oapSparkConf.set("spark.sql.oap.mix.data.memory.manager", "tmp")
-  // here we set a larger size for tmp memory manager
-  // also we low the data size in some unit tests
-  oapSparkConf.set("spark.sql.oap.cache.guardian.memory.size", "1024m")
 
   private def fiberCacheManager = OapRuntime.getOrCreate.fiberCacheManager
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
@@ -174,9 +174,9 @@ class IndexDataCacheSeparationSuite extends SharedOapContext with BeforeAndAfter
     indexThreads.foreach(_.start())
     dataThreads.foreach(_.join(10000))
     indexThreads.foreach(_.join(10000))
+    Thread.sleep(1000)
     dataThreads.foreach(t => assert(!t.isAlive))
     indexThreads.foreach(t => assert(!t.isAlive))
-    Thread.sleep(1000)
   }
 
   test("add a very large fiber") {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
@@ -47,8 +47,8 @@ class IndexDataCacheSeparationSuite extends SharedOapContext with BeforeAndAfter
 
   private def fiberCacheManager = OapRuntime.getOrCreate.fiberCacheManager
 
-  private def dataCacheMemorySize = fiberCacheManager.dataCacheMemory
-  private def indexCacheMemorySize = fiberCacheManager.indexCacheMemory
+  private def dataCacheMemorySize = fiberCacheManager.dataCacheMemorySize
+  private def indexCacheMemorySize = fiberCacheManager.indexCacheMemorySize
 
   override def afterEach(): Unit = {
     fiberCacheManager.clearAllFibers()

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.{Callable, Executors, TimeUnit}
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.sql.test.oap.SharedOapContext
 import org.apache.spark.util.Utils
@@ -45,6 +44,7 @@ class IndexDataCacheSeparationSuite extends SharedOapContext with BeforeAndAfter
 
   oapSparkConf.set("spark.sql.oap.index.data.cache.separation.enable", "true")
   oapSparkConf.set("spark.sql.oap.fiberCache.memory.manager", "mix")
+  oapSparkConf.set("spark.oap.cache.strategy", "mix")
   oapSparkConf.set("spark.sql.oap.mix.data.memory.manager", "tmp")
   // here we set a larger size for tmp memory manager
   // also we low the data size in some unit tests
@@ -542,7 +542,7 @@ class IndexDataCacheSeparationSuite extends SharedOapContext with BeforeAndAfter
     // make fiber in use the 1st element in release queue.
     fiberCacheManager.releaseFiber(indexFiberInUse)
 
-    (1 to indexMemorySizeInMB * 2).foreach { i =>
+    (1 to indexMemorySizeInMB).foreach { i =>
       val data = generateData(mbSize)
       val fiber = TestDataFiberId(
         () => fiberCacheManager.toDataFiberCache(data),


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support different cache backend for memory manager. Previous, guava cache is the only one strategy, but now VMemcache is included. So we need this feature.

## How was this patch tested?
A modified unit test IndexDataCacheSeparationSuite
tpcds query testing, add index for table store_sales
![conf](https://user-images.githubusercontent.com/7370904/76775882-fa6cf000-67e0-11ea-97b7-d3c6f8388741.png)
![oap_tab](https://user-images.githubusercontent.com/7370904/76775888-fd67e080-67e0-11ea-8cc9-e83e2e5c166d.png)

TPCDS test
The first two part is for no sepration and mix .
 the thrid part is for mix. We should set spark.sql.oap.mix.index.memory.manager to mix and spark.oap.cache.strategy to mix
![image](https://user-images.githubusercontent.com/7370904/77381763-a43c1600-6db9-11ea-86e8-41eb2955d057.png)

Add another test for share offheap/pm memorymanager in separate cache.
We should  set spark.oap.cache.strategy=mix and spark.sql.oap.index.data.cache.separation.enable to true
<img width="956" alt="Capture" src="https://user-images.githubusercontent.com/7370904/77509205-4685f780-6ea7-11ea-823e-f6b8427428d9.PNG">

![image](https://user-images.githubusercontent.com/7370904/77509270-62899900-6ea7-11ea-89fe-f4088df3a900.png)



