### PR TITLE
fix cache guardian use too much memory

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -169,7 +169,9 @@ private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
     sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE)
   val cacheGuardianMemory = Utils.byteStringAsBytes(cacheGuardianMemorySizeStr)
   logInfo(s"cacheGuardian total use $cacheGuardianMemory bytes memory")
-  val cacheGuardianRetryTime = sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_RETRY_TIME_IN_MS) / 10
+  val cacheGuardianRetrySleepTimeInMs = 10
+  val cacheGuardianRetryTime =
+    sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_RETRY_TIME_IN_MS) / cacheGuardianRetrySleepTimeInMs
 
   private val _memoryUsed = new AtomicLong(0)
   override def memoryUsed: Long = _memoryUsed.get()
@@ -179,11 +181,12 @@ private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
     var retryTime: Int = 0
     while(memoryUsed + size > cacheGuardianMemory) {
       retryTime += 1
-      Thread.sleep(10)
+      Thread.sleep(cacheGuardianRetrySleepTimeInMs)
       if (retryTime > cacheGuardianRetryTime) {
         throw new OapException("cache guardian use too much memory over " +
-          cacheGuardianRetryTime * 10 + "ms," +
-          " please consider increase cache guardian size")
+          cacheGuardianRetryTime * cacheGuardianRetrySleepTimeInMs + "ms, please consider " +
+          "increase memory size by 'spark.sql.oap.cache.guardian.memory.size' configuration or " +
+          "increase retry time by 'spark.sql.oap.cache.guardian.retry.time.in.ms' configuration")
       }
     }
     val startTime = System.currentTimeMillis()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -175,8 +175,14 @@ private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
   override def memorySize: Long = cacheGuardianMemory
 
   override private[filecache] def allocate(size: Long): MemoryBlockHolder = {
-    if (memoryUsed + size > cacheGuardianMemory) {
-      throw new OapException("cache guardian use too much memory")
+    var retryTime: Int = 0
+    while(memoryUsed + size > cacheGuardianMemory) {
+      retryTime += 1
+      Thread.sleep(10)
+      if (retryTime > 100) {
+        throw new OapException("cache guardian use too much memory over 1000 ms," +
+          " please consider increase cache guardian size")
+      }
     }
     val startTime = System.currentTimeMillis()
     val occupiedSize = size

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -169,7 +169,7 @@ private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
     sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE)
   val cacheGuardianMemory = Utils.byteStringAsBytes(cacheGuardianMemorySizeStr)
   logInfo(s"cacheGuardian total use $cacheGuardianMemory bytes memory")
-  val cacheGuardianRetryTime: Int = sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_RETRY_TIME)
+  val cacheGuardianRetryTime = sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_RETRY_TIME_IN_MS) / 10
 
   private val _memoryUsed = new AtomicLong(0)
   override def memoryUsed: Long = _memoryUsed.get()

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -415,8 +415,8 @@ object OapConf {
       .stringConf
       .createWithDefault("10g")
 
-  val OAP_CACHE_GUARDIAN_RETRY_TIME =
-    SqlConfAdapter.buildConf("spark.sql.oap.cache.guardian.retry.time")
+  val OAP_CACHE_GUARDIAN_RETRY_TIME_IN_MS =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.guardian.retry.time.in.ms")
     .internal()
     .doc("Retry time for TmpMemoryManager allocate")
     .intConf

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -415,6 +415,13 @@ object OapConf {
       .stringConf
       .createWithDefault("10g")
 
+  val OAP_CACHE_GUARDIAN_RETRY_TIME =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.guardian.retry.time")
+    .internal()
+    .doc("Retry time for TmpMemoryManager allocate")
+    .intConf
+    .createWithDefault(100)
+
   val OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.index.statistic.externalsorter.enable")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

TmpMemmroyManager will use too much memory and throw exception when allocate size is more than 'spark.sql.oap.cache.guardian.memory.size'.  TmpMemoryManager.allocate() will sleep for a while and will not throw exception directly.

## How was this patch tested?

I tested this patch with tpc-ds 9 query on Parquet 1TB, 3TB dataset (generated by spark-sql-perf 0.5.1). Test passed while previous version failed.

