### PR TITLE
modify cache guardian retry time default value

### DIFF
--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -445,7 +445,7 @@ object OapConf {
     .internal()
     .doc("Retry time for TmpMemoryManager allocate")
     .intConf
-    .createWithDefault(100)
+    .createWithDefault(5000)
 
   val OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.index.statistic.externalsorter.enable")


### PR DESCRIPTION
## What changes were proposed in this pull request?

modify 'spark.sql.oap.cache.guardian.retry.time.in.ms' config default value.


## How was this patch tested?
Using Beaver test, passed daily test.

A simple fix for [PR-1174 ](https://github.com/Intel-bigdata/OAP/pull/1174)
