### PR TITLE
[remote-shuffle]Add docs for performance evaluation tool

### DIFF
--- a/oap-shuffle/remote-shuffle/README.md
+++ b/oap-shuffle/remote-shuffle/README.md
@@ -123,6 +123,68 @@ These configurations are deprecated and will not take effect.
 
 ## Performance Evaluation Tool
 
-Leverage this tool to evaluate shuffle write/read performance separately under specific storage system.
+Leverage this tool to evaluate shuffle write/read performance separately under your specific storage system. This tool starts one Java process with #poolSize number of threads, running the specified remote-shuffle writers/readers in this module. Additional Spark configurations can be put in "./spark.conf" and will be loaded.(and printed as part of the summary for recording)
 
 Configuration details:
+* `-h` or `--help`: display help messages
+* `-m` or `--mappers`: the number of mappers, default to 5
+* `-r` or `--reducers`: the number of reducers, default to 5
+* `-p` or `--poolSize`: the number task threads in write/read thread pool, similar to spark.executor.cores. e.g. if mappers=15, poolSize=5, it takes 3 rounds to finish this job
+* `-n` or `--rows`: the number of rows per mapper, default to 1000
+* `-b` or `--shuffleBlockRawSize`: the size of each shuffle block, default to 20000 Bytes
+* `-w` or `--writer`: the type of shuffle writers for benchmark, can be one of general, unsafe and bypassmergesort, default to unsafe
+* `-onlyWrite` or `--onlyWrite`: containing this flag then the benchmark only includes shuffle write stage, default behavior is perform both write & read
+* `-uri` or `--storageMasterUri`: Hadoop-compatible storage Master URI, default to file://
+* `-d` or `--dir`: Shuffle directory, default /tmp
+* `-l` or `--log`: Log level, default to WARN
+
+
+Sample command:
+```
+java -cp target/remote-shuffle-0.1-SNAPSHOT-test-jar-with-dependencies.jar org.apache.spark.shuffle.remote.PerformanceEvaluationTool -h
+```
+
+Sample output
+```
+unsafe shuffle writer:
+    raw total size:      123 GB
+    compressed size:     135 GB
+    duration:            88.3 seconds
+
+    throughput(raw):     1429.06843144412 MB/s
+    throughput(storage): 1570.9931870053674 MB/s
+
+    number of mappers:   210
+    number of reducers:  70
+    block size(raw):     8 MB
+    block size(storage): 9 MB
+
+    properties:          spark.reducer.maxSizeInFlight -> 100m, spark.shuffle.remote.numReadThreads -> 8, spark.shuffle.remote.reducer.maxBlocksInFlightPerAddress -> 3
+
+    records per mapper:  70
+    load size per record:9000000
+
+    shuffle storage      daos://default:1
+    shuffle folder:      /tmp/shuffle
+-------------------------------------------------------------------------------------------------------------------------
+shuffle reader:
+    raw total size:      123 GB
+    compressed size:     135 GB
+    duration:            49.8 seconds
+
+    throughput(raw):     2533.665772753123 MB/s
+    throughput(storage): 2785.2911586057153 MB/s
+
+    number of mappers:   210
+    number of reducers:  70
+    block size(raw):     8 MB
+    block size(storage): 9 MB
+
+    properties:          spark.reducer.maxSizeInFlight -> 100m, spark.shuffle.remote.numReadThreads -> 8, spark.shuffle.remote.reducer.maxBlocksInFlightPerAddress -> 3
+
+    records per mapper:  70
+    load size per record:9000000
+
+    shuffle storage      daos://default:1
+    shuffle folder:      /tmp/shuffle                                                      
+```

