### PR TITLE
[DO NOT MERGE]WIP Q2 fix

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregation.scala
@@ -172,7 +172,6 @@ class ColumnarAggregation(
   logInfo(s"resultAttributes is ${resultAttributes},\naggregateToResultOrdinalList is ${aggregateToResultOrdinalList}")
 //////////////////////////////////////////////////////////////////////////////////////////////////
   def close(): Unit = {
-    logInfo(" closed");
     if (aggregator != null) {
       aggregator.close()
       aggregator = null
@@ -260,6 +259,10 @@ class ColumnarAggregation(
           return true
         }
         if ( !nextBatch ) {
+          if (result_iterator != null) {
+            result_iterator.close()
+            result_iterator = null
+          }
           return false
         }
 
@@ -273,7 +276,6 @@ class ColumnarAggregation(
             }
             cb = cbIterator.next()
   
-            val beforeEval = System.nanoTime()
             if (cb.numRows > 0) {
               updateAggregationResult(cb)
               processedNumRows += cb.numRows

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarShuffledHashJoin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarShuffledHashJoin.scala
@@ -321,14 +321,6 @@ class ColumnarShuffledHashJoin(
       last_cb.close()
       last_cb = null
     }
-    if (prober != null) {
-      prober.close()
-      prober = null
-    }
-    if (build_shuffler != null) {
-      build_shuffler.close()
-      build_shuffler = null
-    }
     if (probe_iterator != null) {
       probe_iterator.close()
       probe_iterator = null
@@ -337,8 +329,15 @@ class ColumnarShuffledHashJoin(
       build_shuffle_iterator.close()
       build_shuffle_iterator = null
     }
+    if (build_shuffler != null) {
+      build_shuffler.close()
+      build_shuffler = null
+    }
+    if (prober != null) {
+      prober.close()
+      prober = null
+    }
   }
-
 }
 
 object ColumnarShuffledHashJoin {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
@@ -7,6 +7,7 @@
 #include <arrow/type_fwd.h>
 #include <arrow/type_traits.h>
 #include <arrow/util/checked_cast.h>
+
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -1108,6 +1109,40 @@ arrow::Status MakeAvgAction(arrow::compute::FunctionContext* ctx,
 #define PROCESS(InType)                                         \
   case InType::type_id: {                                       \
     auto action_ptr = std::make_shared<AvgAction<InType>>(ctx); \
+    *out = std::dynamic_pointer_cast<ActionBase>(action_ptr);   \
+  } break;
+    PROCESS_SUPPORTED_TYPES(PROCESS)
+#undef PROCESS
+    default:
+      break;
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status MakeMinAction(arrow::compute::FunctionContext* ctx,
+                            std::shared_ptr<arrow::DataType> type,
+                            std::shared_ptr<ActionBase>* out) {
+  switch (type->id()) {
+#define PROCESS(InType)                                         \
+  case InType::type_id: {                                       \
+    auto action_ptr = std::make_shared<MinAction<InType>>(ctx); \
+    *out = std::dynamic_pointer_cast<ActionBase>(action_ptr);   \
+  } break;
+    PROCESS_SUPPORTED_TYPES(PROCESS)
+#undef PROCESS
+    default:
+      break;
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status MakeMaxAction(arrow::compute::FunctionContext* ctx,
+                            std::shared_ptr<arrow::DataType> type,
+                            std::shared_ptr<ActionBase>* out) {
+  switch (type->id()) {
+#define PROCESS(InType)                                         \
+  case InType::type_id: {                                       \
+    auto action_ptr = std::make_shared<MaxAction<InType>>(ctx); \
     *out = std::dynamic_pointer_cast<ActionBase>(action_ptr);   \
   } break;
     PROCESS_SUPPORTED_TYPES(PROCESS)

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -75,9 +75,9 @@ class SplitArrayListWithActionKernel::Impl {
       } else if (action_name_list_[action_id].compare("action_avg") == 0) {
         RETURN_NOT_OK(MakeAvgAction(ctx_, type_list[type_id], &action));
       } else if (action_name_list_[action_id].compare("action_min") == 0) {
-        RETURN_NOT_OK(MakeAvgAction(ctx_, type_list[type_id], &action));
+        RETURN_NOT_OK(MakeMinAction(ctx_, type_list[type_id], &action));
       } else if (action_name_list_[action_id].compare("action_max") == 0) {
-        RETURN_NOT_OK(MakeAvgAction(ctx_, type_list[type_id], &action));
+        RETURN_NOT_OK(MakeMaxAction(ctx_, type_list[type_id], &action));
       } else if (action_name_list_[action_id].compare("action_sum_count") == 0) {
         RETURN_NOT_OK(MakeSumCountAction(ctx_, type_list[type_id], &action));
       } else if (action_name_list_[action_id].compare("action_avgByCount") == 0) {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -37,6 +37,7 @@
 #include "codegen/arrow_compute/ext/codegen_node_visitor.h"
 #include "codegen/arrow_compute/ext/item_iterator.h"
 #include "codegen/arrow_compute/ext/shuffle_v2_action.h"
+#include "utils/macros.h"
 
 namespace sparkcolumnarplugin {
 namespace codegen {
@@ -183,6 +184,10 @@ class SplitArrayListWithActionKernel::Impl {
                                     std::shared_ptr<arrow::RecordBatch>* out)>
             eval_func)
         : ctx_(ctx), total_length_(total_length), eval_func_(eval_func) {}
+    ~SplitArrayWithActionResultIterator() {
+      std::cout << "SplitArrayWithActionResultIterator total took " << elapse_time_
+                << " us." << std::endl;
+    }
 
     bool HasNext() override {
       if (offset_ >= total_length_) {
@@ -197,7 +202,7 @@ class SplitArrayListWithActionKernel::Impl {
         return arrow::Status::OK();
       }
       auto length = (total_length_ - offset_) > 4096 ? 4096 : (total_length_ - offset_);
-      RETURN_NOT_OK(eval_func_(offset_, length, out));
+      TIME_MICRO_OR_RAISE(elapse_time_, eval_func_(offset_, length, out));
       offset_ += length;
       // arrow::PrettyPrint(*(*out).get(), 2, &std::cout);
       return arrow::Status::OK();
@@ -210,6 +215,7 @@ class SplitArrayListWithActionKernel::Impl {
         eval_func_;
     uint64_t offset_ = 0;
     const uint64_t total_length_;
+    uint64_t elapse_time_ = 0;
   };
 };
 


### PR DESCRIPTION
Observed that the reason Q2 produced incorrect result is due to one inner join operator generated less matched lines than vanilla spark, still figuring the reason

Below is some codes fix which should be a bug but not related to this issue.
[CPP & Scala] Fixed some codes for ConditionedShuffle