### PR TITLE
simplify memorymanager configuration

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
@@ -69,8 +69,8 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
 
   private def init(): (MemoryManager, MemoryManager) = {
     if (separateMemory) {
-      val dataManager = MemoryManager(sparkEnv, OapConf.OAP_MIX_DATA_MEMORY_MANAGER)
-      val indexManager = MemoryManager(sparkEnv, OapConf.OAP_MIX_INDEX_MEMORY_MANAGER)
+      val dataManager = MemoryManager(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY)
+      val indexManager = MemoryManager(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY)
       if (indexManager.getClass.equals(dataManager.getClass)) {
         throw new UnsupportedOperationException(
           "Index Cache type and Data Cache type need to be different in Mixed mode")

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -55,7 +55,8 @@ private[sql] class FiberCacheManager(
   def dcpmmWaitingThreshold: Long = _dcpmmWaitingThreshold
 
   private val cacheBackend: OapCache = {
-    val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
+    val cacheName =
+      sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_STRATEGY.key, DEFAULT_CACHE_STRATEGY).toLowerCase
     if (cacheName.equals(GUAVA_CACHE)) {
       val separateCache = sparkEnv.conf.getBoolean(
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -169,6 +169,16 @@ object OapConf {
       .stringConf
       .createWithDefault("offheap")
 
+  val OAP_FIBERCACHE_STRATEGY =
+    SqlConfAdapter.buildConf("spark.oap.cache.strategy")
+      .internal()
+      .doc("Sets the implement of cache strategy, it currently supports guava(Guava Cache), " +
+        "vmem(VMemCache), simple, noevict." +
+        "To enable mix mode, you need to set " +
+        "spark.sql.oap.index.data.cache.separation.enable to true")
+      .stringConf
+      .createWithDefault("guava")
+
   val OAP_MIX_INDEX_MEMORY_MANAGER =
     SqlConfAdapter.buildConf("spark.sql.oap.mix.index.memory.manager")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, there are several memory manager options(offheap, pm, tmp, hybrid) and cache strategies(guava, nonevict, vmemcache). User probably don't understand the mapping between these options. This PR try to simplify this configuration by initializing memorymanager based on the cache strategy directly, except for guava cache which has 2 memorymanager options(offheap, pm)

## How was this patch tested?

UT passed.

