### PR TITLE
[oap-native-sql][Scala] support PartialMerge mode for aggregate

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregateExpression.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregateExpression.scala
@@ -80,7 +80,7 @@ class ColumnarAggregateExpression(
 
   var aggrFieldList: List[Field] = _
   val (funcName, argSize, resSize) = mode match {
-    case Partial => 
+    case Partial | PartialMerge =>
       aggregateFunction.prettyName match {
         case "avg" => ("sum_count", 1, 2)
         case "count" => {

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregation.scala
@@ -119,7 +119,7 @@ class ColumnarAggregation(
         projectOrdinalList = beforeAggregateProjector.getOrdinalList
         aggregateInputAttributes = beforeAggregateProjector.output
       }
-      case Final => {
+      case Final | PartialMerge => {
         val ordinal_attr_list = originalInputAttributes.toList.zipWithIndex
           .filter{case(expr, i) => !groupingOrdinalList.contains(i)}
           .map{case(expr, i) => {
@@ -160,7 +160,14 @@ class ColumnarAggregation(
   // 5. create nativeAggregate evaluator
   val allNativeExpressions = groupingNativeExpression ::: aggregateNativeExpressions
   val allAggregateInputFieldList = groupingFieldList ::: aggregateFieldList
-  val allAggregateResultAttributes = groupingAttributes ::: aggregateAttributes.toList
+  var allAggregateResultAttributes : List[Attribute] = _
+  mode match {
+    case Partial | PartialMerge =>
+      val aggregateResultAttributes = getAttrForAggregateExpr(aggregateExpressions)
+      allAggregateResultAttributes = groupingAttributes ::: aggregateResultAttributes
+    case _ =>
+      allAggregateResultAttributes = groupingAttributes ::: aggregateAttributes.toList
+  }
   val aggregateResultFieldList = allAggregateResultAttributes.map(attr => {
     Field.nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
   })
@@ -199,6 +206,47 @@ class ColumnarAggregation(
       result_iterator.close()
       result_iterator = null
     }
+  }
+
+  def getAttrForAggregateExpr(aggregateExpressions: Seq[AggregateExpression]): List[Attribute] = {
+    var aggregateAttr = new ListBuffer[Attribute]()
+    val size = aggregateExpressions.size
+    for (expIdx <- 0 until size) {
+      val exp: AggregateExpression = aggregateExpressions(expIdx)
+      val aggregateFunc = exp.aggregateFunction
+      aggregateFunc match {
+        case Average(_) =>
+          val avg = aggregateFunc.asInstanceOf[Average]
+          val aggBufferAttr = avg.inputAggBufferAttributes
+          for (index <- 0 until aggBufferAttr.size) {
+            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
+            aggregateAttr += attr
+          }
+        case Sum(_) =>
+          val sum = aggregateFunc.asInstanceOf[Sum]
+          val aggBufferAttr = sum.inputAggBufferAttributes
+          val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
+          aggregateAttr += attr
+        case Count(_) =>
+          val count = aggregateFunc.asInstanceOf[Count]
+          val aggBufferAttr = count.inputAggBufferAttributes
+          val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
+          aggregateAttr += attr
+        case Max(_) =>
+          val max = aggregateFunc.asInstanceOf[Max]
+          val aggBufferAttr = max.inputAggBufferAttributes
+          val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
+          aggregateAttr += attr
+        case Min(_) =>
+          val min = aggregateFunc.asInstanceOf[Min]
+          val aggBufferAttr = min.inputAggBufferAttributes
+          val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
+          aggregateAttr += attr
+        case other =>
+          throw new UnsupportedOperationException(s"not currently supported: $other.")
+      }
+    }
+    aggregateAttr.toList
   }
 
   def updateAggregationResult(columnarBatch: ColumnarBatch): Unit = {

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarCoalesceOperator.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarCoalesceOperator.scala
@@ -47,7 +47,7 @@ class ColumnarCoalesce(exps: Seq[Expression], original: Expression)
     with Logging {
   override def doColumnarCodeGen(args: java.lang.Object): (TreeNode, ArrowType) = {
     val iter: Iterator[Expression] = exps.iterator
-    val exp = exps.head
+    val exp = iter.next()
 
     val (exp_node, expType): (TreeNode, ArrowType) =
       exp.asInstanceOf[ColumnarExpression].doColumnarCodeGen(args)

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarExpressionConverter.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarExpressionConverter.scala
@@ -25,10 +25,10 @@ object ColumnarExpressionConverter extends Logging {
 
   var check_if_no_calculation = true
 
-  def replaceWithColumnarExpression(expr: Expression, attributeSeq: Seq[Attribute] = null): Expression = expr match {
+  def replaceWithColumnarExpression(expr: Expression, attributeSeq: Seq[Attribute] = null, expIdx : Int = -1): Expression = expr match {
     case a: Alias =>
       logInfo(s"${expr.getClass} ${expr} is supported, no_cal is $check_if_no_calculation.")
-      new ColumnarAlias(replaceWithColumnarExpression(a.child, attributeSeq), a.name)(
+      new ColumnarAlias(replaceWithColumnarExpression(a.child, attributeSeq, expIdx), a.name)(
         a.exprId,
         a.qualifier,
         a.explicitMetadata)
@@ -37,7 +37,11 @@ object ColumnarExpressionConverter extends Logging {
       if (attributeSeq != null) {
         val bindReference = BindReferences.bindReference(expr, attributeSeq, true)
         if (bindReference == expr) {
-          return new ColumnarAttributeReference(a.name, a.dataType, a.nullable, a.metadata)(a.exprId, a.qualifier) 
+          if (expIdx == -1) {
+            return new ColumnarAttributeReference(a.name, a.dataType, a.nullable, a.metadata)(a.exprId, a.qualifier)
+          } else {
+            return new ColumnarBoundReference(expIdx, a.dataType, a.nullable)
+          }
         }
         val b = bindReference.asInstanceOf[BoundReference]
         new ColumnarBoundReference(b.ordinal, b.dataType, b.nullable)

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarProjection.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarProjection.scala
@@ -73,10 +73,7 @@ class ColumnarProjection (
     case (expr, i) => {
       ColumnarExpressionConverter.reset()
       var columnarExpr: Expression =
-        ColumnarExpressionConverter.replaceWithColumnarExpression(expr, originalInputAttributes)
-      if (columnarExpr.isInstanceOf[AttributeReference]) {
-        columnarExpr = new ColumnarBoundReference(i, columnarExpr.dataType, columnarExpr.nullable)
-      }
+        ColumnarExpressionConverter.replaceWithColumnarExpression(expr, originalInputAttributes, i)
       if (ColumnarExpressionConverter.ifNoCalculation == false) {
         check_if_no_calculation = false     
       }
@@ -87,7 +84,8 @@ class ColumnarProjection (
     }
   }
 
-  val (ordinalList, arrowSchema) = if (projPrepareList.size > 0 && check_if_no_calculation == false) {
+  val (ordinalList, arrowSchema) = if (projPrepareList.size > 0 &&
+    (!check_if_no_calculation || projPrepareList.size != inputList.size)) {
     val inputFieldList = inputList.asScala.toList.distinct
     val schema = new Schema(inputFieldList.asJava)
     projector = Projector.make(schema, projPrepareList.toList.asJava)


### PR DESCRIPTION
This patch was used to get aggregate result attrs from buffer attrs, so as to solve the avg attr missing error.