--- a/oap-shuffle/remote-shuffle/README.md
+++ b/oap-shuffle/remote-shuffle/README.md
@@ -120,3 +120,9 @@ These configurations are deprecated and will not take effect.
     spark.shuffle.registration.timeout
     spark.shuffle.registration.maxAttempts
 ```
+
+## Performance Evaluation Tool
+
+Leverage this tool to evaluate shuffle write/read performance separately under specific storage system.
+
+This tool is 

--- a/oap-shuffle/remote-shuffle/README.md
+++ b/oap-shuffle/remote-shuffle/README.md
@@ -125,4 +125,4 @@ These configurations are deprecated and will not take effect.
 
 Leverage this tool to evaluate shuffle write/read performance separately under specific storage system.
 
-This tool is 
+Configuration details:

--- a/oap-shuffle/remote-shuffle/pom.xml
+++ b/oap-shuffle/remote-shuffle/pom.xml
@@ -219,6 +219,24 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <descriptors>
+            <descriptor>test-jar-with-dependencies.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/BypassMergeSortShuffleWriterPerfEvaluation.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/BypassMergeSortShuffleWriterPerfEvaluation.scala
@@ -30,23 +30,6 @@ object BypassMergeSortShuffleWriterPerfEvaluation extends ShuffleWriterPerfEvalu
       numMaps = 1,
       dependency)
 
-
-  def getWriter(mapId: Int, transferTo: Boolean, conf: SparkConf)
-  : BypassMergeSortShuffleWriter[Int, ByteBuffer] = {
-
-    setup()
-
-    val shuffleWriter = new BypassMergeSortShuffleWriter[Int, ByteBuffer](
-      blockManager,
-      blockResolver,
-      shuffleHandle,
-      mapId,
-      taskContext.get(),
-      conf)
-
-    shuffleWriter
-  }
-
   def getRemoteWriter(
     mapId: Int, conf: SparkConf): RemoteBypassMergeSortShuffleWriter[Int, ByteBuffer] = {
 

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/PerformanceEvaluationTool.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/PerformanceEvaluationTool.scala
@@ -189,8 +189,6 @@ object PerformanceEvaluationTool {
     options.addOption("d", "dir", true, "Shuffle directory")
     options.addOption("l", "log", true, "Log level")
     options.addOption("noDelete", "noDelete", false, "Not deleting shuffle files after testing")
-    options.addOption("transferTo", "transferTo", true, "Shuffle directory"
-    )
 
     options
   }

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/ShuffleReaderPerfEvaluation.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/ShuffleReaderPerfEvaluation.scala
@@ -59,7 +59,6 @@ object ShuffleReaderPerfEvaluation {
     mapStatus: MapStatus,
     storageMasterUri: String,
     shuffleDir: String,
-    conf: SparkConf,
     remoteConf: SparkConf): Unit = {
 
     MockitoAnnotations.initMocks(this)
@@ -88,24 +87,6 @@ object ShuffleReaderPerfEvaluation {
   }
 
   def getRemoteReader(
-    startPartition: Int,
-    endPartition: Int): RemoteShuffleReader[Int, ByteBuffer] = {
-
-    val taskContext = new TestTaskContext
-    TaskContext.setTaskContext(taskContext)
-
-    new RemoteShuffleReader[Int, ByteBuffer](
-      shuffleHandle,
-      remoteBlockResolver.asInstanceOf[RemoteShuffleBlockResolver],
-      startPartition,
-      endPartition,
-      taskContext,
-      serializerManager,
-      mapOutputTracker
-    )
-  }
-
-  def getReader(
     startPartition: Int,
     endPartition: Int): RemoteShuffleReader[Int, ByteBuffer] = {
 

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/ShuffleWriterPerfEvaluationBase.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/ShuffleWriterPerfEvaluationBase.scala
@@ -80,12 +80,12 @@ abstract class ShuffleWriterPerfEvaluationBase {
     }
   }
 
-  class TestBlockManager(tempDir: File, memoryManager: MemoryManager, conf: SparkConf)
+  class TestBlockManager(tempDir: File, memoryManager: MemoryManager, remoteConf: SparkConf)
     extends BlockManager("0",
     rpcEnv,
     null,
     serializerManager,
-      conf,
+    remoteConf,
     memoryManager,
     null,
     null,
@@ -99,7 +99,6 @@ abstract class ShuffleWriterPerfEvaluationBase {
   protected var tempDir: File = _
 
   protected var blockManager: BlockManager = _
-  protected var blockResolver: IndexShuffleBlockResolver = _
   protected var blockResolverRemote: RemoteShuffleBlockResolver = _
 
   protected var memoryManager: TestMemoryManager = _
@@ -114,21 +113,18 @@ abstract class ShuffleWriterPerfEvaluationBase {
   when(rpcEnv.setupEndpoint(any[String], any[RpcEndpoint])).thenReturn(rpcEndpointRef)
 
   def globalSetup(reducers: Int, storageMasterUri: String, shuffleDir: String,
-    conf: SparkConf, remoteConf: SparkConf): ShuffleBlockResolver = {
+                  remoteConf: SparkConf): ShuffleBlockResolver = {
     partitioner = new HashPartitioner(reducers)
     when(dependency.partitioner).thenReturn(partitioner)
 
 
     // For vanilla Spark shuffle directory customization
     tempDir = Utils.createTempDir(shuffleDir)
-    memoryManager = new TestMemoryManager(conf)
+    memoryManager = new TestMemoryManager(remoteConf)
     // Infinite memory
     // memoryManager.limit(MAXIMUM_PAGE_SIZE_BYTES)
 
-    blockManager = new TestBlockManager(tempDir, memoryManager, conf)
-    blockResolver = new IndexShuffleBlockResolver(
-      conf,
-      blockManager)
+    blockManager = new TestBlockManager(tempDir, memoryManager, remoteConf)
     blockResolverRemote = new RemoteShuffleBlockResolver(remoteConf)
     blockResolverRemote
   }

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/SortShuffleWriterPerfEvaluation.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/SortShuffleWriterPerfEvaluation.scala
@@ -33,17 +33,6 @@ object SortShuffleWriterPerfEvaluation extends ShuffleWriterPerfEvaluationBase {
       numMaps = 1,
       dependency = dependency)
 
-  def getWriter(mapId: Int): SortShuffleWriter[Int, ByteBuffer, ByteBuffer] = {
-
-    setup()
-
-    new SortShuffleWriter[Int, ByteBuffer, ByteBuffer](
-      blockResolver,
-      shuffleHandle,
-      mapId,
-      taskContext.get())
-  }
-
   def getRemoteWriter(mapId: Int): RemoteShuffleWriter[Int, ByteBuffer, ByteBuffer] = {
 
     setup()

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/UnsafeShuffleWriterPerfEvaluation.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/UnsafeShuffleWriterPerfEvaluation.scala
@@ -26,23 +26,6 @@ object UnsafeShuffleWriterPerfEvaluation extends ShuffleWriterPerfEvaluationBase
   private val shuffleHandle: SerializedShuffleHandle[Int, ByteBuffer] =
     new SerializedShuffleHandle[Int, ByteBuffer](0, 0, this.dependency)
 
-  def getWriter(
-    transferTo: Boolean, mapId: Int, conf: SparkConf): UnsafeShuffleWriter[Int, ByteBuffer] = {
-
-    val taskMemoryManager = setup()
-
-    conf.set("spark.file.transferTo", String.valueOf(transferTo))
-
-    new UnsafeShuffleWriter[Int, ByteBuffer](
-      blockManager,
-      blockResolver,
-      taskMemoryManager,
-      shuffleHandle,
-      mapId,
-      taskContext.get(),
-      conf)
-  }
-
   def getRemoteWriter(mapId: Int, conf: SparkConf): RemoteUnsafeShuffleWriter[Int, ByteBuffer] = {
 
     val taskMemoryManager = setup()

--- a/oap-shuffle/remote-shuffle/test-jar-with-dependencies.xml
+++ b/oap-shuffle/remote-shuffle/test-jar-with-dependencies.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>test-jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <!-- we're creating the test-jar as an attachement -->
+            <useProjectAttachments>true</useProjectAttachments>
+            <unpack>true</unpack>
+            <scope>test</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Followup #1172 . It includes:

- Docs.
- Allow producing a test jar with dependencies, which is convenient for running.
- Remove the local shuffle-related code, only focuses on the testing of this module.

## How was this patch tested?

Existing tests.