### PR TITLE
[NativeSql] DeCouple Gandiva protobuf and hashing dependency

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/ColumnarBatchScanExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/ColumnarBatchScanExec.scala
@@ -2,7 +2,7 @@ package com.intel.sparkColumnarPlugin.execution
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
-import org.apache.spark.sql.sources.v2.reader._
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/ColumnarDataSourceRDD.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/ColumnarDataSourceRDD.scala
@@ -2,7 +2,7 @@ package com.intel.sparkColumnarPlugin.execution
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.sources.v2.reader.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory, PartitionReader}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregateExpression.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregateExpression.scala
@@ -57,7 +57,7 @@ class ColumnarAggregateExpression(
     mode: AggregateMode,
     isDistinct: Boolean,
     resultId: ExprId)
-    extends AggregateExpression(aggregateFunction, mode, isDistinct, resultId)
+    extends AggregateExpression(aggregateFunction, mode, isDistinct, None, resultId)
     with ColumnarAggregateExpressionBase
     with Logging {
 

--- a/oap-native-sql/cpp/src/CMakeLists.txt
+++ b/oap-native-sql/cpp/src/CMakeLists.txt
@@ -19,9 +19,39 @@ option(BENCHMARKS "Build the benchmarks" OFF)
 option(DEBUG "Enable Debug Info" OFF)
 
 find_package(JNI REQUIRED)
-
 set(source_root_directory ${CMAKE_CURRENT_SOURCE_DIR})
 
+# Gandiva protobuf
+
+find_package(Protobuf REQUIRED)
+file(MAKE_DIRECTORY ${root_directory}/src/proto)
+set(PROTO_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/proto")
+set(PROTO_OUTPUT_FILES "${PROTO_OUTPUT_DIR}/Exprs.pb.cc")
+set(PROTO_OUTPUT_FILES ${PROTO_OUTPUT_FILES} "${PROTO_OUTPUT_DIR}/Exprs.pb.h")
+
+set_source_files_properties(${PROTO_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
+
+get_filename_component(ABS_GANDIVA_PROTO ${CMAKE_CURRENT_SOURCE_DIR}/proto/Exprs.proto
+                       ABSOLUTE)
+
+add_custom_command(OUTPUT ${PROTO_OUTPUT_FILES}
+                   COMMAND protobuf::protoc
+                           --proto_path
+                           ${CMAKE_CURRENT_SOURCE_DIR}/proto
+                           --cpp_out
+                           ${PROTO_OUTPUT_DIR}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/proto/Exprs.proto
+                   DEPENDS ${ABS_GANDIVA_PROTO} protobuf::libprotobuf
+                   COMMENT "Running PROTO compiler on Exprs.proto"
+                   VERBATIM)
+
+add_custom_target(jni_proto ALL DEPENDS ${PROTO_OUTPUT_FILES})
+set(PROTO_SRCS "${PROTO_OUTPUT_DIR}/Exprs.pb.cc")
+set(PROTO_HDRS "${PROTO_OUTPUT_DIR}/Exprs.pb.h")
+
+set(GANDIVA_LINK_LIBS protobuf::libprotobuf gandiva)
+
+#######
 if(TESTS)
   find_package(GTest)
 macro(package_add_test TESTNAME)
@@ -43,7 +73,7 @@ endif()
 if(BENCHMARKS)
   find_package(GTest)
   #add_definitions(-DBENCHMARK_FILE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/source_files/)
-  add_compile_definitions(BENCHMARK_FILE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/source_files/")
+  add_compile_definitions(BENCHMARK_FILE_PATH="file://${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/source_files/")
 macro(package_add_benchmark TESTNAME)
   #configure_file(${ARGN}.in ${ARGN})
   add_executable(${TESTNAME} ${ARGN})
@@ -66,7 +96,7 @@ if(DEBUG)
 endif()
 find_library(ARROW_LIB arrow)
 find_library(GANDIVA_LIB gandiva)
-find_library(GANDIVA_PROTOBUF_LIB gandiva_protobuf)
+# find_library(GANDIVA_PROTOBUF_LIB gandiva_protobuf)
 
 # message("jni headers ${JNI_INCLUDE_DIRS}")
 # message("arrow lib ${ARROW_LIB}")
@@ -81,12 +111,14 @@ if(NOT GANDIVA_LIB)
     message(FATAL_ERROR "Gandiva library not found")
 endif()
 
-if(NOT GANDIVA_PROTOBUF_LIB)
-    message(FATAL_ERROR "Gandiva protobuf library not found")
-endif()
+# if(NOT GANDIVA_PROTOBUF_LIB)
+#    message(FATAL_ERROR "Gandiva protobuf library not found")
+# endif()
 
 set(SPARK_COLUMNAR_PLUGIN_SRCS
         jni/jni_wrapper.cc
+        ${PROTO_SRCS}
+        proto/protobuf_utils.cc
         codegen/expr_visitor.cc
         codegen/arrow_compute/expr_visitor.cc
         codegen/arrow_compute/ext/item_iterator.cc
@@ -100,8 +132,9 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
 
 file(MAKE_DIRECTORY ${root_directory}/releases)
 add_library(spark_columnar_jni SHARED ${SPARK_COLUMNAR_PLUGIN_SRCS})
-target_link_libraries(spark_columnar_jni ${ARROW_LIB} ${GANDIVA_LIB} ${GANDIVA_PROTOBUF_LIB})
-target_include_directories(spark_columnar_jni PUBLIC ${CMAKE_SYSTEM_INCLUDE_PATH} ${JNI_INCLUDE_DIRS} ${source_root_directory})
+add_dependencies(spark_columnar_jni jni_proto)
+target_link_libraries(spark_columnar_jni ${ARROW_LIB} ${GANDIVA_LIB} ${GANDIVA_LINK_LIBS})
+target_include_directories(spark_columnar_jni PUBLIC ${CMAKE_SYSTEM_INCLUDE_PATH} ${JNI_INCLUDE_DIRS} ${source_root_directory} ${PROTO_OUTPUT_DIR})
 set_target_properties(spark_columnar_jni PROPERTIES
                       LIBRARY_OUTPUT_DIRECTORY ${root_directory}/releases
 )

--- a/oap-native-sql/cpp/src/benchmarks/arrow_compute_benchmark.cc
+++ b/oap-native-sql/cpp/src/benchmarks/arrow_compute_benchmark.cc
@@ -3,6 +3,7 @@
 #include <arrow/memory_pool.h>
 #include <arrow/pretty_print.h>
 #include <arrow/record_batch.h>
+#include <arrow/testing/gtest_util.h>
 #include <arrow/type.h>
 #include <gandiva/node.h>
 #include <gtest/gtest.h>
@@ -33,7 +34,7 @@ class BenchmarkArrowCompute : public ::testing::Test {
               << std::endl;
     std::shared_ptr<arrow::fs::FileSystem> fs;
     std::string file_name;
-    ASSERT_NOT_OK(arrow::fs::FileSystemFromUri(path, &fs, &file_name));
+    ASSERT_OK_AND_ASSIGN(fs, arrow::fs::FileSystemFromUri(path, &file_name));
 
     ARROW_ASSIGN_OR_THROW(file, fs->OpenInputFile(file_name));
 

--- a/oap-native-sql/cpp/src/benchmarks/arrow_compute_benchmark_big_scale.cc
+++ b/oap-native-sql/cpp/src/benchmarks/arrow_compute_benchmark_big_scale.cc
@@ -2,6 +2,7 @@
 #include <arrow/io/interfaces.h>
 #include <arrow/memory_pool.h>
 #include <arrow/record_batch.h>
+#include <arrow/testing/gtest_util.h>
 #include <arrow/type.h>
 #include <gandiva/node.h>
 #include <gtest/gtest.h>
@@ -31,7 +32,7 @@ class BenchmarkArrowComputeBigScale : public ::testing::Test {
               << std::endl;
     std::shared_ptr<arrow::fs::FileSystem> fs;
     std::string file_name;
-    ASSERT_NOT_OK(arrow::fs::FileSystemFromUri(path, &fs, &file_name));
+    ASSERT_OK_AND_ASSIGN(fs, arrow::fs::FileSystemFromUri(path, &file_name));
 
     ARROW_ASSIGN_OR_THROW(file, fs->OpenInputFile(file_name));
 

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
@@ -10,7 +10,6 @@
 #include <arrow/type_traits.h>
 #include <arrow/util/bit_util.h>
 #include <arrow/util/checked_cast.h>
-#include <arrow/util/hashing.h>
 #include <arrow/visitor_inline.h>
 #include <dlfcn.h>
 #include <gandiva/configuration.h>
@@ -33,6 +32,7 @@
 #include "codegen/arrow_compute/ext/item_iterator.h"
 #include "codegen/arrow_compute/ext/kernels_ext.h"
 #include "codegen/arrow_compute/ext/shuffle_v2_action.h"
+#include "third_party/arrow/utils/hashing.h"
 
 namespace sparkcolumnarplugin {
 namespace codegen {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_shuffle_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_shuffle_kernel.cc
@@ -9,7 +9,6 @@
 #include <arrow/type_traits.h>
 #include <arrow/util/bit_util.h>
 #include <arrow/util/checked_cast.h>
-#include <arrow/util/hashing.h>
 #include <arrow/visitor_inline.h>
 #include <dlfcn.h>
 #include <gandiva/configuration.h>

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -16,13 +16,13 @@
 #include <arrow/type_traits.h>
 #include <arrow/util/bit_util.h>
 #include <arrow/util/checked_cast.h>
-#include <arrow/util/hashing.h>
 #include <arrow/visitor_inline.h>
 #include <dlfcn.h>
 #include <gandiva/configuration.h>
 #include <gandiva/node.h>
 #include <gandiva/projector.h>
 #include <gandiva/tree_expr_builder.h>
+#include "third_party/arrow/utils/hashing.h"
 
 #include <chrono>
 #include <cstring>

--- a/oap-native-sql/cpp/src/jni/jni_common.h
+++ b/oap-native-sql/cpp/src/jni/jni_common.h
@@ -121,7 +121,7 @@ arrow::Status MakeSchema(JNIEnv* env, jbyteArray schema_arr,
 arrow::Status MakeExprVector(JNIEnv* env, jbyteArray exprs_arr,
                              gandiva::ExpressionVector* expr_vector,
                              gandiva::FieldVector* ret_types) {
-  types::ExpressionList exprs;
+  exprs::ExpressionList exprs;
   jsize exprs_len = env->GetArrayLength(exprs_arr);
   jbyte* exprs_bytes = env->GetByteArrayElements(exprs_arr, 0);
 

--- a/oap-native-sql/cpp/src/jni/jni_wrapper.cc
+++ b/oap-native-sql/cpp/src/jni/jni_wrapper.cc
@@ -4,10 +4,10 @@
 #include <arrow/ipc/dictionary.h>
 #include <arrow/pretty_print.h>
 #include <arrow/record_batch.h>
-#include <gandiva/jni/protobuf_utils.h>
 #include <jni.h>
 #include <iostream>
 #include <string>
+#include "proto/protobuf_utils.h"
 
 #include "codegen/code_generator_factory.h"
 #include "codegen/common/result_iterator.h"

--- a/oap-native-sql/cpp/src/proto/Exprs.proto
+++ b/oap-native-sql/cpp/src/proto/Exprs.proto
@@ -1,0 +1,239 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto2";
+package exprs;
+
+option java_package = "org.apache.arrow.gandiva.ipc";
+option java_outer_classname = "GandivaTypes";
+option optimize_for = SPEED;
+
+enum GandivaType {
+  NONE = 0;    // arrow::Type::NA
+  BOOL = 1;    // arrow::Type::BOOL
+  UINT8 = 2;   // arrow::Type::UINT8
+  INT8 = 3;    // arrow::Type::INT8
+  UINT16 = 4;  // represents arrow::Type fields in src/arrow/type.h
+  INT16 = 5;
+  UINT32 = 6;
+  INT32 = 7;
+  UINT64 = 8;
+  INT64 = 9;
+  HALF_FLOAT = 10;
+  FLOAT = 11;
+  DOUBLE = 12;
+  UTF8 = 13;
+  BINARY = 14;
+  FIXED_SIZE_BINARY = 15;
+  DATE32 = 16;
+  DATE64 = 17;
+  TIMESTAMP = 18;
+  TIME32 = 19;
+  TIME64 = 20;
+  INTERVAL = 21;
+  DECIMAL = 22;
+  LIST = 23;
+  STRUCT = 24;
+  UNION = 25;
+  DICTIONARY = 26;
+  MAP = 27;
+}
+
+enum DateUnit {
+  DAY = 0;
+  MILLI = 1;
+}
+
+enum TimeUnit {
+  SEC = 0;
+  MILLISEC = 1;
+  MICROSEC = 2;
+  NANOSEC = 3;
+}
+
+enum IntervalType {
+  YEAR_MONTH = 0;
+  DAY_TIME = 1;
+}
+
+enum SelectionVectorType {
+  SV_NONE = 0;
+  SV_INT16 = 1;
+  SV_INT32 = 2;
+}
+
+message ExtGandivaType {
+  optional GandivaType type = 1;
+  optional uint32 width = 2;               // used by FIXED_SIZE_BINARY
+  optional int32 precision = 3;            // used by DECIMAL
+  optional int32 scale = 4;                // used by DECIMAL
+  optional DateUnit dateUnit = 5;          // used by DATE32/DATE64
+  optional TimeUnit timeUnit = 6;          // used by TIME32/TIME64
+  optional string timeZone = 7;            // used by TIMESTAMP
+  optional IntervalType intervalType = 8;  // used by INTERVAL
+}
+
+message Field {
+  // name of the field
+  optional string name = 1;
+  optional ExtGandivaType type = 2;
+  optional bool nullable = 3;
+  // for complex data types like structs, unions
+  repeated Field children = 4;
+}
+
+message FieldNode {
+  optional Field field = 1;
+}
+
+message FunctionNode {
+  optional string functionName = 1;
+  repeated TreeNode inArgs = 2;
+  optional ExtGandivaType returnType = 3;
+}
+
+message IfNode {
+  optional TreeNode cond = 1;
+  optional TreeNode thenNode = 2;
+  optional TreeNode elseNode = 3;
+  optional ExtGandivaType returnType = 4;
+}
+
+message AndNode {
+  repeated TreeNode args = 1;
+}
+
+message OrNode {
+  repeated TreeNode args = 1;
+}
+
+message NullNode {
+  optional ExtGandivaType type = 1;
+}
+
+message IntNode {
+  optional int32 value = 1;
+}
+
+message FloatNode {
+  optional float value = 1;
+}
+
+message DoubleNode {
+  optional double value = 1;
+}
+
+message BooleanNode {
+  optional bool value = 1;
+}
+
+message LongNode {
+  optional int64 value = 1;
+}
+
+message StringNode {
+  optional bytes value = 1;
+}
+
+message BinaryNode {
+  optional bytes value = 1;
+}
+
+message DecimalNode {
+  optional string value = 1;
+  optional int32 precision = 2;
+  optional int32 scale = 3;
+}
+
+message TreeNode {
+  optional FieldNode fieldNode = 1;
+  optional FunctionNode fnNode = 2;
+
+  // control expressions
+  optional IfNode ifNode = 6;
+  optional AndNode andNode = 7;
+  optional OrNode orNode = 8;
+
+  // literals
+  optional NullNode nullNode = 11;
+  optional IntNode intNode = 12;
+  optional FloatNode floatNode = 13;
+  optional LongNode longNode = 14;
+  optional BooleanNode booleanNode = 15;
+  optional DoubleNode doubleNode = 16;
+  optional StringNode stringNode = 17;
+  optional BinaryNode binaryNode = 18;
+  optional DecimalNode decimalNode = 19;
+
+  // in expr
+  optional InNode inNode = 21;
+}
+
+message ExpressionRoot {
+  optional TreeNode root = 1;
+  optional Field resultType = 2;
+}
+
+message ExpressionList {
+  repeated ExpressionRoot exprs = 2;
+}
+
+message Condition {
+  optional TreeNode root = 1;
+}
+
+message Schema {
+  repeated Field columns = 1;
+}
+
+message GandivaDataTypes {
+  repeated ExtGandivaType dataType = 1;
+}
+
+message GandivaFunctions {
+  repeated FunctionSignature function = 1;
+}
+
+message FunctionSignature {
+  optional string name = 1;
+  optional ExtGandivaType returnType = 2;
+  repeated ExtGandivaType paramTypes = 3;
+}
+
+message InNode {
+  optional TreeNode node = 1;
+  optional IntConstants intValues = 2;
+  optional LongConstants longValues = 3;
+  optional StringConstants stringValues = 4;
+  optional BinaryConstants binaryValues = 5;
+}
+
+message IntConstants {
+  repeated IntNode intValues = 1;
+}
+
+message LongConstants {
+  repeated LongNode longValues = 1;
+}
+
+message StringConstants {
+  repeated StringNode stringValues = 1;
+}
+
+message BinaryConstants {
+  repeated BinaryNode binaryValues = 1;
+}

--- a/oap-native-sql/cpp/src/proto/protobuf_utils.cc
+++ b/oap-native-sql/cpp/src/proto/protobuf_utils.cc
@@ -1,0 +1,391 @@
+#include "protobuf_utils.h"
+
+using gandiva::ConditionPtr;
+using gandiva::DataTypePtr;
+using gandiva::ExpressionPtr;
+using gandiva::ExpressionVector;
+using gandiva::FieldPtr;
+using gandiva::FieldVector;
+using gandiva::NodePtr;
+using gandiva::NodeVector;
+using gandiva::SchemaPtr;
+using gandiva::Status;
+using gandiva::TreeExprBuilder;
+
+using gandiva::ArrayDataVector;
+
+// forward declarations
+NodePtr ProtoTypeToNode(const exprs::TreeNode& node);
+
+DataTypePtr ProtoTypeToTime32(const exprs::ExtGandivaType& ext_type) {
+  switch (ext_type.timeunit()) {
+    case exprs::SEC:
+      return arrow::time32(arrow::TimeUnit::SECOND);
+    case exprs::MILLISEC:
+      return arrow::time32(arrow::TimeUnit::MILLI);
+    default:
+      std::cerr << "Unknown time unit: " << ext_type.timeunit() << " for time32\n";
+      return nullptr;
+  }
+}
+
+DataTypePtr ProtoTypeToTime64(const exprs::ExtGandivaType& ext_type) {
+  switch (ext_type.timeunit()) {
+    case exprs::MICROSEC:
+      return arrow::time64(arrow::TimeUnit::MICRO);
+    case exprs::NANOSEC:
+      return arrow::time64(arrow::TimeUnit::NANO);
+    default:
+      std::cerr << "Unknown time unit: " << ext_type.timeunit() << " for time64\n";
+      return nullptr;
+  }
+}
+
+DataTypePtr ProtoTypeToTimestamp(const exprs::ExtGandivaType& ext_type) {
+  switch (ext_type.timeunit()) {
+    case exprs::SEC:
+      return arrow::timestamp(arrow::TimeUnit::SECOND);
+    case exprs::MILLISEC:
+      return arrow::timestamp(arrow::TimeUnit::MILLI);
+    case exprs::MICROSEC:
+      return arrow::timestamp(arrow::TimeUnit::MICRO);
+    case exprs::NANOSEC:
+      return arrow::timestamp(arrow::TimeUnit::NANO);
+    default:
+      std::cerr << "Unknown time unit: " << ext_type.timeunit() << " for timestamp\n";
+      return nullptr;
+  }
+}
+
+DataTypePtr ProtoTypeToDataType(const exprs::ExtGandivaType& ext_type) {
+  switch (ext_type.type()) {
+    case exprs::NONE:
+      return arrow::null();
+    case exprs::BOOL:
+      return arrow::boolean();
+    case exprs::UINT8:
+      return arrow::uint8();
+    case exprs::INT8:
+      return arrow::int8();
+    case exprs::UINT16:
+      return arrow::uint16();
+    case exprs::INT16:
+      return arrow::int16();
+    case exprs::UINT32:
+      return arrow::uint32();
+    case exprs::INT32:
+      return arrow::int32();
+    case exprs::UINT64:
+      return arrow::uint64();
+    case exprs::INT64:
+      return arrow::int64();
+    case exprs::HALF_FLOAT:
+      return arrow::float16();
+    case exprs::FLOAT:
+      return arrow::float32();
+    case exprs::DOUBLE:
+      return arrow::float64();
+    case exprs::UTF8:
+      return arrow::utf8();
+    case exprs::BINARY:
+      return arrow::binary();
+    case exprs::DATE32:
+      return arrow::date32();
+    case exprs::DATE64:
+      return arrow::date64();
+    case exprs::DECIMAL:
+      // TODO: error handling
+      return arrow::decimal(ext_type.precision(), ext_type.scale());
+    case exprs::TIME32:
+      return ProtoTypeToTime32(ext_type);
+    case exprs::TIME64:
+      return ProtoTypeToTime64(ext_type);
+    case exprs::TIMESTAMP:
+      return ProtoTypeToTimestamp(ext_type);
+
+    case exprs::FIXED_SIZE_BINARY:
+    case exprs::INTERVAL:
+    case exprs::LIST:
+    case exprs::STRUCT:
+    case exprs::UNION:
+    case exprs::DICTIONARY:
+    case exprs::MAP:
+      std::cerr << "Unhandled data type: " << ext_type.type() << "\n";
+      return nullptr;
+
+    default:
+      std::cerr << "Unknown data type: " << ext_type.type() << "\n";
+      return nullptr;
+  }
+}
+
+FieldPtr ProtoTypeToField(const exprs::Field& f) {
+  const std::string& name = f.name();
+  DataTypePtr type = ProtoTypeToDataType(f.type());
+  bool nullable = true;
+  if (f.has_nullable()) {
+    nullable = f.nullable();
+  }
+
+  return field(name, type, nullable);
+}
+
+NodePtr ProtoTypeToFieldNode(const exprs::FieldNode& node) {
+  FieldPtr field_ptr = ProtoTypeToField(node.field());
+  if (field_ptr == nullptr) {
+    std::cerr << "Unable to create field node from protobuf\n";
+    return nullptr;
+  }
+
+  return TreeExprBuilder::MakeField(field_ptr);
+}
+
+NodePtr ProtoTypeToFnNode(const exprs::FunctionNode& node) {
+  const std::string& name = node.functionname();
+  NodeVector children;
+
+  for (int i = 0; i < node.inargs_size(); i++) {
+    const exprs::TreeNode& arg = node.inargs(i);
+
+    NodePtr n = ProtoTypeToNode(arg);
+    if (n == nullptr) {
+      std::cerr << "Unable to create argument for function: " << name << "\n";
+      return nullptr;
+    }
+
+    children.push_back(n);
+  }
+
+  DataTypePtr return_type = ProtoTypeToDataType(node.returntype());
+  if (return_type == nullptr) {
+    std::cerr << "Unknown return type for function: " << name << "\n";
+    return nullptr;
+  }
+
+  return TreeExprBuilder::MakeFunction(name, children, return_type);
+}
+
+NodePtr ProtoTypeToIfNode(const exprs::IfNode& node) {
+  NodePtr cond = ProtoTypeToNode(node.cond());
+  if (cond == nullptr) {
+    std::cerr << "Unable to create cond node for if node\n";
+    return nullptr;
+  }
+
+  NodePtr then_node = ProtoTypeToNode(node.thennode());
+  if (then_node == nullptr) {
+    std::cerr << "Unable to create then node for if node\n";
+    return nullptr;
+  }
+
+  NodePtr else_node = ProtoTypeToNode(node.elsenode());
+  if (else_node == nullptr) {
+    std::cerr << "Unable to create else node for if node\n";
+    return nullptr;
+  }
+
+  DataTypePtr return_type = ProtoTypeToDataType(node.returntype());
+  if (return_type == nullptr) {
+    std::cerr << "Unknown return type for if node\n";
+    return nullptr;
+  }
+
+  return TreeExprBuilder::MakeIf(cond, then_node, else_node, return_type);
+}
+
+NodePtr ProtoTypeToAndNode(const exprs::AndNode& node) {
+  NodeVector children;
+
+  for (int i = 0; i < node.args_size(); i++) {
+    const exprs::TreeNode& arg = node.args(i);
+
+    NodePtr n = ProtoTypeToNode(arg);
+    if (n == nullptr) {
+      std::cerr << "Unable to create argument for boolean and\n";
+      return nullptr;
+    }
+    children.push_back(n);
+  }
+  return TreeExprBuilder::MakeAnd(children);
+}
+
+NodePtr ProtoTypeToOrNode(const exprs::OrNode& node) {
+  NodeVector children;
+
+  for (int i = 0; i < node.args_size(); i++) {
+    const exprs::TreeNode& arg = node.args(i);
+
+    NodePtr n = ProtoTypeToNode(arg);
+    if (n == nullptr) {
+      std::cerr << "Unable to create argument for boolean or\n";
+      return nullptr;
+    }
+    children.push_back(n);
+  }
+  return TreeExprBuilder::MakeOr(children);
+}
+
+NodePtr ProtoTypeToInNode(const exprs::InNode& node) {
+  NodePtr field = ProtoTypeToNode(node.node());
+
+  if (node.has_intvalues()) {
+    std::unordered_set<int32_t> int_values;
+    for (int i = 0; i < node.intvalues().intvalues_size(); i++) {
+      int_values.insert(node.intvalues().intvalues(i).value());
+    }
+    return TreeExprBuilder::MakeInExpressionInt32(field, int_values);
+  }
+
+  if (node.has_longvalues()) {
+    std::unordered_set<int64_t> long_values;
+    for (int i = 0; i < node.longvalues().longvalues_size(); i++) {
+      long_values.insert(node.longvalues().longvalues(i).value());
+    }
+    return TreeExprBuilder::MakeInExpressionInt64(field, long_values);
+  }
+
+  if (node.has_stringvalues()) {
+    std::unordered_set<std::string> stringvalues;
+    for (int i = 0; i < node.stringvalues().stringvalues_size(); i++) {
+      stringvalues.insert(node.stringvalues().stringvalues(i).value());
+    }
+    return TreeExprBuilder::MakeInExpressionString(field, stringvalues);
+  }
+
+  if (node.has_binaryvalues()) {
+    std::unordered_set<std::string> stringvalues;
+    for (int i = 0; i < node.binaryvalues().binaryvalues_size(); i++) {
+      stringvalues.insert(node.binaryvalues().binaryvalues(i).value());
+    }
+    return TreeExprBuilder::MakeInExpressionBinary(field, stringvalues);
+  }
+  // not supported yet.
+  std::cerr << "Unknown constant type for in expression.\n";
+  return nullptr;
+}
+
+NodePtr ProtoTypeToNullNode(const exprs::NullNode& node) {
+  DataTypePtr data_type = ProtoTypeToDataType(node.type());
+  if (data_type == nullptr) {
+    std::cerr << "Unknown type " << data_type->ToString() << " for null node\n";
+    return nullptr;
+  }
+
+  return TreeExprBuilder::MakeNull(data_type);
+}
+
+NodePtr ProtoTypeToNode(const exprs::TreeNode& node) {
+  if (node.has_fieldnode()) {
+    return ProtoTypeToFieldNode(node.fieldnode());
+  }
+
+  if (node.has_fnnode()) {
+    return ProtoTypeToFnNode(node.fnnode());
+  }
+
+  if (node.has_ifnode()) {
+    return ProtoTypeToIfNode(node.ifnode());
+  }
+
+  if (node.has_andnode()) {
+    return ProtoTypeToAndNode(node.andnode());
+  }
+
+  if (node.has_ornode()) {
+    return ProtoTypeToOrNode(node.ornode());
+  }
+
+  if (node.has_innode()) {
+    return ProtoTypeToInNode(node.innode());
+  }
+
+  if (node.has_nullnode()) {
+    return ProtoTypeToNullNode(node.nullnode());
+  }
+
+  if (node.has_intnode()) {
+    return TreeExprBuilder::MakeLiteral(node.intnode().value());
+  }
+
+  if (node.has_floatnode()) {
+    return TreeExprBuilder::MakeLiteral(node.floatnode().value());
+  }
+
+  if (node.has_longnode()) {
+    return TreeExprBuilder::MakeLiteral(node.longnode().value());
+  }
+
+  if (node.has_booleannode()) {
+    return TreeExprBuilder::MakeLiteral(node.booleannode().value());
+  }
+
+  if (node.has_doublenode()) {
+    return TreeExprBuilder::MakeLiteral(node.doublenode().value());
+  }
+
+  if (node.has_stringnode()) {
+    return TreeExprBuilder::MakeStringLiteral(node.stringnode().value());
+  }
+
+  if (node.has_binarynode()) {
+    return TreeExprBuilder::MakeBinaryLiteral(node.binarynode().value());
+  }
+
+  if (node.has_decimalnode()) {
+    std::string value = node.decimalnode().value();
+    gandiva::DecimalScalar128 literal(value, node.decimalnode().precision(),
+                                      node.decimalnode().scale());
+    return TreeExprBuilder::MakeDecimalLiteral(literal);
+  }
+  std::cerr << "Unknown node type in protobuf\n";
+  return nullptr;
+}
+
+ExpressionPtr ProtoTypeToExpression(const exprs::ExpressionRoot& root) {
+  NodePtr root_node = ProtoTypeToNode(root.root());
+  if (root_node == nullptr) {
+    std::cerr << "Unable to create expression node from expression protobuf\n";
+    return nullptr;
+  }
+
+  FieldPtr field = ProtoTypeToField(root.resulttype());
+  if (field == nullptr) {
+    std::cerr << "Unable to extra return field from expression protobuf\n";
+    return nullptr;
+  }
+
+  return TreeExprBuilder::MakeExpression(root_node, field);
+}
+
+ConditionPtr ProtoTypeToCondition(const exprs::Condition& condition) {
+  NodePtr root_node = ProtoTypeToNode(condition.root());
+  if (root_node == nullptr) {
+    return nullptr;
+  }
+
+  return TreeExprBuilder::MakeCondition(root_node);
+}
+
+SchemaPtr ProtoTypeToSchema(const exprs::Schema& schema) {
+  std::vector<FieldPtr> fields;
+
+  for (int i = 0; i < schema.columns_size(); i++) {
+    FieldPtr field = ProtoTypeToField(schema.columns(i));
+    if (field == nullptr) {
+      std::cerr << "Unable to extract arrow field from schema\n";
+      return nullptr;
+    }
+
+    fields.push_back(field);
+  }
+
+  return arrow::schema(fields);
+}
+
+// Common for both projector and filters.
+
+bool ParseProtobuf(uint8_t* buf, int bufLen, google::protobuf::Message* msg) {
+  google::protobuf::io::CodedInputStream cis(buf, bufLen);
+  cis.SetRecursionLimit(1000);
+  return msg->ParseFromCodedStream(&cis);
+}

--- a/oap-native-sql/cpp/src/proto/protobuf_utils.h
+++ b/oap-native-sql/cpp/src/proto/protobuf_utils.h
@@ -1,0 +1,55 @@
+#include <google/protobuf/io/coded_stream.h>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <arrow/builder.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+
+#include <gandiva/arrow.h>
+#include <gandiva/gandiva_aliases.h>
+#include <gandiva/tree_expr_builder.h>
+
+#include "Exprs.pb.h"
+
+using gandiva::ConditionPtr;
+using gandiva::DataTypePtr;
+using gandiva::ExpressionPtr;
+using gandiva::ExpressionVector;
+using gandiva::FieldPtr;
+using gandiva::FieldVector;
+using gandiva::NodePtr;
+using gandiva::NodeVector;
+using gandiva::SchemaPtr;
+using gandiva::Status;
+using gandiva::TreeExprBuilder;
+
+using gandiva::ArrayDataVector;
+
+// forward declarations
+NodePtr ProtoTypeToNode(const exprs::TreeNode& node);
+
+DataTypePtr ProtoTypeToTime32(const exprs::ExtGandivaType& ext_type);
+DataTypePtr ProtoTypeToTime64(const exprs::ExtGandivaType& ext_type);
+DataTypePtr ProtoTypeToTimestamp(const exprs::ExtGandivaType& ext_type);
+DataTypePtr ProtoTypeToDataType(const exprs::ExtGandivaType& ext_type);
+FieldPtr ProtoTypeToField(const exprs::Field& f);
+NodePtr ProtoTypeToFieldNode(const exprs::FieldNode& node);
+NodePtr ProtoTypeToFnNode(const exprs::FunctionNode& node);
+NodePtr ProtoTypeToIfNode(const exprs::IfNode& node);
+NodePtr ProtoTypeToAndNode(const exprs::AndNode& node);
+NodePtr ProtoTypeToOrNode(const exprs::OrNode& node);
+NodePtr ProtoTypeToInNode(const exprs::InNode& node);
+NodePtr ProtoTypeToNullNode(const exprs::NullNode& node);
+NodePtr ProtoTypeToNode(const exprs::TreeNode& node);
+ExpressionPtr ProtoTypeToExpression(const exprs::ExpressionRoot& root);
+ConditionPtr ProtoTypeToCondition(const exprs::Condition& condition);
+SchemaPtr ProtoTypeToSchema(const exprs::Schema& schema);
+// Common for both projector and filters.
+bool ParseProtobuf(uint8_t* buf, int bufLen, google::protobuf::Message* msg);

--- a/oap-native-sql/cpp/src/tests/test_utils.h
+++ b/oap-native-sql/cpp/src/tests/test_utils.h
@@ -69,8 +69,8 @@ void MakeInputBatch(std::vector<std::string> input_data,
   int i = 0;
   for (auto data : input_data) {
     std::shared_ptr<Array> a0;
-    ASSERT_NOT_OK(
-        arrow::ipc::internal::json::ArrayFromJSON(sch->field(i++)->type(), data.c_str(), &a0));
+    ASSERT_NOT_OK(arrow::ipc::internal::json::ArrayFromJSON(sch->field(i++)->type(),
+                                                            data.c_str(), &a0));
     if (length == -1) {
       length = a0->length();
     }

--- a/oap-native-sql/cpp/src/third_party/arrow/utils/hashing.h
+++ b/oap-native-sql/cpp/src/third_party/arrow/utils/hashing.h
@@ -1,0 +1,870 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Private header, not to be exported
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/buffer.h"
+#include "arrow/builder.h"
+#include "arrow/status.h"
+#include "arrow/type.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
+#include "arrow/util/string_view.h"
+
+#define XXH_INLINE_ALL
+#define XXH_PRIVATE_API
+#define XXH_NAMESPACE arrow_hashing_
+
+#include "third_party/arrow/vendored/xxhash/xxhash.h"
+
+namespace arrow {
+namespace internal {
+
+// XXX would it help to have a 32-bit hash value on large datasets?
+typedef uint64_t hash_t;
+
+// Notes about the choice of a hash function.
+// - XXH3 is extremely fast on most data sizes, from small to huge;
+//   faster even than HW CRC-based hashing schemes
+// - our custom hash function for tiny values (< 16 bytes) is still
+//   significantly faster (~30%), at least on this machine and compiler
+
+template <uint64_t AlgNum>
+inline hash_t ComputeStringHash(const void* data, int64_t length);
+
+template <typename Scalar, uint64_t AlgNum>
+struct ScalarHelperBase {
+  static bool CompareScalars(Scalar u, Scalar v) { return u == v; }
+
+  static hash_t ComputeHash(const Scalar& value) {
+    // Generic hash computation for scalars.  Simply apply the string hash
+    // to the bit representation of the value.
+
+    // XXX in the case of FP values, we'd like equal values to have the same hash,
+    // even if they have different bit representations...
+    return ComputeStringHash<AlgNum>(&value, sizeof(value));
+  }
+};
+
+template <typename Scalar, uint64_t AlgNum = 0, typename Enable = void>
+struct ScalarHelper : public ScalarHelperBase<Scalar, AlgNum> {};
+
+template <typename Scalar, uint64_t AlgNum>
+struct ScalarHelper<Scalar, AlgNum, enable_if_t<std::is_integral<Scalar>::value>>
+    : public ScalarHelperBase<Scalar, AlgNum> {
+  // ScalarHelper specialization for integers
+
+  static hash_t ComputeHash(const Scalar& value) {
+    // Faster hash computation for integers.
+
+    // Two of xxhash's prime multipliers (which are chosen for their
+    // bit dispersion properties)
+    static constexpr uint64_t multipliers[] = {11400714785074694791ULL,
+                                               14029467366897019727ULL};
+
+    // Multiplying by the prime number mixes the low bits into the high bits,
+    // then byte-swapping (which is a single CPU instruction) allows the
+    // combined high and low bits to participate in the initial hash table index.
+    auto h = static_cast<hash_t>(value);
+    return BitUtil::ByteSwap(multipliers[AlgNum] * h);
+  }
+};
+
+template <typename Scalar, uint64_t AlgNum>
+struct ScalarHelper<Scalar, AlgNum,
+                    enable_if_t<std::is_same<util::string_view, Scalar>::value>>
+    : public ScalarHelperBase<Scalar, AlgNum> {
+  // ScalarHelper specialization for util::string_view
+
+  static hash_t ComputeHash(const util::string_view& value) {
+    return ComputeStringHash<AlgNum>(value.data(), static_cast<int64_t>(value.size()));
+  }
+};
+
+template <typename Scalar, uint64_t AlgNum>
+struct ScalarHelper<Scalar, AlgNum, enable_if_t<std::is_floating_point<Scalar>::value>>
+    : public ScalarHelperBase<Scalar, AlgNum> {
+  // ScalarHelper specialization for reals
+
+  static bool CompareScalars(Scalar u, Scalar v) {
+    if (std::isnan(u)) {
+      // XXX should we do a bit-precise comparison?
+      return std::isnan(v);
+    }
+    return u == v;
+  }
+};
+
+template <uint64_t AlgNum = 0>
+hash_t ComputeStringHash(const void* data, int64_t length) {
+  if (ARROW_PREDICT_TRUE(length <= 16)) {
+    // Specialize for small hash strings, as they are quite common as
+    // hash table keys.  Even XXH3 isn't quite as fast.
+    auto p = reinterpret_cast<const uint8_t*>(data);
+    auto n = static_cast<uint32_t>(length);
+    if (n <= 8) {
+      if (n <= 3) {
+        if (n == 0) {
+          return 1U;
+        }
+        uint32_t x = (n << 24) ^ (p[0] << 16) ^ (p[n / 2] << 8) ^ p[n - 1];
+        return ScalarHelper<uint32_t, AlgNum>::ComputeHash(x);
+      }
+      // 4 <= length <= 8
+      // We can read the string as two overlapping 32-bit ints, apply
+      // different hash functions to each of them in parallel, then XOR
+      // the results
+      uint32_t x, y;
+      hash_t hx, hy;
+      x = util::SafeLoadAs<uint32_t>(p + n - 4);
+      y = util::SafeLoadAs<uint32_t>(p);
+      hx = ScalarHelper<uint32_t, AlgNum>::ComputeHash(x);
+      hy = ScalarHelper<uint32_t, AlgNum ^ 1>::ComputeHash(y);
+      return n ^ hx ^ hy;
+    }
+    // 8 <= length <= 16
+    // Apply the same principle as above
+    uint64_t x, y;
+    hash_t hx, hy;
+    x = util::SafeLoadAs<uint64_t>(p + n - 8);
+    y = util::SafeLoadAs<uint64_t>(p);
+    hx = ScalarHelper<uint64_t, AlgNum>::ComputeHash(x);
+    hy = ScalarHelper<uint64_t, AlgNum ^ 1>::ComputeHash(y);
+    return n ^ hx ^ hy;
+  }
+
+#if XXH3_SECRET_SIZE_MIN != 136
+#error XXH3_SECRET_SIZE_MIN changed, please fix kXxh3Secrets
+#endif
+
+  // XXH3_64bits_withSeed generates a secret based on the seed, which is too slow.
+  // Instead, we use hard-coded random secrets.  To maximize cache efficiency,
+  // they reuse the same memory area.
+  static constexpr unsigned char kXxh3Secrets[XXH3_SECRET_SIZE_MIN + 1] = {
+      0xe7, 0x8b, 0x13, 0xf9, 0xfc, 0xb5, 0x8e, 0xef, 0x81, 0x48, 0x2c, 0xbf, 0xf9, 0x9f,
+      0xc1, 0x1e, 0x43, 0x6d, 0xbf, 0xa6, 0x6d, 0xb5, 0x72, 0xbc, 0x97, 0xd8, 0x61, 0x24,
+      0x0f, 0x12, 0xe3, 0x05, 0x21, 0xf7, 0x5c, 0x66, 0x67, 0xa5, 0x65, 0x03, 0x96, 0x26,
+      0x69, 0xd8, 0x29, 0x20, 0xf8, 0xc7, 0xb0, 0x3d, 0xdd, 0x7d, 0x18, 0xa0, 0x60, 0x75,
+      0x92, 0xa4, 0xce, 0xba, 0xc0, 0x77, 0xf4, 0xac, 0xb7, 0x03, 0x53, 0xf0, 0x98, 0xce,
+      0xe6, 0x2b, 0x20, 0xc7, 0x82, 0x91, 0xab, 0xbf, 0x68, 0x5c, 0x62, 0x4d, 0x33, 0xa3,
+      0xe1, 0xb3, 0xff, 0x97, 0x54, 0x4c, 0x44, 0x34, 0xb5, 0xb9, 0x32, 0x4c, 0x75, 0x42,
+      0x89, 0x53, 0x94, 0xd4, 0x9f, 0x2b, 0x76, 0x4d, 0x4e, 0xe6, 0xfa, 0x15, 0x3e, 0xc1,
+      0xdb, 0x71, 0x4b, 0x2c, 0x94, 0xf5, 0xfc, 0x8c, 0x89, 0x4b, 0xfb, 0xc1, 0x82, 0xa5,
+      0x6a, 0x53, 0xf9, 0x4a, 0xba, 0xce, 0x1f, 0xc0, 0x97, 0x1a, 0x87};
+
+  static_assert(AlgNum < 2, "AlgNum too large");
+  static constexpr auto secret = kXxh3Secrets + AlgNum;
+  return XXH3_64bits_withSecret(data, static_cast<size_t>(length), secret,
+                                XXH3_SECRET_SIZE_MIN);
+}
+
+// XXX add a HashEq<ArrowType> struct with both hash and compare functions?
+
+// ----------------------------------------------------------------------
+// An open-addressing insert-only hash table (no deletes)
+
+template <typename Payload>
+class HashTable {
+ public:
+  static constexpr hash_t kSentinel = 0ULL;
+  static constexpr int64_t kLoadFactor = 2UL;
+
+  struct Entry {
+    hash_t h;
+    Payload payload;
+
+    // An entry is valid if the hash is different from the sentinel value
+    operator bool() const { return h != kSentinel; }
+  };
+
+  HashTable(MemoryPool* pool, uint64_t capacity) : entries_builder_(pool) {
+    DCHECK_NE(pool, nullptr);
+    // Minimum of 32 elements
+    capacity = std::max<uint64_t>(capacity, 32UL);
+    capacity_ = BitUtil::NextPower2(capacity);
+    capacity_mask_ = capacity_ - 1;
+    size_ = 0;
+
+    DCHECK_OK(UpsizeBuffer(capacity_));
+  }
+
+  // Lookup with non-linear probing
+  // cmp_func should have signature bool(const Payload*).
+  // Return a (Entry*, found) pair.
+  template <typename CmpFunc>
+  std::pair<Entry*, bool> Lookup(hash_t h, CmpFunc&& cmp_func) {
+    auto p = Lookup<DoCompare, CmpFunc>(h, entries_, capacity_mask_,
+                                        std::forward<CmpFunc>(cmp_func));
+    return {&entries_[p.first], p.second};
+  }
+
+  template <typename CmpFunc>
+  std::pair<const Entry*, bool> Lookup(hash_t h, CmpFunc&& cmp_func) const {
+    auto p = Lookup<DoCompare, CmpFunc>(h, entries_, capacity_mask_,
+                                        std::forward<CmpFunc>(cmp_func));
+    return {&entries_[p.first], p.second};
+  }
+
+  Status Insert(Entry* entry, hash_t h, const Payload& payload) {
+    // Ensure entry is empty before inserting
+    assert(!*entry);
+    entry->h = FixHash(h);
+    entry->payload = payload;
+    ++size_;
+
+    if (ARROW_PREDICT_FALSE(NeedUpsizing())) {
+      // Resize less frequently since it is expensive
+      return Upsize(capacity_ * kLoadFactor * 2);
+    }
+    return Status::OK();
+  }
+
+  uint64_t size() const { return size_; }
+
+  // Visit all non-empty entries in the table
+  // The visit_func should have signature void(const Entry*)
+  template <typename VisitFunc>
+  void VisitEntries(VisitFunc&& visit_func) const {
+    for (uint64_t i = 0; i < capacity_; i++) {
+      const auto& entry = entries_[i];
+      if (entry) {
+        visit_func(&entry);
+      }
+    }
+  }
+
+ protected:
+  // NoCompare is for when the value is known not to exist in the table
+  enum CompareKind { DoCompare, NoCompare };
+
+  // The workhorse lookup function
+  template <CompareKind CKind, typename CmpFunc>
+  std::pair<uint64_t, bool> Lookup(hash_t h, const Entry* entries, uint64_t size_mask,
+                                   CmpFunc&& cmp_func) const {
+    static constexpr uint8_t perturb_shift = 5;
+
+    uint64_t index, perturb;
+    const Entry* entry;
+
+    h = FixHash(h);
+    index = h & size_mask;
+    perturb = (h >> perturb_shift) + 1U;
+
+    while (true) {
+      entry = &entries[index];
+      if (CompareEntry<CKind, CmpFunc>(h, entry, std::forward<CmpFunc>(cmp_func))) {
+        // Found
+        return {index, true};
+      }
+      if (entry->h == kSentinel) {
+        // Empty slot
+        return {index, false};
+      }
+
+      // Perturbation logic inspired from CPython's set / dict object.
+      // The goal is that all 64 bits of the unmasked hash value eventually
+      // participate in the probing sequence, to minimize clustering.
+      index = (index + perturb) & size_mask;
+      perturb = (perturb >> perturb_shift) + 1U;
+    }
+  }
+
+  template <CompareKind CKind, typename CmpFunc>
+  bool CompareEntry(hash_t h, const Entry* entry, CmpFunc&& cmp_func) const {
+    if (CKind == NoCompare) {
+      return false;
+    } else {
+      return entry->h == h && cmp_func(&entry->payload);
+    }
+  }
+
+  bool NeedUpsizing() const {
+    // Keep the load factor <= 1/2
+    return size_ * kLoadFactor >= capacity_;
+  }
+
+  Status UpsizeBuffer(uint64_t capacity) {
+    RETURN_NOT_OK(entries_builder_.Resize(capacity));
+    entries_ = entries_builder_.mutable_data();
+    memset(static_cast<void*>(entries_), 0, capacity * sizeof(Entry));
+
+    return Status::OK();
+  }
+
+  Status Upsize(uint64_t new_capacity) {
+    assert(new_capacity > capacity_);
+    uint64_t new_mask = new_capacity - 1;
+    assert((new_capacity & new_mask) == 0);  // it's a power of two
+
+    // Stash old entries and seal builder, effectively resetting the Buffer
+    const Entry* old_entries = entries_;
+    std::shared_ptr<Buffer> previous;
+    RETURN_NOT_OK(entries_builder_.Finish(&previous));
+    // Allocate new buffer
+    RETURN_NOT_OK(UpsizeBuffer(new_capacity));
+
+    for (uint64_t i = 0; i < capacity_; i++) {
+      const auto& entry = old_entries[i];
+      if (entry) {
+        // Dummy compare function will not be called
+        auto p = Lookup<NoCompare>(entry.h, entries_, new_mask,
+                                   [](const Payload*) { return false; });
+        // Lookup<NoCompare> (and CompareEntry<NoCompare>) ensure that an
+        // empty slots is always returned
+        assert(!p.second);
+        entries_[p.first] = entry;
+      }
+    }
+    capacity_ = new_capacity;
+    capacity_mask_ = new_mask;
+
+    return Status::OK();
+  }
+
+  hash_t FixHash(hash_t h) const { return (h == kSentinel) ? 42U : h; }
+
+  // The number of slots available in the hash table array.
+  uint64_t capacity_;
+  uint64_t capacity_mask_;
+  // The number of used slots in the hash table array.
+  uint64_t size_;
+
+  Entry* entries_;
+  TypedBufferBuilder<Entry> entries_builder_;
+};
+
+// XXX typedef memo_index_t int32_t ?
+
+constexpr int32_t kKeyNotFound = -1;
+
+// ----------------------------------------------------------------------
+// A base class for memoization table.
+
+class MemoTable {
+ public:
+  virtual ~MemoTable() = default;
+
+  virtual int32_t size() const = 0;
+};
+
+// ----------------------------------------------------------------------
+// A memoization table for memory-cheap scalar values.
+
+// The memoization table remembers and allows to look up the insertion
+// index for each key.
+
+template <typename Scalar, template <class> class HashTableTemplateType = HashTable>
+class ScalarMemoTable : public MemoTable {
+ public:
+  explicit ScalarMemoTable(MemoryPool* pool, int64_t entries = 0)
+      : hash_table_(pool, static_cast<uint64_t>(entries)) {}
+
+  int32_t Get(const Scalar& value) const {
+    auto cmp_func = [value](const Payload* payload) -> bool {
+      return ScalarHelper<Scalar, 0>::CompareScalars(payload->value, value);
+    };
+    hash_t h = ComputeHash(value);
+    auto p = hash_table_.Lookup(h, cmp_func);
+    if (p.second) {
+      return p.first->payload.memo_index;
+    } else {
+      return kKeyNotFound;
+    }
+  }
+
+  template <typename Func1, typename Func2>
+  Status GetOrInsert(const Scalar& value, Func1&& on_found, Func2&& on_not_found,
+                     int32_t* out_memo_index) {
+    auto cmp_func = [value](const Payload* payload) -> bool {
+      return ScalarHelper<Scalar, 0>::CompareScalars(value, payload->value);
+    };
+    hash_t h = ComputeHash(value);
+    auto p = hash_table_.Lookup(h, cmp_func);
+    int32_t memo_index;
+    if (p.second) {
+      memo_index = p.first->payload.memo_index;
+      on_found(memo_index);
+    } else {
+      memo_index = size();
+      RETURN_NOT_OK(hash_table_.Insert(p.first, h, {value, memo_index}));
+      on_not_found(memo_index);
+    }
+    *out_memo_index = memo_index;
+    return Status::OK();
+  }
+
+  Status GetOrInsert(const Scalar& value, int32_t* out_memo_index) {
+    return GetOrInsert(value, [](int32_t i) {}, [](int32_t i) {}, out_memo_index);
+  }
+
+  int32_t GetNull() const { return null_index_; }
+
+  template <typename Func1, typename Func2>
+  int32_t GetOrInsertNull(Func1&& on_found, Func2&& on_not_found) {
+    int32_t memo_index = GetNull();
+    if (memo_index != kKeyNotFound) {
+      on_found(memo_index);
+    } else {
+      null_index_ = memo_index = size();
+      on_not_found(memo_index);
+    }
+    return memo_index;
+  }
+
+  int32_t GetOrInsertNull() {
+    return GetOrInsertNull([](int32_t i) {}, [](int32_t i) {});
+  }
+
+  // The number of entries in the memo table +1 if null was added.
+  // (which is also 1 + the largest memo index)
+  int32_t size() const override {
+    return static_cast<int32_t>(hash_table_.size()) + (GetNull() != kKeyNotFound);
+  }
+
+  // Copy values starting from index `start` into `out_data`
+  void CopyValues(int32_t start, Scalar* out_data) const {
+    hash_table_.VisitEntries([=](const HashTableEntry* entry) {
+      int32_t index = entry->payload.memo_index - start;
+      if (index >= 0) {
+        out_data[index] = entry->payload.value;
+      }
+    });
+  }
+
+  void CopyValues(Scalar* out_data) const { CopyValues(0, out_data); }
+
+ protected:
+  struct Payload {
+    Scalar value;
+    int32_t memo_index;
+  };
+
+  using HashTableType = HashTableTemplateType<Payload>;
+  using HashTableEntry = typename HashTableType::Entry;
+  HashTableType hash_table_;
+  int32_t null_index_ = kKeyNotFound;
+
+  hash_t ComputeHash(const Scalar& value) const {
+    return ScalarHelper<Scalar, 0>::ComputeHash(value);
+  }
+};
+
+// ----------------------------------------------------------------------
+// A memoization table for small scalar values, using direct indexing
+
+template <typename Scalar, typename Enable = void>
+struct SmallScalarTraits {};
+
+template <>
+struct SmallScalarTraits<bool> {
+  static constexpr int32_t cardinality = 2;
+
+  static uint32_t AsIndex(bool value) { return value ? 1 : 0; }
+};
+
+template <typename Scalar>
+struct SmallScalarTraits<Scalar, enable_if_t<std::is_integral<Scalar>::value>> {
+  using Unsigned = typename std::make_unsigned<Scalar>::type;
+
+  static constexpr int32_t cardinality = 1U + std::numeric_limits<Unsigned>::max();
+
+  static uint32_t AsIndex(Scalar value) { return static_cast<Unsigned>(value); }
+};
+
+template <typename Scalar, template <class> class HashTableTemplateType = HashTable>
+class SmallScalarMemoTable : public MemoTable {
+ public:
+  explicit SmallScalarMemoTable(MemoryPool* pool, int64_t entries = 0) {
+    std::fill(value_to_index_, value_to_index_ + cardinality + 1, kKeyNotFound);
+    index_to_value_.reserve(cardinality);
+  }
+
+  int32_t Get(const Scalar value) const {
+    auto value_index = AsIndex(value);
+    return value_to_index_[value_index];
+  }
+
+  template <typename Func1, typename Func2>
+  Status GetOrInsert(const Scalar value, Func1&& on_found, Func2&& on_not_found,
+                     int32_t* out_memo_index) {
+    auto value_index = AsIndex(value);
+    auto memo_index = value_to_index_[value_index];
+    if (memo_index == kKeyNotFound) {
+      memo_index = static_cast<int32_t>(index_to_value_.size());
+      index_to_value_.push_back(value);
+      value_to_index_[value_index] = memo_index;
+      DCHECK_LT(memo_index, cardinality + 1);
+      on_not_found(memo_index);
+    } else {
+      on_found(memo_index);
+    }
+    *out_memo_index = memo_index;
+    return Status::OK();
+  }
+
+  Status GetOrInsert(const Scalar value, int32_t* out_memo_index) {
+    return GetOrInsert(value, [](int32_t i) {}, [](int32_t i) {}, out_memo_index);
+  }
+
+  int32_t GetNull() const { return value_to_index_[cardinality]; }
+
+  template <typename Func1, typename Func2>
+  int32_t GetOrInsertNull(Func1&& on_found, Func2&& on_not_found) {
+    auto memo_index = GetNull();
+    if (memo_index == kKeyNotFound) {
+      memo_index = value_to_index_[cardinality] = size();
+      index_to_value_.push_back(0);
+      on_not_found(memo_index);
+    } else {
+      on_found(memo_index);
+    }
+    return memo_index;
+  }
+
+  int32_t GetOrInsertNull() {
+    return GetOrInsertNull([](int32_t i) {}, [](int32_t i) {});
+  }
+
+  // The number of entries in the memo table
+  // (which is also 1 + the largest memo index)
+  int32_t size() const override { return static_cast<int32_t>(index_to_value_.size()); }
+
+  // Copy values starting from index `start` into `out_data`
+  void CopyValues(int32_t start, Scalar* out_data) const {
+    DCHECK_GE(start, 0);
+    DCHECK_LE(static_cast<size_t>(start), index_to_value_.size());
+    int64_t offset = start * static_cast<int32_t>(sizeof(Scalar));
+    memcpy(out_data, index_to_value_.data() + offset, (size() - start) * sizeof(Scalar));
+  }
+
+  void CopyValues(Scalar* out_data) const { CopyValues(0, out_data); }
+
+  const std::vector<Scalar>& values() const { return index_to_value_; }
+
+ protected:
+  static constexpr auto cardinality = SmallScalarTraits<Scalar>::cardinality;
+  static_assert(cardinality <= 256, "cardinality too large for direct-addressed table");
+
+  uint32_t AsIndex(Scalar value) const {
+    return SmallScalarTraits<Scalar>::AsIndex(value);
+  }
+
+  // The last index is reserved for the null element.
+  int32_t value_to_index_[cardinality + 1];
+  std::vector<Scalar> index_to_value_;
+};
+
+// ----------------------------------------------------------------------
+// A memoization table for variable-sized binary data.
+
+template <typename BinaryBuilderT>
+class BinaryMemoTable : public MemoTable {
+ public:
+  using builder_offset_type = typename BinaryBuilderT::offset_type;
+  explicit BinaryMemoTable(MemoryPool* pool, int64_t entries = 0,
+                           int64_t values_size = -1)
+      : hash_table_(pool, static_cast<uint64_t>(entries)), binary_builder_(pool) {
+    const int64_t data_size = (values_size < 0) ? entries * 4 : values_size;
+    DCHECK_OK(binary_builder_.Resize(entries));
+    DCHECK_OK(binary_builder_.ReserveData(data_size));
+  }
+
+  int32_t Get(const void* data, builder_offset_type length) const {
+    hash_t h = ComputeStringHash<0>(data, length);
+    auto p = Lookup(h, data, length);
+    if (p.second) {
+      return p.first->payload.memo_index;
+    } else {
+      return kKeyNotFound;
+    }
+  }
+
+  int32_t Get(const util::string_view& value) const {
+    return Get(value.data(), static_cast<builder_offset_type>(value.length()));
+  }
+
+  template <typename Func1, typename Func2>
+  Status GetOrInsert(const void* data, builder_offset_type length, Func1&& on_found,
+                     Func2&& on_not_found, int32_t* out_memo_index) {
+    hash_t h = ComputeStringHash<0>(data, length);
+    auto p = Lookup(h, data, length);
+    int32_t memo_index;
+    if (p.second) {
+      memo_index = p.first->payload.memo_index;
+      on_found(memo_index);
+    } else {
+      memo_index = size();
+      // Insert string value
+      RETURN_NOT_OK(binary_builder_.Append(static_cast<const char*>(data), length));
+      // Insert hash entry
+      RETURN_NOT_OK(
+          hash_table_.Insert(const_cast<HashTableEntry*>(p.first), h, {memo_index}));
+
+      on_not_found(memo_index);
+    }
+    *out_memo_index = memo_index;
+    return Status::OK();
+  }
+
+  template <typename Func1, typename Func2>
+  Status GetOrInsert(const util::string_view& value, Func1&& on_found,
+                     Func2&& on_not_found, int32_t* out_memo_index) {
+    return GetOrInsert(value.data(), static_cast<builder_offset_type>(value.length()),
+                       std::forward<Func1>(on_found), std::forward<Func2>(on_not_found),
+                       out_memo_index);
+  }
+
+  Status GetOrInsert(const void* data, builder_offset_type length,
+                     int32_t* out_memo_index) {
+    return GetOrInsert(data, length, [](int32_t i) {}, [](int32_t i) {}, out_memo_index);
+  }
+
+  Status GetOrInsert(const util::string_view& value, int32_t* out_memo_index) {
+    return GetOrInsert(value.data(), static_cast<builder_offset_type>(value.length()),
+                       out_memo_index);
+  }
+
+  int32_t GetNull() const { return null_index_; }
+
+  template <typename Func1, typename Func2>
+  int32_t GetOrInsertNull(Func1&& on_found, Func2&& on_not_found) {
+    int32_t memo_index = GetNull();
+    if (memo_index == kKeyNotFound) {
+      memo_index = null_index_ = size();
+      DCHECK_OK(binary_builder_.AppendNull());
+      on_not_found(memo_index);
+    } else {
+      on_found(memo_index);
+    }
+    return memo_index;
+  }
+
+  int32_t GetOrInsertNull() {
+    return GetOrInsertNull([](int32_t i) {}, [](int32_t i) {});
+  }
+
+  // The number of entries in the memo table
+  // (which is also 1 + the largest memo index)
+  int32_t size() const override {
+    return static_cast<int32_t>(hash_table_.size() + (GetNull() != kKeyNotFound));
+  }
+
+  int64_t values_size() const { return binary_builder_.value_data_length(); }
+
+  // Copy (n + 1) offsets starting from index `start` into `out_data`
+  template <class Offset>
+  void CopyOffsets(int32_t start, Offset* out_data) const {
+    DCHECK_LE(start, size());
+
+    const builder_offset_type* offsets = binary_builder_.offsets_data();
+    const builder_offset_type delta = offsets[start];
+    for (int32_t i = start; i < size(); ++i) {
+      const builder_offset_type adjusted_offset = offsets[i] - delta;
+      Offset cast_offset = static_cast<Offset>(adjusted_offset);
+      assert(static_cast<builder_offset_type>(cast_offset) ==
+             adjusted_offset);  // avoid truncation
+      *out_data++ = cast_offset;
+    }
+
+    // Copy last value since BinaryBuilder only materializes it on in Finish()
+    *out_data = static_cast<Offset>(binary_builder_.value_data_length() - delta);
+  }
+
+  template <class Offset>
+  void CopyOffsets(Offset* out_data) const {
+    CopyOffsets(0, out_data);
+  }
+
+  // Copy values starting from index `start` into `out_data`
+  void CopyValues(int32_t start, uint8_t* out_data) const {
+    CopyValues(start, -1, out_data);
+  }
+
+  // Same as above, but check output size in debug mode
+  void CopyValues(int32_t start, int64_t out_size, uint8_t* out_data) const {
+    DCHECK_LE(start, size());
+
+    // The absolute byte offset of `start` value in the binary buffer.
+    const builder_offset_type offset = binary_builder_.offset(start);
+    const auto length = binary_builder_.value_data_length() - static_cast<size_t>(offset);
+
+    if (out_size != -1) {
+      assert(static_cast<int64_t>(length) <= out_size);
+    }
+
+    auto view = binary_builder_.GetView(start);
+    memcpy(out_data, view.data(), length);
+  }
+
+  void CopyValues(uint8_t* out_data) const { CopyValues(0, -1, out_data); }
+
+  void CopyValues(int64_t out_size, uint8_t* out_data) const {
+    CopyValues(0, out_size, out_data);
+  }
+
+  void CopyFixedWidthValues(int32_t start, int32_t width_size, int64_t out_size,
+                            uint8_t* out_data) const {
+    // This method exists to cope with the fact that the BinaryMemoTable does
+    // not know the fixed width when inserting the null value. The data
+    // buffer hold a zero length string for the null value (if found).
+    //
+    // Thus, the method will properly inject an empty value of the proper width
+    // in the output buffer.
+    //
+    if (start >= size()) {
+      return;
+    }
+
+    int32_t null_index = GetNull();
+    if (null_index < start) {
+      // Nothing to skip, proceed as usual.
+      CopyValues(start, out_size, out_data);
+      return;
+    }
+
+    builder_offset_type left_offset = binary_builder_.offset(start);
+
+    // Ensure that the data length is exactly missing width_size bytes to fit
+    // in the expected output (n_values * width_size).
+#ifndef NDEBUG
+    int64_t data_length = values_size() - static_cast<size_t>(left_offset);
+    assert(data_length + width_size == out_size);
+    ARROW_UNUSED(data_length);
+#endif
+
+    auto in_data = binary_builder_.value_data() + left_offset;
+    // The null use 0-length in the data, slice the data in 2 and skip by
+    // width_size in out_data. [part_1][width_size][part_2]
+    auto null_data_offset = binary_builder_.offset(null_index);
+    auto left_size = null_data_offset - left_offset;
+    if (left_size > 0) {
+      memcpy(out_data, in_data + left_offset, left_size);
+    }
+
+    auto right_size = values_size() - static_cast<size_t>(null_data_offset);
+    if (right_size > 0) {
+      // skip the null fixed size value.
+      auto out_offset = left_size + width_size;
+      assert(out_data + out_offset + right_size == out_data + out_size);
+      memcpy(out_data + out_offset, in_data + null_data_offset, right_size);
+    }
+  }
+
+  // Visit the stored values in insertion order.
+  // The visitor function should have the signature `void(util::string_view)`
+  // or `void(const util::string_view&)`.
+  template <typename VisitFunc>
+  void VisitValues(int32_t start, VisitFunc&& visit) const {
+    for (int32_t i = start; i < size(); ++i) {
+      visit(binary_builder_.GetView(i));
+    }
+  }
+
+ protected:
+  struct Payload {
+    int32_t memo_index;
+  };
+
+  using HashTableType = HashTable<Payload>;
+  using HashTableEntry = typename HashTable<Payload>::Entry;
+  HashTableType hash_table_;
+  BinaryBuilderT binary_builder_;
+
+  int32_t null_index_ = kKeyNotFound;
+
+  std::pair<const HashTableEntry*, bool> Lookup(hash_t h, const void* data,
+                                                builder_offset_type length) const {
+    auto cmp_func = [=](const Payload* payload) {
+      util::string_view lhs = binary_builder_.GetView(payload->memo_index);
+      util::string_view rhs(static_cast<const char*>(data), length);
+      return lhs == rhs;
+    };
+    return hash_table_.Lookup(h, cmp_func);
+  }
+};
+
+template <typename T, typename Enable = void>
+struct HashTraits {};
+
+template <>
+struct HashTraits<BooleanType> {
+  using MemoTableType = SmallScalarMemoTable<bool>;
+};
+
+template <typename T>
+struct HashTraits<T, enable_if_8bit_int<T>> {
+  using c_type = typename T::c_type;
+  using MemoTableType = SmallScalarMemoTable<typename T::c_type>;
+};
+
+template <typename T>
+struct HashTraits<T, enable_if_t<has_c_type<T>::value && !is_8bit_int<T>::value>> {
+  using c_type = typename T::c_type;
+  using MemoTableType = ScalarMemoTable<c_type, HashTable>;
+};
+
+template <typename T>
+struct HashTraits<T, enable_if_t<has_string_view<T>::value &&
+                                 !std::is_base_of<LargeBinaryType, T>::value>> {
+  using MemoTableType = BinaryMemoTable<BinaryBuilder>;
+};
+
+template <typename T>
+struct HashTraits<T, enable_if_t<std::is_base_of<LargeBinaryType, T>::value>> {
+  using MemoTableType = BinaryMemoTable<LargeBinaryBuilder>;
+};
+
+template <typename MemoTableType>
+static inline Status ComputeNullBitmap(MemoryPool* pool, const MemoTableType& memo_table,
+                                       int64_t start_offset, int64_t* null_count,
+                                       std::shared_ptr<Buffer>* null_bitmap) {
+  int64_t dict_length = static_cast<int64_t>(memo_table.size()) - start_offset;
+  int64_t null_index = memo_table.GetNull();
+
+  *null_count = 0;
+  *null_bitmap = nullptr;
+
+  if (null_index != kKeyNotFound && null_index >= start_offset) {
+    null_index -= start_offset;
+    *null_count = 1;
+    ARROW_ASSIGN_OR_RAISE(*null_bitmap,
+                          internal::BitmapAllButOne(pool, dict_length, null_index));
+  }
+
+  return Status::OK();
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/oap-native-sql/cpp/src/third_party/arrow/vendored/xxhash/README.md
+++ b/oap-native-sql/cpp/src/third_party/arrow/vendored/xxhash/README.md
@@ -1,0 +1,20 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+The files in this directory are vendored from xxHash git tag v0.7.1.

--- a/oap-native-sql/cpp/src/third_party/arrow/vendored/xxhash/xxh3.h
+++ b/oap-native-sql/cpp/src/third_party/arrow/vendored/xxhash/xxh3.h
@@ -1,0 +1,1583 @@
+/*
+   xxHash - Extremely Fast Hash algorithm
+   Development source file for `xxh3`
+   Copyright (C) 2019-present, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+/* Note :
+   This file is separated for development purposes.
+   It will be integrated into `xxhash.c` when development phase is complete.
+*/
+
+#ifndef XXH3_H
+#define XXH3_H
+
+
+/* ===   Dependencies   === */
+
+#undef XXH_INLINE_ALL   /* in case it's already defined */
+#define XXH_INLINE_ALL
+#include "xxhash.h"
+
+
+/* ===   Compiler specifics   === */
+
+#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* >= C99 */
+#  define XXH_RESTRICT   restrict
+#else
+/* note : it might be useful to define __restrict or __restrict__ for some C++ compilers */
+#  define XXH_RESTRICT   /* disable */
+#endif
+
+#if defined(__GNUC__)
+#  if defined(__AVX2__)
+#    include <immintrin.h>
+#  elif defined(__SSE2__)
+#    include <emmintrin.h>
+#  elif defined(__ARM_NEON__) || defined(__ARM_NEON)
+#    define inline __inline__  /* clang bug */
+#    include <arm_neon.h>
+#    undef inline
+#  endif
+#elif defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
+
+
+/* ==========================================
+ * Vectorization detection
+ * ========================================== */
+#define XXH_SCALAR 0
+#define XXH_SSE2   1
+#define XXH_AVX2   2
+#define XXH_NEON   3
+#define XXH_VSX    4
+
+#ifndef XXH_VECTOR    /* can be defined on command line */
+#  if defined(__AVX2__)
+#    define XXH_VECTOR XXH_AVX2
+#  elif defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2))
+#    define XXH_VECTOR XXH_SSE2
+#  elif defined(__GNUC__) /* msvc support maybe later */ \
+  && (defined(__ARM_NEON__) || defined(__ARM_NEON)) \
+  && defined(__LITTLE_ENDIAN__) /* ARM big endian is a thing */
+#    define XXH_VECTOR XXH_NEON
+#  elif defined(__PPC64__) && defined(__VSX__) && defined(__GNUC__)
+#    define XXH_VECTOR XXH_VSX
+#  else
+#    define XXH_VECTOR XXH_SCALAR
+#  endif
+#endif
+
+/* control alignment of accumulator,
+ * for compatibility with fast vector loads */
+#ifndef XXH_ACC_ALIGN
+#  if XXH_VECTOR == 0   /* scalar */
+#     define XXH_ACC_ALIGN 8
+#  elif XXH_VECTOR == 1  /* sse2 */
+#     define XXH_ACC_ALIGN 16
+#  elif XXH_VECTOR == 2  /* avx2 */
+#     define XXH_ACC_ALIGN 32
+#  elif XXH_VECTOR == 3  /* neon */
+#     define XXH_ACC_ALIGN 16
+#  elif XXH_VECTOR == 4  /* vsx */
+#     define XXH_ACC_ALIGN 16
+#  endif
+#endif
+
+/* U64 XXH_mult32to64(U32 a, U64 b) { return (U64)a * (U64)b; } */
+#if defined(_MSC_VER) && defined(_M_IX86)
+#    include <intrin.h>
+#    define XXH_mult32to64(x, y) __emulu(x, y)
+#else
+#    define XXH_mult32to64(x, y) ((U64)((x) & 0xFFFFFFFF) * (U64)((y) & 0xFFFFFFFF))
+#endif
+
+/* VSX stuff */
+#if XXH_VECTOR == XXH_VSX
+#  include <altivec.h>
+#  undef vector
+typedef __vector unsigned long long U64x2;
+typedef __vector unsigned U32x4;
+/* Adapted from https://github.com/google/highwayhash/blob/master/highwayhash/hh_vsx.h. */
+XXH_FORCE_INLINE U64x2 XXH_vsxMultOdd(U32x4 a, U32x4 b) {
+    U64x2 result;
+    __asm__("vmulouw %0, %1, %2" : "=v" (result) : "v" (a), "v" (b));
+    return result;
+}
+XXH_FORCE_INLINE U64x2 XXH_vsxMultEven(U32x4 a, U32x4 b) {
+    U64x2 result;
+    __asm__("vmuleuw %0, %1, %2" : "=v" (result) : "v" (a), "v" (b));
+    return result;
+}
+#endif
+
+
+/* ==========================================
+ * XXH3 default settings
+ * ========================================== */
+
+#define XXH_SECRET_DEFAULT_SIZE 192   /* minimum XXH3_SECRET_SIZE_MIN */
+
+#if (XXH_SECRET_DEFAULT_SIZE < XXH3_SECRET_SIZE_MIN)
+#  error "default keyset is not large enough"
+#endif
+
+XXH_ALIGN(64) static const BYTE kSecret[XXH_SECRET_DEFAULT_SIZE] = {
+    0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c, 0xf7, 0x21, 0xad, 0x1c,
+    0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb, 0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f,
+    0xcb, 0x79, 0xe6, 0x4e, 0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
+    0xb8, 0x08, 0x46, 0x74, 0xf7, 0x43, 0x24, 0x8e, 0xe0, 0x35, 0x90, 0xe6, 0x81, 0x3a, 0x26, 0x4c,
+    0x3c, 0x28, 0x52, 0xbb, 0x91, 0xc3, 0x00, 0xcb, 0x88, 0xd0, 0x65, 0x8b, 0x1b, 0x53, 0x2e, 0xa3,
+    0x71, 0x64, 0x48, 0x97, 0xa2, 0x0d, 0xf9, 0x4e, 0x38, 0x19, 0xef, 0x46, 0xa9, 0xde, 0xac, 0xd8,
+    0xa8, 0xfa, 0x76, 0x3f, 0xe3, 0x9c, 0x34, 0x3f, 0xf9, 0xdc, 0xbb, 0xc7, 0xc7, 0x0b, 0x4f, 0x1d,
+    0x8a, 0x51, 0xe0, 0x4b, 0xcd, 0xb4, 0x59, 0x31, 0xc8, 0x9f, 0x7e, 0xc9, 0xd9, 0x78, 0x73, 0x64,
+
+    0xea, 0xc5, 0xac, 0x83, 0x34, 0xd3, 0xeb, 0xc3, 0xc5, 0x81, 0xa0, 0xff, 0xfa, 0x13, 0x63, 0xeb,
+    0x17, 0x0d, 0xdd, 0x51, 0xb7, 0xf0, 0xda, 0x49, 0xd3, 0x16, 0x55, 0x26, 0x29, 0xd4, 0x68, 0x9e,
+    0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc, 0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce,
+    0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
+};
+
+
+static XXH128_hash_t
+XXH3_mul128(U64 ll1, U64 ll2)
+{
+/* __uint128_t seems a bad choice with emscripten current, see https://github.com/Cyan4973/xxHash/issues/211#issuecomment-515575677 */
+#if !defined(__wasm__) && defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+
+    __uint128_t lll = (__uint128_t)ll1 * ll2;
+    XXH128_hash_t const r128 = { (U64)(lll), (U64)(lll >> 64) };
+    return r128;
+
+#elif defined(_M_X64) || defined(_M_IA64)
+
+#ifndef _MSC_VER
+#   pragma intrinsic(_umul128)
+#endif
+    U64 llhigh;
+    U64 const lllow = _umul128(ll1, ll2, &llhigh);
+    XXH128_hash_t const r128 = { lllow, llhigh };
+    return r128;
+
+#else /* Portable scalar version */
+
+    /* emulate 64x64->128b multiplication, using four 32x32->64 */
+    U32 const h1 = (U32)(ll1 >> 32);
+    U32 const h2 = (U32)(ll2 >> 32);
+    U32 const l1 = (U32)ll1;
+    U32 const l2 = (U32)ll2;
+
+    U64 const llh  = XXH_mult32to64(h1, h2);
+    U64 const llm1 = XXH_mult32to64(l1, h2);
+    U64 const llm2 = XXH_mult32to64(h1, l2);
+    U64 const lll  = XXH_mult32to64(l1, l2);
+
+    U64 const t = lll + (llm1 << 32);
+    U64 const carry1 = t < lll;
+
+    U64 const lllow = t + (llm2 << 32);
+    U64 const carry2 = lllow < t;
+    U64 const llhigh = llh + (llm1 >> 32) + (llm2 >> 32) + carry1 + carry2;
+
+    XXH128_hash_t const r128 = { lllow, llhigh };
+    return r128;
+
+#endif
+}
+
+
+#if defined(__GNUC__) && defined(__i386__)
+/* GCC is stupid and tries to vectorize this.
+ * This tells GCC that it is wrong. */
+__attribute__((__target__("no-sse")))
+#endif
+static U64
+XXH3_mul128_fold64(U64 ll1, U64 ll2)
+{
+/* __uint128_t seems a bad choice with emscripten current, see https://github.com/Cyan4973/xxHash/issues/211#issuecomment-515575677 */
+#if !defined(__wasm__) && defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+
+    __uint128_t lll = (__uint128_t)ll1 * ll2;
+    return (U64)lll ^ (U64)(lll >> 64);
+
+#elif defined(_M_X64) || defined(_M_IA64)
+
+#ifndef _MSC_VER
+#   pragma intrinsic(_umul128)
+#endif
+    U64 llhigh;
+    U64 const lllow = _umul128(ll1, ll2, &llhigh);
+    return lllow ^ llhigh;
+
+    /* We have to do it out manually on 32-bit.
+     * This is a modified, unrolled, widened, and optimized version of the
+     * mulqdu routine from Hacker's Delight.
+     *
+     *   https://www.hackersdelight.org/hdcodetxt/mulqdu.c.txt
+     *
+     * This was modified to use U32->U64 multiplication instead
+     * of U16->U32, to add the high and low values in the end,
+     * be endian-independent, and I added a partial assembly
+     * implementation for ARM. */
+
+    /* An easy 128-bit folding multiply on ARMv6T2 and ARMv7-A/R can be done with
+     * the mighty umaal (Unsigned Multiply Accumulate Accumulate Long) which takes 4 cycles
+     * or less, doing a long multiply and adding two 32-bit integers:
+     *
+     *     void umaal(U32 *RdLo, U32 *RdHi, U32 Rn, U32 Rm)
+     *     {
+     *         U64 prodAcc = (U64)Rn * (U64)Rm;
+     *         prodAcc += *RdLo;
+     *         prodAcc += *RdHi;
+     *         *RdLo = prodAcc & 0xFFFFFFFF;
+     *         *RdHi = prodAcc >> 32;
+     *     }
+     *
+     * This is compared to umlal which adds to a single 64-bit integer:
+     *
+     *     void umlal(U32 *RdLo, U32 *RdHi, U32 Rn, U32 Rm)
+     *     {
+     *         U64 prodAcc = (U64)Rn * (U64)Rm;
+     *         prodAcc += (*RdLo | ((U64)*RdHi << 32);
+     *         *RdLo = prodAcc & 0xFFFFFFFF;
+     *         *RdHi = prodAcc >> 32;
+     *     }
+     *
+     * Getting the compiler to emit them is like pulling teeth, and checking
+     * for it is annoying because ARMv7-M lacks this instruction. However, it
+     * is worth it, because this is an otherwise expensive operation. */
+
+     /* GCC-compatible, ARMv6t2 or ARMv7+, non-M variant, and 32-bit */
+#elif defined(__GNUC__) /* GCC-compatible */ \
+    && defined(__ARM_ARCH) && !defined(__aarch64__) && !defined(__arm64__) /* 32-bit ARM */\
+    && !defined(__ARM_ARCH_7M__) /* <- Not ARMv7-M  vv*/ \
+        && !(defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM == 0 && __TARGET_ARCH_THUMB == 4) \
+    && (defined(__ARM_ARCH_6T2__) || __ARM_ARCH > 6) /* ARMv6T2 or later */
+
+    U32 w[4] = { 0 };
+    U32 u[2] = { (U32)(ll1 >> 32), (U32)ll1 };
+    U32 v[2] = { (U32)(ll2 >> 32), (U32)ll2 };
+    U32 k;
+
+    /* U64 t = (U64)u[1] * (U64)v[1];
+     * w[3] = t & 0xFFFFFFFF;
+     * k = t >> 32; */
+    __asm__("umull %0, %1, %2, %3"
+            : "=r" (w[3]), "=r" (k)
+            : "r" (u[1]), "r" (v[1]));
+
+    /* t = (U64)u[0] * (U64)v[1] + w[2] + k;
+     * w[2] = t & 0xFFFFFFFF;
+     * k = t >> 32; */
+    __asm__("umaal %0, %1, %2, %3"
+            : "+r" (w[2]), "+r" (k)
+            : "r" (u[0]), "r" (v[1]));
+    w[1] = k;
+    k = 0;
+
+    /* t = (U64)u[1] * (U64)v[0] + w[2] + k;
+     * w[2] = t & 0xFFFFFFFF;
+     * k = t >> 32; */
+    __asm__("umaal %0, %1, %2, %3"
+            : "+r" (w[2]), "+r" (k)
+            : "r" (u[1]), "r" (v[0]));
+
+    /* t = (U64)u[0] * (U64)v[0] + w[1] + k;
+     * w[1] = t & 0xFFFFFFFF;
+     * k = t >> 32; */
+    __asm__("umaal %0, %1, %2, %3"
+            : "+r" (w[1]), "+r" (k)
+            : "r" (u[0]), "r" (v[0]));
+    w[0] = k;
+
+    return (w[1] | ((U64)w[0] << 32)) ^ (w[3] | ((U64)w[2] << 32));
+
+#else /* Portable scalar version */
+
+    /* emulate 64x64->128b multiplication, using four 32x32->64 */
+    U32 const h1 = (U32)(ll1 >> 32);
+    U32 const h2 = (U32)(ll2 >> 32);
+    U32 const l1 = (U32)ll1;
+    U32 const l2 = (U32)ll2;
+
+    U64 const llh  = XXH_mult32to64(h1, h2);
+    U64 const llm1 = XXH_mult32to64(l1, h2);
+    U64 const llm2 = XXH_mult32to64(h1, l2);
+    U64 const lll  = XXH_mult32to64(l1, l2);
+
+    U64 const t = lll + (llm1 << 32);
+    U64 const carry1 = t < lll;
+
+    U64 const lllow = t + (llm2 << 32);
+    U64 const carry2 = lllow < t;
+    U64 const llhigh = llh + (llm1 >> 32) + (llm2 >> 32) + carry1 + carry2;
+
+    return llhigh ^ lllow;
+
+#endif
+}
+
+
+static XXH64_hash_t XXH3_avalanche(U64 h64)
+{
+    h64 ^= h64 >> 37;
+    h64 *= PRIME64_3;
+    h64 ^= h64 >> 32;
+    return h64;
+}
+
+
+/* ==========================================
+ * Short keys
+ * ========================================== */
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_len_1to3_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+{
+    XXH_ASSERT(data != NULL);
+    XXH_ASSERT(1 <= len && len <= 3);
+    XXH_ASSERT(keyPtr != NULL);
+    {   BYTE const c1 = ((const BYTE*)data)[0];
+        BYTE const c2 = ((const BYTE*)data)[len >> 1];
+        BYTE const c3 = ((const BYTE*)data)[len - 1];
+        U32  const combined = ((U32)c1) + (((U32)c2) << 8) + (((U32)c3) << 16) + (((U32)len) << 24);
+        U64  const keyed = (U64)combined ^ (XXH_readLE32(keyPtr) + seed);
+        U64  const mixed = keyed * PRIME64_1;
+        return XXH3_avalanche(mixed);
+    }
+}
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_len_4to8_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+{
+    XXH_ASSERT(data != NULL);
+    XXH_ASSERT(keyPtr != NULL);
+    XXH_ASSERT(4 <= len && len <= 8);
+    {   U32 const in1 = XXH_readLE32(data);
+        U32 const in2 = XXH_readLE32((const BYTE*)data + len - 4);
+        U64 const in64 = in1 + ((U64)in2 << 32);
+        U64 const keyed = in64 ^ (XXH_readLE64(keyPtr) + seed);
+        U64 const mix64 = len + ((keyed ^ (keyed >> 51)) * PRIME32_1);
+        return XXH3_avalanche((mix64 ^ (mix64 >> 47)) * PRIME64_2);
+    }
+}
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_len_9to16_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+{
+    XXH_ASSERT(data != NULL);
+    XXH_ASSERT(keyPtr != NULL);
+    XXH_ASSERT(9 <= len && len <= 16);
+    {   const U64* const key64 = (const U64*) keyPtr;
+        U64 const ll1 = XXH_readLE64(data) ^ (XXH_readLE64(key64) + seed);
+        U64 const ll2 = XXH_readLE64((const BYTE*)data + len - 8) ^ (XXH_readLE64(key64+1) - seed);
+        U64 const acc = len + (ll1 + ll2) + XXH3_mul128_fold64(ll1, ll2);
+        return XXH3_avalanche(acc);
+    }
+}
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_len_0to16_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+{
+    XXH_ASSERT(len <= 16);
+    {   if (len > 8) return XXH3_len_9to16_64b(data, len, keyPtr, seed);
+        if (len >= 4) return XXH3_len_4to8_64b(data, len, keyPtr, seed);
+        if (len) return XXH3_len_1to3_64b(data, len, keyPtr, seed);
+        return 0;
+    }
+}
+
+
+/* ===    Long Keys    === */
+
+#define STRIPE_LEN 64
+#define XXH_SECRET_CONSUME_RATE 8   /* nb of secret bytes consumed at each accumulation */
+#define ACC_NB (STRIPE_LEN / sizeof(U64))
+
+typedef enum { XXH3_acc_64bits, XXH3_acc_128bits } XXH3_accWidth_e;
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512(      void* XXH_RESTRICT acc,
+                    const void* XXH_RESTRICT data,
+                    const void* XXH_RESTRICT key,
+                    XXH3_accWidth_e accWidth)
+{
+#if (XXH_VECTOR == XXH_AVX2)
+
+    XXH_ASSERT((((size_t)acc) & 31) == 0);
+    {   XXH_ALIGN(32) __m256i* const xacc  =       (__m256i *) acc;
+        const         __m256i* const xdata = (const __m256i *) data;  /* not really aligned, just for ptr arithmetic, and because _mm256_loadu_si256() requires this type */
+        const         __m256i* const xkey  = (const __m256i *) key;   /* not really aligned, just for ptr arithmetic, and because _mm256_loadu_si256() requires this type */
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
+            __m256i const d   = _mm256_loadu_si256 (xdata+i);
+            __m256i const k   = _mm256_loadu_si256 (xkey+i);
+            __m256i const dk  = _mm256_xor_si256 (d,k);                                  /* uint32 dk[8]  = {d0+k0, d1+k1, d2+k2, d3+k3, ...} */
+            __m256i const mul = _mm256_mul_epu32 (dk, _mm256_shuffle_epi32 (dk, 0x31));  /* uint64 mul[4] = {dk0*dk1, dk2*dk3, ...} */
+            if (accWidth == XXH3_acc_128bits) {
+                __m256i const dswap = _mm256_shuffle_epi32(d, _MM_SHUFFLE(1,0,3,2));
+                __m256i const add = _mm256_add_epi64(xacc[i], dswap);
+                xacc[i]  = _mm256_add_epi64(mul, add);
+            } else {  /* XXH3_acc_64bits */
+                __m256i const add = _mm256_add_epi64(xacc[i], d);
+                xacc[i]  = _mm256_add_epi64(mul, add);
+            }
+    }   }
+
+#elif (XXH_VECTOR == XXH_SSE2)
+
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+    {   XXH_ALIGN(16) __m128i* const xacc  =       (__m128i *) acc;   /* presumed */
+        const         __m128i* const xdata = (const __m128i *) data;  /* not really aligned, just for ptr arithmetic, and because _mm_loadu_si128() requires this type */
+        const         __m128i* const xkey  = (const __m128i *) key;   /* not really aligned, just for ptr arithmetic, and because _mm_loadu_si128() requires this type */
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
+            __m128i const d   = _mm_loadu_si128 (xdata+i);
+            __m128i const k   = _mm_loadu_si128 (xkey+i);
+            __m128i const dk  = _mm_xor_si128 (d,k);                                 /* uint32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
+            __m128i const mul = _mm_mul_epu32 (dk, _mm_shuffle_epi32 (dk, 0x31));    /* uint64 mul[2] = {dk0*dk1,dk2*dk3} */
+            if (accWidth == XXH3_acc_128bits) {
+                __m128i const dswap = _mm_shuffle_epi32(d, _MM_SHUFFLE(1,0,3,2));
+                __m128i const add = _mm_add_epi64(xacc[i], dswap);
+                xacc[i]  = _mm_add_epi64(mul, add);
+            } else {  /* XXH3_acc_64bits */
+                __m128i const add = _mm_add_epi64(xacc[i], d);
+                xacc[i]  = _mm_add_epi64(mul, add);
+            }
+    }   }
+
+#elif (XXH_VECTOR == XXH_NEON)
+
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+    {
+        XXH_ALIGN(16) uint64x2_t* const xacc = (uint64x2_t *) acc;
+        /* We don't use a uint32x4_t pointer because it causes bus errors on ARMv7. */
+        uint32_t const* const xdata = (const uint32_t *) data;
+        uint32_t const* const xkey  = (const uint32_t *) key;
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN / sizeof(uint64x2_t); i++) {
+#if !defined(__aarch64__) && !defined(__arm64__) && defined(__GNUC__) /* ARM32-specific hack */
+            /* vzip on ARMv7 Clang generates a lot of vmovs (technically vorrs) without this.
+             * vzip on 32-bit ARM NEON will overwrite the original register, and I think that Clang
+             * assumes I don't want to destroy it and tries to make a copy. This slows down the code
+             * a lot.
+             * aarch64 not only uses an entirely different syntax, but it requires three
+             * instructions...
+             *    ext    v1.16B, v0.16B, #8    // select high bits because aarch64 can't address them directly
+             *    zip1   v3.2s, v0.2s, v1.2s   // first zip
+             *    zip2   v2.2s, v0.2s, v1.2s   // second zip
+             * ...to do what ARM does in one:
+             *    vzip.32 d0, d1               // Interleave high and low bits and overwrite. */
+
+            /* data_vec = xdata[i]; */
+            uint32x4_t const data_vec    = vld1q_u32(xdata + (i * 4));
+            /* key_vec  = xkey[i];  */
+            uint32x4_t const key_vec     = vld1q_u32(xkey  + (i * 4));
+            /* data_key = data_vec ^ key_vec; */
+            uint32x4_t       data_key;
+
+            if (accWidth == XXH3_acc_64bits) {
+                /* Add first to prevent register swaps */
+                /* xacc[i] += data_vec; */
+                xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u32(data_vec));
+            } else {  /* XXH3_acc_128bits */
+                /* xacc[i] += swap(data_vec); */
+                /* can probably be optimized better */
+                uint64x2_t const data64 = vreinterpretq_u64_u32(data_vec);
+                uint64x2_t const swapped= vextq_u64(data64, data64, 1);
+                xacc[i] = vaddq_u64 (xacc[i], swapped);
+            }
+
+            data_key = veorq_u32(data_vec, key_vec);
+
+            /* Here's the magic. We use the quirkiness of vzip to shuffle data_key in place.
+             * shuffle: data_key[0, 1, 2, 3] = data_key[0, 2, 1, 3] */
+            __asm__("vzip.32 %e0, %f0" : "+w" (data_key));
+            /* xacc[i] += (uint64x2_t) data_key[0, 1] * (uint64x2_t) data_key[2, 3]; */
+            xacc[i] = vmlal_u32(xacc[i], vget_low_u32(data_key), vget_high_u32(data_key));
+
+#else
+            /* On aarch64, vshrn/vmovn seems to be equivalent to, if not faster than, the vzip method. */
+
+            /* data_vec = xdata[i]; */
+            uint32x4_t const data_vec    = vld1q_u32(xdata + (i * 4));
+            /* key_vec  = xkey[i];  */
+            uint32x4_t const key_vec     = vld1q_u32(xkey  + (i * 4));
+            /* data_key = data_vec ^ key_vec; */
+            uint32x4_t const data_key    = veorq_u32(data_vec, key_vec);
+            /* data_key_lo = (uint32x2_t) (data_key & 0xFFFFFFFF); */
+            uint32x2_t const data_key_lo = vmovn_u64  (vreinterpretq_u64_u32(data_key));
+            /* data_key_hi = (uint32x2_t) (data_key >> 32); */
+            uint32x2_t const data_key_hi = vshrn_n_u64 (vreinterpretq_u64_u32(data_key), 32);
+            if (accWidth == XXH3_acc_64bits) {
+                /* xacc[i] += data_vec; */
+                xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u32(data_vec));
+            } else {  /* XXH3_acc_128bits */
+                /* xacc[i] += swap(data_vec); */
+                uint64x2_t const data64 = vreinterpretq_u64_u32(data_vec);
+                uint64x2_t const swapped= vextq_u64(data64, data64, 1);
+                xacc[i] = vaddq_u64 (xacc[i], swapped);
+            }
+            /* xacc[i] += (uint64x2_t) data_key_lo * (uint64x2_t) data_key_hi; */
+            xacc[i] = vmlal_u32 (xacc[i], data_key_lo, data_key_hi);
+
+#endif
+        }
+    }
+
+#elif (XXH_VECTOR == XXH_VSX) && 0   /* <=========================== DISABLED : MUST BE VALIDATED */
+    /* note : vsx code path currently not tested in CI (limitation of cross-compiler and/or emulator)
+     *        for vsx code path to be shipped and supported, it is critical to create a CI test for it */
+          U64x2* const xacc =        (U64x2*) acc;    /* presumed aligned */
+    U64x2 const* const xdata = (U64x2 const*) data;   /* no alignment restriction */
+    U64x2 const* const xkey  = (U64x2 const*) key;    /* no alignment restriction */
+    U64x2 const v32 = { 32,  32 };
+
+    size_t i;
+    for (i = 0; i < STRIPE_LEN / sizeof(U64x2); i++) {
+        /* data_vec = xdata[i]; */
+        /* key_vec = xkey[i]; */
+#ifdef __BIG_ENDIAN__
+        /* byteswap */
+        U64x2 const data_vec = vec_revb(vec_vsx_ld(0, xdata + i));  /* note : vec_revb is power9+ */
+        U64x2 const key_vec = vec_revb(vec_vsx_ld(0, xkey + i));    /* note : vec_revb is power9+ */
+#else
+        U64x2 const data_vec = vec_vsx_ld(0, xdata + i);
+        U64x2 const key_vec = vec_vsx_ld(0, xkey + i);
+#endif
+        U64x2 const data_key = data_vec ^ key_vec;
+        /* shuffled = (data_key << 32) | (data_key >> 32); */
+        U32x4 const shuffled = (U32x4)vec_rl(data_key, v32);
+        /* product = ((U64x2)data_key & 0xFFFFFFFF) * ((U64x2)shuffled & 0xFFFFFFFF); */
+        U64x2 const product = XXH_vsxMultOdd((U32x4)data_key, shuffled);
+
+        xacc[i] += product;
+
+        if (accWidth == XXH3_acc_64bits) {
+            xacc[i] += data_vec;
+        } else {  /* XXH3_acc_128bits */
+            U64x2 const data_swapped = vec_permi(data_vec, data_vec, 2);   /* <===== untested !!! */
+            xacc[i] += data_swapped;
+        }
+    }
+
+#else   /* scalar variant of Accumulator - universal */
+
+    XXH_ALIGN(XXH_ACC_ALIGN) U64* const xacc = (U64*) acc;    /* presumed aligned on 32-bytes boundaries, little hint for the auto-vectorizer */
+    const char* const xdata = (const char*) data;  /* no alignment restriction */
+    const char* const xkey  = (const char*) key;   /* no alignment restriction */
+    size_t i;
+    XXH_ASSERT(((size_t)acc & (XXH_ACC_ALIGN-1)) == 0);
+    for (i=0; i < ACC_NB; i+=2) {
+        U64 const in1 = XXH_readLE64(xdata + 8*i);
+        U64 const in2 = XXH_readLE64(xdata + 8*(i+1));
+        U64 const key1  = XXH_readLE64(xkey + 8*i);
+        U64 const key2  = XXH_readLE64(xkey + 8*(i+1));
+        U64 const data_key1 = key1 ^ in1;
+        U64 const data_key2 = key2 ^ in2;
+        xacc[i]   += XXH_mult32to64(data_key1 & 0xFFFFFFFF, data_key1 >> 32);
+        xacc[i+1] += XXH_mult32to64(data_key2 & 0xFFFFFFFF, data_key2 >> 32);
+        if (accWidth == XXH3_acc_128bits) {
+            xacc[i]   += in2;
+            xacc[i+1] += in1;
+        } else {  /* XXH3_acc_64bits */
+            xacc[i]   += in1;
+            xacc[i+1] += in2;
+        }
+    }
+#endif
+}
+
+XXH_FORCE_INLINE void
+XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT key)
+{
+#if (XXH_VECTOR == XXH_AVX2)
+
+    XXH_ASSERT((((size_t)acc) & 31) == 0);
+    {   XXH_ALIGN(32) __m256i* const xacc = (__m256i*) acc;
+        const         __m256i* const xkey = (const __m256i *) key;   /* not really aligned, just for ptr arithmetic, and because _mm256_loadu_si256() requires this argument type */
+        const __m256i prime32 = _mm256_set1_epi32((int)PRIME32_1);
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
+            __m256i data = xacc[i];
+            __m256i const shifted = _mm256_srli_epi64(data, 47);
+            data = _mm256_xor_si256(data, shifted);
+
+            {   __m256i const k   = _mm256_loadu_si256 (xkey+i);
+                __m256i const dk  = _mm256_xor_si256   (data, k);
+
+                __m256i const dk1 = _mm256_mul_epu32 (dk, prime32);
+
+                __m256i const d2  = _mm256_shuffle_epi32 (dk, 0x31);
+                __m256i const dk2 = _mm256_mul_epu32 (d2, prime32);
+                __m256i const dk2h= _mm256_slli_epi64 (dk2, 32);
+
+                xacc[i] = _mm256_add_epi64(dk1, dk2h);
+        }   }
+    }
+
+#elif (XXH_VECTOR == XXH_SSE2)
+
+    {   XXH_ALIGN(16) __m128i* const xacc = (__m128i*) acc;
+        const         __m128i* const xkey = (const __m128i *) key;   /* not really aligned, just for ptr arithmetic */
+        const __m128i prime32 = _mm_set1_epi32((int)PRIME32_1);
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
+            __m128i data = xacc[i];
+            __m128i const shifted = _mm_srli_epi64(data, 47);
+            data = _mm_xor_si128(data, shifted);
+
+            {   __m128i const k   = _mm_loadu_si128 (xkey+i);
+                __m128i const dk  = _mm_xor_si128   (data,k);
+
+                __m128i const dk1 = _mm_mul_epu32 (dk, prime32);
+
+                __m128i const d2  = _mm_shuffle_epi32 (dk, 0x31);
+                __m128i const dk2 = _mm_mul_epu32 (d2, prime32);
+                __m128i const dk2h= _mm_slli_epi64(dk2, 32);
+
+                xacc[i] = _mm_add_epi64(dk1, dk2h);
+        }   }
+    }
+
+#elif (XXH_VECTOR == XXH_NEON)
+
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+
+    {   uint64x2_t* const xacc =     (uint64x2_t*) acc;
+        uint32_t const* const xkey = (uint32_t const*) key;
+        uint32x2_t const prime     = vdup_n_u32 (PRIME32_1);
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(uint64x2_t); i++) {
+            /* data_vec = xacc[i] ^ (xacc[i] >> 47); */
+            uint64x2_t const   acc_vec  = xacc[i];
+            uint64x2_t const   shifted  = vshrq_n_u64 (acc_vec, 47);
+            uint64x2_t const   data_vec = veorq_u64   (acc_vec, shifted);
+
+            /* key_vec  = xkey[i]; */
+            uint32x4_t const   key_vec  = vld1q_u32   (xkey + (i * 4));
+            /* data_key = data_vec ^ key_vec; */
+            uint32x4_t const   data_key = veorq_u32   (vreinterpretq_u32_u64(data_vec), key_vec);
+            /* shuffled = { data_key[0, 2], data_key[1, 3] }; */
+            uint32x2x2_t const shuffled = vzip_u32    (vget_low_u32(data_key), vget_high_u32(data_key));
+
+            /* data_key *= PRIME32_1 */
+
+            /* prod_hi = (data_key >> 32) * PRIME32_1; */
+            uint64x2_t const   prod_hi = vmull_u32    (shuffled.val[1], prime);
+            /* xacc[i] = prod_hi << 32; */
+            xacc[i] = vshlq_n_u64(prod_hi, 32);
+            /* xacc[i] += (prod_hi & 0xFFFFFFFF) * PRIME32_1; */
+            xacc[i] = vmlal_u32(xacc[i], shuffled.val[0], prime);
+    }   }
+
+#elif (XXH_VECTOR == XXH_VSX)
+
+          U64x2* const xacc =       (U64x2*) acc;
+    const U64x2* const xkey = (const U64x2*) key;
+    /* constants */
+    U64x2 const v32  = { 32, 32 };
+    U64x2 const v47 = { 47, 47 };
+    U32x4 const prime = { PRIME32_1, PRIME32_1, PRIME32_1, PRIME32_1 };
+    size_t i;
+
+    for (i = 0; i < STRIPE_LEN / sizeof(U64x2); i++) {
+        U64x2 const acc_vec  = xacc[i];
+        U64x2 const data_vec = acc_vec ^ (acc_vec >> v47);
+        /* key_vec = xkey[i]; */
+#ifdef __BIG_ENDIAN__
+        /* swap 32-bit words */
+        U64x2 const key_vec  = vec_rl(vec_vsx_ld(0, xkey + i), v32);
+#else
+        U64x2 const key_vec  = vec_vsx_ld(0, xkey + i);
+#endif
+        U64x2 const data_key = data_vec ^ key_vec;
+
+        /* data_key *= PRIME32_1 */
+
+        /* prod_lo = ((U64x2)data_key & 0xFFFFFFFF) * ((U64x2)prime & 0xFFFFFFFF);  */
+        U64x2 const prod_lo  = XXH_vsxMultOdd((U32x4)data_key, prime);
+        /* prod_hi = ((U64x2)data_key >> 32) * ((U64x2)prime >> 32);  */
+        U64x2 const prod_hi  = XXH_vsxMultEven((U32x4)data_key, prime);
+        xacc[i] = prod_lo + (prod_hi << v32);
+    }
+
+#else   /* scalar variant of Scrambler - universal */
+
+    XXH_ALIGN(XXH_ACC_ALIGN) U64* const xacc = (U64*) acc;   /* presumed aligned on 32-bytes boundaries, little hint for the auto-vectorizer */
+    const char* const xkey = (const char*) key;   /* no alignment restriction */
+    int i;
+    XXH_ASSERT((((size_t)acc) & (XXH_ACC_ALIGN-1)) == 0);
+
+    for (i=0; i < (int)ACC_NB; i++) {
+        U64 const key64 = XXH_readLE64(xkey + 8*i);
+        U64 acc64 = xacc[i];
+        acc64 ^= acc64 >> 47;
+        acc64 ^= key64;
+        acc64 *= PRIME32_1;
+        xacc[i] = acc64;
+    }
+
+#endif
+}
+
+/* assumption : nbStripes will not overflow secret size */
+XXH_FORCE_INLINE void
+XXH3_accumulate(       U64* XXH_RESTRICT acc,
+                const void* XXH_RESTRICT data,
+                const void* XXH_RESTRICT secret,
+                      size_t nbStripes,
+                      XXH3_accWidth_e accWidth)
+{
+    size_t n;
+    /* Clang doesn't unroll this loop without the pragma. Unrolling can be up to 1.4x faster.
+     * The unroll statement seems detrimental for WASM (@aras-p) and ARM though.
+     */
+#if defined(__clang__) && !defined(__OPTIMIZE_SIZE__) && !defined(__ARM_ARCH) && !defined(__EMSCRIPTEN__)
+#  pragma clang loop unroll(enable)
+#endif
+
+    for (n = 0; n < nbStripes; n++ ) {
+        XXH3_accumulate_512(acc,
+               (const char*)data   + n*STRIPE_LEN,
+               (const char*)secret + n*XXH_SECRET_CONSUME_RATE,
+                            accWidth);
+    }
+}
+
+/* note : clang auto-vectorizes well in SS2 mode _if_ this function is `static`,
+ *        and doesn't auto-vectorize it at all if it is `FORCE_INLINE`.
+ *        However, it auto-vectorizes better AVX2 if it is `FORCE_INLINE`
+ *        Pretty much every other modes and compilers prefer `FORCE_INLINE`.
+ */
+#if defined(__clang__) && (XXH_VECTOR==0) && !defined(__AVX2__)
+static void
+#else
+XXH_FORCE_INLINE void
+#endif
+XXH3_hashLong_internal_loop( U64* XXH_RESTRICT acc,
+                      const void* XXH_RESTRICT data, size_t len,
+                      const void* XXH_RESTRICT secret, size_t secretSize,
+                            XXH3_accWidth_e accWidth)
+{
+    size_t const nb_rounds = (secretSize - STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
+    size_t const block_len = STRIPE_LEN * nb_rounds;
+    size_t const nb_blocks = len / block_len;
+
+    size_t n;
+
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+
+    for (n = 0; n < nb_blocks; n++) {
+        XXH3_accumulate(acc, (const char*)data + n*block_len, secret, nb_rounds, accWidth);
+        XXH3_scrambleAcc(acc, (const char*)secret + secretSize - STRIPE_LEN);
+    }
+
+    /* last partial block */
+    XXH_ASSERT(len > STRIPE_LEN);
+    {   size_t const nbStripes = (len - (block_len * nb_blocks)) / STRIPE_LEN;
+        XXH_ASSERT(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE));
+        XXH3_accumulate(acc, (const char*)data + nb_blocks*block_len, secret, nbStripes, accWidth);
+
+        /* last stripe */
+        if (len & (STRIPE_LEN - 1)) {
+            const void* const p = (const char*)data + len - STRIPE_LEN;
+#define XXH_SECRET_LASTACC_START 7  /* do not align on 8, so that secret is different from scrambler */
+            XXH3_accumulate_512(acc, p, (const char*)secret + secretSize - STRIPE_LEN - XXH_SECRET_LASTACC_START, accWidth);
+    }   }
+}
+
+XXH_FORCE_INLINE U64
+XXH3_mix2Accs(const U64* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    const U64* const key64 = (const U64*)secret;
+    return XXH3_mul128_fold64(
+               acc[0] ^ XXH_readLE64(key64),
+               acc[1] ^ XXH_readLE64(key64+1) );
+}
+
+static XXH64_hash_t
+XXH3_mergeAccs(const U64* XXH_RESTRICT acc, const void* XXH_RESTRICT secret, U64 start)
+{
+    U64 result64 = start;
+
+    result64 += XXH3_mix2Accs(acc+0, (const char*)secret +  0);
+    result64 += XXH3_mix2Accs(acc+2, (const char*)secret + 16);
+    result64 += XXH3_mix2Accs(acc+4, (const char*)secret + 32);
+    result64 += XXH3_mix2Accs(acc+6, (const char*)secret + 48);
+
+    return XXH3_avalanche(result64);
+}
+
+#define XXH3_INIT_ACC { PRIME32_3, PRIME64_1, PRIME64_2, PRIME64_3, \
+                        PRIME64_4, PRIME32_2, PRIME64_5, PRIME32_1 };
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_hashLong_internal(const void* XXH_RESTRICT data, size_t len,
+                       const void* XXH_RESTRICT secret, size_t secretSize)
+{
+    XXH_ALIGN(XXH_ACC_ALIGN) U64 acc[ACC_NB] = XXH3_INIT_ACC;
+
+    XXH3_hashLong_internal_loop(acc, data, len, secret, secretSize, XXH3_acc_64bits);
+
+    /* converge into final hash */
+    XXH_STATIC_ASSERT(sizeof(acc) == 64);
+#define XXH_SECRET_MERGEACCS_START 11  /* do not align on 8, so that secret is different from accumulator */
+    XXH_ASSERT(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
+    return XXH3_mergeAccs(acc, (const char*)secret + XXH_SECRET_MERGEACCS_START, (U64)len * PRIME64_1);
+}
+
+
+XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_64b_defaultSecret(const void* XXH_RESTRICT data, size_t len)
+{
+    return XXH3_hashLong_internal(data, len, kSecret, sizeof(kSecret));
+}
+
+XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_64b_withSecret(const void* XXH_RESTRICT data, size_t len,
+                             const void* XXH_RESTRICT secret, size_t secretSize)
+{
+    return XXH3_hashLong_internal(data, len, secret, secretSize);
+}
+
+
+XXH_FORCE_INLINE void XXH_writeLE64(void* dst, U64 v64)
+{
+    if (!XXH_CPU_LITTLE_ENDIAN) v64 = XXH_swap64(v64);
+    memcpy(dst, &v64, sizeof(v64));
+}
+
+/* XXH3_initKeySeed() :
+ * destination `customSecret` is presumed allocated and same size as `kSecret`.
+ */
+XXH_FORCE_INLINE void XXH3_initKeySeed(void* customSecret, U64 seed64)
+{
+          char* const dst = (char*)customSecret;
+    const char* const src = (const char*)kSecret;
+    int const nbRounds = XXH_SECRET_DEFAULT_SIZE / 16;
+    int i;
+
+    XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
+
+    for (i=0; i < nbRounds; i++) {
+        XXH_writeLE64(dst + 16*i,     XXH_readLE64(src + 16*i)     + seed64);
+        XXH_writeLE64(dst + 16*i + 8, XXH_readLE64(src + 16*i + 8) - seed64);
+    }
+}
+
+
+/* XXH3_hashLong_64b_withSeed() :
+ * Generate a custom key,
+ * based on alteration of default kSecret with the seed,
+ * and then use this key for long mode hashing.
+ * This operation is decently fast but nonetheless costs a little bit of time.
+ * Try to avoid it whenever possible (typically when seed==0).
+ */
+XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_64b_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+{
+    XXH_ALIGN(8) char secret[XXH_SECRET_DEFAULT_SIZE];
+    if (seed==0) return XXH3_hashLong_64b_defaultSecret(data, len);
+    XXH3_initKeySeed(secret, seed);
+    return XXH3_hashLong_internal(data, len, secret, sizeof(secret));
+}
+
+
+XXH_FORCE_INLINE U64 XXH3_mix16B(const void* XXH_RESTRICT data,
+                                 const void* XXH_RESTRICT key, U64 seed64)
+{
+    const U64* const key64 = (const U64*)key;
+    U64 const ll1 = XXH_readLE64(data);
+    U64 const ll2 = XXH_readLE64((const BYTE*)data+8);
+    return XXH3_mul128_fold64(
+               ll1 ^ (XXH_readLE64(key64)   + seed64),
+               ll2 ^ (XXH_readLE64(key64+1) - seed64) );
+}
+
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_len_17to128_64b(const void* XXH_RESTRICT data, size_t len,
+                     const void* XXH_RESTRICT secret, size_t secretSize,
+                     XXH64_hash_t seed)
+{
+    const BYTE* const p = (const BYTE*)data;
+    const char* const key = (const char*)secret;
+
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    XXH_ASSERT(16 < len && len <= 128);
+
+    {   U64 acc = len * PRIME64_1;
+        if (len > 32) {
+            if (len > 64) {
+                if (len > 96) {
+                    acc += XXH3_mix16B(p+48, key+96, seed);
+                    acc += XXH3_mix16B(p+len-64, key+112, seed);
+                }
+                acc += XXH3_mix16B(p+32, key+64, seed);
+                acc += XXH3_mix16B(p+len-48, key+80, seed);
+            }
+            acc += XXH3_mix16B(p+16, key+32, seed);
+            acc += XXH3_mix16B(p+len-32, key+48, seed);
+        }
+        acc += XXH3_mix16B(p+0, key+0, seed);
+        acc += XXH3_mix16B(p+len-16, key+16, seed);
+
+        return XXH3_avalanche(acc);
+    }
+}
+
+#define XXH3_MIDSIZE_MAX 240
+
+XXH_NO_INLINE XXH64_hash_t
+XXH3_len_129to240_64b(const void* XXH_RESTRICT data, size_t len,
+                      const void* XXH_RESTRICT secret, size_t secretSize,
+                      XXH64_hash_t seed)
+{
+    const BYTE* const p = (const BYTE*)data;
+    const char* const key = (const char*)secret;
+
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
+
+    #define XXH3_MIDSIZE_STARTOFFSET 3
+    #define XXH3_MIDSIZE_LASTOFFSET  17
+
+    {   U64 acc = len * PRIME64_1;
+        int const nbRounds = (int)len / 16;
+        int i;
+        for (i=0; i<8; i++) {
+            acc += XXH3_mix16B(p+(16*i), key+(16*i), seed);
+        }
+        acc = XXH3_avalanche(acc);
+        XXH_ASSERT(nbRounds >= 8);
+        for (i=8 ; i < nbRounds; i++) {
+            acc += XXH3_mix16B(p+(16*i), key+(16*(i-8)) + XXH3_MIDSIZE_STARTOFFSET, seed);
+        }
+        /* last bytes */
+        acc += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
+        return XXH3_avalanche(acc);
+    }
+}
+
+/* ===   Public entry point   === */
+
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len)
+{
+    if (len <= 16) return XXH3_len_0to16_64b(data, len, kSecret, 0);
+    if (len <= 128) return XXH3_len_17to128_64b(data, len, kSecret, sizeof(kSecret), 0);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b(data, len, kSecret, sizeof(kSecret), 0);
+    return XXH3_hashLong_64b_defaultSecret(data, len);
+}
+
+XXH_PUBLIC_API XXH64_hash_t
+XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize)
+{
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+    /* if an action must be taken should `secret` conditions not be respected,
+     * it should be done here.
+     * For now, it's a contract pre-condition.
+     * Adding a check and a branch here would cost performance at every hash */
+     if (len <= 16) return XXH3_len_0to16_64b(data, len, secret, 0);
+     if (len <= 128) return XXH3_len_17to128_64b(data, len, secret, secretSize, 0);
+     if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b(data, len, secret, secretSize, 0);
+     return XXH3_hashLong_64b_withSecret(data, len, secret, secretSize);
+}
+
+XXH_PUBLIC_API XXH64_hash_t
+XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+{
+    if (len <= 16) return XXH3_len_0to16_64b(data, len, kSecret, seed);
+    if (len <= 128) return XXH3_len_17to128_64b(data, len, kSecret, sizeof(kSecret), seed);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b(data, len, kSecret, sizeof(kSecret), seed);
+    return XXH3_hashLong_64b_withSeed(data, len, seed);
+}
+
+/* ===   XXH3 streaming   === */
+
+XXH_PUBLIC_API XXH3_state_t* XXH3_createState(void)
+{
+    return (XXH3_state_t*)XXH_malloc(sizeof(XXH3_state_t));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API void
+XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state)
+{
+    memcpy(dst_state, src_state, sizeof(*dst_state));
+}
+
+static void
+XXH3_64bits_reset_internal(XXH3_state_t* statePtr,
+                           XXH64_hash_t seed,
+                           const void* secret, size_t secretSize)
+{
+    XXH_ASSERT(statePtr != NULL);
+    memset(statePtr, 0, sizeof(*statePtr));
+    statePtr->acc[0] = PRIME32_3;
+    statePtr->acc[1] = PRIME64_1;
+    statePtr->acc[2] = PRIME64_2;
+    statePtr->acc[3] = PRIME64_3;
+    statePtr->acc[4] = PRIME64_4;
+    statePtr->acc[5] = PRIME32_2;
+    statePtr->acc[6] = PRIME64_5;
+    statePtr->acc[7] = PRIME32_1;
+    statePtr->seed = seed;
+    XXH_ASSERT(secret != NULL);
+    statePtr->secret = secret;
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+    statePtr->secretLimit = (XXH32_hash_t)(secretSize - STRIPE_LEN);
+    statePtr->nbStripesPerBlock = statePtr->secretLimit / XXH_SECRET_CONSUME_RATE;
+}
+
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_reset(XXH3_state_t* statePtr)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    XXH3_64bits_reset_internal(statePtr, 0, kSecret, XXH_SECRET_DEFAULT_SIZE);
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    XXH3_64bits_reset_internal(statePtr, 0, secret, secretSize);
+    if (secret == NULL) return XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    XXH3_64bits_reset_internal(statePtr, seed, kSecret, XXH_SECRET_DEFAULT_SIZE);
+    XXH3_initKeySeed(statePtr->customSecret, seed);
+    statePtr->secret = statePtr->customSecret;
+    return XXH_OK;
+}
+
+XXH_FORCE_INLINE void
+XXH3_consumeStripes( U64* acc,
+                            XXH32_hash_t* nbStripesSoFarPtr, XXH32_hash_t nbStripesPerBlock,
+                            const void* data, size_t totalStripes,
+                            const void* secret, size_t secretLimit,
+                            XXH3_accWidth_e accWidth)
+{
+    XXH_ASSERT(*nbStripesSoFarPtr < nbStripesPerBlock);
+    if (nbStripesPerBlock - *nbStripesSoFarPtr <= totalStripes) {
+        /* need a scrambling operation */
+        size_t const nbStripes = nbStripesPerBlock - *nbStripesSoFarPtr;
+        XXH3_accumulate(acc, data, (const char*)secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, accWidth);
+        XXH3_scrambleAcc(acc, (const char*)secret + secretLimit);
+        XXH3_accumulate(acc, (const char*)data + nbStripes * STRIPE_LEN, secret, totalStripes - nbStripes, accWidth);
+        *nbStripesSoFarPtr = (XXH32_hash_t)(totalStripes - nbStripes);
+    } else {
+        XXH3_accumulate(acc, data, (const char*)secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, totalStripes, accWidth);
+        *nbStripesSoFarPtr += (XXH32_hash_t)totalStripes;
+    }
+}
+
+XXH_FORCE_INLINE XXH_errorcode
+XXH3_update(XXH3_state_t* state, const void* input, size_t len, XXH3_accWidth_e accWidth)
+{
+    if (input==NULL)
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
+        return XXH_OK;
+#else
+        return XXH_ERROR;
+#endif
+
+    {   const BYTE* p = (const BYTE*)input;
+        const BYTE* const bEnd = p + len;
+
+        state->totalLen += len;
+
+        if (state->bufferedSize + len <= XXH3_INTERNALBUFFER_SIZE) {  /* fill in tmp buffer */
+            XXH_memcpy(state->buffer + state->bufferedSize, input, len);
+            state->bufferedSize += (XXH32_hash_t)len;
+            return XXH_OK;
+        }
+        /* input now > XXH3_INTERNALBUFFER_SIZE */
+
+        #define XXH3_INTERNALBUFFER_STRIPES (XXH3_INTERNALBUFFER_SIZE / STRIPE_LEN)
+        XXH_STATIC_ASSERT(XXH3_INTERNALBUFFER_SIZE % STRIPE_LEN == 0);   /* clean multiple */
+
+        if (state->bufferedSize) {   /* some data within internal buffer: fill then consume it */
+            size_t const loadSize = XXH3_INTERNALBUFFER_SIZE - state->bufferedSize;
+            XXH_memcpy(state->buffer + state->bufferedSize, input, loadSize);
+            p += loadSize;
+            XXH3_consumeStripes(state->acc,
+                               &state->nbStripesSoFar, state->nbStripesPerBlock,
+                                state->buffer, XXH3_INTERNALBUFFER_STRIPES,
+                                state->secret, state->secretLimit,
+                                accWidth);
+            state->bufferedSize = 0;
+        }
+
+        /* consume input by full buffer quantities */
+        if (p+XXH3_INTERNALBUFFER_SIZE <= bEnd) {
+            const BYTE* const limit = bEnd - XXH3_INTERNALBUFFER_SIZE;
+            do {
+                XXH3_consumeStripes(state->acc,
+                                   &state->nbStripesSoFar, state->nbStripesPerBlock,
+                                    p, XXH3_INTERNALBUFFER_STRIPES,
+                                    state->secret, state->secretLimit,
+                                    accWidth);
+                p += XXH3_INTERNALBUFFER_SIZE;
+            } while (p<=limit);
+        }
+
+        if (p < bEnd) { /* some remaining input data : buffer it */
+            XXH_memcpy(state->buffer, p, (size_t)(bEnd-p));
+            state->bufferedSize = (XXH32_hash_t)(bEnd-p);
+        }
+    }
+
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_update(XXH3_state_t* state, const void* input, size_t len)
+{
+    return XXH3_update(state, input, len, XXH3_acc_64bits);
+}
+
+
+XXH_FORCE_INLINE void
+XXH3_digest_long (XXH64_hash_t* acc, const XXH3_state_t* state, XXH3_accWidth_e accWidth)
+{
+    memcpy(acc, state->acc, sizeof(state->acc));  /* digest locally, state remains unaltered, and can continue ingesting more data afterwards */
+    if (state->bufferedSize >= STRIPE_LEN) {
+        size_t const totalNbStripes = state->bufferedSize / STRIPE_LEN;
+        XXH32_hash_t nbStripesSoFar = state->nbStripesSoFar;
+        XXH3_consumeStripes(acc,
+                           &nbStripesSoFar, state->nbStripesPerBlock,
+                            state->buffer, totalNbStripes,
+                            state->secret, state->secretLimit,
+                            accWidth);
+        if (state->bufferedSize % STRIPE_LEN) {  /* one last partial stripe */
+            XXH3_accumulate_512(acc,
+                                state->buffer + state->bufferedSize - STRIPE_LEN,
+                   (const char*)state->secret + state->secretLimit - XXH_SECRET_LASTACC_START,
+                                accWidth);
+        }
+    } else {  /* bufferedSize < STRIPE_LEN */
+        if (state->bufferedSize) { /* one last stripe */
+            char lastStripe[STRIPE_LEN];
+            size_t const catchupSize = STRIPE_LEN - state->bufferedSize;
+            memcpy(lastStripe, (const char*)state->buffer + sizeof(state->buffer) - catchupSize, catchupSize);
+            memcpy(lastStripe + catchupSize, state->buffer, state->bufferedSize);
+            XXH3_accumulate_512(acc,
+                                lastStripe,
+                   (const char*)state->secret + state->secretLimit - XXH_SECRET_LASTACC_START,
+                                accWidth);
+    }   }
+}
+
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_digest (const XXH3_state_t* state)
+{
+    if (state->totalLen > XXH3_MIDSIZE_MAX) {
+        XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[ACC_NB];
+        XXH3_digest_long(acc, state, XXH3_acc_64bits);
+        return XXH3_mergeAccs(acc, (const char*)state->secret + XXH_SECRET_MERGEACCS_START, (U64)state->totalLen * PRIME64_1);
+    }
+    /* len <= XXH3_MIDSIZE_MAX : short code */
+    if (state->seed)
+        return XXH3_64bits_withSeed(state->buffer, (size_t)state->totalLen, state->seed);
+    return XXH3_64bits_withSecret(state->buffer, (size_t)(state->totalLen), state->secret, state->secretLimit + STRIPE_LEN);
+}
+
+/* ==========================================
+ * XXH3 128 bits (=> XXH128)
+ * ========================================== */
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_len_1to3_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+{
+    XXH_ASSERT(data != NULL);
+    XXH_ASSERT(1 <= len && len <= 3);
+    XXH_ASSERT(keyPtr != NULL);
+    {   const U32* const key32 = (const U32*) keyPtr;
+        BYTE const c1 = ((const BYTE*)data)[0];
+        BYTE const c2 = ((const BYTE*)data)[len >> 1];
+        BYTE const c3 = ((const BYTE*)data)[len - 1];
+        U32  const combinedl = ((U32)c1) + (((U32)c2) << 8) + (((U32)c3) << 16) + (((U32)len) << 24);
+        U32  const combinedh = XXH_swap32(combinedl);
+        U64  const keyedl = (U64)combinedl ^ (XXH_readLE32(key32)   + seed);
+        U64  const keyedh = (U64)combinedh ^ (XXH_readLE32(key32+1) - seed);
+        U64  const mixedl = keyedl * PRIME64_1;
+        U64  const mixedh = keyedh * PRIME64_2;
+        XXH128_hash_t const h128 = { XXH3_avalanche(mixedl) /*low64*/, XXH3_avalanche(mixedh) /*high64*/ };
+        return h128;
+    }
+}
+
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_len_4to8_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+{
+    XXH_ASSERT(data != NULL);
+    XXH_ASSERT(keyPtr != NULL);
+    XXH_ASSERT(4 <= len && len <= 8);
+    {   U32 const in1 = XXH_readLE32(data);
+        U32 const in2 = XXH_readLE32((const BYTE*)data + len - 4);
+        U64 const in64l = in1 + ((U64)in2 << 32);
+        U64 const in64h = XXH_swap64(in64l);
+        U64 const keyedl = in64l ^ (XXH_readLE64(keyPtr) + seed);
+        U64 const keyedh = in64h ^ (XXH_readLE64((const char*)keyPtr + 8) - seed);
+        U64 const mix64l1 = len + ((keyedl ^ (keyedl >> 51)) * PRIME32_1);
+        U64 const mix64l2 = (mix64l1 ^ (mix64l1 >> 47)) * PRIME64_2;
+        U64 const mix64h1 = ((keyedh ^ (keyedh >> 47)) * PRIME64_1) - len;
+        U64 const mix64h2 = (mix64h1 ^ (mix64h1 >> 43)) * PRIME64_4;
+        {   XXH128_hash_t const h128 = { XXH3_avalanche(mix64l2) /*low64*/, XXH3_avalanche(mix64h2) /*high64*/ };
+            return h128;
+    }   }
+}
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_len_9to16_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+{
+    XXH_ASSERT(data != NULL);
+    XXH_ASSERT(keyPtr != NULL);
+    XXH_ASSERT(9 <= len && len <= 16);
+    {   const U64* const key64 = (const U64*) keyPtr;
+        U64 const ll1 = XXH_readLE64(data) ^ (XXH_readLE64(key64) + seed);
+        U64 const ll2 = XXH_readLE64((const BYTE*)data + len - 8) ^ (XXH_readLE64(key64+1) - seed);
+        U64 const inlow = ll1 ^ ll2;
+        XXH128_hash_t m128 = XXH3_mul128(inlow, PRIME64_1);
+        m128.high64 += ll2 * PRIME64_1;
+        m128.low64  ^= (m128.high64 >> 32);
+        {   XXH128_hash_t h128 = XXH3_mul128(m128.low64, PRIME64_2);
+            h128.high64 += m128.high64 * PRIME64_2;
+            h128.low64   = XXH3_avalanche(h128.low64);
+            h128.high64  = XXH3_avalanche(h128.high64);
+            return h128;
+    }   }
+}
+
+/* Assumption : `secret` size is >= 16
+ * Note : it should be >= XXH3_SECRET_SIZE_MIN anyway */
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_len_0to16_128b(const void* data, size_t len, const void* secret, XXH64_hash_t seed)
+{
+    XXH_ASSERT(len <= 16);
+    {   if (len > 8) return XXH3_len_9to16_128b(data, len, secret, seed);
+        if (len >= 4) return XXH3_len_4to8_128b(data, len, secret, seed);
+        if (len) return XXH3_len_1to3_128b(data, len, secret, seed);
+        {   XXH128_hash_t const h128 = { 0, 0 };
+            return h128;
+    }   }
+}
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_hashLong_128b_internal(const void* XXH_RESTRICT data, size_t len,
+                            const void* XXH_RESTRICT secret, size_t secretSize)
+{
+    XXH_ALIGN(XXH_ACC_ALIGN) U64 acc[ACC_NB] = XXH3_INIT_ACC;
+
+    XXH3_hashLong_internal_loop(acc, data, len, secret, secretSize, XXH3_acc_128bits);
+
+    /* converge into final hash */
+    XXH_STATIC_ASSERT(sizeof(acc) == 64);
+    XXH_ASSERT(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
+    {   U64 const low64 = XXH3_mergeAccs(acc, (const char*)secret + XXH_SECRET_MERGEACCS_START, (U64)len * PRIME64_1);
+        U64 const high64 = XXH3_mergeAccs(acc, (const char*)secret + secretSize - sizeof(acc) - XXH_SECRET_MERGEACCS_START, ~((U64)len * PRIME64_2));
+        XXH128_hash_t const h128 = { low64, high64 };
+        return h128;
+    }
+}
+
+XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_128b_defaultSecret(const void* data, size_t len)
+{
+    return XXH3_hashLong_128b_internal(data, len, kSecret, sizeof(kSecret));
+}
+
+XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_128b_withSecret(const void* data, size_t len,
+                              const void* secret, size_t secretSize)
+{
+    return XXH3_hashLong_128b_internal(data, len, secret, secretSize);
+}
+
+XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_128b_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+{
+    XXH_ALIGN(8) char secret[XXH_SECRET_DEFAULT_SIZE];
+    if (seed == 0) return XXH3_hashLong_128b_defaultSecret(data, len);
+    XXH3_initKeySeed(secret, seed);
+    return XXH3_hashLong_128b_internal(data, len, secret, sizeof(secret));
+}
+
+XXH_NO_INLINE XXH128_hash_t
+XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
+                      const void* XXH_RESTRICT secret, size_t secretSize,
+                      XXH64_hash_t seed)
+{
+    const BYTE* const p = (const BYTE*)data;
+    const char* const key = (const char*)secret;
+
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
+
+    {   U64 acc1 = len * PRIME64_1;
+        U64 acc2 = 0;
+        int const nbRounds = (int)len / 32;
+        int i;
+        for (i=0; i<4; i++) {
+            acc1 += XXH3_mix16B(p+(32*i),    key+(32*i),     seed);
+            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*i)+16, -seed);
+        }
+        acc1 = XXH3_avalanche(acc1);
+        acc2 = XXH3_avalanche(acc2);
+        XXH_ASSERT(nbRounds >= 4);
+        for (i=4 ; i < nbRounds; i++) {
+            acc1 += XXH3_mix16B(p+(32*i)   , key+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,  seed);
+            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, -seed);
+        }
+        /* last bytes */
+        acc1 += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,  seed);
+        acc2 += XXH3_mix16B(p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, -seed);
+
+        {   U64 const low64 = acc1 + acc2;
+            U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
+            XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
+            return h128;
+        }
+    }
+}
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_len_17to128_128b(const void* XXH_RESTRICT data, size_t len,
+                     const void* XXH_RESTRICT secret, size_t secretSize,
+                     XXH64_hash_t seed)
+{
+    const BYTE* const p = (const BYTE*)data;
+    const char* const key = (const char*)secret;
+
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    XXH_ASSERT(16 < len && len <= 128);
+
+    {   U64 acc1 = len * PRIME64_1;
+        U64 acc2 = 0;
+        if (len > 32) {
+            if (len > 64) {
+                if (len > 96) {
+                    acc1 += XXH3_mix16B(p+48, key+96, seed);
+                    acc2 += XXH3_mix16B(p+len-64, key+112, seed);
+                }
+                acc1 += XXH3_mix16B(p+32, key+64, seed);
+                acc2 += XXH3_mix16B(p+len-48, key+80, seed);
+            }
+            acc1 += XXH3_mix16B(p+16, key+32, seed);
+            acc2 += XXH3_mix16B(p+len-32, key+48, seed);
+        }
+        acc1 += XXH3_mix16B(p+0, key+0, seed);
+        acc2 += XXH3_mix16B(p+len-16, key+16, seed);
+
+        {   U64 const low64 = acc1 + acc2;
+            U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
+            XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
+            return h128;
+        }
+    }
+}
+
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len)
+{
+    if (len <= 16) return XXH3_len_0to16_128b(data, len, kSecret, 0);
+    if (len <= 128) return XXH3_len_17to128_128b(data, len, kSecret, sizeof(kSecret), 0);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b(data, len, kSecret, sizeof(kSecret), 0);
+    return XXH3_hashLong_128b_defaultSecret(data, len);
+}
+
+XXH_PUBLIC_API XXH128_hash_t
+XXH3_128bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize)
+{
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+    /* if an action must be taken should `secret` conditions not be respected,
+     * it should be done here.
+     * For now, it's a contract pre-condition.
+     * Adding a check and a branch here would cost performance at every hash */
+     if (len <= 16) return XXH3_len_0to16_128b(data, len, secret, 0);
+     if (len <= 128) return XXH3_len_17to128_128b(data, len, secret, secretSize, 0);
+     if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b(data, len, secret, secretSize, 0);
+     return XXH3_hashLong_128b_withSecret(data, len, secret, secretSize);
+}
+
+XXH_PUBLIC_API XXH128_hash_t
+XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+{
+    if (len <= 16) return XXH3_len_0to16_128b(data, len, kSecret, seed);
+    if (len <= 128) return XXH3_len_17to128_128b(data, len, kSecret, sizeof(kSecret), seed);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b(data, len, kSecret, sizeof(kSecret), seed);
+    return XXH3_hashLong_128b_withSeed(data, len, seed);
+}
+
+XXH_PUBLIC_API XXH128_hash_t
+XXH128(const void* data, size_t len, XXH64_hash_t seed)
+{
+    return XXH3_128bits_withSeed(data, len, seed);
+}
+
+
+/* ===   XXH3 128-bit streaming   === */
+
+/* all the functions are actually the same as for 64-bit streaming variant,
+   just the reset one is different (different initial acc values for 0,5,6,7),
+   and near the end of the digest function */
+
+static void
+XXH3_128bits_reset_internal(XXH3_state_t* statePtr,
+                           XXH64_hash_t seed,
+                           const void* secret, size_t secretSize)
+{
+    XXH3_64bits_reset_internal(statePtr, seed, secret, secretSize);
+}
+
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_reset(XXH3_state_t* statePtr)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    XXH3_128bits_reset_internal(statePtr, 0, kSecret, XXH_SECRET_DEFAULT_SIZE);
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    XXH3_128bits_reset_internal(statePtr, 0, secret, secretSize);
+    if (secret == NULL) return XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    XXH3_128bits_reset_internal(statePtr, seed, kSecret, XXH_SECRET_DEFAULT_SIZE);
+    XXH3_initKeySeed(statePtr->customSecret, seed);
+    statePtr->secret = statePtr->customSecret;
+    return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len)
+{
+    return XXH3_update(state, input, len, XXH3_acc_128bits);
+}
+
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
+{
+    if (state->totalLen > XXH3_MIDSIZE_MAX) {
+        XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[ACC_NB];
+        XXH3_digest_long(acc, state, XXH3_acc_128bits);
+        XXH_ASSERT(state->secretLimit + STRIPE_LEN >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
+        {   U64 const low64 = XXH3_mergeAccs(acc, (const char*)state->secret + XXH_SECRET_MERGEACCS_START, (U64)state->totalLen * PRIME64_1);
+            U64 const high64 = XXH3_mergeAccs(acc, (const char*)state->secret + state->secretLimit + STRIPE_LEN - sizeof(acc) - XXH_SECRET_MERGEACCS_START, ~((U64)state->totalLen * PRIME64_2));
+            XXH128_hash_t const h128 = { low64, high64 };
+            return h128;
+        }
+    }
+    /* len <= XXH3_MIDSIZE_MAX : short code */
+    if (state->seed)
+        return XXH3_128bits_withSeed(state->buffer, (size_t)state->totalLen, state->seed);
+    return XXH3_128bits_withSecret(state->buffer, (size_t)(state->totalLen), state->secret, state->secretLimit + STRIPE_LEN);
+}
+
+/* 128-bit utility functions */
+
+#include <string.h>   /* memcmp */
+
+/* return : 1 is equal, 0 if different */
+XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2)
+{
+    /* note : XXH128_hash_t is compact, it has no padding byte */
+    return !(memcmp(&h1, &h2, sizeof(h1)));
+}
+
+/* This prototype is compatible with stdlib's qsort().
+ * return : >0 if *h128_1  > *h128_2
+ *          <0 if *h128_1  < *h128_2
+ *          =0 if *h128_1 == *h128_2  */
+XXH_PUBLIC_API int XXH128_cmp(const void* h128_1, const void* h128_2)
+{
+    XXH128_hash_t const h1 = *(const XXH128_hash_t*)h128_1;
+    XXH128_hash_t const h2 = *(const XXH128_hash_t*)h128_2;
+    int const hcmp = (h1.high64 > h2.high64) - (h2.high64 > h1.high64);
+    /* note : bets that, in most cases, hash values are different */
+    if (hcmp) return hcmp;
+    return (h1.low64 > h2.low64) - (h2.low64 > h1.low64);
+}
+
+
+/*======   Canonical representation   ======*/
+XXH_PUBLIC_API void
+XXH128_canonicalFromHash(XXH128_canonical_t* dst, XXH128_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH128_canonical_t) == sizeof(XXH128_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) {
+        hash.high64 = XXH_swap64(hash.high64);
+        hash.low64  = XXH_swap64(hash.low64);
+    }
+    memcpy(dst, &hash.high64, sizeof(hash.high64));
+    memcpy((char*)dst + sizeof(hash.high64), &hash.low64, sizeof(hash.low64));
+}
+
+XXH_PUBLIC_API XXH128_hash_t
+XXH128_hashFromCanonical(const XXH128_canonical_t* src)
+{
+    XXH128_hash_t h;
+    h.high64 = XXH_readBE64(src);
+    h.low64  = XXH_readBE64(src->digest + 8);
+    return h;
+}
+
+
+
+#endif  /* XXH3_H */

