### PR TITLE
Vmemcache doesn't support fiber cache compression

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -487,6 +487,10 @@ class VMemCache(fiberType: FiberType) extends OapCache with Logging {
       val length = res
       val fiberCache = emptyDataFiber(length)
       val startTime = System.currentTimeMillis()
+      if( OapRuntime.getOrCreate.fiberCacheManager.dataCacheCompressEnable ) {
+        throw new OapException("Vmemcache strategy doesn't support fiber cache compression" +
+          " currently, please try other strategy.")
+      }
       val get = VMEMCacheJNI.getNative(fiberKey.getBytes(), null,
         0, fiberKey.length, fiberCache.getBaseOffset, 0, fiberCache.size().toInt)
       logDebug(s"second getNative require ${length} bytes. " +
@@ -524,6 +528,10 @@ class VMemCache(fiberType: FiberType) extends OapCache with Logging {
 
   override def cache(fiberId: FiberId): FiberCache = {
     val fiber = super.cache(fiberId)
+    if( OapRuntime.getOrCreate.fiberCacheManager.dataCacheCompressEnable ) {
+      throw new OapException("Vmemcache strategy doesn't support fiber cache compression" +
+        " currently, please try other strategy.")
+    }
     VMEMCacheJNI.putNative(fiberId.toFiberKey().getBytes(), null, 0,
       fiberId.toFiberKey().length, fiber.getBaseOffset,
       0, fiber.getOccupiedSize().toInt)


### PR DESCRIPTION

## What changes were proposed in this pull request?
Vmemcache doesn't support fiber cache compression, will throw an Exception([Issue 1186](https://github.com/Intel-bigdata/OAP/issues/1186) )


## How was this patch tested?


