### PR TITLE
[oap-native-sql] Enable ColumnarSort kernel with code generation

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/ColumnarPluginConfig.scala
@@ -1,0 +1,27 @@
+package com.intel.sparkColumnarPlugin
+
+import org.apache.spark.SparkConf
+
+class ColumnarPluginConfig(conf: SparkConf) {
+  val enableColumnarSort: Boolean =
+    conf.getBoolean("spark.sql.columnar.sort", defaultValue = false)
+}
+
+object ColumnarPluginConfig {
+  var ins: ColumnarPluginConfig = null
+  def getConf(conf: SparkConf): ColumnarPluginConfig = synchronized {
+    if (ins == null) {
+      ins = new ColumnarPluginConfig(conf)
+      ins
+    } else {
+      ins
+    }
+  }
+  def getConf: ColumnarPluginConfig = synchronized {
+    if (ins == null) {
+      throw new IllegalStateException("ColumnarPluginConfig is not initialized yet")
+    } else {
+      ins
+    }
+  }
+}

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/ColumnarSortExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/ColumnarSortExec.scala
@@ -9,6 +9,7 @@ import org.apache.spark.{SparkEnv, TaskContext, SparkContext}
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
@@ -21,35 +22,46 @@ class ColumnarSortExec(
     global: Boolean,
     child: SparkPlan,
     testSpillFrequency: Int = 0)
