### PR TITLE
Option to build oap with spark souce code which applid numa code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ metastore_db/
 null/
 src/main/native/build
 conf/persistent-memory.xml
+patched_file/
+src/main/spark2.4.4/scala/org/apache/spark/deploy/
+src/main/spark2.4.4/scala/org/apache/spark/executor/
+

--- a/docs/OAP-User-Guide.md
+++ b/docs/OAP-User-Guide.md
@@ -176,7 +176,7 @@ Patch to upstream spark source code is supported. You can find the built spark u
 ```
 cd scripts
 ./apply_patch_to_spark.sh -v SPARK_VERSION
-mvn clean package -Ppersistent-memory,numa-binding -DskipTests
+mvn clean -q package -Ppersistent-memory,numa-binding -DskipTests
 ```
 Patch to the local customized spark. Notice that some conflicts need resolve and copy the patched file to patched_file directory manually for this usage.
 ```

--- a/patches/OAP-SparkEnv-numa-binding.patch
+++ b/patches/OAP-SparkEnv-numa-binding.patch
@@ -1,0 +1,51 @@
+diff --git a/src/main/spark2.4.4/scala/org/apache/spark/SparkEnv.scala b/src/main/spark2.4.4/scala/org/apache/spark/SparkEnv.scala
+index d0217a3d24..07e16a0178 100644
+--- a/src/main/spark2.4.4/scala/org/apache/spark/SparkEnv.scala
++++ b/src/main/spark2.4.4/scala/org/apache/spark/SparkEnv.scala
+@@ -177,6 +177,7 @@ object SparkEnv extends Logging {
+     create(
+       conf,
+       SparkContext.DRIVER_IDENTIFIER,
++      None,
+       bindAddress,
+       advertiseAddress,
+       Option(port),
+@@ -195,6 +196,7 @@ object SparkEnv extends Logging {
+   private[spark] def createExecutorEnv(
+       conf: SparkConf,
+       executorId: String,
++      numaNodeId: Option[String],
+       hostname: String,
+       numCores: Int,
+       ioEncryptionKey: Option[Array[Byte]],
+@@ -202,6 +204,7 @@ object SparkEnv extends Logging {
+     val env = create(
+       conf,
+       executorId,
++      numaNodeId,
+       hostname,
+       hostname,
+       None,
+@@ -216,9 +219,11 @@ object SparkEnv extends Logging {
+   /**
+    * Helper method to create a SparkEnv for a driver or an executor.
+    */
++  // scalastyle:off
+   private def create(
+       conf: SparkConf,
+       executorId: String,
++      numaNodeId: Option[String],
+       bindAddress: String,
+       advertiseAddress: String,
+       port: Option[Int],
+@@ -228,6 +233,10 @@ object SparkEnv extends Logging {
+       listenerBus: LiveListenerBus = null,
+       mockOutputCommitCoordinator: Option[OutputCommitCoordinator] = None): SparkEnv = {
+
++    // scalastyInt
++    // set Numa node id through SparkConf
++    conf.set("spark.executor.numa.id", numaNodeId.getOrElse("-1"))
++
+     val isDriver = executorId == SparkContext.DRIVER_IDENTIFIER
+
+     // Listener bus is only used on the driver

--- a/patches/v2.4.4/Spark2.4.4-support-numa-binding.patch
+++ b/patches/v2.4.4/Spark2.4.4-support-numa-binding.patch
@@ -1,5 +1,5 @@
 diff --git a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
-index 48d3630..c001191 100644
+index 48d3630abd..84111d870f 100644
 --- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
 +++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
 @@ -41,6 +41,7 @@ private[spark] class CoarseGrainedExecutorBackend(
@@ -18,19 +18,20 @@ index 48d3630..c001191 100644
        hostname: String,
        cores: Int,
        appId: String,
-@@ -221,8 +223,10 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
-       val env = SparkEnv.createExecutorEnv(
-         driverConf, executorId, hostname, cores, cfg.ioEncryptionKey, isLocal = false)
+@@ -219,10 +221,10 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
+       }
  
-+      SparkEnv.get.conf.set("spark.executor.numa.id", s"${numaNodeId.getOrElse(-1)}")
-+
+       val env = SparkEnv.createExecutorEnv(
+-        driverConf, executorId, hostname, cores, cfg.ioEncryptionKey, isLocal = false)
++        driverConf, executorId, numaNodeId, hostname, cores, cfg.ioEncryptionKey, isLocal = false)
+ 
        env.rpcEnv.setupEndpoint("Executor", new CoarseGrainedExecutorBackend(
 -        env.rpcEnv, driverUrl, executorId, hostname, cores, userClassPath, env))
 +        env.rpcEnv, driverUrl, executorId, numaNodeId, hostname, cores, userClassPath, env))
        workerUrl.foreach { url =>
          env.rpcEnv.setupEndpoint("WorkerWatcher", new WorkerWatcher(env.rpcEnv, url))
        }
-@@ -233,6 +237,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
+@@ -233,6 +235,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
    def main(args: Array[String]) {
      var driverUrl: String = null
      var executorId: String = null
@@ -38,7 +39,7 @@ index 48d3630..c001191 100644
      var hostname: String = null
      var cores: Int = 0
      var appId: String = null
-@@ -257,6 +262,9 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
+@@ -257,6 +260,9 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
          case ("--app-id") :: value :: tail =>
            appId = value
            argv = tail
@@ -48,17 +49,16 @@ index 48d3630..c001191 100644
          case ("--worker-url") :: value :: tail =>
            // Worker url is used in spark standalone mode to enforce fate-sharing with worker
            workerUrl = Some(value)
-@@ -278,7 +286,8 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
+@@ -278,7 +284,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
        printUsageAndExit()
      }
  
 -    run(driverUrl, executorId, hostname, cores, appId, workerUrl, userClassPath)
-+    logInfo(s"[NUMACHECK] numaNodeId $numaNodeId")
-+    run(driverUrl, executorId, numaNodeId, hostname,  cores, appId, workerUrl, userClassPath)
++    run(driverUrl, executorId, numaNodeId, hostname, cores, appId, workerUrl, userClassPath)
      System.exit(0)
    }
  
-@@ -291,6 +300,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
+@@ -291,6 +297,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
        | Options are:
        |   --driver-url <driverUrl>
        |   --executor-id <executorId>
@@ -67,7 +67,7 @@ index 48d3630..c001191 100644
        |   --cores <cores>
        |   --app-id <appid>
 diff --git a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
-index 5ff826a..954849a 100644
+index 5ff826a2e1..954849ae27 100644
 --- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
 +++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
 @@ -428,7 +428,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments) extends
@@ -80,7 +80,7 @@ index 5ff826a..954849a 100644
      }
  
 diff --git a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
-index 49a0b93..cf66363 100644
+index 49a0b93aa5..4517385cd9 100644
 --- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
 +++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
 @@ -36,6 +36,7 @@ import org.apache.hadoop.yarn.ipc.YarnRPC
@@ -99,24 +99,27 @@ index 49a0b93..cf66363 100644
      hostname: String,
      executorMemory: Int,
      executorCores: Int,
-@@ -197,9 +199,23 @@ private[yarn] class ExecutorRunnable(
+@@ -197,9 +199,26 @@ private[yarn] class ExecutorRunnable(
        Seq("--user-class-path", "file:" + absPath)
      }.toSeq
  
 +    val numaEnabled = sparkConf.get(SPARK_YARN_NUMA_ENABLED)
 +
-+    logInfo(s"[NUMACHECK] numaEnabled $numaEnabled executorId $executorId")
 +    // Don't need numa binding for driver.
-+    val (numaCtlCommand, numaNodeOpts) = if (numaEnabled && executorId != "<executorId>"
-+      && numaNodeId.nonEmpty) {
-+      logInfo(s"numaNodeId ${numaNodeId.get}")
++    val numaCtlCommand = if (numaEnabled && executorId != "<executorId>" && numaNodeId.nonEmpty) {
 +      val command = s"numactl --cpubind=${numaNodeId.get} --membind=${numaNodeId.get} "
-+      (command, Seq("--numa-node-id", numaNodeId.get.toString))
++      command
 +    } else {
-+      ("", Nil)
++      ""
 +    }
 +
-+    logInfo(s"[NUMACHECK] numactl command $numaCtlCommand")
++    val numaNodeOpts = if (executorId != "<executorId>" && numaNodeId.nonEmpty) {
++      val numanode = Seq("--numa-node-id", numaNodeId.get.toString)
++      numanode
++    } else {
++      Nil
++    }
++
      YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
      val commands = prefixEnv ++
 -      Seq(Environment.JAVA_HOME.$$() + "/bin/java", "-server") ++
@@ -124,7 +127,7 @@ index 49a0b93..cf66363 100644
        javaOpts ++
        Seq("org.apache.spark.executor.CoarseGrainedExecutorBackend",
          "--driver-url", masterAddress,
-@@ -207,11 +223,13 @@ private[yarn] class ExecutorRunnable(
+@@ -207,6 +226,7 @@ private[yarn] class ExecutorRunnable(
          "--hostname", hostname,
          "--cores", executorCores.toString,
          "--app-id", appId) ++
@@ -132,50 +135,27 @@ index 49a0b93..cf66363 100644
        userClassPath ++
        Seq(
          s"1>${ApplicationConstants.LOG_DIR_EXPANSION_VAR}/stdout",
-         s"2>${ApplicationConstants.LOG_DIR_EXPANSION_VAR}/stderr")
- 
-+    logInfo(s"[NUMACHECK] container command $commands")
-     // TODO: it would be nicer to just make sure there are no null commands here
-     commands.map(s => if (s == null) "null" else s).toList
-   }
 diff --git a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
-index 96bc1c7..de9ef6b 100644
+index 96bc1c7889..62b3087ae3 100644
 --- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
 +++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
-@@ -171,6 +171,13 @@ private[yarn] class YarnAllocator(
+@@ -163,6 +163,8 @@ private[yarn] class YarnAllocator(
+   private[yarn] val containerPlacementStrategy =
+     new LocalityPreferredContainerPlacementStrategy(sparkConf, conf, resource, resolver)
  
-   def isAllNodeBlacklisted: Boolean = allocatorBlacklistTracker.isAllNodeBlacklisted
++  private[yarn] val numaManager = new NumaManager(sparkConf)
++
+   def getNumExecutorsRunning: Int = runningExecutors.size()
  
-+  // The total number of numa node
-+  private[yarn] val totalNumaNumber = sparkConf.get(SPARK_YARN_NUMA_NUMBER)
-+  // Mapping from host to executor counter
-+  private[yarn] case class NumaInfo(cotainer2numa: mutable.HashMap[String, Int], numaUsed: Array[Int])
-+
-+  private[yarn] val hostToNumaInfo = new mutable.HashMap[String, NumaInfo]()
-+
-   /**
-    * A sequence of pending container requests that have not yet been fulfilled.
-    */
-@@ -507,11 +514,25 @@ private[yarn] class YarnAllocator(
-     for (container <- containersToUse) {
-       executorIdCounter += 1
+   def getNumReleasedContainers: Int = releasedContainers.size()
+@@ -509,9 +511,13 @@ private[yarn] class YarnAllocator(
        val executorHostname = container.getNodeId.getHost
-+      // Setting the numa id that the executor should binding.
-+      // new numaid binding method
-+      val numaInfo = hostToNumaInfo.getOrElseUpdate(executorHostname,
-+        NumaInfo(new mutable.HashMap[String, Int], new Array[Int](totalNumaNumber)))
-+      val minUsed = numaInfo.numaUsed.min
-+      val newNumaNodeId = numaInfo.numaUsed.indexOf(minUsed)
-+      numaInfo.cotainer2numa.put(container.getId.toString, newNumaNodeId)
-+      numaInfo.numaUsed(newNumaNodeId) += 1
-+
-+      val numaNodeId = newNumaNodeId.toString
-+      logInfo(s"numaNodeId: $numaNodeId on host $executorHostname," +
-+        "container: " + container.getId.toString +
-+        ", minUsed: " + minUsed)
-+
        val containerId = container.getId
        val executorId = executorIdCounter.toString
++
++      // Set the numa id that the executor should binding.
++      val numaNodeId = numaManager.assignNumaId(containerId, executorHostname)
++
        assert(container.getResource.getMemory >= resource.getMemory)
        logInfo(s"Launching container $containerId on host $executorHostname " +
 -        s"for executor with ID $executorId")
@@ -183,50 +163,92 @@ index 96bc1c7..de9ef6b 100644
  
        def updateInternalState(): Unit = synchronized {
          runningExecutors.add(executorId)
-@@ -537,6 +558,7 @@ private[yarn] class YarnAllocator(
+@@ -537,6 +543,7 @@ private[yarn] class YarnAllocator(
                    sparkConf,
                    driverUrl,
                    executorId,
-+                  Some(numaNodeId),
++                  numaNodeId,
                    executorHostname,
                    executorMemory,
                    executorCores,
-@@ -595,6 +617,17 @@ private[yarn] class YarnAllocator(
-         // there are some exit status' we shouldn't necessarily count against us, but for
-         // now I think its ok as none of the containers are expected to exit.
-         val exitStatus = completedContainer.getExitStatus
+@@ -657,6 +664,7 @@ private[yarn] class YarnAllocator(
+         }
+ 
+         allocatedContainerToHostMap.remove(containerId)
++        numaManager.releaseNuma(containerId, host)
+       }
+ 
+       containerIdToExecutorId.remove(containerId).foreach { eid =>
+@@ -751,6 +759,51 @@ private[yarn] class YarnAllocator(
+ 
+ }
+ 
++// scalastyle:off
++// Manage how to bind numa with an exector. No matter numa binding turn on/off
++// we should assign a numa id since Persistent Memory always be associate with a numa id
++private[yarn] class NumaManager(sparkConf: SparkConf) extends Logging {
++  private final val totalNumaNode = sparkConf.get(SPARK_YARN_NUMA_NUM)
++  private val hostToNumaIds = new ConcurrentHashMap[String, Array[Int]]()
++  private val hostToContainers = new ConcurrentHashMap[String, mutable.HashMap[ContainerId, String]]()
 +
-+        var numaNodeId = -1
-+        val hostName = hostOpt.getOrElse("nohost")
-+        val numaInfoOp = hostToNumaInfo.get(hostName)
-+        numaInfoOp match {
-+          case Some(numaInfo) =>
-+            numaNodeId = numaInfo.cotainer2numa.get(containerId.toString).getOrElse(-1)
-+            if(-1 != numaNodeId) numaInfo.numaUsed(numaNodeId) -= 1
-+          case _ => numaNodeId = -1
++  def assignNumaId(
++                    containerId: ContainerId,
++                    executorHostName: String): Option[String] = {
++    if (totalNumaNode == 0) return None
++    if (hostToContainers.containsKey(executorHostName)) {
++      if (!hostToContainers.get(executorHostName).contains(containerId)) {
++        this.synchronized {
++          val numaIds = hostToNumaIds.get(executorHostName)
++          val v = numaIds.zipWithIndex.min._2
++          logDebug(s"bind $containerId with $v on host $executorHostName")
++          hostToContainers.get(executorHostName) += (containerId -> v.toString)
++          numaIds(v) += 1
++          Some(v.toString)
 +        }
++      } else {
++        hostToContainers.get(executorHostName).get(containerId)
++      }
++    } else {
++      logDebug(s"bind $containerId with 0 on host $executorHostName")
++      hostToNumaIds.put(executorHostName, Array.fill[Int](totalNumaNode)(0))
++      hostToNumaIds.get(executorHostName)(0) += 1
++      hostToContainers.putIfAbsent(executorHostName, mutable.HashMap[ContainerId, String](containerId -> "0"))
++      Some("0")
++    }
++  }
 +
-         val (exitCausedByApp, containerExitReason) = exitStatus match {
-           case ContainerExitStatus.SUCCESS =>
-             (false, s"Executor for container $containerId exited because of a YARN event (e.g., " +
++  def releaseNuma(containerId: ContainerId, executorHostName: String): Unit = {
++    if (hostToContainers.get(executorHostName) != null) {
++      val numaIdToRelease = hostToContainers.get(executorHostName).getOrElseUpdate(containerId, "null")
++      logDebug(s"release $containerId with $numaIdToRelease on host $executorHostName")
++      hostToNumaIds.get(executorHostName)(numaIdToRelease.toInt) -= 1
++      hostToContainers.get(executorHostName).remove(containerId)
++    }
++  }
++
++}
++
+ private object YarnAllocator {
+   val MEM_REGEX = "[0-9.]+ [KMG]B"
+   val PMEM_EXCEEDED_PATTERN =
 diff --git a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
-index ab8273b..d5203a7 100644
+index ab8273bd63..46c2591a57 100644
 --- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
 +++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
 @@ -129,6 +129,17 @@ package object config {
  
    /* Launcher configuration. */
  
-+   private[spark] val SPARK_YARN_NUMA_ENABLED = ConfigBuilder("spark.yarn.numa.enabled")
++  private[spark] val SPARK_YARN_NUMA_ENABLED = ConfigBuilder("spark.yarn.numa.enabled")
 +    .doc("Whether enabling numa binding when executor start up. This is recommend to true " +
 +      "when persistent memory is enabled.")
 +    .booleanConf
 +    .createWithDefault(false)
 +
-+  private[spark] val SPARK_YARN_NUMA_NUMBER = ConfigBuilder("spark.yarn.numa.number")
-+    .doc("Total number of numanodes in physical server")
++  private[spark] val SPARK_YARN_NUMA_NUM = ConfigBuilder("spark.yarn.numa.num")
++    .doc("Specify numa node number in the host")
 +    .intConf
-+    .createWithDefault(2)
++    .createWithDefault(0)
 +
    private[spark] val WAIT_FOR_APP_COMPLETION = ConfigBuilder("spark.yarn.submit.waitAppCompletion")
      .doc("In cluster mode, whether to wait for the application to finish before exiting the " +

--- a/pom.xml
+++ b/pom.xml
@@ -807,5 +807,71 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>numa-binding</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-yarn_${scala.binary.version}</artifactId>
+          <version>${spark.internal.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-yarn_${scala.binary.version}</artifactId>
+          <version>${spark.internal.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.8</version>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>Copy numa pacthed file as OAP source code</echo>
+                    <copy todir="${basedir}/src/main/spark${spark.internal.version}/scala/org/apache/spark/deploy/yarn/">
+                      <resources>
+                        <file file="${basedir}/patched_file/ApplicationMaster.scala"/>
+                        <file file="${basedir}/patched_file/ExecutorRunnable.scala"/>
+                        <file file="${basedir}/patched_file/YarnAllocator.scala"/>
+                        <file file="${basedir}/patched_file/config.scala"/>
+                      </resources>
+                    </copy>
+                    <copy file="${basedir}/patched_file/CoarseGrainedExecutorBackend.scala"
+                          todir="${basedir}/src/main/spark${spark.internal.version}/scala/org/apache/spark/executor/"/>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>exec-maven-plugin</artifactId>
+            <groupId>org.codehaus.mojo</groupId>
+            <version>${exec.maven.version}</version>
+            <executions>
+              <execution>
+                <id>Apply numa patch to OAP</id>
+                <phase>process-sources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>${basedir}/scripts/apply_patch_to_oap.sh</executable>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/scripts/apply_patch_to_oap.sh
+++ b/scripts/apply_patch_to_oap.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+CUR_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+OAP_HOME=$(dirname $CUR_DIR)
+PATCH_DIR=$OAP_HOME/patches
+
+GIT=$(command -v git)
+check_git_exist() {
+  if ! [ -x "$GIT" ]; then
+    echo "ERROR: git is not found!"
+    exit 1
+  fi
+}
+patch_to_oap() {
+  check_git_exist
+  cd $OAP_HOME
+
+  if ! [ -d .git ]; then
+    $GIT init
+  fi
+
+  $GIT checkout -- src/main/spark2.4.4/scala/org/apache/spark/SparkEnv.scala
+  $GIT apply $PATCH_DIR/OAP-SparkEnv-numa-binding.patch
+  if [ $? != 0 ]; then
+    echo "Fail to apply the patch to oap. Please check if you have already patched."
+  else
+    echo "Apply patches to oap successfully."
+  fi
+}
+
+patch_to_oap

--- a/scripts/apply_patch_to_oap.sh
+++ b/scripts/apply_patch_to_oap.sh
@@ -11,6 +11,53 @@ check_git_exist() {
     exit 1
   fi
 }
+
+NDCTL=$(command -v ndctl)
+check_ndctl_exist() {
+  if ! [ -x "$NDCTL" ]; then
+    echo "ERROR: ndctl is not found!"
+    exit 1
+  fi
+}
+
+NUMACTL=$(command -v numactl)
+check_numactl_exist() {
+  if ! [ -x "$NUMACTL" ]; then
+    echo "ERROR: numactl is not found!"
+    exit 1
+  fi
+}
+
+check_pmem_numa() {
+  check_numactl_exist
+  check_ndctl_exist
+
+  numa_node_num=`$NUMACTL -H | grep "available" | cut -f2 -d" "`
+  if [ -z $numa_node_num ]; then
+    echo "The machine is not numa architecture. It does not help to apply the numa patch."
+    exit 1
+  fi
+
+  pmem_initialized=`$NDCTL list -R`
+  if [ -z "$pmem_initialized" ]; then
+    echo "Please initialize the persistent memory with AppDirect Mode first."
+    exit 1
+  fi
+
+  for ((i=0; i<$numa_node_num; i++));
+  do
+    pmem_device=`$NDCTL list -U $i | grep "blockdev" | cut -f2 -d":" | sed 's/"//g'`
+    mount_point=`grep $pmem_device /proc/mounts | cut -f2 -d" "`
+    echo "$pmem_device is associate with numa node $i"
+    if [ -z $mount_point ]; then
+      echo "Please mount /dev/$pmem_device at the initial path which numa node id is $i in persistent-memory.xml"
+    else
+      echo "Current /dev/$pmem_device mounted at $mount_point."
+      echo "Please check if $mount_point is associate with numa node id $i in persistent-memory.xml."
+    fi
+  done
+}
+
 patch_to_oap() {
   check_git_exist
   cd $OAP_HOME
@@ -28,4 +75,5 @@ patch_to_oap() {
   fi
 }
 
+check_pmem_numa
 patch_to_oap

--- a/scripts/apply_patch_to_spark.sh
+++ b/scripts/apply_patch_to_spark.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+SPARK_UPSTREAM_URL="https://github.com/apache/spark/archive/"
+SPARK_VERSION_SUPPORTED=(
+  "v2.4.4"
+)
+
+CUR_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+OAP_HOME=$(dirname $CUR_DIR)
+DOWNLOADED_SPARK_DIR=$(dirname $OAP_HOME)
+PATCH_DIR=$OAP_HOME/patches
+
+function echo_usage() {
+  cat << EOF
+  Usage:
+    ${0} -c <path>
+    ${0} -v <spark_version>
+    -c | --custom-spark   - OPTIONAL. Patch to the customed spark. It you don't set, we will download from upstream
+    -v | --version        - REQUIRED. Patch to the upstream spark, current we support ${SPARK_VERSION_SUPPORTED}
+                            Also you can select one of version and try to apply to your spark
+
+    For example:
+      apply_patch.sh -v v2.4.4
+      apply_patch.sh -v v2.4.4 -c YOUR_SPARK_DIR
+EOF
+exit 1
+}
+
+CURL=$(command -v curl)
+check_curl_exist() {
+  if ! [ -x "$CURL" ]; then
+    echo "ERROR: curl is not found!"
+    exit 1
+  fi
+}
+
+GIT=$(command -v git)
+check_git_exist() {
+  if ! [ -x "$GIT" ]; then
+    echo "ERROR: git is not found!"
+    exit 1
+  fi
+}
+
+TARBALL_SUFFIX=".tar.gz"
+fetch_from_upstream() {
+  check_curl_exist
+
+  TARBALL_NAME=$UPSTREAM_SPARK_VERSION$TARBALL_SUFFIX
+  mkdir -p $DOWNLOADED_SPARK_DIR/spark_source
+  $CURL --fail -L $SPARK_UPSTREAM_URL$TARBALL_NAME \
+          -o $TARBALL_NAME
+  if [ $? != 0 ]; then
+    echo "Please check whether the spark version is in support list ($SPARK_VERSION_SUPPORTED) and ensure the network available"
+    exit 1
+  fi
+
+  SPARK_SOURCE_NAME=`tar -tf $TARBALL_NAME | head -1 | cut -f1 -d"/"`
+  if [ $? != 0 ]; then
+    exit 1
+  fi
+  SPARK_SOURCE_DIR=$DOWNLOADED_SPARK_DIR/spark_source/$SPARK_SOURCE_NAME
+  if [ -d $SPARK_SOURCE_DIR ]; then
+    rm -rf $SPARK_SOURCE_DIR
+  fi
+  tar -zxf $TARBALL_NAME -C $DOWNLOADED_SPARK_DIR/spark_source
+  rm $TARBALL_NAME
+}
+
+patch_to_spark() {
+  # TODO: we'd better use /usr/bin/patch to apply patch. Here seems the current patch file is not applicable
+  check_git_exist
+  cd $SPARK_SOURCE_DIR
+
+  if ! [ -d .git ]; then
+    $GIT init
+  fi
+
+  $GIT apply $PATCH_DIR/$UPSTREAM_SPARK_VERSION/*.patch
+  if [ $? != 0 ]; then
+    echo "Fail to apply the patch to spark. Please try to solve conflicts if you are using custom spark."
+    exit 1
+  fi
+  echo "Apply patches to spark successfully."
+}
+
+copy_to_oap() {
+  mkdir -p $OAP_HOME/patched_file
+  PATHED_FILE_DIR=$OAP_HOME/patched_file
+  PATCHED_FILES=`grep -r "git" $PATCH_DIR/$UPSTREAM_SPARK_VERSION/* | awk '{print substr($3,2)}'`
+  for FILE in $PATCHED_FILES
+  do
+    cp $SPARK_SOURCE_DIR$FILE $PATHED_FILE_DIR
+  done
+}
+
+###################################################################################
+
+OPTS=`getopt --options c:v: --long "custom-spark:,version:" -n "$0" -- "$@"`
+if [ $? != 0 ]; then
+  echo "Failed parsing options."
+  echo_usage
+  exit 1
+fi
+
+while true; do
+  case "$1" in
+    -c | --custom-spark)
+      SPARK_SOURCE_DIR=$2; shift 2;;
+    -v | --version)
+      UPSTREAM_SPARK_VERSION=$2; shift 2;;
+    --)
+      shift; break;;
+    *)
+      break ;;
+  esac
+done
+
+if [ -z "$UPSTREAM_SPARK_VERSION" ]; then
+  echo_usage
+fi
+
+if [[ "${SPARK_VERSION_SUPPORTED[*]}" =~ $UPSTREAM_SPARK_VERSION ]]; then
+  fetch_from_upstream
+fi
+
+patch_to_spark
+copy_to_oap


### PR DESCRIPTION
## What changes were proposed in this pull request?

An option script for the user to build OAP with numa code and no need for them to change the spark source code. Support binding numa to executors in balance and fault-tolerant.

## How was this patch tested?
Start two executors and kill one several times to check whether the restarted executor will bind numa in balance.
<img width="799" alt="numa" src="https://user-images.githubusercontent.com/7370904/76832223-e4544380-6863-11ea-9fc0-87caf0c082ad.PNG">


