### PR TITLE
[oap-native-sql][Scala] refine coalesce

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarCoalesceOperator.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarCoalesceOperator.scala
@@ -37,9 +37,9 @@ import scala.collection.mutable.ListBuffer
  *   coalesce(1, 2) => 1
  *   coalesce(null, 1, 2) => 1
  *   coalesce(null, null, 2) => 2
+ *   coalesce(null, null, null) => null
  * }}}
 **/
-//TODO(): coalesce(null, null, null) => null
 
 class ColumnarCoalesce(exps: Seq[Expression], original: Expression)
     extends Coalesce(exps: Seq[Expression])
@@ -63,10 +63,7 @@ class ColumnarCoalesce(exps: Seq[Expression], original: Expression)
       // Return the last element no matter if it is null
       val (exp_node, expType): (TreeNode, ArrowType) =
         exps.last.asInstanceOf[ColumnarExpression].doColumnarCodeGen(args)
-      val isnotnullNode =
-        TreeBuilder.makeFunction("isnotnull", Lists.newArrayList(exp_node), new ArrowType.Bool())
-      val funcNode = TreeBuilder.makeIf(isnotnullNode, exp_node, exp_node, expType)
-      funcNode
+      exp_node
     } else {
       val exp = iter.next()
       val (exp_node, expType): (TreeNode, ArrowType) =


### PR DESCRIPTION
##### supports coalesce(null, null, null) => null after bypassing nullPointerException
Manually tested 
+----------+-------------------------------------------------------------+--------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------+--------------------------------+
|ss_ext_tax|coalesce((ss_ext_tax * ss_ext_list_price), CAST(0 AS DOUBLE))|coalesce(CAST(NULL AS DECIMAL(2,1)), 5.0, CAST(NULL AS DECIMAL(2,1)), 6.0)|coalesce(CAST(NULL AS DECIMAL(1,1)), CAST(NULL AS DECIMAL(1,1)), CAST(NULL AS DECIMAL(1,1)), 0.0)|coalesce(NULL, NULL, NULL, NULL)|
+----------+-------------------------------------------------------------+--------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------+--------------------------------+
|    170.67|                                                 1011532.0761|                                                                       5.0|                                                                                              0.0|                            null|
|     14.06|                                                     98954.28|                                                                       5.0|                                                                                              0.0|                            null|
|      8.68|                                           16666.902000000002|                                                                       5.0|                                                                                              0.0|                            null|
|      7.76|                                           10389.165599999998|                                                                       5.0|                                                                                              0.0|                            null|
|      11.8|                                                    24025.036|                                                                       5.0|                                                                                              0.0|                            null|
|    165.41|                                                  1272846.491|                                                                       5.0|                                                                                              0.0|                            null|
|      null|                                                          0.0|                                                                       5.0|                                                                                              0.0|                            null|
|      null|                                                          0.0|                                                                       5.0|                                                                                              0.0|                            null|
|       1.4|                                                       449.12|                                                                       5.0|                                                                                              0.0|                            null|
|     537.9|                                                  7516001.394|                                                                       5.0|                                                                                              0.0|                            null|
|     61.27|                                                   587554.792|                                                                       5.0|                                                                                              0.0|                            null|
|     56.17|                                                  197318.4696|                                                                       5.0|                                                                                              0.0|                            null|
|     40.79|                                                    23707.148|                                                                       5.0|                                                                                              0.0|                            null|
|     41.76|                                                   50591.8224|                                                                       5.0|                                                                                              0.0|                            null|
|    411.76|                                           2864095.5023999996|                                                                       5.0|                                                                                              0.0|                            null|
|      68.7|                                                   166216.902|                                                                       5.0|                                                                                              0.0|                            null|
|      7.09|                                                     8992.956|                                                                       5.0|                                                                                              0.0|                            null|
|     32.17|                                           47933.943400000004|                                                                       5.0|                                                                                              0.0|                            null|
|       0.0|                                                          0.0|                                                                       5.0|                                                                                              0.0|                            null|
|     80.43|                                                  156648.6852|                                                                       5.0|                                                                                              0.0|                            null|
+----------+-------------------------------------------------------------+--------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------+--------------------------------+

