### PR TITLE
[oap-native-sql][C++] pass arrow/gcc  to runtime filter codegen

### DIFF
--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
@@ -584,8 +584,12 @@ extern "C" void MakeConditioner(std::shared_ptr<ConditionerBase> *out) {
     out.flush();
     out.close();
 
+    const char* env_arrow_dir = std::getenv("LIBARROW_DIR");
+    std::string arrow_header = " -I" + std::string(env_arrow_dir) + "/include ";
+    std::string arrow_lib = " -L" + std::string(env_arrow_dir) + "/lib64 ";
     // compile the code
-    std::string cmd = "gcc -std=c++11 -Wall -Wextra " + cppfile + " -o " + libfile +
+    std::string cmd = "gcc -std=c++11 -Wall -Wextra " + arrow_header +
+	              arrow_lib + cppfile + " -o " + libfile +
                       " -O3 -shared -fPIC -larrow 2> " + logfile;
     int ret = system(cmd.c_str());
     if (WEXITSTATUS(ret) != EXIT_SUCCESS) {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
@@ -584,11 +584,17 @@ extern "C" void MakeConditioner(std::shared_ptr<ConditionerBase> *out) {
     out.flush();
     out.close();
 
+    const char* env_gcc_ = std::getenv("CC");
+    if (env_gcc_ == nullptr) {
+      env_gcc_ = "gcc";
+    }
+    std::string env_gcc = std::string(env_gcc_);
+
     const char* env_arrow_dir = std::getenv("LIBARROW_DIR");
     std::string arrow_header = " -I" + std::string(env_arrow_dir) + "/include ";
     std::string arrow_lib = " -L" + std::string(env_arrow_dir) + "/lib64 ";
     // compile the code
-    std::string cmd = "gcc -std=c++11 -Wall -Wextra " + arrow_header +
+    std::string cmd = env_gcc + " -std=c++11 -Wall -Wextra " + arrow_header +
 	              arrow_lib + cppfile + " -o " + libfile +
                       " -O3 -shared -fPIC -larrow 2> " + logfile;
     int ret = system(cmd.c_str());


### PR DESCRIPTION
Make codegen work with customized arrow installation 