### PR TITLE
[CI] update travis distrbution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: java
 jobs:
   include:


### PR DESCRIPTION
trusty is too old to use newer software stack(cmake, gcc)
let's upgrade to binoc

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## What changes were proposed in this pull request?

update travis to use bionic so we could use newer cmake and gcc


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


travis based unit testing