--- a/oap-native-sql/cpp/src/third_party/arrow/vendored/xxhash/xxhash.c
+++ b/oap-native-sql/cpp/src/third_party/arrow/vendored/xxhash/xxhash.c
@@ -1,0 +1,1155 @@
+/*
+ *  xxHash - Fast Hash algorithm
+ *  Copyright (C) 2012-2016, Yann Collet
+ *
+ *  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *  copyright notice, this list of conditions and the following disclaimer
+ *  in the documentation and/or other materials provided with the
+ *  distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  You can contact the author at :
+ *  - xxHash homepage: http://www.xxhash.com
+ *  - xxHash source repository : https://github.com/Cyan4973/xxHash
+ */
+
+/* *************************************
+ *  Tuning parameters
+ ***************************************/
+/*!XXH_FORCE_MEMORY_ACCESS :
+ * By default, access to unaligned memory is controlled by `memcpy()`, which is safe and
+ * portable. Unfortunately, on some target/compiler combinations, the generated assembly
+ * is sub-optimal. The below switch allow to select different access method for improved
+ * performance. Method 0 (default) : use `memcpy()`. Safe and portable. Method 1 :
+ * `__packed` statement. It depends on compiler extension (ie, not portable). This method
+ * is safe if your compiler supports it, and *generally* as fast or faster than `memcpy`.
+ * Method 2 : direct access. This method doesn't depend on compiler but violate C
+ * standard. It can generate buggy code on targets which do not support unaligned memory
+ * accesses. But in some circumstances, it's the only known way to get the most
+ * performance (ie GCC + ARMv6) See http://stackoverflow.com/a/32095106/646947 for
+ * details. Prefer these methods in priority order (0 > 1 > 2)
+ */
+#ifndef XXH_FORCE_MEMORY_ACCESS /* can be defined externally, on command line for \
+                                   example */
+#if defined(__GNUC__) &&                                                                \
+    (defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || \
+     defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__))
+#define XXH_FORCE_MEMORY_ACCESS 2
+#elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) ||                                 \
+    (defined(__GNUC__) &&                                                                \
+     (defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || \
+      defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__)))
+#define XXH_FORCE_MEMORY_ACCESS 1
+#endif
+#endif
+
+/*!XXH_ACCEPT_NULL_INPUT_POINTER :
+ * If input pointer is NULL, xxHash default behavior is to dereference it, triggering a
+ * segfault. When this macro is enabled, xxHash actively checks input for null pointer. It
+ * it is, result for null input pointers is the same as a null-length input.
+ */
+#ifndef XXH_ACCEPT_NULL_INPUT_POINTER /* can be defined externally */
+#define XXH_ACCEPT_NULL_INPUT_POINTER 0
+#endif
+
+/*!XXH_FORCE_ALIGN_CHECK :
+ * This is a minor performance trick, only useful with lots of very small keys.
+ * It means : check for aligned/unaligned input.
+ * The check costs one initial branch per hash;
+ * set it to 0 when the input is guaranteed to be aligned,
+ * or when alignment doesn't matter for performance.
+ */
+#ifndef XXH_FORCE_ALIGN_CHECK /* can be defined externally */
+#if defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
+#define XXH_FORCE_ALIGN_CHECK 0
+#else
+#define XXH_FORCE_ALIGN_CHECK 1
+#endif
+#endif
+
+/*!XXH_REROLL:
+ * Whether to reroll XXH32_finalize, and XXH64_finalize,
+ * instead of using an unrolled jump table/if statement loop.
+ *
+ * This is automatically defined on -Os/-Oz on GCC and Clang. */
+#ifndef XXH_REROLL
+#if defined(__OPTIMIZE_SIZE__)
+#define XXH_REROLL 1
+#else
+#define XXH_REROLL 0
+#endif
+#endif
+
+/* *************************************
+ *  Includes & Memory related functions
+ ***************************************/
+/*! Modify the local functions below should you wish to use some other memory routines
+ *   for malloc(), free() */
+#include <stdlib.h>
+static void* XXH_malloc(size_t s) { return malloc(s); }
+static void XXH_free(void* p) { free(p); }
+/*! and for memcpy() */
+#include <string.h>
+static void* XXH_memcpy(void* dest, const void* src, size_t size) {
+  return memcpy(dest, src, size);
+}
+
+#include <limits.h> /* ULLONG_MAX */
+
+#define XXH_STATIC_LINKING_ONLY
+#include "xxhash.h"
+
+/* *************************************
+ *  Compiler Specific Options
+ ***************************************/
+#ifdef _MSC_VER                 /* Visual Studio */
+#pragma warning(disable : 4127) /* disable: C4127: conditional expression is constant */
+#define XXH_FORCE_INLINE static __forceinline
+#define XXH_NO_INLINE static __declspec(noinline)
+#else
+#if defined(__cplusplus) || \
+    defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L /* C99 */
+#ifdef __GNUC__
+#define XXH_FORCE_INLINE static inline __attribute__((always_inline))
+#define XXH_NO_INLINE static __attribute__((noinline))
+#else
+#define XXH_FORCE_INLINE static inline
+#define XXH_NO_INLINE static
+#endif
+#else
+#define XXH_FORCE_INLINE static
+#define XXH_NO_INLINE static
+#endif /* __STDC_VERSION__ */
+#endif
+
+/* *************************************
+ *  Debug
+ ***************************************/
+/* DEBUGLEVEL is expected to be defined externally,
+ * typically through compiler command line.
+ * Value must be a number. */
+#ifndef DEBUGLEVEL
+#define DEBUGLEVEL 0
+#endif
+
+#if (DEBUGLEVEL >= 1)
+#include <assert.h> /* note : can still be disabled with NDEBUG */
+#define XXH_ASSERT(c) assert(c)
+#else
+#define XXH_ASSERT(c) ((void)0)
+#endif
+
+/* note : use after variable declarations */
+#define XXH_STATIC_ASSERT(c)            \
+  {                                     \
+    enum { XXH_sa = 1 / (int)(!!(c)) }; \
+  }
+
+/* *************************************
+ *  Basic Types
+ ***************************************/
+#ifndef MEM_MODULE
+#if !defined(__VMS) &&       \
+    (defined(__cplusplus) || \
+     (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */))
+#include <stdint.h>
+typedef uint8_t BYTE;
+typedef uint16_t U16;
+typedef uint32_t U32;
+#else
+typedef unsigned char BYTE;
+typedef unsigned short U16;
+typedef unsigned int U32;
+#endif
+#endif
+
+/* ===   Memory access   === */
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS == 2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in
+ * hardware */
+static U32 XXH_read32(const void* memPtr) { return *(const U32*)memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS == 1))
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for
+ * some compilers */
+/* currently only defined for gcc and icc */
+typedef union {
+  U32 u32;
+} __attribute__((packed)) unalign;
+static U32 XXH_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
+
+#else
+
+/* portable and safe solution. Generally efficient.
+ * see : http://stackoverflow.com/a/32095106/646947
+ */
+static U32 XXH_read32(const void* memPtr) {
+  U32 val;
+  memcpy(&val, memPtr, sizeof(val));
+  return val;
+}
+
+#endif /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+/* ===   Endianess   === */
+typedef enum { XXH_bigEndian = 0, XXH_littleEndian = 1 } XXH_endianess;
+
+/* XXH_CPU_LITTLE_ENDIAN can be defined externally, for example on the compiler command
+ * line */
+#ifndef XXH_CPU_LITTLE_ENDIAN
+static int XXH_isLittleEndian(void) {
+  const union {
+    U32 u;
+    BYTE c[4];
+  } one = {1}; /* don't use static : performance detrimental  */
+  return one.c[0];
+}
+#define XXH_CPU_LITTLE_ENDIAN XXH_isLittleEndian()
+#endif
+
+/* ****************************************
+ *  Compiler-specific Functions and Macros
+ ******************************************/
+#define XXH_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if !defined(NO_CLANG_BUILTIN) && __has_builtin(__builtin_rotateleft32) && \
+    __has_builtin(__builtin_rotateleft64)
+#define XXH_rotl32 __builtin_rotateleft32
+#define XXH_rotl64 __builtin_rotateleft64
+/* Note : although _rotl exists for minGW (GCC under windows), performance seems poor */
+#elif defined(_MSC_VER)
+#define XXH_rotl32(x, r) _rotl(x, r)
+#define XXH_rotl64(x, r) _rotl64(x, r)
+#else
+#define XXH_rotl32(x, r) (((x) << (r)) | ((x) >> (32 - (r))))
+#define XXH_rotl64(x, r) (((x) << (r)) | ((x) >> (64 - (r))))
+#endif
+
+#if defined(_MSC_VER) /* Visual Studio */
+#define XXH_swap32 _byteswap_ulong
+#elif XXH_GCC_VERSION >= 403
+#define XXH_swap32 __builtin_bswap32
+#else
+static U32 XXH_swap32(U32 x) {
+  return ((x << 24) & 0xff000000) | ((x << 8) & 0x00ff0000) | ((x >> 8) & 0x0000ff00) |
+         ((x >> 24) & 0x000000ff);
+}
+#endif
+
+/* ***************************
+ *  Memory reads
+ *****************************/
+typedef enum { XXH_aligned, XXH_unaligned } XXH_alignment;
+
+XXH_FORCE_INLINE U32 XXH_readLE32(const void* ptr) {
+  return XXH_CPU_LITTLE_ENDIAN ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
+}
+
+static U32 XXH_readBE32(const void* ptr) {
+  return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
+}
+
+XXH_FORCE_INLINE U32 XXH_readLE32_align(const void* ptr, XXH_alignment align) {
+  if (align == XXH_unaligned) {
+    return XXH_readLE32(ptr);
+  } else {
+    return XXH_CPU_LITTLE_ENDIAN ? *(const U32*)ptr : XXH_swap32(*(const U32*)ptr);
+  }
+}
+
+/* *************************************
+ *  Misc
+ ***************************************/
+XXH_PUBLIC_API unsigned XXH_versionNumber(void) { return XXH_VERSION_NUMBER; }
+
+/* *******************************************************************
+ *  32-bit hash functions
+ *********************************************************************/
+static const U32 PRIME32_1 = 0x9E3779B1U; /* 0b10011110001101110111100110110001 */
+static const U32 PRIME32_2 = 0x85EBCA77U; /* 0b10000101111010111100101001110111 */
+static const U32 PRIME32_3 = 0xC2B2AE3DU; /* 0b11000010101100101010111000111101 */
+static const U32 PRIME32_4 = 0x27D4EB2FU; /* 0b00100111110101001110101100101111 */
+static const U32 PRIME32_5 = 0x165667B1U; /* 0b00010110010101100110011110110001 */
+
+static U32 XXH32_round(U32 acc, U32 input) {
+  acc += input * PRIME32_2;
+  acc = XXH_rotl32(acc, 13);
+  acc *= PRIME32_1;
+#if defined(__GNUC__) && defined(__SSE4_1__) && !defined(XXH_ENABLE_AUTOVECTORIZE)
+  /* UGLY HACK:
+   * This inline assembly hack forces acc into a normal register. This is the
+   * only thing that prevents GCC and Clang from autovectorizing the XXH32 loop
+   * (pragmas and attributes don't work for some resason) without globally
+   * disabling SSE4.1.
+   *
+   * The reason we want to avoid vectorization is because despite working on
+   * 4 integers at a time, there are multiple factors slowing XXH32 down on
+   * SSE4:
+   * - There's a ridiculous amount of lag from pmulld (10 cycles of latency on newer
+   * chips!) making it slightly slower to multiply four integers at once compared to four
+   *   integers independently. Even when pmulld was fastest, Sandy/Ivy Bridge, it is
+   *   still not worth it to go into SSE just to multiply unless doing a long operation.
+   *
+   * - Four instructions are required to rotate,
+   *      movqda tmp,  v // not required with VEX encoding
+   *      pslld  tmp, 13 // tmp <<= 13
+   *      psrld  v,   19 // x >>= 19
+   *      por    v,  tmp // x |= tmp
+   *   compared to one for scalar:
+   *      roll   v, 13    // reliably fast across the board
+   *      shldl  v, v, 13 // Sandy Bridge and later prefer this for some reason
+   *
+   * - Instruction level parallelism is actually more beneficial here because the
+   *   SIMD actually serializes this operation: While v1 is rotating, v2 can load data,
+   *   while v3 can multiply. SSE forces them to operate together.
+   *
+   * How this hack works:
+   * __asm__(""       // Declare an assembly block but don't declare any instructions
+   *          :       // However, as an Input/Output Operand,
+   *          "+r"    // constrain a read/write operand (+) as a general purpose register
+   * (r). (acc)   // and set acc as the operand
+   * );
+   *
+   * Because of the 'r', the compiler has promised that seed will be in a
+   * general purpose register and the '+' says that it will be 'read/write',
+   * so it has to assume it has changed. It is like volatile without all the
+   * loads and stores.
+   *
+   * Since the argument has to be in a normal register (not an SSE register),
+   * each time XXH32_round is called, it is impossible to vectorize. */
+  __asm__("" : "+r"(acc));
+#endif
+  return acc;
+}
+
+/* mix all bits */
+static U32 XXH32_avalanche(U32 h32) {
+  h32 ^= h32 >> 15;
+  h32 *= PRIME32_2;
+  h32 ^= h32 >> 13;
+  h32 *= PRIME32_3;
+  h32 ^= h32 >> 16;
+  return (h32);
+}
+
+#define XXH_get32bits(p) XXH_readLE32_align(p, align)
+
+static U32 XXH32_finalize(U32 h32, const void* ptr, size_t len, XXH_alignment align) {
+  const BYTE* p = (const BYTE*)ptr;
+
+#define PROCESS1             \
+  h32 += (*p++) * PRIME32_5; \
+  h32 = XXH_rotl32(h32, 11) * PRIME32_1;
+
+#define PROCESS4                       \
+  h32 += XXH_get32bits(p) * PRIME32_3; \
+  p += 4;                              \
+  h32 = XXH_rotl32(h32, 17) * PRIME32_4;
+
+  /* Compact rerolled version */
+  if (XXH_REROLL) {
+    len &= 15;
+    while (len >= 4) {
+      PROCESS4;
+      len -= 4;
+    }
+    while (len > 0) {
+      PROCESS1;
+      --len;
+    }
+    return XXH32_avalanche(h32);
+  } else {
+    switch (len & 15) /* or switch(bEnd - p) */ {
+      case 12:
+        PROCESS4;
+        /* fallthrough */
+      case 8:
+        PROCESS4;
+        /* fallthrough */
+      case 4:
+        PROCESS4;
+        return XXH32_avalanche(h32);
+
+      case 13:
+        PROCESS4;
+        /* fallthrough */
+      case 9:
+        PROCESS4;
+        /* fallthrough */
+      case 5:
+        PROCESS4;
+        PROCESS1;
+        return XXH32_avalanche(h32);
+
+      case 14:
+        PROCESS4;
+        /* fallthrough */
+      case 10:
+        PROCESS4;
+        /* fallthrough */
+      case 6:
+        PROCESS4;
+        PROCESS1;
+        PROCESS1;
+        return XXH32_avalanche(h32);
+
+      case 15:
+        PROCESS4;
+        /* fallthrough */
+      case 11:
+        PROCESS4;
+        /* fallthrough */
+      case 7:
+        PROCESS4;
+        /* fallthrough */
+      case 3:
+        PROCESS1;
+        /* fallthrough */
+      case 2:
+        PROCESS1;
+        /* fallthrough */
+      case 1:
+        PROCESS1;
+        /* fallthrough */
+      case 0:
+        return XXH32_avalanche(h32);
+    }
+    XXH_ASSERT(0);
+    return h32; /* reaching this point is deemed impossible */
+  }
+}
+
+XXH_FORCE_INLINE U32 XXH32_endian_align(const void* input, size_t len, U32 seed,
+                                        XXH_alignment align) {
+  const BYTE* p = (const BYTE*)input;
+  const BYTE* bEnd = p + len;
+  U32 h32;
+
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER >= 1)
+  if (p == NULL) {
+    len = 0;
+    bEnd = p = (const BYTE*)(size_t)16;
+  }
+#endif
+
+  if (len >= 16) {
+    const BYTE* const limit = bEnd - 15;
+    U32 v1 = seed + PRIME32_1 + PRIME32_2;
+    U32 v2 = seed + PRIME32_2;
+    U32 v3 = seed + 0;
+    U32 v4 = seed - PRIME32_1;
+
+    do {
+      v1 = XXH32_round(v1, XXH_get32bits(p));
+      p += 4;
+      v2 = XXH32_round(v2, XXH_get32bits(p));
+      p += 4;
+      v3 = XXH32_round(v3, XXH_get32bits(p));
+      p += 4;
+      v4 = XXH32_round(v4, XXH_get32bits(p));
+      p += 4;
+    } while (p < limit);
+
+    h32 = XXH_rotl32(v1, 1) + XXH_rotl32(v2, 7) + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+  } else {
+    h32 = seed + PRIME32_5;
+  }
+
+  h32 += (U32)len;
+
+  return XXH32_finalize(h32, p, len & 15, align);
+}
+
+XXH_PUBLIC_API unsigned int XXH32(const void* input, size_t len, unsigned int seed) {
+#if 0
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH32_state_t state;
+    XXH32_reset(&state, seed);
+    XXH32_update(&state, input, len);
+    return XXH32_digest(&state);
+
+#else
+
+  if (XXH_FORCE_ALIGN_CHECK) {
+    if ((((size_t)input) & 3) ==
+        0) { /* Input is 4-bytes aligned, leverage the speed benefit */
+      return XXH32_endian_align(input, len, seed, XXH_aligned);
+    }
+  }
+
+  return XXH32_endian_align(input, len, seed, XXH_unaligned);
+#endif
+}
+
+/*======   Hash streaming   ======*/
+
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void) {
+  return (XXH32_state_t*)XXH_malloc(sizeof(XXH32_state_t));
+}
+XXH_PUBLIC_API XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr) {
+  XXH_free(statePtr);
+  return XXH_OK;
+}
+
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dstState,
+                                    const XXH32_state_t* srcState) {
+  memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, unsigned int seed) {
+  XXH32_state_t state; /* using a local state to memcpy() in order to avoid
+                          strict-aliasing warnings */
+  memset(&state, 0, sizeof(state));
+  state.v1 = seed + PRIME32_1 + PRIME32_2;
+  state.v2 = seed + PRIME32_2;
+  state.v3 = seed + 0;
+  state.v4 = seed - PRIME32_1;
+  /* do not write into reserved, planned to be removed in a future version */
+  memcpy(statePtr, &state, sizeof(state) - sizeof(state.reserved));
+  return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input,
+                                          size_t len) {
+  if (input == NULL)
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER >= 1)
+    return XXH_OK;
+#else
+    return XXH_ERROR;
+#endif
+
+  {
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* const bEnd = p + len;
+
+    state->total_len_32 += (XXH32_hash_t)len;
+    state->large_len |= (XXH32_hash_t)((len >= 16) | (state->total_len_32 >= 16));
+
+    if (state->memsize + len < 16) { /* fill in tmp buffer */
+      XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, len);
+      state->memsize += (XXH32_hash_t)len;
+      return XXH_OK;
+    }
+
+    if (state->memsize) { /* some data left from previous update */
+      XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, 16 - state->memsize);
+      {
+        const U32* p32 = state->mem32;
+        state->v1 = XXH32_round(state->v1, XXH_readLE32(p32));
+        p32++;
+        state->v2 = XXH32_round(state->v2, XXH_readLE32(p32));
+        p32++;
+        state->v3 = XXH32_round(state->v3, XXH_readLE32(p32));
+        p32++;
+        state->v4 = XXH32_round(state->v4, XXH_readLE32(p32));
+      }
+      p += 16 - state->memsize;
+      state->memsize = 0;
+    }
+
+    if (p <= bEnd - 16) {
+      const BYTE* const limit = bEnd - 16;
+      U32 v1 = state->v1;
+      U32 v2 = state->v2;
+      U32 v3 = state->v3;
+      U32 v4 = state->v4;
+
+      do {
+        v1 = XXH32_round(v1, XXH_readLE32(p));
+        p += 4;
+        v2 = XXH32_round(v2, XXH_readLE32(p));
+        p += 4;
+        v3 = XXH32_round(v3, XXH_readLE32(p));
+        p += 4;
+        v4 = XXH32_round(v4, XXH_readLE32(p));
+        p += 4;
+      } while (p <= limit);
+
+      state->v1 = v1;
+      state->v2 = v2;
+      state->v3 = v3;
+      state->v4 = v4;
+    }
+
+    if (p < bEnd) {
+      XXH_memcpy(state->mem32, p, (size_t)(bEnd - p));
+      state->memsize = (unsigned)(bEnd - p);
+    }
+  }
+
+  return XXH_OK;
+}
+
+XXH_PUBLIC_API unsigned int XXH32_digest(const XXH32_state_t* state) {
+  U32 h32;
+
+  if (state->large_len) {
+    h32 = XXH_rotl32(state->v1, 1) + XXH_rotl32(state->v2, 7) +
+          XXH_rotl32(state->v3, 12) + XXH_rotl32(state->v4, 18);
+  } else {
+    h32 = state->v3 /* == seed */ + PRIME32_5;
+  }
+
+  h32 += state->total_len_32;
+
+  return XXH32_finalize(h32, state->mem32, state->memsize, XXH_aligned);
+}
+
+/*======   Canonical representation   ======*/
+
+/*! Default XXH result types are basic unsigned 32 and 64 bits.
+ *   The canonical representation follows human-readable write convention, aka big-endian
+ * (large digits first). These functions allow transformation of hash result into and from
+ * its canonical format. This way, hash values can be written into a file or buffer,
+ * remaining comparable across different systems.
+ */
+
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) {
+  XXH_STATIC_ASSERT(sizeof(XXH32_canonical_t) == sizeof(XXH32_hash_t));
+  if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap32(hash);
+  memcpy(dst, &hash, sizeof(*dst));
+}
+
+XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) {
+  return XXH_readBE32(src);
+}
+
+#ifndef XXH_NO_LONG_LONG
+
+/* *******************************************************************
+ *  64-bit hash functions
+ *********************************************************************/
+
+/*======   Memory access   ======*/
+
+#ifndef MEM_MODULE
+#define MEM_MODULE
+#if !defined(__VMS) &&       \
+    (defined(__cplusplus) || \
+     (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */))
+#include <stdint.h>
+typedef uint64_t U64;
+#else
+/* if compiler doesn't support unsigned long long, replace by another 64-bit type */
+typedef unsigned long long U64;
+#endif
+#endif
+
+/*! XXH_REROLL_XXH64:
+ * Whether to reroll the XXH64_finalize() loop.
+ *
+ * Just like XXH32, we can unroll the XXH64_finalize() loop. This can be a performance
+ * gain on 64-bit hosts, as only one jump is required.
+ *
+ * However, on 32-bit hosts, because arithmetic needs to be done with two 32-bit
+ * registers, and 64-bit arithmetic needs to be simulated, it isn't beneficial to unroll.
+ * The code becomes ridiculously large (the largest function in the binary on i386!), and
+ * rerolling it saves anywhere from 3kB to 20kB. It is also slightly faster because it
+ * fits into cache better and is more likely to be inlined by the compiler.
+ *
+ * If XXH_REROLL is defined, this is ignored and the loop is always rerolled. */
+#ifndef XXH_REROLL_XXH64
+#if (defined(__ILP32__) ||                                                             \
+     defined(_ILP32)) /* ILP32 is often defined on 32-bit GCC family */                \
+    ||                                                                                 \
+    !(defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64)        /* x86-64 */  \
+      || defined(_M_ARM64) || defined(__aarch64__) || defined(__arm64__) /* aarch64 */ \
+      || defined(__PPC64__) || defined(__PPC64LE__) || defined(__ppc64__) ||           \
+      defined(__powerpc64__)                         /* ppc64 */                       \
+      || defined(__mips64__) || defined(__mips64))   /* mips64 */                      \
+    || (!defined(SIZE_MAX) || SIZE_MAX < ULLONG_MAX) /* check limits */
+#define XXH_REROLL_XXH64 1
+#else
+#define XXH_REROLL_XXH64 0
+#endif
+#endif /* !defined(XXH_REROLL_XXH64) */
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS == 2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in
+ * hardware */
+static U64 XXH_read64(const void* memPtr) { return *(const U64*)memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS == 1))
+
+/* __pack instructions are safer, but compiler specific, hence potentially problematic for
+ * some compilers */
+/* currently only defined for gcc and icc */
+typedef union {
+  U32 u32;
+  U64 u64;
+} __attribute__((packed)) unalign64;
+static U64 XXH_read64(const void* ptr) { return ((const unalign64*)ptr)->u64; }
+
+#else
+
+/* portable and safe solution. Generally efficient.
+ * see : http://stackoverflow.com/a/32095106/646947
+ */
+
+static U64 XXH_read64(const void* memPtr) {
+  U64 val;
+  memcpy(&val, memPtr, sizeof(val));
+  return val;
+}
+
+#endif /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+#if defined(_MSC_VER) /* Visual Studio */
+#define XXH_swap64 _byteswap_uint64
+#elif XXH_GCC_VERSION >= 403
+#define XXH_swap64 __builtin_bswap64
+#else
+static U64 XXH_swap64(U64 x) {
+  return ((x << 56) & 0xff00000000000000ULL) | ((x << 40) & 0x00ff000000000000ULL) |
+         ((x << 24) & 0x0000ff0000000000ULL) | ((x << 8) & 0x000000ff00000000ULL) |
+         ((x >> 8) & 0x00000000ff000000ULL) | ((x >> 24) & 0x0000000000ff0000ULL) |
+         ((x >> 40) & 0x000000000000ff00ULL) | ((x >> 56) & 0x00000000000000ffULL);
+}
+#endif
+
+XXH_FORCE_INLINE U64 XXH_readLE64(const void* ptr) {
+  return XXH_CPU_LITTLE_ENDIAN ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
+}
+
+static U64 XXH_readBE64(const void* ptr) {
+  return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
+}
+
+XXH_FORCE_INLINE U64 XXH_readLE64_align(const void* ptr, XXH_alignment align) {
+  if (align == XXH_unaligned)
+    return XXH_readLE64(ptr);
+  else
+    return XXH_CPU_LITTLE_ENDIAN ? *(const U64*)ptr : XXH_swap64(*(const U64*)ptr);
+}
+
+/*======   xxh64   ======*/
+
+static const U64 PRIME64_1 =
+    0x9E3779B185EBCA87ULL; /* 0b1001111000110111011110011011000110000101111010111100101010000111
+                            */
+static const U64 PRIME64_2 =
+    0xC2B2AE3D27D4EB4FULL; /* 0b1100001010110010101011100011110100100111110101001110101101001111
+                            */
+static const U64 PRIME64_3 =
+    0x165667B19E3779F9ULL; /* 0b0001011001010110011001111011000110011110001101110111100111111001
+                            */
+static const U64 PRIME64_4 =
+    0x85EBCA77C2B2AE63ULL; /* 0b1000010111101011110010100111011111000010101100101010111001100011
+                            */
+static const U64 PRIME64_5 =
+    0x27D4EB2F165667C5ULL; /* 0b0010011111010100111010110010111100010110010101100110011111000101
+                            */
+
+static U64 XXH64_round(U64 acc, U64 input) {
+  acc += input * PRIME64_2;
+  acc = XXH_rotl64(acc, 31);
+  acc *= PRIME64_1;
+  return acc;
+}
+
+static U64 XXH64_mergeRound(U64 acc, U64 val) {
+  val = XXH64_round(0, val);
+  acc ^= val;
+  acc = acc * PRIME64_1 + PRIME64_4;
+  return acc;
+}
+
+static U64 XXH64_avalanche(U64 h64) {
+  h64 ^= h64 >> 33;
+  h64 *= PRIME64_2;
+  h64 ^= h64 >> 29;
+  h64 *= PRIME64_3;
+  h64 ^= h64 >> 32;
+  return h64;
+}
+
+#define XXH_get64bits(p) XXH_readLE64_align(p, align)
+
+static U64 XXH64_finalize(U64 h64, const void* ptr, size_t len, XXH_alignment align) {
+  const BYTE* p = (const BYTE*)ptr;
+
+#define PROCESS1_64          \
+  h64 ^= (*p++) * PRIME64_5; \
+  h64 = XXH_rotl64(h64, 11) * PRIME64_1;
+
+#define PROCESS4_64                           \
+  h64 ^= (U64)(XXH_get32bits(p)) * PRIME64_1; \
+  p += 4;                                     \
+  h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
+
+#define PROCESS8_64                                    \
+  {                                                    \
+    U64 const k1 = XXH64_round(0, XXH_get64bits(p));   \
+    p += 8;                                            \
+    h64 ^= k1;                                         \
+    h64 = XXH_rotl64(h64, 27) * PRIME64_1 + PRIME64_4; \
+  }
+
+  /* Rerolled version for 32-bit targets is faster and much smaller. */
+  if (XXH_REROLL || XXH_REROLL_XXH64) {
+    len &= 31;
+    while (len >= 8) {
+      PROCESS8_64;
+      len -= 8;
+    }
+    if (len >= 4) {
+      PROCESS4_64;
+      len -= 4;
+    }
+    while (len > 0) {
+      PROCESS1_64;
+      --len;
+    }
+    return XXH64_avalanche(h64);
+  } else {
+    switch (len & 31) {
+      case 24:
+        PROCESS8_64;
+        /* fallthrough */
+      case 16:
+        PROCESS8_64;
+        /* fallthrough */
+      case 8:
+        PROCESS8_64;
+        return XXH64_avalanche(h64);
+
+      case 28:
+        PROCESS8_64;
+        /* fallthrough */
+      case 20:
+        PROCESS8_64;
+        /* fallthrough */
+      case 12:
+        PROCESS8_64;
+        /* fallthrough */
+      case 4:
+        PROCESS4_64;
+        return XXH64_avalanche(h64);
+
+      case 25:
+        PROCESS8_64;
+        /* fallthrough */
+      case 17:
+        PROCESS8_64;
+        /* fallthrough */
+      case 9:
+        PROCESS8_64;
+        PROCESS1_64;
+        return XXH64_avalanche(h64);
+
+      case 29:
+        PROCESS8_64;
+        /* fallthrough */
+      case 21:
+        PROCESS8_64;
+        /* fallthrough */
+      case 13:
+        PROCESS8_64;
+        /* fallthrough */
+      case 5:
+        PROCESS4_64;
+        PROCESS1_64;
+        return XXH64_avalanche(h64);
+
+      case 26:
+        PROCESS8_64;
+        /* fallthrough */
+      case 18:
+        PROCESS8_64;
+        /* fallthrough */
+      case 10:
+        PROCESS8_64;
+        PROCESS1_64;
+        PROCESS1_64;
+        return XXH64_avalanche(h64);
+
+      case 30:
+        PROCESS8_64;
+        /* fallthrough */
+      case 22:
+        PROCESS8_64;
+        /* fallthrough */
+      case 14:
+        PROCESS8_64;
+        /* fallthrough */
+      case 6:
+        PROCESS4_64;
+        PROCESS1_64;
+        PROCESS1_64;
+        return XXH64_avalanche(h64);
+
+      case 27:
+        PROCESS8_64;
+        /* fallthrough */
+      case 19:
+        PROCESS8_64;
+        /* fallthrough */
+      case 11:
+        PROCESS8_64;
+        PROCESS1_64;
+        PROCESS1_64;
+        PROCESS1_64;
+        return XXH64_avalanche(h64);
+
+      case 31:
+        PROCESS8_64;
+        /* fallthrough */
+      case 23:
+        PROCESS8_64;
+        /* fallthrough */
+      case 15:
+        PROCESS8_64;
+        /* fallthrough */
+      case 7:
+        PROCESS4_64;
+        /* fallthrough */
+      case 3:
+        PROCESS1_64;
+        /* fallthrough */
+      case 2:
+        PROCESS1_64;
+        /* fallthrough */
+      case 1:
+        PROCESS1_64;
+        /* fallthrough */
+      case 0:
+        return XXH64_avalanche(h64);
+    }
+  }
+  /* impossible to reach */
+  XXH_ASSERT(0);
+  return 0; /* unreachable, but some compilers complain without it */
+}
+
+XXH_FORCE_INLINE U64 XXH64_endian_align(const void* input, size_t len, U64 seed,
+                                        XXH_alignment align) {
+  const BYTE* p = (const BYTE*)input;
+  const BYTE* bEnd = p + len;
+  U64 h64;
+
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER >= 1)
+  if (p == NULL) {
+    len = 0;
+    bEnd = p = (const BYTE*)(size_t)32;
+  }
+#endif
+
+  if (len >= 32) {
+    const BYTE* const limit = bEnd - 32;
+    U64 v1 = seed + PRIME64_1 + PRIME64_2;
+    U64 v2 = seed + PRIME64_2;
+    U64 v3 = seed + 0;
+    U64 v4 = seed - PRIME64_1;
+
+    do {
+      v1 = XXH64_round(v1, XXH_get64bits(p));
+      p += 8;
+      v2 = XXH64_round(v2, XXH_get64bits(p));
+      p += 8;
+      v3 = XXH64_round(v3, XXH_get64bits(p));
+      p += 8;
+      v4 = XXH64_round(v4, XXH_get64bits(p));
+      p += 8;
+    } while (p <= limit);
+
+    h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+    h64 = XXH64_mergeRound(h64, v1);
+    h64 = XXH64_mergeRound(h64, v2);
+    h64 = XXH64_mergeRound(h64, v3);
+    h64 = XXH64_mergeRound(h64, v4);
+
+  } else {
+    h64 = seed + PRIME64_5;
+  }
+
+  h64 += (U64)len;
+
+  return XXH64_finalize(h64, p, len, align);
+}
+
+XXH_PUBLIC_API XXH64_hash_t XXH64(const void* input, size_t len,
+                                  unsigned long long seed) {
+#if 0
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH64_state_t state;
+    XXH64_reset(&state, seed);
+    XXH64_update(&state, input, len);
+    return XXH64_digest(&state);
+
+#else
+
+  if (XXH_FORCE_ALIGN_CHECK) {
+    if ((((size_t)input) & 7) ==
+        0) { /* Input is aligned, let's leverage the speed advantage */
+      return XXH64_endian_align(input, len, seed, XXH_aligned);
+    }
+  }
+
+  return XXH64_endian_align(input, len, seed, XXH_unaligned);
+
+#endif
+}
+
+/*======   Hash Streaming   ======*/
+
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void) {
+  return (XXH64_state_t*)XXH_malloc(sizeof(XXH64_state_t));
+}
+XXH_PUBLIC_API XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr) {
+  XXH_free(statePtr);
+  return XXH_OK;
+}
+
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* dstState,
+                                    const XXH64_state_t* srcState) {
+  memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH64_state_t* statePtr,
+                                         unsigned long long seed) {
+  XXH64_state_t state; /* using a local state to memcpy() in order to avoid
+                          strict-aliasing warnings */
+  memset(&state, 0, sizeof(state));
+  state.v1 = seed + PRIME64_1 + PRIME64_2;
+  state.v2 = seed + PRIME64_2;
+  state.v3 = seed + 0;
+  state.v4 = seed - PRIME64_1;
+  /* do not write into reserved, might be removed in a future version */
+  memcpy(statePtr, &state, sizeof(state) - sizeof(state.reserved));
+  return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input,
+                                          size_t len) {
+  if (input == NULL)
+#if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER >= 1)
+    return XXH_OK;
+#else
+    return XXH_ERROR;
+#endif
+
+  {
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* const bEnd = p + len;
+
+    state->total_len += len;
+
+    if (state->memsize + len < 32) { /* fill in tmp buffer */
+      XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, len);
+      state->memsize += (U32)len;
+      return XXH_OK;
+    }
+
+    if (state->memsize) { /* tmp buffer is full */
+      XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, 32 - state->memsize);
+      state->v1 = XXH64_round(state->v1, XXH_readLE64(state->mem64 + 0));
+      state->v2 = XXH64_round(state->v2, XXH_readLE64(state->mem64 + 1));
+      state->v3 = XXH64_round(state->v3, XXH_readLE64(state->mem64 + 2));
+      state->v4 = XXH64_round(state->v4, XXH_readLE64(state->mem64 + 3));
+      p += 32 - state->memsize;
+      state->memsize = 0;
+    }
+
+    if (p + 32 <= bEnd) {
+      const BYTE* const limit = bEnd - 32;
+      U64 v1 = state->v1;
+      U64 v2 = state->v2;
+      U64 v3 = state->v3;
+      U64 v4 = state->v4;
+
+      do {
+        v1 = XXH64_round(v1, XXH_readLE64(p));
+        p += 8;
+        v2 = XXH64_round(v2, XXH_readLE64(p));
+        p += 8;
+        v3 = XXH64_round(v3, XXH_readLE64(p));
+        p += 8;
+        v4 = XXH64_round(v4, XXH_readLE64(p));
+        p += 8;
+      } while (p <= limit);
+
+      state->v1 = v1;
+      state->v2 = v2;
+      state->v3 = v3;
+      state->v4 = v4;
+    }
+
+    if (p < bEnd) {
+      XXH_memcpy(state->mem64, p, (size_t)(bEnd - p));
+      state->memsize = (unsigned)(bEnd - p);
+    }
+  }
+
+  return XXH_OK;
+}
+
+XXH_PUBLIC_API XXH64_hash_t XXH64_digest(const XXH64_state_t* state) {
+  U64 h64;
+
+  if (state->total_len >= 32) {
+    U64 const v1 = state->v1;
+    U64 const v2 = state->v2;
+    U64 const v3 = state->v3;
+    U64 const v4 = state->v4;
+
+    h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+    h64 = XXH64_mergeRound(h64, v1);
+    h64 = XXH64_mergeRound(h64, v2);
+    h64 = XXH64_mergeRound(h64, v3);
+    h64 = XXH64_mergeRound(h64, v4);
+  } else {
+    h64 = state->v3 /*seed*/ + PRIME64_5;
+  }
+
+  h64 += (U64)state->total_len;
+
+  return XXH64_finalize(h64, state->mem64, (size_t)state->total_len, XXH_aligned);
+}
+
+/*====== Canonical representation   ======*/
+
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) {
+  XXH_STATIC_ASSERT(sizeof(XXH64_canonical_t) == sizeof(XXH64_hash_t));
+  if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap64(hash);
+  memcpy(dst, &hash, sizeof(*dst));
+}
+
+XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src) {
+  return XXH_readBE64(src);
+}
+
+/* *********************************************************************
+ *  XXH3
+ *  New generation hash designed for speed on small keys and vectorization
+ ************************************************************************ */
+
+#include "third_party/arrow/vendored/xxhash/xxh3.h"
+
+#endif /* XXH_NO_LONG_LONG */

