### PR TITLE
[oap-native-sql][Scala] Adding upper support

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarUnaryOperator.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarUnaryOperator.scala
@@ -100,6 +100,21 @@ class ColumnarAbs(child: Expression, original: Expression)
   }
 }
 
+class ColumnarUpper(child: Expression, original: Expression)
+  extends Upper(child: Expression)
+    with ColumnarExpression
+    with Logging {
+  override def doColumnarCodeGen(args: java.lang.Object): (TreeNode, ArrowType) = {
+    val (child_node, childType): (TreeNode, ArrowType) =
+      child.asInstanceOf[ColumnarExpression].doColumnarCodeGen(args)
+
+    val resultType = new ArrowType.Utf8()
+    val funcNode =
+      TreeBuilder.makeFunction("upper", Lists.newArrayList(child_node), resultType)
+    (funcNode, resultType)
+  }
+}
+
 object ColumnarUnaryOperator {
 
   def create(child: Expression, original: Expression): Expression = original match {
@@ -113,6 +128,8 @@ object ColumnarUnaryOperator {
       new ColumnarNot(child, n)
     case a: Abs =>
       new ColumnarAbs(child, a)
+    case u: Upper =>
+      new ColumnarUpper(child, u)
     case c: Cast =>
       child
     case a: KnownFloatingPointNormalized =>


### PR DESCRIPTION
Manually tested
scala> time{spark.sql("select upper(ca_street_name) from customer_address").show}
+---------------------+                                                         
|upper(ca_street_name)|
+---------------------+
|          MAIN WILLOW|
|             5TH WEST|
|              CENTER |
|           2ND SPRUCE|
|            SYCAMORE |
|         SUNSET GREEN|
|           WEST BIRCH|
|  CHESTNUT WASHINGTON|
|                 6TH |
|            THIRD 3RD|
|            SYCAMORE |
|             15TH 6TH|
|            BIRCH 6TH|
|                MAIN |
|               NORTH |
|           CEDAR WEST|
|          WALNUT MILL|
|              SUNSET |
|              FOREST |
|          POPLAR MAIN|
+---------------------+