-extends SortExec(
-  sortOrder,
-  global,
-  child,
-  testSpillFrequency) {
+    extends SortExec(sortOrder, global, child, testSpillFrequency) {
   override def supportsColumnar = true
 
   // Disable code generation
   override def supportCodegen: Boolean = false
 
   override lazy val metrics = Map(
+    "totalSortTime" -> SQLMetrics
+      .createTimingMetric(sparkContext, "time in sort + shuffle process"),
     "sortTime" -> SQLMetrics.createTimingMetric(sparkContext, "time in sort process"),
+    "shuffleTime" -> SQLMetrics.createTimingMetric(sparkContext, "time in shuffle process"),
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "numOutputBatches" -> SQLMetrics.createMetric(sparkContext, "number of output batches"))
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val elapse = longMetric("totalSortTime")
     val sortTime = longMetric("sortTime")
+    val shuffleTime = longMetric("shuffleTime")
     val numOutputRows = longMetric("numOutputRows")
     val numOutputBatches = longMetric("numOutputBatches")
-    child.executeColumnar().mapPartitions{ iter =>
+    child.executeColumnar().mapPartitions { iter =>
       val hasInput = iter.hasNext
       val res = if (!hasInput) {
         Iterator.empty
       } else {
-        val sorter = ColumnarSorter.create(sortOrder, child.output, sortTime, numOutputBatches, numOutputRows)
-        TaskContext.get().addTaskCompletionListener[Unit](_ => {
-          sorter.close()
-        })
-        sorter.createIterator(iter)
+        val sorter = ColumnarSorter.create(
+          sortOrder,
+          true,
+          child.output,
+          sortTime,
+          numOutputBatches,
+          numOutputRows,
+          shuffleTime,
+          elapse)
+        TaskContext
+          .get()
+          .addTaskCompletionListener[Unit](_ => {
+            sorter.close()
+          })
+        new CloseableColumnBatchIterator(sorter.createColumnarIterator(iter))
       }
       res
     }

--- a/oap-native-sql/cpp/src/CMakeLists.txt
+++ b/oap-native-sql/cpp/src/CMakeLists.txt
@@ -180,7 +180,9 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
         codegen/arrow_compute/ext/codegen_node_visitor_v2.cc
         codegen/arrow_compute/ext/conditioned_shuffle_kernel.cc
         codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+        codegen/arrow_compute/ext/sort_kernel.cc
         codegen/arrow_compute/ext/kernels_ext.cc
+        codegen/arrow_compute/ext/codegen_common.cc
         )
 
 file(MAKE_DIRECTORY ${root_directory}/releases)

--- a/oap-native-sql/cpp/src/benchmarks/CMakeLists.txt
+++ b/oap-native-sql/cpp/src/benchmarks/CMakeLists.txt
@@ -1,3 +1,4 @@
 package_add_benchmark(BenchmarkArrowCompute arrow_compute_benchmark.cc)
 package_add_benchmark(BenchmarkArrowComputeJoin arrow_compute_benchmark_join.cc)
+package_add_benchmark(BenchmarkArrowComputeSort arrow_compute_benchmark_sort.cc)
 package_add_benchmark(BenchmarkArrowComputeBigScale arrow_compute_benchmark_big_scale.cc)

--- a/oap-native-sql/cpp/src/benchmarks/arrow_compute_benchmark_sort.cc
+++ b/oap-native-sql/cpp/src/benchmarks/arrow_compute_benchmark_sort.cc
@@ -1,0 +1,154 @@
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/memory_pool.h>
+#include <arrow/pretty_print.h>
+#include <arrow/record_batch.h>
+#include <arrow/testing/gtest_util.h>
+#include <arrow/type.h>
+#include <gandiva/gandiva_aliases.h>
+#include <gandiva/node.h>
+#include <gtest/gtest.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/file_reader.h>
+
+#include <chrono>
+
+#include "codegen/code_generator.h"
+#include "codegen/code_generator_factory.h"
+#include "codegen/common/result_iterator.h"
+#include "tests/test_utils.h"
+
+namespace sparkcolumnarplugin {
+namespace codegen {
+
+class BenchmarkArrowComputeSort : public ::testing::Test {
+ public:
+  void SetUp() override {
+    // read input from parquet file
+#ifdef BENCHMARK_FILE_PATH
+    std::string dir_path = BENCHMARK_FILE_PATH;
+#else
+    std::string dir_path = "";
+#endif
+    std::string path = dir_path + "tpcds_websales_sort_big.parquet";
+    std::cout << "This Benchmark used file " << path
+              << ", please download from server "
+                 "vsr200://home/zhouyuan/sparkColumnarPlugin/source_files"
+              << std::endl;
+    std::shared_ptr<arrow::fs::FileSystem> fs;
+    std::string file_name;
+    ASSERT_OK_AND_ASSIGN(fs, arrow::fs::FileSystemFromUri(path, &file_name));
+
+    ARROW_ASSIGN_OR_THROW(file, fs->OpenInputFile(file_name));
+
+    parquet::ArrowReaderProperties properties(true);
+    properties.set_batch_size(4096);
+    auto pool = arrow::default_memory_pool();
+
+    ASSERT_NOT_OK(::parquet::arrow::FileReader::Make(
+        pool, ::parquet::ParquetFileReader::Open(file), properties, &parquet_reader));
+    ASSERT_NOT_OK(
+        parquet_reader->GetRecordBatchReader({0}, {0, 1, 2}, &record_batch_reader));
+
+    schema = record_batch_reader->schema();
+    std::cout << schema->ToString() << std::endl;
+
+    ////////////////// expr prepration ////////////////
+    field_list = record_batch_reader->schema()->fields();
+    ret_field_list = record_batch_reader->schema()->fields();
+  }
+
+  void StartWithIterator() {
+    uint64_t elapse_gen = 0;
+    uint64_t elapse_read = 0;
+    uint64_t elapse_eval = 0;
+    uint64_t elapse_sort = 0;
+    uint64_t elapse_shuffle = 0;
+    uint64_t num_batches = 0;
+    std::shared_ptr<CodeGenerator> sort_expr;
+    TIME_MICRO_OR_THROW(elapse_gen, CreateCodeGenerator(schema, {sortArrays_expr},
+                                                        {f_indices}, &sort_expr, true));
+
+    std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+    std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+    std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+
+    std::shared_ptr<arrow::RecordBatch> record_batch;
+
+    do {
+      TIME_MICRO_OR_THROW(elapse_read, record_batch_reader->ReadNext(&record_batch));
+      if (record_batch) {
+        TIME_MICRO_OR_THROW(elapse_eval,
+                            sort_expr->evaluate(record_batch, &dummy_result_batches));
+        num_batches += 1;
+      }
+    } while (record_batch);
+    std::cout << "Readed " << num_batches << " batches." << std::endl;
+    TIME_MICRO_OR_THROW(elapse_sort, sort_expr->finish(&sort_result_iterator));
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+
+    uint64_t num_output_batches = 0;
+    while (sort_result_iterator->HasNext()) {
+      TIME_MICRO_OR_THROW(elapse_shuffle, sort_result_iterator->Next(&result_batch));
+      num_output_batches++;
+    }
+    arrow::PrettyPrint(*result_batch.get(), 2, &std::cout);
+
+    std::cout << "==================== Summary ====================\n"
+              << "BenchmarkArrowComputeJoin processed " << num_batches
+              << " batches\nthen output " << num_output_batches
+              << " batches\nCodeGen took " << TIME_TO_STRING(elapse_gen)
+              << "\nBatch read took " << TIME_TO_STRING(elapse_read)
+              << "\nEvaluation took " << TIME_TO_STRING(elapse_eval) << "\nSort took "
+              << TIME_TO_STRING(elapse_sort) << "\nShuffle took "
+              << TIME_TO_STRING(elapse_shuffle)
+              << ".\n================================================" << std::endl;
+  }
+
+ protected:
+  std::shared_ptr<arrow::io::RandomAccessFile> file;
+  std::unique_ptr<::parquet::arrow::FileReader> parquet_reader;
+  std::shared_ptr<RecordBatchReader> record_batch_reader;
+  std::shared_ptr<arrow::Schema> schema;
+
+  std::vector<std::shared_ptr<::arrow::Field>> field_list;
+  std::vector<std::shared_ptr<::arrow::Field>> ret_field_list;
+
+  int primary_key_index = 0;
+  std::shared_ptr<arrow::Field> f_indices;
+  std::shared_ptr<arrow::Field> f_res;
+  ::gandiva::ExpressionPtr sortArrays_expr;
+  ::gandiva::ExpressionPtr conditionShuffleExpr;
+};
+
+TEST_F(BenchmarkArrowComputeSort, SortBenchmark) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  f_indices = field("indices", indices_type);
+  f_res = field("res", arrow::uint64());
+
+  std::vector<std::shared_ptr<::gandiva::Node>> gandiva_field_list;
+  for (auto field : field_list) {
+    gandiva_field_list.push_back(TreeExprBuilder::MakeField(field));
+  }
+  auto n_left =
+      TreeExprBuilder::MakeFunction("codegen_left_schema", gandiva_field_list, uint64());
+  auto n_right = TreeExprBuilder::MakeFunction("codegen_right_schema", {}, uint64());
+  auto n_sort_to_indices =
+      TreeExprBuilder::MakeFunction("sortArraysToIndicesNullsFirstAsc",
+                                    {gandiva_field_list[primary_key_index]}, uint64());
+  sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_indices);
+
+  auto n_conditionedShuffleArrayList =
+      TreeExprBuilder::MakeFunction("conditionedShuffleArrayList", {}, uint64());
+  auto n_codegen_shuffle = TreeExprBuilder::MakeFunction(
+      "codegen_withTwoInputs", {n_conditionedShuffleArrayList, n_left, n_right},
+      uint64());
+  conditionShuffleExpr = TreeExprBuilder::MakeExpression(n_codegen_shuffle, f_res);
+
+  ///////////////////// Calculation //////////////////
+  StartWithIterator();
+}
+
+}  // namespace codegen
+}  // namespace sparkcolumnarplugin

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/code_generator.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/code_generator.h
@@ -220,8 +220,6 @@ class ArrowComputeCodeGenerator : public CodeGenerator {
     for (auto visitor : visitor_list_) {
       TIME_MICRO_OR_RAISE(finish_elapse_time_,
                           visitor->MakeResultIterator(arrow::schema(ret_types_), out));
-      visitor->PrintMetrics();
-      std::cout << std::endl;
     }
     return arrow::Status::OK();
   }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -7,7 +7,9 @@
 #include <arrow/type.h>
 #include <gandiva/node.h>
 #include <gandiva/tree_expr_builder.h>
+
 #include <memory>
+
 #include "codegen/arrow_compute/expr_visitor_impl.h"
 #include "codegen/arrow_compute/ext/kernels_ext.h"
 
@@ -281,7 +283,7 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(const std::string& func_name,
     RETURN_NOT_OK(EncodeVisitorImpl::Make(p, &impl_));
     goto finish;
   }