--- a/oap-native-sql/cpp/src/third_party/arrow/vendored/xxhash/xxhash.h
+++ b/oap-native-sql/cpp/src/third_party/arrow/vendored/xxhash/xxhash.h
@@ -1,0 +1,544 @@
+/*
+   xxHash - Extremely Fast Hash algorithm
+   Header File
+   Copyright (C) 2012-2016, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+/* Notice extracted from xxHash homepage :
+
+xxHash is an extremely fast Hash algorithm, running at RAM speed limits.
+It also successfully passes all tests from the SMHasher suite.
+
+Comparison (single thread, Windows Seven 32 bits, using SMHasher on a Core 2 Duo @3GHz)
+
+Name            Speed       Q.Score   Author
+xxHash          5.4 GB/s     10
+CrapWow         3.2 GB/s      2       Andrew
+MumurHash 3a    2.7 GB/s     10       Austin Appleby
+SpookyHash      2.0 GB/s     10       Bob Jenkins
+SBox            1.4 GB/s      9       Bret Mulvey
+Lookup3         1.2 GB/s      9       Bob Jenkins
+SuperFastHash   1.2 GB/s      1       Paul Hsieh
+CityHash64      1.05 GB/s    10       Pike & Alakuijala
+FNV             0.55 GB/s     5       Fowler, Noll, Vo
+CRC32           0.43 GB/s     9
+MD5-32          0.33 GB/s    10       Ronald L. Rivest
+SHA1-32         0.28 GB/s    10
+
+Q.Score is a measure of quality of the hash function.
+It depends on successfully passing SMHasher test set.
+10 is a perfect score.
+
+A 64-bit version, named XXH64, is available since r35.
+It offers much better speed, but for 64-bit applications only.
+Name     Speed on 64 bits    Speed on 32 bits
+XXH64       13.8 GB/s            1.9 GB/s
+XXH32        6.8 GB/s            6.0 GB/s
+*/
+
+#ifndef XXHASH_H_5627135585666179
+#define XXHASH_H_5627135585666179 1
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+
+/* ****************************
+*  Definitions
+******************************/
+#include <stddef.h>   /* size_t */
+typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
+
+
+/* ****************************
+ *  API modifier
+ ******************************/
+/** XXH_INLINE_ALL (and XXH_PRIVATE_API)
+ *  This build macro includes xxhash functions in `static` mode
+ *  in order to inline them, and remove their symbol from the public list.
+ *  Inlining offers great performance improvement on small keys,
+ *  and dramatic ones when length is expressed as a compile-time constant.
+ *  See https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html .
+ *  Methodology :
+ *     #define XXH_INLINE_ALL
+ *     #include "xxhash.h"
+ * `xxhash.c` is automatically included.
+ *  It's not useful to compile and link it as a separate object.
+ */
+#if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
+#  ifndef XXH_STATIC_LINKING_ONLY
+#    define XXH_STATIC_LINKING_ONLY
+#  endif
+#  if defined(__GNUC__)
+#    define XXH_PUBLIC_API static __inline __attribute__((unused))
+#  elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#    define XXH_PUBLIC_API static inline
+#  elif defined(_MSC_VER)
+#    define XXH_PUBLIC_API static __inline
+#  else
+     /* this version may generate warnings for unused static functions */
+#    define XXH_PUBLIC_API static
+#  endif
+#else
+#  if defined(WIN32) && defined(_MSC_VER) && (defined(XXH_IMPORT) || defined(XXH_EXPORT))
+#    ifdef XXH_EXPORT
+#      define XXH_PUBLIC_API __declspec(dllexport)
+#    elif XXH_IMPORT
+#      define XXH_PUBLIC_API __declspec(dllimport)
+#    endif
+#  else
+#    define XXH_PUBLIC_API   /* do nothing */
+#  endif
+#endif /* XXH_INLINE_ALL || XXH_PRIVATE_API */
+
+/*! XXH_NAMESPACE, aka Namespace Emulation :
+ *
+ * If you want to include _and expose_ xxHash functions from within your own library,
+ * but also want to avoid symbol collisions with other libraries which may also include xxHash,
+ *
+ * you can use XXH_NAMESPACE, to automatically prefix any public symbol from xxhash library
+ * with the value of XXH_NAMESPACE (therefore, avoid NULL and numeric values).
+ *
+ * Note that no change is required within the calling program as long as it includes `xxhash.h` :
+ * regular symbol name will be automatically translated by this header.
+ */
+#ifdef XXH_NAMESPACE
+#  define XXH_CAT(A,B) A##B
+#  define XXH_NAME2(A,B) XXH_CAT(A,B)
+#  define XXH_versionNumber XXH_NAME2(XXH_NAMESPACE, XXH_versionNumber)
+#  define XXH32 XXH_NAME2(XXH_NAMESPACE, XXH32)
+#  define XXH32_createState XXH_NAME2(XXH_NAMESPACE, XXH32_createState)
+#  define XXH32_freeState XXH_NAME2(XXH_NAMESPACE, XXH32_freeState)
+#  define XXH32_reset XXH_NAME2(XXH_NAMESPACE, XXH32_reset)
+#  define XXH32_update XXH_NAME2(XXH_NAMESPACE, XXH32_update)
+#  define XXH32_digest XXH_NAME2(XXH_NAMESPACE, XXH32_digest)
+#  define XXH32_copyState XXH_NAME2(XXH_NAMESPACE, XXH32_copyState)
+#  define XXH32_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH32_canonicalFromHash)
+#  define XXH32_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH32_hashFromCanonical)
+#  define XXH64 XXH_NAME2(XXH_NAMESPACE, XXH64)
+#  define XXH64_createState XXH_NAME2(XXH_NAMESPACE, XXH64_createState)
+#  define XXH64_freeState XXH_NAME2(XXH_NAMESPACE, XXH64_freeState)
+#  define XXH64_reset XXH_NAME2(XXH_NAMESPACE, XXH64_reset)
+#  define XXH64_update XXH_NAME2(XXH_NAMESPACE, XXH64_update)
+#  define XXH64_digest XXH_NAME2(XXH_NAMESPACE, XXH64_digest)
+#  define XXH64_copyState XXH_NAME2(XXH_NAMESPACE, XXH64_copyState)
+#  define XXH64_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH64_canonicalFromHash)
+#  define XXH64_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH64_hashFromCanonical)
+#endif
+
+
+/* *************************************
+*  Version
+***************************************/
+#define XXH_VERSION_MAJOR    0
+#define XXH_VERSION_MINOR    7
+#define XXH_VERSION_RELEASE  1
+#define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
+XXH_PUBLIC_API unsigned XXH_versionNumber (void);
+
+
+/*-**********************************************************************
+*  32-bit hash
+************************************************************************/
+#if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint32_t XXH32_hash_t;
+#else
+    typedef unsigned int XXH32_hash_t;
+#endif
+
+/*! XXH32() :
+    Calculate the 32-bit hash of sequence "length" bytes stored at memory address "input".
+    The memory between input & input+length must be valid (allocated and read-accessible).
+    "seed" can be used to alter the result predictably.
+    Speed on Core 2 Duo @ 3 GHz (single thread, SMHasher benchmark) : 5.4 GB/s */
+XXH_PUBLIC_API XXH32_hash_t XXH32 (const void* input, size_t length, unsigned int seed);
+
+/*======   Streaming   ======*/
+typedef struct XXH32_state_s XXH32_state_t;   /* incomplete type */
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void);
+XXH_PUBLIC_API XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr);
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dst_state, const XXH32_state_t* src_state);
+
+XXH_PUBLIC_API XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, unsigned int seed);
+XXH_PUBLIC_API XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length);
+XXH_PUBLIC_API XXH32_hash_t  XXH32_digest (const XXH32_state_t* statePtr);
+
+/*
+ * Streaming functions generate the xxHash of an input provided in multiple segments.
+ * Note that, for small input, they are slower than single-call functions, due to state management.
+ * For small inputs, prefer `XXH32()` and `XXH64()`, which are better optimized.
+ *
+ * XXH state must first be allocated, using XXH*_createState() .
+ *
+ * Start a new hash by initializing state with a seed, using XXH*_reset().
+ *
+ * Then, feed the hash state by calling XXH*_update() as many times as necessary.
+ * The function returns an error code, with 0 meaning OK, and any other value meaning there is an error.
+ *
+ * Finally, a hash value can be produced anytime, by using XXH*_digest().
+ * This function returns the nn-bits hash as an int or long long.
+ *
+ * It's still possible to continue inserting input into the hash state after a digest,
+ * and generate some new hashes later on, by calling again XXH*_digest().
+ *
+ * When done, free XXH state space if it was allocated dynamically.
+ */
+
+/*======   Canonical representation   ======*/
+
+typedef struct { unsigned char digest[4]; } XXH32_canonical_t;
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash);
+XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src);
+
+/* Default result type for XXH functions are primitive unsigned 32 and 64 bits.
+ * The canonical representation uses human-readable write convention, aka big-endian (large digits first).
+ * These functions allow transformation of hash result into and from its canonical format.
+ * This way, hash values can be written into a file / memory, and remain comparable on different systems and programs.
+ */
+
+
+#ifndef XXH_NO_LONG_LONG
+/*-**********************************************************************
+*  64-bit hash
+************************************************************************/
+#if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint64_t XXH64_hash_t;
+#else
+    typedef unsigned long long XXH64_hash_t;
+#endif
+
+/*! XXH64() :
+    Calculate the 64-bit hash of sequence of length "len" stored at memory address "input".
+    "seed" can be used to alter the result predictably.
+    This function runs faster on 64-bit systems, but slower on 32-bit systems (see benchmark).
+*/
+XXH_PUBLIC_API XXH64_hash_t XXH64 (const void* input, size_t length, unsigned long long seed);
+
+/*======   Streaming   ======*/
+typedef struct XXH64_state_s XXH64_state_t;   /* incomplete type */
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void);
+XXH_PUBLIC_API XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr);
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* dst_state, const XXH64_state_t* src_state);
+
+XXH_PUBLIC_API XXH_errorcode XXH64_reset  (XXH64_state_t* statePtr, unsigned long long seed);
+XXH_PUBLIC_API XXH_errorcode XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length);
+XXH_PUBLIC_API XXH64_hash_t  XXH64_digest (const XXH64_state_t* statePtr);
+
+/*======   Canonical representation   ======*/
+typedef struct { unsigned char digest[8]; } XXH64_canonical_t;
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash);
+XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src);
+
+
+#endif  /* XXH_NO_LONG_LONG */
+
+
+
+#ifdef XXH_STATIC_LINKING_ONLY
+
+/* ================================================================================================
+   This section contains declarations which are not guaranteed to remain stable.
+   They may change in future versions, becoming incompatible with a different version of the library.
+   These declarations should only be used with static linking.
+   Never use them in association with dynamic linking !
+=================================================================================================== */
+
+/* These definitions are only present to allow
+ * static allocation of XXH state, on stack or in a struct for example.
+ * Never **ever** use members directly. */
+
+struct XXH32_state_s {
+   XXH32_hash_t total_len_32;
+   XXH32_hash_t large_len;
+   XXH32_hash_t v1;
+   XXH32_hash_t v2;
+   XXH32_hash_t v3;
+   XXH32_hash_t v4;
+   XXH32_hash_t mem32[4];
+   XXH32_hash_t memsize;
+   XXH32_hash_t reserved;   /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH32_state_t */
+
+#ifndef XXH_NO_LONG_LONG  /* remove 64-bit support */
+struct XXH64_state_s {
+   XXH64_hash_t total_len;
+   XXH64_hash_t v1;
+   XXH64_hash_t v2;
+   XXH64_hash_t v3;
+   XXH64_hash_t v4;
+   XXH64_hash_t mem64[4];
+   XXH32_hash_t memsize;
+   XXH32_hash_t reserved[2];     /* never read nor write, might be removed in a future version */
+};   /* typedef'd to XXH64_state_t */
+#endif   /* XXH_NO_LONG_LONG */
+
+
+/*-**********************************************************************
+*  XXH3
+*  New experimental hash
+************************************************************************/
+#ifndef XXH_NO_LONG_LONG
+
+
+/* ============================================
+ * XXH3 is a new hash algorithm,
+ * featuring improved speed performance for both small and large inputs.
+ * See full speed analysis at : http://fastcompression.blogspot.com/2019/03/presenting-xxh3.html
+ * In general, expect XXH3 to run about ~2x faster on large inputs,
+ * and >3x faster on small ones, though exact differences depend on platform.
+ *
+ * The algorithm is portable, will generate the same hash on all platforms.
+ * It benefits greatly from vectorization units, but does not require it.
+ *
+ * XXH3 offers 2 variants, _64bits and _128bits.
+ * When only 64 bits are needed, prefer calling the _64bits variant :
+ * it reduces the amount of mixing, resulting in faster speed on small inputs.
+ * It's also generally simpler to manipulate a scalar return type than a struct.
+ *
+ * The XXH3 algorithm is still considered experimental.
+ * Produced results can still change between versions.
+ * For example, results produced by v0.7.1 are not comparable with results from v0.7.0 .
+ * It's nonetheless possible to use XXH3 for ephemeral data (local sessions),
+ * but avoid storing values in long-term storage for later re-use.
+ *
+ * The API supports one-shot hashing, streaming mode, and custom secrets.
+ *
+ * There are still a number of opened questions that community can influence during the experimental period.
+ * I'm trying to list a few of them below, though don't consider this list as complete.
+ *
+ * - 128-bits output type : currently defined as a structure of two 64-bits fields.
+ *                          That's because 128-bit values do not exist in C standard.
+ *                          Note that it means that, at byte level, result is not identical depending on endianess.
+ *                          However, at field level, they are identical on all platforms.
+ *                          The canonical representation solves the issue of identical byte-level representation across platforms,
+ *                          which is necessary for serialization.
+ *                          Would there be a better representation for a 128-bit hash result ?
+ *                          Are the names of the inner 64-bit fields important ? Should they be changed ?
+ *
+ * - Seed type for 128-bits variant : currently, it's a single 64-bit value, like the 64-bit variant.
+ *                          It could be argued that it's more logical to offer a 128-bit seed input parameter for a 128-bit hash.
+ *                          But 128-bit seed is more difficult to use, since it requires to pass a structure instead of a scalar value.
+ *                          Such a variant could either replace current one, or become an additional one.
+ *                          Farmhash, for example, offers both variants (the 128-bits seed variant is called `doubleSeed`).
+ *                          If both 64-bit and 128-bit seeds are possible, which variant should be called XXH128 ?
+ *
+ * - Result for len==0 : Currently, the result of hashing a zero-length input is `0`.
+ *                          It seems okay as a return value when using all "default" secret and seed (it used to be a request for XXH32/XXH64).
+ *                          But is it still fine to return `0` when secret or seed are non-default ?
+ *                          Are there use cases which could depend on generating a different hash result for zero-length input when the secret is different ?
+ */
+
+#ifdef XXH_NAMESPACE
+#  define XXH3_64bits XXH_NAME2(XXH_NAMESPACE, XXH3_64bits)
+#  define XXH3_64bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSecret)
+#  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
+
+#  define XXH3_createState XXH_NAME2(XXH_NAMESPACE, XXH3_createState)
+#  define XXH3_freeState XXH_NAME2(XXH_NAMESPACE, XXH3_freeState)
+#  define XXH3_copyState XXH_NAME2(XXH_NAMESPACE, XXH3_copyState)
+
+#  define XXH3_64bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset)
+#  define XXH3_64bits_reset_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset_withSeed)
+#  define XXH3_64bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset_withSecret)
+#  define XXH3_64bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_update)
+#  define XXH3_64bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_digest)
+#endif
+
+/* XXH3_64bits() :
+ * default 64-bit variant, using default secret and default seed of 0.
+ * It's the fastest variant. */
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len);
+
+/* XXH3_64bits_withSecret() :
+ * It's possible to provide any blob of bytes as a "secret" to generate the hash.
+ * This makes it more difficult for an external actor to prepare an intentional collision.
+ * The secret *must* be large enough (>= XXH3_SECRET_SIZE_MIN).
+ * It should consist of random bytes.
+ * Avoid repeating same character, or sequences of bytes,
+ * and especially avoid swathes of \0.
+ * Failure to respect these conditions will result in a poor quality hash.
+ */
+#define XXH3_SECRET_SIZE_MIN 136
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
+
+/* XXH3_64bits_withSeed() :
+ * This variant generates on the fly a custom secret,
+ * based on the default secret, altered using the `seed` value.
+ * While this operation is decently fast, note that it's not completely free.
+ * note : seed==0 produces same results as XXH3_64bits() */
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);
+
+
+/* streaming 64-bit */
+
+#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)   /* C11+ */
+#  include <stdalign.h>
+#  define XXH_ALIGN(n)      alignas(n)
+#elif defined(__GNUC__)
+#  define XXH_ALIGN(n)      __attribute__ ((aligned(n)))
+#elif defined(_MSC_VER)
+#  define XXH_ALIGN(n)      __declspec(align(n))
+#else
+#  define XXH_ALIGN(n)   /* disabled */
+#endif
+
+typedef struct XXH3_state_s XXH3_state_t;
+
+#define XXH3_SECRET_DEFAULT_SIZE 192   /* minimum XXH3_SECRET_SIZE_MIN */
+#define XXH3_INTERNALBUFFER_SIZE 256
+struct XXH3_state_s {
+   XXH_ALIGN(64) XXH64_hash_t acc[8];
+   XXH_ALIGN(64) char customSecret[XXH3_SECRET_DEFAULT_SIZE];  /* used to store a custom secret generated from the seed. Makes state larger. Design might change */
+   XXH_ALIGN(64) char buffer[XXH3_INTERNALBUFFER_SIZE];
+   const void* secret;
+   XXH32_hash_t bufferedSize;
+   XXH32_hash_t nbStripesPerBlock;
+   XXH32_hash_t nbStripesSoFar;
+   XXH32_hash_t reserved32;
+   XXH32_hash_t reserved32_2;
+   XXH32_hash_t secretLimit;
+   XXH64_hash_t totalLen;
+   XXH64_hash_t seed;
+   XXH64_hash_t reserved64;
+};   /* typedef'd to XXH3_state_t */
+
+/* Streaming requires state maintenance.
+ * This operation costs memory and cpu.
+ * As a consequence, streaming is slower than one-shot hashing.
+ * For better performance, prefer using one-shot functions whenever possible. */
+
+XXH_PUBLIC_API XXH3_state_t* XXH3_createState(void);
+XXH_PUBLIC_API XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr);
+XXH_PUBLIC_API void XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state);
+
+
+/* XXH3_64bits_reset() :
+ * initialize with default parameters.
+ * result will be equivalent to `XXH3_64bits()`. */
+XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr);
+/* XXH3_64bits_reset_withSeed() :
+ * generate a custom secret from `seed`, and store it into state.
+ * digest will be equivalent to `XXH3_64bits_withSeed()`. */
+XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed);
+/* XXH3_64bits_reset_withSecret() :
+ * `secret` is referenced, and must outlive the hash streaming session.
+ * secretSize must be >= XXH3_SECRET_SIZE_MIN.
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize);
+
+XXH_PUBLIC_API XXH_errorcode XXH3_64bits_update (XXH3_state_t* statePtr, const void* input, size_t length);
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_digest (const XXH3_state_t* statePtr);
+
+
+/* 128-bit */
+
+#ifdef XXH_NAMESPACE
+#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
+#  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
+#  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
+#  define XXH3_128bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSecret)
+
+#  define XXH3_128bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset)
+#  define XXH3_128bits_reset_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSeed)
+#  define XXH3_128bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSecret)
+#  define XXH3_128bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_update)
+#  define XXH3_128bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_digest)
+
+#  define XXH128_isEqual XXH_NAME2(XXH_NAMESPACE, XXH128_isEqual)
+#  define XXH128_cmp     XXH_NAME2(XXH_NAMESPACE, XXH128_cmp)
+#  define XXH128_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH128_canonicalFromHash)
+#  define XXH128_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH128_hashFromCanonical)
+#endif
+
+typedef struct {
+    XXH64_hash_t low64;
+    XXH64_hash_t high64;
+} XXH128_hash_t;
+
+XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t seed);
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len);
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);  /* == XXH128() */
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
+
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr);
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed);
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize);
+
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_update (XXH3_state_t* statePtr, const void* input, size_t length);
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* statePtr);
+
+
+/* Note : for better performance, following functions should be inlined,
+ * using XXH_INLINE_ALL */
+
+/* return : 1 is equal, 0 if different */
+XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2);
+
+/* This comparator is compatible with stdlib's qsort().
+ * return : >0 if *h128_1  > *h128_2
+ *          <0 if *h128_1  < *h128_2
+ *          =0 if *h128_1 == *h128_2  */
+XXH_PUBLIC_API int XXH128_cmp(const void* h128_1, const void* h128_2);
+
+
+/*======   Canonical representation   ======*/
+typedef struct { unsigned char digest[16]; } XXH128_canonical_t;
+XXH_PUBLIC_API void XXH128_canonicalFromHash(XXH128_canonical_t* dst, XXH128_hash_t hash);
+XXH_PUBLIC_API XXH128_hash_t XXH128_hashFromCanonical(const XXH128_canonical_t* src);
+
+
+#endif  /* XXH_NO_LONG_LONG */
+
+
+/*-**********************************************************************
+*  XXH_INLINE_ALL
+************************************************************************/
+#if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
+#  include "xxhash.c"   /* include xxhash function bodies as `static`, for inlining */
+#endif
+
+
+
+#endif /* XXH_STATIC_LINKING_ONLY */
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* XXHASH_H_5627135585666179 */

--- a/oap-native-sql/pom.xml
+++ b/oap-native-sql/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <sbt.project.name>SparkColumnarPlugin</sbt.project.name>
-    <spark.version>3.0.0-SNAPSHOT</spark.version>
+    <spark.version>3.1.0-SNAPSHOT</spark.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scala.version>2.12.8</scala.version>
     <build.testJarPhase>none</build.testJarPhase>


### PR DESCRIPTION
This PR is aim to decouple our dependency on gandiva protobuf and hashing.h inside arrow
Since we are intensively using this two feature and it is a little pain to keep in state with upstream arrow with cmake changes, we decided to maintain by our own of these two features.