### PR TITLE
[oap-native-sql][Building] building with spark-sql from our maven repo

### DIFF
--- a/oap-native-sql/core/pom.xml
+++ b/oap-native-sql/core/pom.xml
@@ -19,28 +19,34 @@
     <arrow.version>0.17.0</arrow.version>
     <cpp.build.dir>../cpp/build/releases/</cpp.build.dir>
   </properties>
+  <repositories>
+  <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
   <dependencies>
     <!-- Prevent our dummy JAR from being included in Spark distributions or uploaded to YARN -->
     <dependency>
-      <groupId>org.apache.spark</groupId>
+      <groupId>com.intel.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.spark</groupId>
+      <groupId>com.intel.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.spark</groupId>
+      <groupId>com.intel.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.spark</groupId>
+      <groupId>com.intel.spark</groupId>
       <artifactId>spark-network-shuffle_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>test</scope>


### PR DESCRIPTION
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

use spark-sql jar file from our maven

(Please fill in changes proposed in this fix)

manually tested

