### PR TITLE
[oap-native-sql]Wip refine protobuf install

### DIFF
--- a/oap-native-sql/cpp/src/CMakeLists.txt
+++ b/oap-native-sql/cpp/src/CMakeLists.txt
@@ -23,10 +23,16 @@ set(source_root_directory ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Gandiva protobuf
 
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".so")
 find_package(Protobuf)
 
-if(NOT Protobuf_FOUND)
-  message("Building Protocol Buffers from source")
+if ("${Protobuf_LIBRARY}" STREQUAL "Protobuf_LIBRARY-NOTFOUND")
+  message(WARNING "libprotobuf.so not found, will build from source")
+  set(BUILD_PROTOBUF true)
+endif()
+
+if(BUILD_PROTOBUF)
+  message(STATUS "Building Protocol Buffers from source")
   set (PROTOBUF_SOURCE_URL
        "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-all-3.7.1.tar.gz"
         "https://github.com/ursa-labs/thirdparty/releases/download/latest/protobuf-v3.7.1.tar.gz"
@@ -180,7 +186,7 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
 file(MAKE_DIRECTORY ${root_directory}/releases)
 add_library(spark_columnar_jni SHARED ${SPARK_COLUMNAR_PLUGIN_SRCS})
 add_dependencies(spark_columnar_jni jni_proto)
-if(NOT Protobuf_FOUND)
+if(BUILD_PROTOBUF)
 target_link_libraries(spark_columnar_jni
                       LINK_PUBLIC ${ARROW_LIB} ${PARQUET_LIB} ${GANDIVA_LIB} ${GANDIVA_LINK_LIBS}
                       LINK_PRIVATE protobuf::libprotobuf)

--- a/oap-native-sql/cpp/src/CMakeLists.txt
+++ b/oap-native-sql/cpp/src/CMakeLists.txt
@@ -25,9 +25,7 @@ set(source_root_directory ${CMAKE_CURRENT_SOURCE_DIR})
 
 find_package(Protobuf)
 
-if(Protobuf_FOUND)
-  set(PROTOBUF_SOURCE_URL "${Protobuf_INCLUDE_DIRS}")
-else()
+if(NOT Protobuf_FOUND)
   message("Building Protocol Buffers from source")
   set (PROTOBUF_SOURCE_URL
        "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-all-3.7.1.tar.gz"
@@ -67,6 +65,7 @@ else()
                       CONFIGURE_COMMAND "./configure" ${PROTOBUF_CONFIGURE_ARGS}
                       BUILD_COMMAND ${PROTOBUF_BUILD_COMMAND}
                       BUILD_IN_SOURCE 1
+                      URL_MD5 cda6ae370a5df941f8aa837c8a0292ba
                       URL ${PROTOBUF_SOURCE_URL}
   )
 
@@ -77,6 +76,8 @@ else()
     PROPERTIES IMPORTED_LOCATION "${PROTOBUF_STATIC_LIB}" INTERFACE_INCLUDE_DIRECTORIES
                "${PROTOBUF_INCLUDE_DIR}")
   add_dependencies(protobuf::libprotobuf protobuf_ep)
+else()
+  set(PROTOC_BIN ${Protobuf_PROTOC_EXECUTABLE})
 endif()
 
 file(MAKE_DIRECTORY ${root_directory}/src/proto)
@@ -96,7 +97,7 @@ add_custom_command(OUTPUT ${PROTO_OUTPUT_FILES}
                            --cpp_out
                        ${PROTO_OUTPUT_DIR}
                            ${CMAKE_CURRENT_SOURCE_DIR}/proto/Exprs.proto
-                   DEPENDS protobuf_ep ${ABS_GANDIVA_PROTO}
+                   DEPENDS  ${ABS_GANDIVA_PROTO}
                    COMMENT "Running PROTO compiler on Exprs.proto"
                    VERBATIM)
 
@@ -179,9 +180,14 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
 file(MAKE_DIRECTORY ${root_directory}/releases)
 add_library(spark_columnar_jni SHARED ${SPARK_COLUMNAR_PLUGIN_SRCS})
 add_dependencies(spark_columnar_jni jni_proto)
+if(NOT Protobuf_FOUND)
 target_link_libraries(spark_columnar_jni
                       LINK_PUBLIC ${ARROW_LIB} ${PARQUET_LIB} ${GANDIVA_LIB} ${GANDIVA_LINK_LIBS}
                       LINK_PRIVATE protobuf::libprotobuf)
+else()
+target_link_libraries(spark_columnar_jni
+                      LINK_PUBLIC ${ARROW_LIB} ${PARQUET_LIB} ${GANDIVA_LIB} ${GANDIVA_LINK_LIBS} ${PROTOBUF_LIBRARY})
+endif()
 target_include_directories(spark_columnar_jni PUBLIC ${CMAKE_SYSTEM_INCLUDE_PATH} ${JNI_INCLUDE_DIRS} ${source_root_directory} ${PROTO_OUTPUT_DIR} ${PROTOBUF_INCLUDE})
 set_target_properties(spark_columnar_jni PROPERTIES
                       LIBRARY_OUTPUT_DIRECTORY ${root_directory}/releases


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch refines protobuf check

 - if not found, download protobuf and statically link to it
 - if found, reuse system level protobuf and dynamically link to it

## How was this patch tested?
manually tested on local cluster

