### PR TITLE
[remote-shuffle]Disable hash-based shuffle writer by default

### DIFF
--- a/oap-shuffle/remote-shuffle/src/main/java/org/apache/spark/shuffle/sort/RemoteBypassMergeSortShuffleWriter.java
+++ b/oap-shuffle/remote-shuffle/src/main/java/org/apache/spark/shuffle/sort/RemoteBypassMergeSortShuffleWriter.java
@@ -135,7 +135,8 @@ public final class RemoteBypassMergeSortShuffleWriter<K, V> extends ShuffleWrite
     if (!records.hasNext()) {
       partitionLengths = new long[numPartitions];
       shuffleBlockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, null);
-      mapStatus = MapStatus$.MODULE$.apply(blockManager.shuffleServerId(), partitionLengths);
+      mapStatus = MapStatus$.MODULE$.apply(
+          RemoteShuffleManager$.MODULE$.getResolver().shuffleServerId(), partitionLengths);
       return;
     }
     final SerializerInstance serInstance = serializer.newInstance();

--- a/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/RemoteShuffleConf.scala
+++ b/oap-shuffle/remote-shuffle/src/main/scala/org/apache/spark/shuffle/remote/RemoteShuffleConf.scala
@@ -56,12 +56,15 @@ object RemoteShuffleConf {
   val REMOTE_BYPASS_MERGE_THRESHOLD: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.remote.bypassMergeThreshold")
       .doc("Remote shuffle manager uses this threshold to decide using bypass-merge(hash-based)" +
-        "shuffle or not, a new configuration is introduced because HDFS poorly handles large" +
-        "number of small files, and the bypass-merge shuffle write algorithm may produce" +
-        "M * R files as intermediate state. Note that this is compared with M * R, instead of" +
-        " R in local file system shuffle manager")
+        "shuffle or not, a new configuration is introduced(and it's -1 by default) because we" +
+        " want to explicitly make disabling hash-based shuffle writer as the default behavior." +
+        " When memory is relatively sufficient, using sort-based shuffle writer in remote shuffle" +
+        " is often more efficient than the hash-based one. Because the bypass-merge shuffle " +
+        "writer proceeds I/O of 3x total shuffle size: 1 time for read I/O and 2 times for write" +
+        " I/Os, and this can be an even larger overhead under remote shuffle, the 3x shuffle size" +
+        " is gone through network, arriving at remote storage system.")
       .intConf
-      .createWithDefault(300)
+      .createWithDefault(-1)
 
   val REMOTE_INDEX_CACHE_SIZE: ConfigEntry[String] =
     ConfigBuilder("spark.shuffle.remote.index.cache.size")

--- a/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/RemoteShuffleManagerSuite.scala
+++ b/oap-shuffle/remote-shuffle/src/test/scala/org/apache/spark/shuffle/remote/RemoteShuffleManagerSuite.scala
@@ -35,7 +35,7 @@ class RemoteShuffleManagerSuite extends SparkFunSuite with LocalSparkContext {
   testWithMultiplePath("sort")(sort(500, 13, true))
   testWithMultiplePath("sort large partition")(sort(500000, 2))
 
-  test("decide using bypass-merge-sort shuffle writer or not") {
+  test("disable bypass-merge-sort shuffle writer by default") {
     sc = new SparkContext("local", "test", new SparkConf(true))
     val partitioner = new HashPartitioner(100)
     val rdd = sc.parallelize((1 to 10).map(x => (x, x + 1)), 10)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some code are merged to https://github.com/Intel-bigdata/RemoteShuffle after https://github.com/Intel-bigdata/OAP/pull/1156 is merged to OAP. They should be incorporated in OAP to make the two repository consistent.

- Disable hash-based shuffle writer by default @ https://github.com/Intel-bigdata/RemoteShuffle/pull/49
- Minor fix: hash shuffle writer return right id when there is no records  https://github.com/Intel-bigdata/RemoteShuffle/commit/13a92a32fb074dac57334d372309dafad7f2681c

## How was this patch tested?

Existing tests.

