### PR TITLE
[OAP-Cache-OAP] fix plasma metrics

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -987,7 +987,8 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
 
   override def cacheStats: CacheStats = {
     val array = new Array[Long](4)
-//    plasmaClientPool(clientRoundRobin.getAndAdd(1) % clientPoolSize).metrics(array)
+    // TODO:total size will be incorrect due to it's an external cache
+    plasmaClientPool(clientRoundRobin.getAndAdd(1) % clientPoolSize).metrics(array)
     cacheTotalSize = new AtomicLong(array(3) + array(1))
     // Memory store and external store used size
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix plasma metrics, cache size is 0 on web UI.


## How was this patch tested?

Verified via spark web UI.

