### PR TITLE
[remote-shuffle]Refactor

### DIFF
--- a/oap-shuffle/remote-shuffle/README.md
+++ b/oap-shuffle/remote-shuffle/README.md
@@ -87,6 +87,14 @@ the 3x shuffle size is gone through network, arriving at a remote storage system
     spark.shuffle.remote.bypassMergeThreshold     -1
 ```
 
+### Configurations fetching port for HDFS
+
+When the backend storage is HDFS, we contact http://$host:$port/conf to fetch configurations. They were not locally loaded because we assume absence of local storage.
+
+```
+    spark.shuffle.remote.hdfs.storageMasterUIPort  50070
+```
+
 ### Inherited Spark Shuffle Configurations
 
 These configurations are inherited from upstream Spark, they are still supported in remote shuffle. More explanations can be found in [Spark core docs](https://spark.apache.org/docs/2.4.4/configuration.html#shuffle-behavior) and [Spark SQL docs](https://spark.apache.org/docs/2.4.4/sql-performance-tuning.html).

--- a/oap-shuffle/remote-shuffle/src/main/java/org/apache/spark/shuffle/sort/RemoteSpillInfo.java
+++ b/oap-shuffle/remote-shuffle/src/main/java/org/apache/spark/shuffle/sort/RemoteSpillInfo.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.storage.TempShuffleBlockId;
 
 /**
- * Metadata for a block of data written by {@link ShuffleRemoteSorter}.
+ * Metadata for a block of data written by {@link RemoteUnsafeShuffleSorter}.
  */
 final class RemoteSpillInfo {
   final long[] partitionLengths;

--- a/oap-shuffle/remote-shuffle/src/main/java/org/apache/spark/shuffle/sort/RemoteUnsafeShuffleSorter.java
+++ b/oap-shuffle/remote-shuffle/src/main/java/org/apache/spark/shuffle/sort/RemoteUnsafeShuffleSorter.java
@@ -67,11 +67,11 @@ import org.apache.spark.util.Utils;
  * spill files. Instead, this merging is performed in {@link UnsafeShuffleWriter}, which uses a
  * specialized merge procedure that avoids extra serialization/deserialization.
  */
-final class ShuffleRemoteSorter extends MemoryConsumer {
+final class RemoteUnsafeShuffleSorter extends MemoryConsumer {
 
   private SerializerManager serializerManager = SparkEnv.get().serializerManager();
 
-  private static final Logger logger = LoggerFactory.getLogger(ShuffleRemoteSorter.class);
+  private static final Logger logger = LoggerFactory.getLogger(RemoteUnsafeShuffleSorter.class);
 
   @VisibleForTesting
   static final int DISK_WRITE_BUFFER_SIZE = 1024 * 1024;
@@ -112,7 +112,7 @@ final class ShuffleRemoteSorter extends MemoryConsumer {
   @Nullable private MemoryBlock currentPage = null;
   private long pageCursor = -1;
 
-  ShuffleRemoteSorter(
+  RemoteUnsafeShuffleSorter(
       TaskMemoryManager memoryManager,
       BlockManager blockManager,
       TaskContext taskContext,

--- a/oap-shuffle/remote-shuffle/src/main/java/org/apache/spark/shuffle/sort/RemoteUnsafeShuffleWriter.java
+++ b/oap-shuffle/remote-shuffle/src/main/java/org/apache/spark/shuffle/sort/RemoteUnsafeShuffleWriter.java
@@ -93,7 +93,7 @@ public class RemoteUnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
   private final int outputBufferSizeInBytes;
 
   @Nullable private MapStatus mapStatus;
-  @Nullable private ShuffleRemoteSorter sorter;
+  @Nullable private RemoteUnsafeShuffleSorter sorter;
   private long peakMemoryUsedBytes = 0;
 
   /** Subclass of ByteArrayOutputStream that exposes `buf` directly. */
@@ -220,7 +220,7 @@ public class RemoteUnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
 
   private void open() {
     assert (sorter == null);
-    sorter = new ShuffleRemoteSorter(
+    sorter = new RemoteUnsafeShuffleSorter(
         memoryManager,
         blockManager,
         taskContext,

--- a/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/HadoopFileSegmentManagedBuffer.scala
+++ b/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/HadoopFileSegmentManagedBuffer.scala
@@ -119,7 +119,7 @@ private[remote] object HadoopFileSegmentManagedBuffer {
   * This is an RPC message encapsulating HadoopFileSegmentManagedBuffers. Slightly different with
   * the OpenBlocks message, this doesn't transfer block stream between executors through netty, but
   * only returns file segment ranges(offsets and lengths). Due to in remote shuffle, there is a
-  * globally-accessible remote storage, like HDFS.
+  * globally-accessible remote storage, like HDFS or DAOS.
   */
 class MessageForHadoopManagedBuffers(
     val buffers: Array[(String, HadoopFileSegmentManagedBuffer)]) extends Encodable {

--- a/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/RemoteShuffleConf.scala
+++ b/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/RemoteShuffleConf.scala
@@ -28,7 +28,7 @@ object RemoteShuffleConf {
       .createWithDefault("hdfs://localhost:9001")
 
   val STORAGE_HDFS_MASTER_UI_PORT: ConfigEntry[String] =
-    ConfigBuilder("spark.shuffle.remote.storageMasterUIPort")
+    ConfigBuilder("spark.shuffle.remote.hdfs.storageMasterUIPort")
       .doc("Contact this UI port to retrieve HDFS configurations")
       .stringConf
       .createWithDefault("50070")
@@ -40,7 +40,7 @@ object RemoteShuffleConf {
       .createWithDefault("/shuffle")
 
   val DFS_REPLICATION: ConfigEntry[Int] =
-    ConfigBuilder("spark.shuffle.remote.dfsReplication")
+    ConfigBuilder("spark.shuffle.remote.hdfs.replication")
       .doc("The default replication of remote storage system, will override dfs.replication" +
         " when HDFS is used as shuffling storage")
       .intConf
@@ -85,20 +85,6 @@ object RemoteShuffleConf {
       .doc("The maximum number of concurrent reading threads fetching shuffle data blocks")
       .intConf
       .createWithDefault(Runtime.getRuntime.availableProcessors())
-
-  val MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS: ConfigEntry[Int] =
-    ConfigBuilder("spark.shuffle.remote.reducer.maxBlocksInFlightPerAddress")
-      .doc("This configuration overrides spark.reducer.maxBlocksInFlightPerAddress and takes" +
-        "effect in RemoteShuffle, which controls the maximum blocks sending requests sent to" +
-        " one Executor. Generally a reduce task fetches index files from another executor and" +
-        " then read data files from remote storage. This is by default set to a small Int" +
-        " instead of Int.MAX in vanilla Spark due to remotely reading index files" +
-        "(of too many blocks) can be expensive, and this way we can get the index information" +
-        " earlier, and then asynchronously read data files earlier. However, a small value of" +
-        " this setting can also increase the RPC messages sent between client Executor and " +
-        "server Executor.")
-      .intConf
-      .createWithDefault(10)
 
   val DATA_FETCH_EAGER_REQUIREMENT: ConfigEntry[Boolean] =
     ConfigBuilder("spark.shuffle.remote.eagerRequirementDataFetch")

--- a/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/RemoteShuffleManager.scala
+++ b/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/RemoteShuffleManager.scala
@@ -143,10 +143,10 @@ private[spark] class RemoteShuffleManager(private val conf: SparkConf) extends S
   private[spark] val getHadoopConf = {
     val storageMasterUri = active.conf.get("spark.shuffle.remote.storageMasterUri")
 
+    // DAOS-Hadoop-compatible-filesystem configurations are loaded by DAOS Filesystem itself
     val hadoopConf = new Configuration(false)
-    // Hadoop configuration will be loaded remotely if the shuffle storage system is HDFS, due to
-    // we assume there may not be a local storage, and there can be useful HDFS client-related
-    // configuration needed here
+    // Hadoop configuration will be loaded from a remote web URI if the shuffle storage
+    // system is HDFS
     if (storageMasterUri.startsWith("hdfs")) {
       val host = storageMasterUri.split("//")(1).split(":")(0)
       val port = active.conf.get(RemoteShuffleConf.STORAGE_HDFS_MASTER_UI_PORT)

--- a/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/RemoteShuffleReader.scala
+++ b/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/RemoteShuffleReader.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.shuffle.remote
 
 import org.apache.spark._
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleReader}
 import org.apache.spark.util.CompletionIterator
@@ -51,7 +51,7 @@ private[spark] class RemoteShuffleReader[K, C](
       // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
       SparkEnv.get.conf.getSizeAsMb("spark.reducer.maxSizeInFlight", "48m") * 1024 * 1024,
       SparkEnv.get.conf.getInt("spark.reducer.maxReqsInFlight", Int.MaxValue),
-      SparkEnv.get.conf.get(RemoteShuffleConf.MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
+      SparkEnv.get.conf.get(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
       SparkEnv.get.conf.getBoolean("spark.shuffle.detectCorrupt", true))
 
     val serializerInstance = dep.serializer.newInstance()

--- a/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/util/collection/RemoteSorter.scala
+++ b/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/util/collection/RemoteSorter.scala
@@ -35,7 +35,7 @@ import org.apache.spark.storage.BlockId
 
 /**
   * NOTE: This version of Spark 2.4.0 ExternalSorter is currently imported for the interface
-  * modification of function: writePartitionedFile, to support writing to HDFS
+  * modification of function: writePartitionedFile, to support writing to Hadoop Filesystem
   *
   * Sorts and potentially merges a number of key-value pairs of type (K, V) to produce key-combiner
   * pairs of type (K, C). Uses a Partitioner to first group the keys into partitions, and then
@@ -166,9 +166,10 @@ private[spark] class RemoteSorter[K, V, C](
     }
   }
 
-  // NOTE: This is an HDFS version SpilledFile, compared with [[ExternalSorter.SpilledFile]]
-  // Information about a spilled file. Includes sizes in bytes of "batches" written by the
-  // serializer as we periodically reset its stream, as well as number of elements in each
+  // NOTE: This is an Hadoop-Filesystem-version SpilledFile, comparing with
+  // [[ExternalSorter.SpilledFile]] Information about a spilled file.
+  // Includes sizes in bytes of "batches" written by the serializer as we
+  // periodically reset its stream, as well as number of elements in each
   // partition, used to efficiently keep track of partitions when merging.
   private[this] case class SpilledFile(
       file: Path,

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/RemoteShuffleBlockIteratorSuite.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/RemoteShuffleBlockIteratorSuite.scala
@@ -29,6 +29,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
 import org.apache.spark._
+import org.apache.spark.internal.config
 import org.apache.spark.network.BlockTransferService
 import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.netty.RemoteShuffleTransferService
@@ -134,10 +135,10 @@ class RemoteShuffleBlockIteratorSuite extends SparkFunSuite with LocalSparkConte
       body(indexCacheEnabledConf)
     }
     test(name + " w/o index cache, constraining maxBlocksInFlightPerAddress") {
-      body(indexCacheDisabledConf.set(RemoteShuffleConf.MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS.key, "1"))
+      body(indexCacheDisabledConf.set(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS.key, "1"))
     }
     test(name + " w index cache, constraining maxBlocksInFlightPerAddress") {
-      body(indexCacheEnabledConf.set(RemoteShuffleConf.MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS.key, "1"))
+      body(indexCacheEnabledConf.set(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS.key, "1"))
     }
     val default = RemoteShuffleConf.DATA_FETCH_EAGER_REQUIREMENT.defaultValue.get
     val testWith = (true ^ default)

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/RemoteShuffleManagerSuite.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/RemoteShuffleManagerSuite.scala
@@ -21,6 +21,7 @@ import org.mockserver.integration.ClientAndServer.startClientAndServer
 import org.mockserver.model.{HttpRequest, HttpResponse}
 
 import org.apache.spark._
+import org.apache.spark.internal.config
 import org.apache.spark.util.Utils
 
 class RemoteShuffleManagerSuite extends SparkFunSuite with LocalSparkContext {
@@ -68,7 +69,7 @@ class RemoteShuffleManagerSuite extends SparkFunSuite with LocalSparkContext {
     try {
       val conf = new SparkConf(false)
           .set("spark.shuffle.manager", "org.apache.spark.shuffle.remote.RemoteShuffleManager")
-          .set("spark.shuffle.remote.storageMasterUIPort", port.toString)
+          .set(RemoteShuffleConf.STORAGE_HDFS_MASTER_UI_PORT, port.toString)
           .set("spark.shuffle.remote.storageMasterUri", "hdfs://localhost:9001")
       val manager = new RemoteShuffleManager(conf)
       assert(manager.getHadoopConf.get(expectKey) == expectVal)
@@ -174,7 +175,7 @@ class RemoteShuffleManagerSuite extends SparkFunSuite with LocalSparkContext {
       conf.set("spark.shuffle.remote.index.cache.size", "3m")
     }
     if (setMaxBlocksPerAdress) {
-      conf.set(RemoteShuffleConf.MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS.key, "1")
+      conf.set(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS.key, "1")
     }
     conf
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR 
- renames some classes, to be more clear, like `ShuffleRemoteSorter` -> `RemoteUnsafeShuffleSorter`
- Eliminates some comments containing 'HDFS', which should instead be general: for all Hadoop compatible filesystem, resolving https://github.com/Intel-bigdata/RemoteShuffle/issues/46
- Uses vanilla Spark's configuration as much as possible, avoiding to create new ones, like -> turn to using spark.reducer.maxBlocksInFlightPerAddress

## How was this patch tested?

Existed tests