### PR TITLE
[oap-native-sql][Scala] support date32

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ArrowWritableColumnVector.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ArrowWritableColumnVector.java
@@ -1565,6 +1565,11 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     }
 
     @Override
+    final void setInt(int rowId, int value) {
+      writer.set(rowId, value);
+    }
+
+    @Override
     final void setNull(int rowId) {
       writer.setNull(rowId);
     }

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ArrowWritableColumnVector.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ArrowWritableColumnVector.java
@@ -948,6 +948,12 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     final int getInt(int rowId) {
       return accessor.get(rowId);
     }
+
+    @Override
+    final UTF8String getUTF8String(int rowId) {
+      return UTF8String.fromString(Integer.toString(accessor.get(rowId)));
+    }
+
   }
 
   private static class TimestampAccessor extends ArrowVectorAccessor {

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarLiterals.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarLiterals.scala
@@ -1,5 +1,6 @@
 package com.intel.sparkColumnarPlugin.expression
 
+import com.google.common.collect.Lists
 import org.apache.arrow.gandiva.evaluator._
 import org.apache.arrow.gandiva.exceptions.GandivaException
 import org.apache.arrow.gandiva.expression._
@@ -32,9 +33,9 @@ class ColumnarLiteral(lit: Literal)
         val v = value.asInstanceOf[Decimal]
         (TreeBuilder.makeDecimalLiteral(v.toString, v.precision, v.scale), resultType)
       case d: DateType =>
-        val stringDate = DateTimeUtils.toJavaDate(value.asInstanceOf[Integer])
-        (TreeBuilder.makeStringLiteral(stringDate.toString), new ArrowType.Utf8())
-        //throw new UnsupportedOperationException(s"DateType is not supported yet.")
+        val origIntNode = TreeBuilder.makeLiteral(value.asInstanceOf[Integer])
+        val dateNode = TreeBuilder.makeFunction("castDATE", Lists.newArrayList(origIntNode), new ArrowType.Date(DateUnit.DAY))
+        (dateNode, new ArrowType.Date(DateUnit.DAY))
     }
   }
 }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
@@ -1063,6 +1063,12 @@ arrow::Status MakeUniqueAction(arrow::compute::FunctionContext* ctx,
           std::make_shared<UniqueAction<arrow::StringType, std::string>>(ctx);
       *out = std::dynamic_pointer_cast<ActionBase>(action_ptr);
     } break;
+    case arrow::Date32Type::type_id: {
+      auto action_ptr =
+          std::make_shared<UniqueAction<arrow::Date32Type, int32_t>>(ctx);
+      *out = std::dynamic_pointer_cast<ActionBase>(action_ptr);
+    } break;
+
     default: {
       std::cout << "Not Found " << type->ToString() << ", type id is " << type->id()
                 << std::endl;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/item_iterator.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/item_iterator.cc
@@ -29,7 +29,8 @@ class ItemIterator::Impl {
   PROCESS(UInt64Type)                    \
   PROCESS(Int64Type)                     \
   PROCESS(FloatType)                     \
-  PROCESS(DoubleType)
+  PROCESS(DoubleType)                    \
+  PROCESS(Date32Type)
 
   static arrow::Status MakeItemIteratorImpl(std::shared_ptr<arrow::DataType> type,
                                             bool is_array_list,

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/shuffle_v2_action.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/shuffle_v2_action.cc
@@ -25,7 +25,8 @@ class ShuffleV2Action::Impl {
   PROCESS(UInt64Type)                    \
   PROCESS(Int64Type)                     \
   PROCESS(FloatType)                     \
-  PROCESS(DoubleType)
+  PROCESS(DoubleType)                    \
+  PROCESS(Date32Type)
   static arrow::Status MakeShuffleV2ActionImpl(arrow::compute::FunctionContext* ctx,
                                                std::shared_ptr<arrow::DataType> type,
                                                bool is_arr_list,


### PR DESCRIPTION
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## What changes were proposed in this pull request?

This patch adds support for date32 type in native sql engine. Note it depends on below arrow commits: 
https://github.com/apache/arrow/commit/6d92694d00aec08081ae1bfe06f0a265e141b1b7
https://github.com/apache/arrow/commit/8b21c7af54adf90c6a07cb59ce6a9ae56ea2465c



## How was this patch tested?

manually tested on local dev
