### PR TITLE
[oap-native-sql] Enable mvn package to build native libs

### DIFF
--- a/oap-native-sql/core/pom.xml
+++ b/oap-native-sql/core/pom.xml
@@ -17,6 +17,7 @@
 
   <properties>
     <arrow.version>0.17.0</arrow.version>
+    <cpp.dir>../cpp/</cpp.dir>
     <cpp.build.dir>../cpp/build/releases/</cpp.build.dir>
   </properties>
   <repositories>
@@ -165,6 +166,23 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+          <artifactId>exec-maven-plugin</artifactId>
+          <groupId>org.codehaus.mojo</groupId>
+          <version>1.6.0</version>
+          <executions>
+              <execution>
+                  <id>Build cpp</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                      <goal>exec</goal>
+                  </goals>
+                  <configuration>
+                      <executable>${cpp.dir}/compile.sh</executable>
+                  </configuration>
+              </execution>
+          </executions>
+      </plugin>
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>

--- a/oap-native-sql/cpp/compile.sh
+++ b/oap-native-sql/cpp/compile.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+echo $CURRENT_DIR
+
+cd ${CURRENT_DIR}
+if [ -d build ]; then
+    rm -r build
+fi
+mkdir build
+cd build
+cmake ..
+make -j
+make -j
+make install
+
+# cd $CURRENT_DIR
+# rm -r build

--- a/oap-native-sql/cpp/compile.sh
+++ b/oap-native-sql/cpp/compile.sh
@@ -1,4 +1,6 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
+set -eu
 
 CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 echo $CURRENT_DIR
@@ -16,3 +18,6 @@ make install
 
 # cd $CURRENT_DIR
 # rm -r build
+
+set +eu
+

--- a/oap-native-sql/cpp/compile.sh
+++ b/oap-native-sql/cpp/compile.sh
@@ -10,8 +10,8 @@ fi
 mkdir build
 cd build
 cmake ..
-make -j
-make -j
+make
+make
 make install
 
 # cd $CURRENT_DIR

--- a/oap-native-sql/cpp/compile.sh
+++ b/oap-native-sql/cpp/compile.sh
@@ -14,7 +14,7 @@ cd build
 cmake ..
 make
 make
-make install
+#sudo make install
 
 # cd $CURRENT_DIR
 # rm -r build

--- a/oap-native-sql/cpp/compile.sh
+++ b/oap-native-sql/cpp/compile.sh
@@ -13,11 +13,6 @@ mkdir build
 cd build
 cmake ..
 make
-make
-#sudo make install
-
-# cd $CURRENT_DIR
-# rm -r build
 
 set +eu
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added the generate resource phase in spark columnar core to execute compile.sh and build the native library.

## How was this patch tested?

Manually tested.