-  /*if (func_name.compare("sortArraysToIndicesNullsFirstAsc") == 0) {
+  if (func_name.compare("sortArraysToIndicesNullsFirstAsc") == 0) {
     RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(p, &impl_, true, true));
     goto finish;
   }
@@ -296,7 +298,7 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(const std::string& func_name,
   if (func_name.compare("sortArraysToIndicesNullsLastDesc") == 0) {
     RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(p, &impl_, false, false));
     goto finish;
-  }*/
+  }
   goto unrecognizedFail;
 finish:
   return arrow::Status::OK();

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_item_index.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_item_index.h
@@ -8,6 +8,7 @@ namespace extra {
 struct ArrayItemIndex {
   uint64_t id = 0;
   uint64_t array_id = 0;
+  ArrayItemIndex() : array_id(0), id(0) {}
   ArrayItemIndex(uint64_t array_id, uint64_t id) : array_id(array_id), id(id) {}
 };
 }  // namespace extra

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/code_generator_base.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/code_generator_base.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <arrow/array.h>
+#include <arrow/type.h>
+#include "codegen/common/result_iterator.h"
+
+#include <memory>
+#include <vector>
+
+namespace sparkcolumnarplugin {
+namespace codegen {
+namespace arrowcompute {
+namespace extra {
+using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
+class CodeGenBase {
+ public:
+  virtual arrow::Status Evaluate(const ArrayList& in) {
+    return arrow::Status::NotImplemented("SortBase Evaluate is an abstract interface.");
+  }
+  virtual arrow::Status Finish(std::shared_ptr<arrow::Array>* out) {
+    return arrow::Status::NotImplemented("SortBase Finish is an abstract interface.");
+  }
+  virtual arrow::Status MakeResultIterator(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) {
+    return arrow::Status::NotImplemented(
+        "SortBase MakeResultIterator is an abstract interface.");
+  }
+};
+}  // namespace extra
+}  // namespace arrowcompute
+}  // namespace codegen
+}  // namespace sparkcolumnarplugin

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
@@ -1,0 +1,197 @@
+#include "codegen/arrow_compute/ext/codegen_common.h"
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace sparkcolumnarplugin {
+namespace codegen {
+namespace arrowcompute {
+namespace extra {
+
+std::string BaseCodes() {
+  return R"(
+#include <arrow/array.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/buffer.h>
+#include <arrow/builder.h>
+#include <arrow/compute/context.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+#include <arrow/type_traits.h>
+
+#include <algorithm>
+#include <iostream>
+
+template <typename T> class ResultIterator {
+public:
+  virtual bool HasNext() { return false; }
+  virtual arrow::Status Next(std::shared_ptr<T> *out) {
+    return arrow::Status::NotImplemented("ResultIterator abstract Next function");
+  }
+  virtual arrow::Status
+  Process(std::vector<std::shared_ptr<arrow::Array>> in,
+          std::shared_ptr<T> *out,
+          const std::shared_ptr<arrow::Array> &selection = nullptr) {
+    return arrow::Status::NotImplemented("ResultIterator abstract Process function");
+  }
+  virtual arrow::Status
+  ProcessAndCacheOne(std::vector<std::shared_ptr<arrow::Array>> in,
+                     const std::shared_ptr<arrow::Array> &selection = nullptr) {
+    return arrow::Status::NotImplemented(
+        "ResultIterator abstract ProcessAndCacheOne function");
+  }
+  virtual arrow::Status GetResult(std::shared_ptr<arrow::RecordBatch>* out) {
+    return arrow::Status::NotImplemented("ResultIterator abstract GetResult function");
+  }
+  virtual std::string ToString() { return ""; }
+};
+
+using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
+struct ArrayItemIndex {
+  uint64_t id = 0;
+  uint64_t array_id = 0;
+  ArrayItemIndex(uint64_t array_id, uint64_t id) : array_id(array_id), id(id) {}
+};
+
+class CodeGenBase {
+ public:
+  virtual arrow::Status Evaluate(const ArrayList& in) {
+    return arrow::Status::NotImplemented("SortBase Evaluate is an abstract interface.");
+  }
+  virtual arrow::Status Finish(std::shared_ptr<arrow::Array>* out) {
+    return arrow::Status::NotImplemented("SortBase Finish is an abstract interface.");
+  }
+  virtual arrow::Status MakeResultIterator(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) {
+    return arrow::Status::NotImplemented(
+        "SortBase MakeResultIterator is an abstract interface.");
+  }
+};)";
+}
+
+int FileSpinLock(std::string path) {
+  std::string lockfile = path + "/nativesql_compile.lock";
+
+  auto fd = open(lockfile.c_str(), O_CREAT);
+  flock(fd, LOCK_EX);
+
+  return fd;
+}
+
+void FileSpinUnLock(int fd) {
+  flock(fd, LOCK_UN);
+  close(fd);
+}
+
+std::string GetTypeString(std::shared_ptr<arrow::DataType> type) {
+  switch (type->id()) {
+    case arrow::UInt8Type::type_id:
+      return "UInt8Type";
+    case arrow::Int8Type::type_id:
+      return "Int8Type";
+    case arrow::UInt16Type::type_id:
+      return "UInt16Type";
+    case arrow::Int16Type::type_id:
+      return "Int16Type";
+    case arrow::UInt32Type::type_id:
+      return "UInt32Type";
+    case arrow::Int32Type::type_id:
+      return "Int32Type";
+    case arrow::UInt64Type::type_id:
+      return "UInt64Type";
+    case arrow::Int64Type::type_id:
+      return "Int64Type";
+    case arrow::FloatType::type_id:
+      return "FloatType";
+    case arrow::DoubleType::type_id:
+      return "DoubleType";
+    case arrow::Date32Type::type_id:
+      return "Date32Type";
+    case arrow::StringType::type_id:
+      return "StringType";
+    default:
+      std::cout << "GetTypeString can't convert " << type->ToString() << std::endl;
+      throw;
+  }
+}
+
+arrow::Status CompileCodes(std::string codes, std::string signature) {
+  // temporary cpp/library output files
+  srand(time(NULL));
+  std::string outpath = "/tmp";
+  std::string prefix = "/spark-columnar-plugin-codegen-";
+  std::string cppfile = outpath + prefix + signature + ".cc";
+  std::string libfile = outpath + prefix + signature + ".so";
+  std::string logfile = outpath + prefix + signature + ".log";
+  std::ofstream out(cppfile.c_str(), std::ofstream::out);
+
+  // output code to file
+  if (out.bad()) {
+    std::cout << "cannot open " << cppfile << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  out << codes;
+  out.flush();
+  out.close();
+
+  // compile the code
+  std::string cmd = "gcc -std=c++11 -Wall -Wextra " + cppfile + " -o " + libfile +
+                    " -O3 -shared -fPIC -larrow 2> " + logfile;
+  int ret = system(cmd.c_str());
+  if (WEXITSTATUS(ret) != EXIT_SUCCESS) {
+    std::cout << "compilation failed, see " << logfile << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  struct stat tstat;
+  ret = stat(libfile.c_str(), &tstat);
+  if (ret == -1) {
+    std::cout << "stat failed: " << strerror(errno) << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status LoadLibrary(std::string signature, arrow::compute::FunctionContext* ctx,
+                          std::shared_ptr<CodeGenBase>* out) {
+  std::string outpath = "/tmp";
+  std::string prefix = "/spark-columnar-plugin-codegen-";
+  std::string libfile = outpath + prefix + signature + ".so";
+  std::cout << "LoadLibrary " << libfile << std::endl;
+  // load dynamic library
+  void* dynlib = dlopen(libfile.c_str(), RTLD_LAZY);
+  if (!dynlib) {
+    return arrow::Status::Invalid(libfile, " is not generated");
+  }
+
+  // loading symbol from library and assign to pointer
+  // (to be cast to function pointer later)
+
+  void (*MakeCodeGen)(arrow::compute::FunctionContext * ctx,
+                      std::shared_ptr<CodeGenBase> * out);
+  *(void**)(&MakeCodeGen) = dlsym(dynlib, "MakeCodeGen");
+  const char* dlsym_error = dlerror();
+  if (dlsym_error != NULL) {
+    std::stringstream ss;
+    ss << "error loading symbol:\n" << dlsym_error << std::endl;
+    return arrow::Status::Invalid(ss.str());
+  }
+
+  MakeCodeGen(ctx, out);
+  return arrow::Status::OK();
+}
+}  // namespace extra
+}  // namespace arrowcompute
+}  // namespace codegen
+}  // namespace sparkcolumnarplugin

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <arrow/compute/context.h>
+#include <arrow/type.h>
+
+#include <string>
+
+#include "codegen/arrow_compute/ext/code_generator_base.h"
+
+namespace sparkcolumnarplugin {
+namespace codegen {
+namespace arrowcompute {
+namespace extra {
+
+std::string BaseCodes();
+
+int FileSpinLock(std::string path);
+
+void FileSpinUnLock(int fd);
+
+std::string GetTypeString(std::shared_ptr<arrow::DataType> type);
+
+arrow::Status CompileCodes(std::string codes, std::string signature);
+
+arrow::Status LoadLibrary(std::string signature, arrow::compute::FunctionContext* ctx,
+                          std::shared_ptr<CodeGenBase>* out);
+}  // namespace extra
+}  // namespace arrowcompute
+}  // namespace codegen
+}  // namespace sparkcolumnarplugin

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -249,55 +249,6 @@ arrow::Status SplitArrayListWithActionKernel::MakeResultIterator(
   return impl_->MakeResultIterator(schema, out);
 }
 
-///////////////  SortArraysToIndices  ////////////////
-/*class SortArraysToIndicesKernel::Impl {
- public:
-  Impl(arrow::compute::FunctionContext* ctx, bool nulls_first, bool asc)
-      : ctx_(ctx), nulls_first_(nulls_first), asc_(asc) {}
-  ~Impl() {}
-  arrow::Status Evaluate(const std::shared_ptr<arrow::Array>& in) {
-    if (in->length() == 0) {
-      return arrow::Status::OK();
-    }
-    array_cache_.push_back(in);
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Finish(std::shared_ptr<arrow::Array>* out) {
-    RETURN_NOT_OK(
-        arrow::compute::SortArraysToIndices(ctx_, array_cache_, out, nulls_first_, asc_));
-    return arrow::Status::OK();
-  }
-
- private:
-  arrow::compute::FunctionContext* ctx_;
-  bool nulls_first_;
-  bool asc_;
-  std::vector<std::shared_ptr<arrow::Array>> array_cache_;
-};
-
-arrow::Status SortArraysToIndicesKernel::Make(arrow::compute::FunctionContext* ctx,
-                                              std::shared_ptr<KernalBase>* out,
-                                              bool nulls_first, bool asc) {
-  *out = std::make_shared<SortArraysToIndicesKernel>(ctx, nulls_first, asc);
-  return arrow::Status::OK();
-}
-
-SortArraysToIndicesKernel::SortArraysToIndicesKernel(arrow::compute::FunctionContext* ctx,
-                                                     bool nulls_first, bool asc) {
-  impl_.reset(new Impl(ctx, nulls_first, asc));
-  kernel_name_ = "SortArraysToIndicesKernelKernel";
-}
-
-arrow::Status SortArraysToIndicesKernel::Evaluate(
-    const std::shared_ptr<arrow::Array>& in) {
-  return impl_->Evaluate(in);
-}
-
-arrow::Status SortArraysToIndicesKernel::Finish(std::shared_ptr<arrow::Array>* out) {
-  return impl_->Finish(out);
-}
-*/
 ///////////////  UniqueArray  ////////////////
 /*class UniqueArrayKernel::Impl {
  public:

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -6,6 +6,7 @@
 #include <arrow/type_fwd.h>
 #include <gandiva/node.h>
 #include <gandiva/tree_expr_builder.h>
+
 #include "codegen/common/result_iterator.h"
 
 using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
@@ -240,20 +241,27 @@ class MaxArrayKernel : public KernalBase {
   arrow::compute::FunctionContext* ctx_;
 };
 
-/*class SortArraysToIndicesKernel : public KernalBase {
+class SortArraysToIndicesKernel : public KernalBase {
  public:
   static arrow::Status Make(arrow::compute::FunctionContext* ctx,
+                            std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+                            std::shared_ptr<arrow::Schema> result_schema,
                             std::shared_ptr<KernalBase>* out, bool nulls_first, bool asc);
-  SortArraysToIndicesKernel(arrow::compute::FunctionContext* ctx, bool nulls_first,
-                            bool asc);
-  arrow::Status Evaluate(const std::shared_ptr<arrow::Array>& in) override;
-  arrow::Status Finish(std::shared_ptr<arrow::Array>* out) override;
+  SortArraysToIndicesKernel(arrow::compute::FunctionContext* ctx,
+                            std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+                            std::shared_ptr<arrow::Schema> result_schema,
+                            bool nulls_first, bool asc);
+  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status MakeResultIterator(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override;
+
+  class Impl;
 
  private:
-  class Impl;
   std::unique_ptr<Impl> impl_;
   arrow::compute::FunctionContext* ctx_;
-};*/
+};
 
 /*class UniqueArrayKernel : public KernalBase {
  public:

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -1,0 +1,532 @@
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/buffer.h>
+#include <arrow/builder.h>
+#include <arrow/compute/context.h>
+#include <arrow/compute/expression.h>
+#include <arrow/compute/kernel.h>
+#include <arrow/compute/kernels/sort_to_indices.h>
+#include <arrow/compute/logical_type.h>
+#include <arrow/type.h>
+#include <arrow/type_fwd.h>
+#include <arrow/type_traits.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include "codegen/arrow_compute/ext/array_item_index.h"
+#include "codegen/arrow_compute/ext/code_generator_base.h"
+#include "codegen/arrow_compute/ext/codegen_common.h"
+#include "codegen/arrow_compute/ext/item_iterator.h"
+#include "codegen/arrow_compute/ext/kernels_ext.h"
+
+namespace sparkcolumnarplugin {
+namespace codegen {
+namespace arrowcompute {
+namespace extra {
+using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
+
+///////////////  SortArraysToIndices  ////////////////
+class SortArraysToIndicesKernel::Impl {
+ public:
+  Impl(arrow::compute::FunctionContext* ctx,
+       std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+       std::shared_ptr<arrow::Schema> result_schema, bool nulls_first, bool asc)
+      : ctx_(ctx), nulls_first_(nulls_first), asc_(asc) {
+    for (auto field : key_field_list) {
+      auto indices = result_schema->GetAllFieldIndices(field->name());
+      if (indices.size() != 1) {
+        std::cout << "[ERROR] SortArraysToIndicesKernel::Impl can't find key "
+                  << field->ToString() << " from " << result_schema->ToString()
+                  << std::endl;
+        throw;
+      }
+      key_index_list_.push_back(indices[0]);
+    }
+
+    auto status = LoadJITFunction(key_field_list, result_schema, &sorter);
+    if (!status.ok()) {
+      std::cout << "LoadJITFunction failed, msg is " << status.message() << std::endl;
+      throw;
+    }
+  }
+
+  arrow::Status Evaluate(const ArrayList& in) {
+    RETURN_NOT_OK(sorter->Evaluate(in));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status MakeResultIterator(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) {
+    RETURN_NOT_OK(sorter->MakeResultIterator(schema, out));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Finish(std::shared_ptr<arrow::Array>* out) { return arrow::Status::OK(); }
+
+ private:
+  std::shared_ptr<CodeGenBase> sorter;
+  arrow::compute::FunctionContext* ctx_;
+  bool nulls_first_;
+  bool asc_;
+  std::vector<int> key_index_list_;
+  class TypedSorterCodeGenImpl {
+   public:
+    TypedSorterCodeGenImpl(std::string indice, std::string dataTypeName, std::string name)
+        : indice_(indice), dataTypeName_(dataTypeName), name_(name) {}
+    std::string GetCachedVariablesDefine() {
+      return "using DataType_" + indice_ + " = typename arrow::" + dataTypeName_ +
+             ";\n"
+             "using ArrayType_" +
+             indice_ + " = typename arrow::TypeTraits<DataType_" + indice_ +
+             ">::ArrayType;\n"
+             "std::vector<std::shared_ptr<ArrayType_" +
+             indice_ + ">> cached_" + indice_ + "_;\n";
+    }
+    std::string GetResultIterDefine() {
+      return "cached_" + indice_ + "_ = cached_" + indice_ +
+             ";\n"
+             "std::unique_ptr<arrow::ArrayBuilder> builder_" +
+             indice_ +
+             ";\n"
+             "arrow::MakeBuilder(ctx_->memory_pool(), data_type_" +
+             indice_ + ", &builder_" + indice_ +
+             ");\n"
+             "builder_" +
+             indice_ + "_.reset(arrow::internal::checked_cast<BuilderType_" + indice_ +
+             "*>(builder_" + indice_ + ".release()));\n";
+    }
+    std::string GetFieldDefine() {
+      return "arrow::field(\"" + name_ + "\", data_type_" + indice_ + ")";
+    }
+    std::string GetResultIterVariables() {
+      return R"(
+    using DataType_)" +
+             indice_ + R"( = typename arrow::)" + dataTypeName_ + R"(;
+    using ArrayType_)" +
+             indice_ + R"( = typename arrow::TypeTraits<DataType_)" + indice_ +
+             R"(>::ArrayType;
+    using BuilderType_)" +
+             indice_ + R"( = typename arrow::TypeTraits<DataType_)" + indice_ +
+             R"(>::BuilderType;
+    std::shared_ptr<arrow::DataType> data_type_)" +
+             indice_ + R"( = arrow::TypeTraits<DataType_)" + indice_ +
+             R"(>::type_singleton();
+    std::vector<std::shared_ptr<ArrayType_)" +
+             indice_ + R"(>> cached_)" + indice_ + R"(_;
+    std::shared_ptr<BuilderType_)" +
+             indice_ + R"(> builder_)" + indice_ + R"(_;
+    )";
+    }
+
+   private:
+    std::string indice_;
+    std::string dataTypeName_;
+    std::string name_;
+  };
+
+  arrow::Status LoadJITFunction(std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+                                std::shared_ptr<arrow::Schema> result_schema,
+                                std::shared_ptr<CodeGenBase>* out) {
+    // generate ddl signature
+    std::stringstream func_args_ss;
+    func_args_ss << "[Sorter]" << (nulls_first_ ? "nulls_first" : "nulls_last") << "|"
+                 << (asc_ ? "asc" : "desc");
+    int i = 0;
+    for (auto field : key_field_list) {
+      func_args_ss << "[sort_key_" << i << "]" << field->ToString();
+    }
+
+    func_args_ss << "[schema]" << result_schema->ToString();
+
+    std::stringstream signature_ss;
+    signature_ss << std::hex << std::hash<std::string>{}(func_args_ss.str());
+    std::string signature = signature_ss.str();
+
+    auto file_lock = FileSpinLock("/tmp");
+    auto status = LoadLibrary(signature, ctx_, out);
+    if (!status.ok()) {
+      // process
+      auto codes = ProduceCodes(result_schema);
+      // compile codes
+      RETURN_NOT_OK(CompileCodes(codes, signature));
+      RETURN_NOT_OK(LoadLibrary(signature, ctx_, out));
+    }
+    FileSpinUnLock(file_lock);
+    return arrow::Status::OK();
+  }
+
+  std::string ProduceCodes(std::shared_ptr<arrow::Schema> result_schema) {
+    int indice = 0;
+    std::vector<std::shared_ptr<TypedSorterCodeGenImpl>> shuffle_typed_codegen_list;
+    for (auto field : result_schema->fields()) {
+      auto codegen = std::make_shared<TypedSorterCodeGenImpl>(
+          std::to_string(indice), GetTypeString(field->type()), field->name());
+      shuffle_typed_codegen_list.push_back(codegen);
+      indice++;
+    }
+    std::string cached_insert_str = GetCachedInsert(shuffle_typed_codegen_list.size());
+    std::string comp_func_str = GetCompFunction(key_index_list_);
+
+    std::string pre_sort_valid_str = GetPreSortValid();
+
+    std::string pre_sort_null_str = GetPreSortNull();
+
+    std::string sort_func_str = GetSortFunction();
+
+    std::string make_result_iter_str =
+        GetMakeResultIter(shuffle_typed_codegen_list.size());
+
+    std::string cached_variables_define_str =
+        GetCachedVariablesDefine(shuffle_typed_codegen_list);
+
+    std::string result_iter_param_define_str =
+        GetResultIterParamsDefine(shuffle_typed_codegen_list.size());
+
+    std::string result_iter_define_str = GetResultIterDefine(shuffle_typed_codegen_list);
+
+    std::string typed_build_str = GetTypedBuild(shuffle_typed_codegen_list.size());
+
+    std::string result_variables_define_str =
+        GetResultIterVariables(shuffle_typed_codegen_list);
+
+    std::string typed_res_array_build_str =
+        GetTypedResArrayBuild(shuffle_typed_codegen_list.size());
+
+    std::string typed_res_array_str = GetTypedResArray(shuffle_typed_codegen_list.size());
+
+    return BaseCodes() + R"(
+class TypedSorterImpl : public CodeGenBase {
+ public:
+  TypedSorterImpl(arrow::compute::FunctionContext* ctx) : ctx_(ctx) {}
+
+  arrow::Status Evaluate(const ArrayList& in) override {
+    num_batches_++;
+    items_total_ += in[0]->length();
+    nulls_total_ += in[0]->null_count();
+    first_.push_back(in[0]);
+    )" + cached_insert_str +
+           R"(
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Finish(std::shared_ptr<arrow::Array>* out) override {
+    )" + comp_func_str +
+           R"(
+    // initiate buffer for all arrays
+    std::shared_ptr<arrow::Buffer> indices_buf;
+    int64_t buf_size = items_total_ * sizeof(ArrayItemIndex);
+    RETURN_NOT_OK(arrow::AllocateBuffer(ctx_->memory_pool(), buf_size, &indices_buf));
+
+    // start to partition not_null with null
+    ArrayItemIndex* indices_begin =
+        reinterpret_cast<ArrayItemIndex*>(indices_buf->mutable_data());
+    ArrayItemIndex* indices_end = indices_begin + items_total_;
+
+    int64_t indices_i = 0;
+    int64_t indices_null = 0;
+
+    // we should support nulls first and nulls last here
+    // we should also support desc and asc here
+
+    for (int array_id = 0; array_id < num_batches_; array_id++) {
+      for (int64_t i = 0; i < first_[array_id]->length(); i++) {
+        if (!first_[array_id]->IsNull(i)) {
+          )" +
+           pre_sort_valid_str +
+           R"(
+          indices_i++;
+        } else {
+          )" +
+           pre_sort_null_str +
+           R"(
+          indices_null++;
+        }
+      }
+    }
+    )" + sort_func_str +
+           R"(
+    auto out_type = std::make_shared<arrow::FixedSizeBinaryType>(sizeof(ArrayItemIndex) /
+                                                                 sizeof(int32_t));
+    *out = std::make_shared<arrow::FixedSizeBinaryArray>(out_type, items_total_,
+                                                         indices_buf);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status MakeResultIterator(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override {
+    std::shared_ptr<arrow::Array> indices_out;
+    RETURN_NOT_OK(Finish(&indices_out));
+    )" + make_result_iter_str +
+           R"(
+    return arrow::Status::OK();
+  }
+
+ private:
+  )" + cached_variables_define_str +
+           R"(
+  std::vector<std::shared_ptr<arrow::Array>> first_;
+  arrow::compute::FunctionContext* ctx_;
+  uint64_t num_batches_ = 0;
+  uint64_t items_total_ = 0;
+  uint64_t nulls_total_ = 0;
+
+  class SorterResultIterator : public ResultIterator<arrow::RecordBatch> {
+   public:
+    SorterResultIterator(arrow::compute::FunctionContext* ctx,
+                       std::shared_ptr<arrow::Array> indices_in,
+   )" + result_iter_param_define_str +
+           R"(): ctx_(ctx), total_length_(indices_in->length()), indices_in_cache_(indices_in) {
+     )" + result_iter_define_str +
+           R"(
+      indices_begin_ = (ArrayItemIndex*)indices_in->data()->buffers[1]->mutable_data();
+    }
+
+    std::string ToString() override { return "SortArraysToIndicesResultIterator"; }
+
+    bool HasNext() override {
+      if (offset_ >= total_length_) {
+        return false;
+      }
+      return true;
+    }
+
+    arrow::Status Next(std::shared_ptr<arrow::RecordBatch>* out) {
+      auto length = (total_length_ - offset_) > 4096 ? 4096 : (total_length_ - offset_);
+      uint64_t count = 0;
+      while (count < length) {
+        auto item = indices_begin_ + offset_ + count++;
+      )" + typed_build_str +
+           R"(
+      }
+      offset_ += length;
+      )" + typed_res_array_build_str +
+           R"(
+      *out = arrow::RecordBatch::Make(result_schema_, length, {)" +
+           typed_res_array_str + R"(});
+      return arrow::Status::OK();
+    }
+
+   private:
+   )" + result_variables_define_str +
+           R"(
+    std::shared_ptr<arrow::Array> indices_in_cache_;
+    uint64_t offset_ = 0;
+    ArrayItemIndex* indices_begin_;
+    const uint64_t total_length_;
+    std::shared_ptr<arrow::Schema> result_schema_;
+    arrow::compute::FunctionContext* ctx_;
+  };
+};
+
+extern "C" void MakeCodeGen(arrow::compute::FunctionContext* ctx,
+                            std::shared_ptr<CodeGenBase>* out) {
+  *out = std::make_shared<TypedSorterImpl>(ctx);
+}
+
+    )";
+  }
+  std::string GetCachedInsert(int shuffle_size) {
+    std::stringstream ss;
+    for (int i = 0; i < shuffle_size; i++) {
+      ss << "cached_" << i << "_.push_back(std::dynamic_pointer_cast<ArrayType_" << i
+         << ">(in[" << i << "]));" << std::endl;
+    }
+    return ss.str();
+  }
+  std::string GetCompFunction(std::vector<int> sort_key_index_list) {
+    std::stringstream ss;
+    ss << "auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {"
+       << GetCompFunction_(0, sort_key_index_list) << "};";
+    return ss.str();
+  }
+  std::string GetCompFunction_(int cur_key_index, std::vector<int> sort_key_index_list) {
+    std::string comp_str;
+    auto cur_key_id = sort_key_index_list[cur_key_index];
+    if (asc_) {
+      std::stringstream ss;
+      ss << "return cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) < cached_"
+         << cur_key_id << "_[y.array_id]->GetView(y.id);\n";
+      comp_str = ss.str();
+    } else {
+      std::stringstream ss;
+      ss << "return cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) > cached_"
+         << cur_key_id << "_[y.array_id]->GetView(y.id);\n";
+      comp_str = ss.str();
+    }
+    if ((cur_key_index + 1) < sort_key_index_list.size()) {
+      std::stringstream ss;
+      ss << "if (cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) == cached_"
+         << cur_key_id << "_[y.array_id]->GetView(y.id)) {"
+         << GetCompFunction_(cur_key_index + 1, sort_key_index_list) << "} else { "
+         << comp_str << "}";
+      return ss.str();
+    } else {
+      return comp_str;
+    }
+  }
+  std::string GetPreSortValid() {
+    if (nulls_first_) {
+      return R"(
+    (indices_begin + nulls_total_ + indices_i)->array_id = array_id;
+    (indices_begin + nulls_total_ + indices_i)->id = i;)";
+
+    } else {
+      return R"(
+    (indices_begin + indices_i)->array_id = array_id;
+    (indices_begin + indices_i)->id = i;)";
+    }
+  }
+  std::string GetPreSortNull() {
+    if (nulls_first_) {
+      return R"(
+    (indices_begin + indices_null)->array_id = array_id;
+    (indices_begin + indices_null)->id = i;)";
+    } else {
+      return R"(
+    (indices_end - nulls_total_ + indices_null)->array_id = array_id;
+    (indices_end - nulls_total_ + indices_null)->id = i;)";
+    }
+  }
+  std::string GetSortFunction() {
+    if (nulls_first_) {
+      return "std::sort(indices_begin + nulls_total_, indices_begin + "
+             "items_total_, "
+             "comp);";
+    } else {
+      return "std::sort(indices_begin, indices_begin + items_total_ - "
+             "nulls_total_, comp);";
+    }
+  }
+  std::string GetMakeResultIter(int shuffle_size) {
+    std::stringstream ss;
+    std::stringstream params_ss;
+    for (int i = 0; i < shuffle_size; i++) {
+      if (i + 1 < shuffle_size) {
+        params_ss << "cached_" << i << "_,";
+      } else {
+        params_ss << "cached_" << i << "_";
+      }
+    }
+    auto params = params_ss.str();
+    ss << "*out = std::make_shared<SorterResultIterator>(ctx_, indices_out, " << params
+       << ");";
+    return ss.str();
+  }
+  std::string GetCachedVariablesDefine(
+      std::vector<std::shared_ptr<TypedSorterCodeGenImpl>> shuffle_typed_codegen_list) {
+    std::stringstream ss;
+    for (auto codegen : shuffle_typed_codegen_list) {
+      ss << codegen->GetCachedVariablesDefine() << std::endl;
+    }
+    return ss.str();
+  }
+  std::string GetResultIterParamsDefine(int shuffle_size) {
+    std::stringstream ss;
+    for (int i = 0; i < shuffle_size; i++) {
+      if (i + 1 < shuffle_size) {
+        ss << "std::vector<std::shared_ptr<ArrayType_" << i << ">> cached_" << i << ","
+           << std::endl;
+      } else {
+        ss << "std::vector<std::shared_ptr<ArrayType_" << i << ">> cached_" << i;
+      }
+    }
+    return ss.str();
+  }
+  std::string GetResultIterDefine(
+      std::vector<std::shared_ptr<TypedSorterCodeGenImpl>> shuffle_typed_codegen_list) {
+    std::stringstream ss;
+    std::stringstream field_define_ss;
+    for (auto codegen : shuffle_typed_codegen_list) {
+      ss << codegen->GetResultIterDefine() << std::endl;
+      if (codegen != *(shuffle_typed_codegen_list.end() - 1)) {
+        field_define_ss << codegen->GetFieldDefine() << ",";
+      } else {
+        field_define_ss << codegen->GetFieldDefine();
+      }
+    }
+    ss << "result_schema_ = arrow::schema({" << field_define_ss.str() << "});\n"
+       << std::endl;
+    return ss.str();
+  }
+  std::string GetTypedBuild(int shuffle_size) {
+    std::stringstream ss;
+    for (int i = 0; i < shuffle_size; i++) {
+      ss << "if (!cached_" << i << "_[item->array_id]->IsNull(item->id)) {\n"
+         << "  RETURN_NOT_OK(builder_" << i << "_->Append(cached_" << i
+         << "_[item->array_id]->GetView(item->id)));\n"
+         << "} else {\n"
+         << "  RETURN_NOT_OK(builder_" << i << "_->AppendNull());\n"
+         << "}" << std::endl;
+    }
+    return ss.str();
+  }
+  std::string GetTypedResArrayBuild(int shuffle_size) {
+    std::stringstream ss;
+    for (int i = 0; i < shuffle_size; i++) {
+      ss << "std::shared_ptr<arrow::Array> out_" << i << ";\n"
+         << "RETURN_NOT_OK(builder_" << i << "_->Finish(&out_" << i << "));\n"
+         << "builder_" << i << "_->Reset();" << std::endl;
+    }
+    return ss.str();
+  }
+  std::string GetTypedResArray(int shuffle_size) {
+    std::stringstream ss;
+    for (int i = 0; i < shuffle_size; i++) {
+      if (i + 1 < shuffle_size) {
+        ss << "out_" << i << ", ";
+      } else {
+        ss << "out_" << i;
+      }
+    }
+    return ss.str();
+  }
+  std::string GetResultIterVariables(
+      std::vector<std::shared_ptr<TypedSorterCodeGenImpl>> shuffle_typed_codegen_list) {
+    std::stringstream ss;
+    for (auto codegen : shuffle_typed_codegen_list) {
+      ss << codegen->GetResultIterVariables() << std::endl;
+    }
+    return ss.str();
+  }
+};
+
+arrow::Status SortArraysToIndicesKernel::Make(
+    arrow::compute::FunctionContext* ctx,
+    std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+    std::shared_ptr<arrow::Schema> result_schema, std::shared_ptr<KernalBase>* out,
+    bool nulls_first, bool asc) {
+  *out = std::make_shared<SortArraysToIndicesKernel>(ctx, key_field_list, result_schema,
+                                                     nulls_first, asc);
+  return arrow::Status::OK();
+}
+
+SortArraysToIndicesKernel::SortArraysToIndicesKernel(
+    arrow::compute::FunctionContext* ctx,
+    std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+    std::shared_ptr<arrow::Schema> result_schema, bool nulls_first, bool asc) {
+  impl_.reset(new Impl(ctx, key_field_list, result_schema, nulls_first, asc));
+  kernel_name_ = "SortArraysToIndicesKernelKernel";
+}
+#undef PROCESS_SUPPORTED_TYPES
+
+arrow::Status SortArraysToIndicesKernel::Evaluate(const ArrayList& in) {
+  return impl_->Evaluate(in);
+}
+
+arrow::Status SortArraysToIndicesKernel::MakeResultIterator(
+    std::shared_ptr<arrow::Schema> schema,
+    std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) {
+  return impl_->MakeResultIterator(schema, out);
+}
+
+}  // namespace extra
+}  // namespace arrowcompute
+}  // namespace codegen
+}  // namespace sparkcolumnarplugin

--- a/oap-native-sql/cpp/src/tests/CMakeLists.txt
+++ b/oap-native-sql/cpp/src/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
-package_add_test(TestArrowCompute arrow_compute_test_aggregate.cc)
+package_add_test(TestArrowComputeAggregate arrow_compute_test_aggregate.cc)
 package_add_test(TestArrowComputeJoin arrow_compute_test_join.cc)
+package_add_test(TestArrowComputeSort arrow_compute_test_sort.cc)

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
@@ -1,0 +1,396 @@
+#include <arrow/array.h>
+#include <arrow/ipc/json_simple.h>
+#include <arrow/record_batch.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "codegen/code_generator.h"
+#include "codegen/code_generator_factory.h"
+#include "tests/test_utils.h"
+
+namespace sparkcolumnarplugin {
+namespace codegen {
+
+TEST(TestArrowComputeSort, SortTestNullsFirstAsc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndicesNullsFirstAsc", {arg_0}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+
+  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null, null, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, "
+      "22, 23, 30, "
+      "32, 33, 35, 37, 41, 42, 43, 50, 52, 59, 64]",
+      "[34, 67, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, null, 16, 18, 19, 20, 21, 22, "
+      "23, 24, "
+      "31, 33, 34, 36, 38, 42, 43, 44, 51, null, 60, 65]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestNullsLastAsc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_sort_to_indices =
+      TreeExprBuilder::MakeFunction("sortArraysToIndicesNullsLastAsc", {arg_0}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+
+  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23, 30, "
+      "32, 33, 35, 37, 41, 42, 43, 50, 52, 59, 64, null, null]",
+      "[2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, null, 16, 18, 19, 20, 21, 22, 23, 24,"
+      "31, 33, 34, 36, 38, 42, 43, 44, 51, null, 60, 65, 34, 67]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestNullsFirstDesc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndicesNullsFirstDesc", {arg_0}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+
+  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null ,null ,64 ,59 ,52 ,50 ,43 ,42 ,41 ,37 ,35 ,33 ,32 ,30 ,23 ,22 ,21 ,20 ,19 "
+      ",18 ,17 ,15 ,14 ,13 ,12 , 11 ,10 ,9 ,8 ,7 ,6 ,4 ,3 ,2 ,1]",
+      "[34 ,67 ,65 ,60 ,null ,51 ,44 ,43 ,42 ,38 ,36 ,34 ,33 ,31 ,24 ,23 ,22 ,21 , 20 "
+      ",19 ,18 ,16 ,null ,14 ,13 ,12 ,11 ,10 ,9 ,8 ,7 ,5 ,4 ,3 ,2]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestNullsLastDesc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndicesNullsLastDesc", {arg_0}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+
+  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[64 ,59 ,52 ,50 ,43 ,42 ,41 ,37 ,35 ,33 ,32 ,30 ,23 ,22 ,21 ,20 ,19 "
+      ",18 ,17 ,15 ,14 ,13 ,12 , 11 ,10 ,9 ,8 ,7 ,6 ,4 ,3 ,2 ,1, null, null]",
+      "[65 ,60 ,null ,51 ,44 ,43 ,42 ,38 ,36 ,34 ,33 ,31 ,24 ,23 ,22 ,21 , 20 "
+      ",19 ,18 ,16 ,null ,14 ,13 ,12 ,11 ,10 ,9 ,8 ,7 ,5 ,4 ,3 ,2, 34, 67]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestNullsFirstAscMultipleKeys) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", utf8());
+  auto f2 = field("f2", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndicesNullsFirstAsc", {arg_0, arg_1}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+
+  auto sch = arrow::schema({f0, f1, f2});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+
+  std::vector<std::string> input_data_string = {"[8, 12, 4, 50, 52, 32, 11]",
+                                                R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 8, 42, 6, null, 2]",
+                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, 33]",
+                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null, null, 1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 8, 9, 11, 12, 13, 14, 17, 18, 20, 21, "
+      "22, 23, 30, 32, 33, 35, 37, 41, 42, 50, 52, 59, 64]",
+      R"(["b","a","a","b","a","a","b","b","a","a","a","b","b","b","b","a","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a"])",
+      "[34, 67, 2, 3, 4, 5, 7, 8, 11, 44, 16, 9, 20, 10, 12, 13, 14, null, 18, 19, 21, "
+      "22, 23, 24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65]"};
+
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+}  // namespace codegen
+}  // namespace sparkcolumnarplugin


### PR DESCRIPTION
1. Use "spark.sql.columnar.sort true" to enable columnar sort
2. TPCH queries passed, multiple columns sort supported.
3. Hot function is std::sort which contributes most process time, we now observed current sort algorithm is slower than vanilar spark.

Signed-off-by: Chendi Xue <chendi.xue@intel.com>