### PR TITLE
[OAP-Cache-OAP] modify arrow build script, will not install all java modules

### DIFF
--- a/dev/install_arrow.sh
+++ b/dev/install_arrow.sh
@@ -7,8 +7,8 @@ rm -rf release
 mkdir release
 cd release
 #build libarrow, libplasma, libplasma_java
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-g -O3" -DCMAKE_CXX_FLAGS="-g -O3" -DARROW_BUILD_TESTS=on -DARROW_PLASMA_JAVA_CLIENT=on -DARROW_PLASMA=on -DARROW_DEPENDENCY_SOURCE=BUNDLED ..
+cmake -DCMAKE_INSTALL_PREFIX=/usr/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-g -O3" -DCMAKE_CXX_FLAGS="-g -O3" -DARROW_BUILD_TESTS=on -DARROW_PLASMA_JAVA_CLIENT=on -DARROW_PLASMA=on -DARROW_DEPENDENCY_SOURCE=BUNDLED ..
 make -j$(nproc)
 sudo make install -j$(nproc)
 cd ../../java
-mvn clean -q -DskipTests install
+mvn clean -pl plasma -am -q -DskipTests install

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -157,11 +157,11 @@ function prepare_intel_arrow() {
   cd release
 
   #build libarrow, libplasma, libplasma_java
-  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-g -O3" -DCMAKE_CXX_FLAGS="-g -O3" -DARROW_BUILD_TESTS=on -DARROW_PLASMA_JAVA_CLIENT=on -DARROW_PLASMA=on -DARROW_DEPENDENCY_SOURCE=BUNDLED ..
+  cmake -DCMAKE_INSTALL_PREFIX=/usr/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-g -O3" -DCMAKE_CXX_FLAGS="-g -O3" -DARROW_BUILD_TESTS=on -DARROW_PLASMA_JAVA_CLIENT=on -DARROW_PLASMA=on -DARROW_DEPENDENCY_SOURCE=BUNDLED ..
   make -j$(nproc)
   make install -j$(nproc)
   cd $dev_path/thirdparty/arrow/java
-  mvn clean -q -DskipTests install
+  mvn clean -pl plasma -am -q -DskipTests install
 }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

modify arrow build script, will not install all java modules


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

