### PR TITLE
[oap-native-sql][Scala] fix contain to use is_substr

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarBinaryOperator.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarBinaryOperator.scala
@@ -108,14 +108,12 @@ class ColumnarContains(left: Expression, right: Expression, original: Expression
   override def doColumnarCodeGen(args: java.lang.Object): (TreeNode, ArrowType) = {
     val (left_node, left_type): (TreeNode, ArrowType) =
       left.asInstanceOf[ColumnarExpression].doColumnarCodeGen(args)
-    //FIXME(): use like %right% as gandiva does not support contains
-    val newRightStr = "%" + right + "%"
     val (right_node, right_type): (TreeNode, ArrowType) =
-      (TreeBuilder.makeStringLiteral(newRightStr), new ArrowType.Utf8())
+      (TreeBuilder.makeStringLiteral(right.toString()), new ArrowType.Utf8())
 
     val resultType = new ArrowType.Bool()
     val funcNode =
-      TreeBuilder.makeFunction("like", Lists.newArrayList(left_node, right_node), resultType)
+      TreeBuilder.makeFunction("is_substr", Lists.newArrayList(left_node, right_node), resultType)
     (funcNode, resultType)
   }
 }


### PR DESCRIPTION
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## What changes were proposed in this pull request?

Fix contain to use Gandiva's new kernel "is_substr" which has better performance


## How was this patch tested?

tested with local cluster

