### PR TITLE
[oap-native-sql] Calling ColumnVectorUtils.populate(...) on ArrowWrit…

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ArrowWritableColumnVector.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ArrowWritableColumnVector.java
@@ -1601,6 +1601,13 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     }
 
     @Override
+    void setInts(int rowId, int count, int value) {
+      for (int i = 0; i < count; i++) {
+        writer.setSafe(rowId + i, value);
+      }
+    }
+
+    @Override
     final void setNull(int rowId) {
       writer.setNull(rowId);
     }
@@ -1613,6 +1620,13 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     TimestampWriter(TimeStampMicroTZVector vector) {
       super(vector);
       this.writer = vector;
+    }
+
+    @Override
+    void setLongs(int rowId, int count, long value) {
+      for (int i = 0; i < count; i++) {
+        writer.setSafe(rowId + i, value);
+      }
     }
 
     @Override


### PR DESCRIPTION
…ableColumnVector leads to UnsupportedOperationException
