### PR TITLE
[oap-native-sql] Add customized batch_size and tmp_dir support

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/datasource/parquet/ParquetReaderJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/datasource/parquet/ParquetReaderJniWrapper.java
@@ -22,13 +22,11 @@ import com.intel.sparkColumnarPlugin.vectorized.JniUtils;
 
 import java.io.IOException;
 
-
 /** Wrapper for Parquet Reader native API. */
 public class ParquetReaderJniWrapper {
-
   /** Construct a Jni Instance. */
-  ParquetReaderJniWrapper() throws IOException {
-    JniUtils.getInstance();
+  ParquetReaderJniWrapper(String tmp_dir) throws IOException {
+    JniUtils.getInstance(tmp_dir);
   }
 
   /**
@@ -39,7 +37,8 @@ public class ParquetReaderJniWrapper {
    * @return long id of the parquet reader instance
    * @throws IOException throws exception in case of any io exception in native codes
    */
-  public native long nativeOpenParquetReader(String path, long batchSize) throws IOException;
+  public native long nativeOpenParquetReader(String path, long batchSize)
+      throws IOException;
 
   /**
    * Init a parquet file reader by specifying columns and rowgroups.
@@ -49,8 +48,8 @@ public class ParquetReaderJniWrapper {
    * @param rowGroupIndices a array of indexes indicate which row groups to be read
    * @throws IOException throws exception in case of any io exception in native codes
    */
-  public native void nativeInitParquetReader(long id, int[] columnIndices, int[] rowGroupIndices)
-      throws IOException;
+  public native void nativeInitParquetReader(
+      long id, int[] columnIndices, int[] rowGroupIndices) throws IOException;
 
   /**
    * Init a parquet file reader by specifying columns and rowgroups.

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ExpressionEvaluator.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ExpressionEvaluator.java
@@ -17,6 +17,7 @@
 
 package com.intel.sparkColumnarPlugin.vectorized;
 
+import com.intel.sparkColumnarPlugin.ColumnarPluginConfig;
 import io.netty.buffer.ArrowBuf;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -40,6 +41,7 @@ public class ExpressionEvaluator implements AutoCloseable {
   public ExpressionEvaluator() throws IOException {
     jniWrapper = new ExpressionEvaluatorJniWrapper();
     jniWrapper.nativeSetJavaTmpDir(System.getProperty("java.io.tmpdir"));
+    jniWrapper.nativeSetBatchSize(ColumnarPluginConfig.getBatchSize());
   }
 
   /** Convert ExpressionTree into native function. */

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ExpressionEvaluator.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ExpressionEvaluator.java
@@ -39,8 +39,12 @@ public class ExpressionEvaluator implements AutoCloseable {
 
   /** Wrapper for native API. */
   public ExpressionEvaluator() throws IOException {
-    jniWrapper = new ExpressionEvaluatorJniWrapper();
-    jniWrapper.nativeSetJavaTmpDir(System.getProperty("java.io.tmpdir"));
+    String tmp_dir = ColumnarPluginConfig.getTempFile();
+    if (tmp_dir == null) {
+      tmp_dir = System.getProperty("java.io.tmpdir");
+    }
+    jniWrapper = new ExpressionEvaluatorJniWrapper(tmp_dir);
+    jniWrapper.nativeSetJavaTmpDir(tmp_dir);
     jniWrapper.nativeSetBatchSize(ColumnarPluginConfig.getBatchSize());
   }
 

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -26,8 +26,8 @@ import java.io.IOException;
  */
 public class ExpressionEvaluatorJniWrapper {
   /** Wrapper for native API. */
-  public ExpressionEvaluatorJniWrapper() throws IOException {
-    JniUtils.getInstance();
+  public ExpressionEvaluatorJniWrapper(String tmp_dir) throws IOException {
+    JniUtils.getInstance(tmp_dir);
   }
 
   /**

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -25,13 +25,25 @@ import java.io.IOException;
  * jni. Avoid all external dependencies in this file.
  */
 public class ExpressionEvaluatorJniWrapper {
-
   /** Wrapper for native API. */
   public ExpressionEvaluatorJniWrapper() throws IOException {
     JniUtils.getInstance();
   }
 
+  /**
+   * Set native env variables NATIVE_TMP_DIR
+   *
+   * @param path  tmp path for native codes, use java.io.tmpdir
+   */
   native void nativeSetJavaTmpDir(String path);
+
+  /**
+   * Set native env variables NATIVE_BATCH_SIZE
+   *
+   * @param batch_size  numRows of one batch, use
+   *     spark.sql.execution.arrow.maxRecordsPerBatch
+   */
+  native void nativeSetBatchSize(int batch_size);
 
   /**
    * Generates the projector module to evaluate the expressions with custom
@@ -48,8 +60,8 @@ public class ExpressionEvaluatorJniWrapper {
    * @return A nativeHandler that is passed to the evaluateProjector() and
    *         closeProjector() methods
    */
-  native long nativeBuild(byte[] schemaBuf, byte[] exprListBuf, byte[] resSchemaBuf, boolean finishReturn)
-      throws RuntimeException;
+  native long nativeBuild(byte[] schemaBuf, byte[] exprListBuf, byte[] resSchemaBuf,
+      boolean finishReturn) throws RuntimeException;
 
   /**
    * Generates the projector module to evaluate the expressions with custom
@@ -66,8 +78,8 @@ public class ExpressionEvaluatorJniWrapper {
    * @return A nativeHandler that is passed to the evaluateProjector() and
    *         closeProjector() methods
    */
-  native long nativeBuildWithFinish(byte[] schemaBuf, byte[] exprListBuf, byte[] finishExprListBuf)
-      throws RuntimeException;
+  native long nativeBuildWithFinish(byte[] schemaBuf, byte[] exprListBuf,
+      byte[] finishExprListBuf) throws RuntimeException;
 
   /**
    * Set return schema for this expressionTree.
@@ -77,7 +89,8 @@ public class ExpressionEvaluatorJniWrapper {
    * @param schemaBuf     The schema serialized as a protobuf. See Types.proto to
    *                      see the protobuf specification
    */
-  native void nativeSetReturnFields(long nativeHandler, byte[] schemaBuf) throws RuntimeException;
+  native void nativeSetReturnFields(long nativeHandler, byte[] schemaBuf)
+      throws RuntimeException;
 
   /**
    * Evaluate the expressions represented by the nativeHandler on a record batch
@@ -94,8 +107,8 @@ public class ExpressionEvaluatorJniWrapper {
    * @return A list of ArrowRecordBatchBuilder which can be used to build a List
    *         of ArrowRecordBatch
    */
-  native ArrowRecordBatchBuilder[] nativeEvaluate(long nativeHandler, int numRows, long[] bufAddrs, long[] bufSizes)
-      throws RuntimeException;
+  native ArrowRecordBatchBuilder[] nativeEvaluate(long nativeHandler, int numRows,
+      long[] bufAddrs, long[] bufSizes) throws RuntimeException;
 
   /**
    * Evaluate the expressions represented by the nativeHandler on a record batch
@@ -116,11 +129,12 @@ public class ExpressionEvaluatorJniWrapper {
    * @return A list of ArrowRecordBatchBuilder which can be used to build a List
    *         of ArrowRecordBatch
    */
-  native ArrowRecordBatchBuilder[] nativeEvaluateWithSelection(long nativeHandler, int numRows, long[] bufAddrs,
-      long[] bufSizes, int selectionVectorRecordCount, long selectionVectorAddr, long selectionVectorSize)
-      throws RuntimeException;
+  native ArrowRecordBatchBuilder[] nativeEvaluateWithSelection(long nativeHandler,
+      int numRows, long[] bufAddrs, long[] bufSizes, int selectionVectorRecordCount,
+      long selectionVectorAddr, long selectionVectorSize) throws RuntimeException;
 
-  native void nativeSetMember(long nativeHandler, int numRows, long[] bufAddrs, long[] bufSizes);
+  native void nativeSetMember(
+      long nativeHandler, int numRows, long[] bufAddrs, long[] bufSizes);
 
   /**
    * Evaluate the expressions represented by the nativeHandler on a record batch
@@ -131,7 +145,8 @@ public class ExpressionEvaluatorJniWrapper {
    * @return A list of ArrowRecordBatchBuilder which can be used to build a List
    *         of ArrowRecordBatch
    */
-  native ArrowRecordBatchBuilder[] nativeFinish(long nativeHandler) throws RuntimeException;
+  native ArrowRecordBatchBuilder[] nativeFinish(long nativeHandler)
+      throws RuntimeException;
 
   /**
    * Call Finish to get result, result will be as a iterator.
@@ -148,7 +163,8 @@ public class ExpressionEvaluatorJniWrapper {
    * @param childInstanceId childInstanceId of a child BatchIterator
    * @param index           exptected index of the output of BatchIterator
    */
-  native void nativeSetDependency(long nativeHandler, long childInstanceId, int index) throws RuntimeException;
+  native void nativeSetDependency(long nativeHandler, long childInstanceId, int index)
+      throws RuntimeException;
 
   /**
    * Closes the projector referenced by nativeHandler.

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/JniUtils.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/JniUtils.java
@@ -36,64 +36,86 @@ public class JniUtils {
   private static final String LIBRARY_NAME = "spark_columnar_jni";
   private static boolean isLoaded = false;
   private static volatile JniUtils INSTANCE;
+  private String tmp_dir;
 
   public static JniUtils getInstance() throws IOException {
+    String tmp_dir = System.getProperty("java.io.tmpdir");
+    return getInstance(tmp_dir);
+  }
+
+  public static JniUtils getInstance(String tmp_dir) throws IOException {
     if (INSTANCE == null) {
       synchronized (JniUtils.class) {
         if (INSTANCE == null) {
           try {
-            INSTANCE = new JniUtils();
+            INSTANCE = new JniUtils(tmp_dir);
           } catch (IllegalAccessException ex) {
             throw new IOException("IllegalAccess");
           }
         }
       }
     }
-
     return INSTANCE;
   }
 
-  private JniUtils() throws IOException, IllegalAccessException, IllegalStateException {
+  private JniUtils(String tmp_dir)
+      throws IOException, IllegalAccessException, IllegalStateException {
     if (!isLoaded) {
       try {
-        loadLibraryFromJar();
+        loadLibraryFromJar(tmp_dir);
       } catch (IOException ex) {
         System.loadLibrary(LIBRARY_NAME);
       }
-      loadIncludeFromJar();
+      loadIncludeFromJar(tmp_dir);
       isLoaded = true;
     }
   }
 
-  static void loadLibraryFromJar() throws IOException, IllegalAccessException {
+  static void loadLibraryFromJar(String tmp_dir)
+      throws IOException, IllegalAccessException {
     synchronized (JniUtils.class) {
+      if (tmp_dir == null) {
+        tmp_dir = System.getProperty("java.io.tmpdir");
+        System.out.println("loadLibraryFromJar " + tmp_dir);
+      }
       final String libraryToLoad = System.mapLibraryName(LIBRARY_NAME);
-      final File libraryFile = moveFileFromJarToTemp(System.getProperty("java.io.tmpdir"), libraryToLoad);
+      final File libraryFile = moveFileFromJarToTemp(tmp_dir, libraryToLoad);
       System.load(libraryFile.getAbsolutePath());
     }
   }
 
-  private static void loadIncludeFromJar() throws IOException, IllegalAccessException {
+  private static void loadIncludeFromJar(String tmp_dir)
+      throws IOException, IllegalAccessException {
     synchronized (JniUtils.class) {
+      if (tmp_dir == null) {
+        tmp_dir = System.getProperty("java.io.tmpdir");
+        System.out.println("loadIncludeFromJar " + tmp_dir);
+      }
       final String folderToLoad = "include";
-      final URLConnection urlConnection = JniUtils.class.getClassLoader().getResource("include").openConnection();
+      final URLConnection urlConnection =
+          JniUtils.class.getClassLoader().getResource("include").openConnection();
       if (urlConnection instanceof JarURLConnection) {
         final JarFile jarFile = ((JarURLConnection) urlConnection).getJarFile();
-        copyResourcesToDirectory(jarFile, folderToLoad, System.getProperty("java.io.tmpdir") + "/" + folderToLoad);
+        copyResourcesToDirectory(jarFile, folderToLoad, tmp_dir + "/" + folderToLoad);
       } else {
         throw new IOException(urlConnection.toString() + " is not JarUrlConnection");
       }
     }
   }
 
-  private static File moveFileFromJarToTemp(final String tmpDir, String libraryToLoad) throws IOException {
+  private static File moveFileFromJarToTemp(String tmpDir, String libraryToLoad)
+      throws IOException {
     // final File temp = File.createTempFile(tmpDir, libraryToLoad);
     final File temp = new File(tmpDir + "/" + libraryToLoad);
-    try (final InputStream is = JniUtils.class.getClassLoader().getResourceAsStream(libraryToLoad)) {
+    try (final InputStream is =
+             JniUtils.class.getClassLoader().getResourceAsStream(libraryToLoad)) {
       if (is == null) {
         throw new FileNotFoundException(libraryToLoad);
       } else {
-        Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        try {
+          Files.copy(is, temp.toPath());
+        } catch (Exception e) {
+        }
       }
     }
     return temp;
@@ -102,11 +124,13 @@ public class JniUtils {
   /**
    * Copies a directory from a jar file to an external directory.
    */
-  public static void copyResourcesToDirectory(JarFile fromJar, String jarDir, String destDir) throws IOException {
+  public static void copyResourcesToDirectory(
+      JarFile fromJar, String jarDir, String destDir) throws IOException {
     for (Enumeration<JarEntry> entries = fromJar.entries(); entries.hasMoreElements();) {
       JarEntry entry = entries.nextElement();
       if (entry.getName().startsWith(jarDir + "/") && !entry.isDirectory()) {
-        File dest = new File(destDir + "/" + entry.getName().substring(jarDir.length() + 1));
+        File dest =
+            new File(destDir + "/" + entry.getName().substring(jarDir.length() + 1));
         File parent = dest.getParentFile();
         if (parent != null) {
           parent.mkdirs();

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/ColumnarPluginConfig.scala
@@ -25,6 +25,8 @@ class ColumnarPluginConfig(conf: SparkConf) {
   val enableColumnarShuffle: Boolean = conf
     .get("spark.shuffle.manager", "sort")
     .equals("org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+  val batchSize: Int =
+    conf.getInt("spark.sql.execution.arrow.maxRecordsPerBatch", defaultValue = 10000)
 }
 
 object ColumnarPluginConfig {
@@ -42,6 +44,13 @@ object ColumnarPluginConfig {
       throw new IllegalStateException("ColumnarPluginConfig is not initialized yet")
     } else {
       ins
+    }
+  }
+  def getBatchSize: Int = synchronized {
+    if (ins == null) {
+      10000
+    } else {
+      ins.batchSize
     }
   }
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/ColumnarPluginConfig.scala
@@ -27,6 +27,8 @@ class ColumnarPluginConfig(conf: SparkConf) {
     .equals("org.apache.spark.shuffle.sort.ColumnarShuffleManager")
   val batchSize: Int =
     conf.getInt("spark.sql.execution.arrow.maxRecordsPerBatch", defaultValue = 10000)
+  val tmpFile: String =
+    conf.getOption("spark.sql.columnar.tmp_dir").getOrElse(null)
 }
 
 object ColumnarPluginConfig {
@@ -51,6 +53,13 @@ object ColumnarPluginConfig {
       10000
     } else {
       ins.batchSize
+    }
+  }
+  def getTempFile: String = synchronized {
+    if (ins != null) {
+      ins.tmpFile
+    } else {
+      System.getProperty("java.io.tmpdir")
     }
   }
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/ColumnarSortExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/ColumnarSortExec.scala
@@ -40,6 +40,8 @@ class ColumnarSortExec(
     child: SparkPlan,
     testSpillFrequency: Int = 0)
     extends SortExec(sortOrder, global, child, testSpillFrequency) {
+
+  val sparkConf = sparkContext.getConf
   override def supportsColumnar = true
 
   // Disable code generation
@@ -72,7 +74,8 @@ class ColumnarSortExec(
           numOutputBatches,
           numOutputRows,
           shuffleTime,
-          elapse)
+          elapse,
+          sparkConf)
         TaskContext
           .get()
           .addTaskCompletionListener[Unit](_ => {

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarAggregation.scala
@@ -23,6 +23,7 @@ import java.util.Collections
 import java.util.concurrent.TimeUnit._
 import util.control.Breaks._
 
+import com.intel.sparkColumnarPlugin.ColumnarPluginConfig
 import com.intel.sparkColumnarPlugin.vectorized.ArrowWritableColumnVector
 import org.apache.spark.sql.util.ArrowUtils
 import com.intel.sparkColumnarPlugin.vectorized.ExpressionEvaluator
@@ -30,6 +31,7 @@ import com.intel.sparkColumnarPlugin.vectorized.BatchIterator
 
 import com.google.common.collect.Lists
 import org.apache.hadoop.mapreduce.TaskAttemptID
+import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
@@ -68,9 +70,11 @@ class ColumnarAggregation(
     numOutputBatches: SQLMetric,
     numOutputRows: SQLMetric,
     aggrTime: SQLMetric,
-    elapseTime: SQLMetric)
+    elapseTime: SQLMetric,
+    sparkConf: SparkConf)
     extends Logging {
   // build gandiva projection here.
+  ColumnarPluginConfig.getConf(sparkConf)
   var elapseTime_make: Long = 0
   var rowId: Int = 0
   var processedNumRows: Int = 0
@@ -103,12 +107,12 @@ class ColumnarAggregation(
 
   // 3. map original input to aggregate input
   var beforeAggregateProjector: ColumnarProjection = _
-  var projectOrdinalList : List[Int] = _
-  var aggregateInputAttributes : List[AttributeReference] = _
+  var projectOrdinalList: List[Int] = _
+  var aggregateInputAttributes: List[AttributeReference] = _
 
   if (mode == null) {
     projectOrdinalList = List[Int]()
-    aggregateInputAttributes =  List[AttributeReference]()
+    aggregateInputAttributes = List[AttributeReference]()
   } else {
     mode match {
       case Partial => { 
@@ -169,7 +173,7 @@ class ColumnarAggregation(
   val resultType = CodeGeneration.getResultType()
   val resultField = Field.nullable(s"dummy_res", resultType)
 
-  val expressionTree: List[ExpressionTree] = allNativeExpressions.map( expr => {
+  val expressionTree: List[ExpressionTree] = allNativeExpressions.map(expr => {
     val node =
       expr.doColumnarCodeGen_ext((groupingFieldList, allAggregateInputFieldList, resultType, resultField))
     TreeBuilder.makeExpression(node, resultField)
@@ -290,7 +294,7 @@ class ColumnarAggregation(
         if (nextCalled == false && resultColumnarBatch != null) {
           return true
         }
-        if ( !nextBatch ) {
+        if (!nextBatch) {
           return false
         }
 
@@ -358,7 +362,8 @@ object ColumnarAggregation {
       numOutputBatches: SQLMetric,
       numOutputRows: SQLMetric,
       aggrTime: SQLMetric,
-      elapseTime: SQLMetric): ColumnarAggregation = synchronized {
+      elapseTime: SQLMetric,
+      sparkConf: SparkConf): ColumnarAggregation = synchronized {
     columnarAggregation = new ColumnarAggregation(
       partIndex,
       groupingExpressions,
@@ -371,7 +376,8 @@ object ColumnarAggregation {
       numOutputBatches,
       numOutputRows,
       aggrTime,
-      elapseTime)
+      elapseTime,
+      sparkConf)
     columnarAggregation
   }
 

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarShuffledHashJoin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarShuffledHashJoin.scala
@@ -19,6 +19,7 @@ package com.intel.sparkColumnarPlugin.expression
 
 import java.util.concurrent.TimeUnit._
 
+import com.intel.sparkColumnarPlugin.ColumnarPluginConfig
 import com.intel.sparkColumnarPlugin.vectorized.ArrowWritableColumnVector
 
 import org.apache.spark.TaskContext
@@ -34,6 +35,7 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, BuildSide}
 
 import scala.collection.JavaConverters._
+import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 import scala.collection.mutable.ListBuffer
@@ -66,8 +68,10 @@ class ColumnarShuffledHashJoin(
     right: SparkPlan,
     buildTime: SQLMetric,
     joinTime: SQLMetric,
-    totalOutputNumRows: SQLMetric)
+    totalOutputNumRows: SQLMetric,
+    sparkConf: SparkConf)
     extends Logging {
+  ColumnarPluginConfig.getConf(sparkConf)
 
   var build_cb: ColumnarBatch = null
   var last_cb: ColumnarBatch = null
@@ -346,7 +350,8 @@ object ColumnarShuffledHashJoin {
       right: SparkPlan,
       buildTime: SQLMetric,
       joinTime: SQLMetric,
-      numOutputRows: SQLMetric): ColumnarShuffledHashJoin = synchronized {
+      numOutputRows: SQLMetric,
+      sparkConf: SparkConf): ColumnarShuffledHashJoin = synchronized {
     columnarShuffedHahsJoin = new ColumnarShuffledHashJoin(
       leftKeys,
       rightKeys,
@@ -358,7 +363,8 @@ object ColumnarShuffledHashJoin {
       right,
       buildTime,
       joinTime,
-      numOutputRows)
+      numOutputRows,
+      sparkConf)
     columnarShuffedHahsJoin
   }
 

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarSorter.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ColumnarSorter.scala
@@ -21,11 +21,13 @@ import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit._
 import com.google.common.collect.Lists
 
+import com.intel.sparkColumnarPlugin.ColumnarPluginConfig
 import com.intel.sparkColumnarPlugin.vectorized.ArrowWritableColumnVector
 import com.intel.sparkColumnarPlugin.vectorized.ExpressionEvaluator
 import com.intel.sparkColumnarPlugin.vectorized.BatchIterator
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -57,10 +59,12 @@ class ColumnarSorter(
     outputBatches: SQLMetric,
     outputRows: SQLMetric,
     shuffleTime: SQLMetric,
-    elapse: SQLMetric)
+    elapse: SQLMetric,
+    sparkConf: SparkConf)
     extends Logging {
 
   logInfo(s"ColumnarSorter sortOrder is ${sortOrder}, outputAttributes is ${outputAttributes}")
+  ColumnarPluginConfig.getConf(sparkConf)
   /////////////// Prepare ColumnarSorter //////////////
   var processedNumRows: Long = 0
   var sort_elapse: Long = 0
@@ -216,7 +220,8 @@ object ColumnarSorter {
       outputBatches: SQLMetric,
       outputRows: SQLMetric,
       shuffleTime: SQLMetric,
-      elapse: SQLMetric): ColumnarSorter = synchronized {
+      elapse: SQLMetric,
+      sparkConf: SparkConf): ColumnarSorter = synchronized {
     new ColumnarSorter(
       sortOrder,
       outputAsColumnar,
@@ -225,7 +230,8 @@ object ColumnarSorter {
       outputBatches,
       outputRows,
       shuffleTime,
-      elapse)
+      elapse,
+      sparkConf)
   }
 
 }

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VectorizedFilePartitionReaderHandler.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VectorizedFilePartitionReaderHandler.scala
@@ -26,7 +26,11 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory, PartitionReader}
+import org.apache.spark.sql.connector.read.{
+  InputPartition,
+  PartitionReaderFactory,
+  PartitionReader
+}
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.v2.PartitionedFileReader
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetPartitionReaderFactory
@@ -35,48 +39,54 @@ import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 object VectorizedFilePartitionReaderHandler {
   def get(
-    inputPartition: InputPartition,
-    parquetReaderFactory: ParquetPartitionReaderFactory) 
-  : FilePartitionReader[ColumnarBatch] = {
-    val iter: Iterator[PartitionedFileReader[ColumnarBatch]] 
-      = inputPartition.asInstanceOf[FilePartition].files.toIterator.map { file =>
-      val filePath = new Path(new URI(file.filePath))
-      val split =
-      new org.apache.parquet.hadoop.ParquetInputSplit(
-        filePath,
-        file.start,
-        file.start + file.length,
-        file.length,
-        Array.empty,
-        null)
-      //val timestampConversion: Boolean = sqlConf.isParquetINT96TimestampConversion
-      /*val convertTz =
+      inputPartition: InputPartition,
+      parquetReaderFactory: ParquetPartitionReaderFactory,
+      tmpDir: String): FilePartitionReader[ColumnarBatch] = {
+    val iter: Iterator[PartitionedFileReader[ColumnarBatch]] =
+      inputPartition.asInstanceOf[FilePartition].files.toIterator.map { file =>
+        val filePath = new Path(new URI(file.filePath))
+        val split =
+          new org.apache.parquet.hadoop.ParquetInputSplit(
+            filePath,
+            file.start,
+            file.start + file.length,
+            file.length,
+            Array.empty,
+            null)
+        //val timestampConversion: Boolean = sqlConf.isParquetINT96TimestampConversion
+        /*val convertTz =
         if (timestampConversion && !isCreatedByParquetMr) {
           Some(DateTimeUtils.getZoneId(conf.get(SQLConf.SESSION_LOCAL_TIMEZONE.key)))
         } else {
           None
         }*/
-      val capacity = 4096
-      //partitionReaderFactory.createColumnarReader(inputPartition)
-      val dataSchema = parquetReaderFactory.dataSchema
-      val readDataSchema = parquetReaderFactory.readDataSchema
-      
-      val conf = parquetReaderFactory.broadcastedConf.value.value
-      val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
-      val hadoopAttemptContext = new TaskAttemptContextImpl(conf, attemptId)
+        val capacity = 4096
+        //partitionReaderFactory.createColumnarReader(inputPartition)
+        val dataSchema = parquetReaderFactory.dataSchema
+        val readDataSchema = parquetReaderFactory.readDataSchema
 
-      val vectorizedReader = new VectorizedParquetArrowReader(split.getPath().toString(), null, false, capacity, dataSchema, readDataSchema)
-      vectorizedReader.initialize(split, hadoopAttemptContext)
-      val partitionReader = new PartitionReader[ColumnarBatch] {
-        override def next(): Boolean = vectorizedReader.nextKeyValue()
-        override def get(): ColumnarBatch =
-          vectorizedReader.getCurrentValue.asInstanceOf[ColumnarBatch]
-        override def close(): Unit = vectorizedReader.close()
+        val conf = parquetReaderFactory.broadcastedConf.value.value
+        val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
+        val hadoopAttemptContext = new TaskAttemptContextImpl(conf, attemptId)
+
+        val vectorizedReader = new VectorizedParquetArrowReader(
+          split.getPath().toString(),
+          null,
+          false,
+          capacity,
+          dataSchema,
+          readDataSchema,
+          tmpDir)
+        vectorizedReader.initialize(split, hadoopAttemptContext)
+        val partitionReader = new PartitionReader[ColumnarBatch] {
+          override def next(): Boolean = vectorizedReader.nextKeyValue()
+          override def get(): ColumnarBatch =
+            vectorizedReader.getCurrentValue.asInstanceOf[ColumnarBatch]
+          override def close(): Unit = vectorizedReader.close()
+        }
+
+        PartitionedFileReader(file, partitionReader)
       }
-
-      PartitionedFileReader(file, partitionReader)
-    }
     new FilePartitionReader[ColumnarBatch](iter)
   }
 }
-

--- a/oap-native-sql/core/src/test/java/com/intel/sparkColumnarPlugin/datasource/parquet/ParquetReadTest.java
+++ b/oap-native-sql/core/src/test/java/com/intel/sparkColumnarPlugin/datasource/parquet/ParquetReadTest.java
@@ -46,7 +46,6 @@ import org.junit.rules.TemporaryFolder;
 import io.netty.buffer.ArrowBuf;
 
 public class ParquetReadTest {
-
   @Rule public TemporaryFolder testFolder = new TemporaryFolder();
 
   private BufferAllocator allocator;
@@ -63,29 +62,26 @@ public class ParquetReadTest {
 
   @Test
   public void testParquetRead() throws Exception {
-
     File testFile = testFolder.newFile("_tmpfile_ParquetReadTest");
-    //String path = testFile.getAbsolutePath();
-    String path = "hdfs://sr602:9000/part-00000-d648dd34-c9d2-4fe9-87f2-770ef3551442-c000.snappy.parquet?user=root&replication=1";
+    // String path = testFile.getAbsolutePath();
+    String path =
+        "hdfs://sr602:9000/part-00000-d648dd34-c9d2-4fe9-87f2-770ef3551442-c000.snappy.parquet?user=root&replication=1";
 
     int numColumns = 0;
     int[] rowGroupIndices = {0};
     int[] columnIndices = new int[numColumns];
 
-    Schema schema =
-        new Schema(
-            asList(
-                field("n_nationkey", new Int(64, true)),
-                field("n_name", new Utf8()),
-                field("n_regionkey", new Int(64, true)),
-                field("n_comment", new Utf8())
-                ));
+    Schema schema = new Schema(
+        asList(field("n_nationkey", new Int(64, true)), field("n_name", new Utf8()),
+            field("n_regionkey", new Int(64, true)), field("n_comment", new Utf8())));
 
-    ParquetReader reader = new ParquetReader(path, rowGroupIndices, columnIndices, 16, allocator);
+    ParquetReader reader =
+        new ParquetReader(path, rowGroupIndices, columnIndices, 16, allocator, "");
 
     Schema readedSchema = reader.getSchema();
     for (int i = 0; i < readedSchema.getFields().size(); i++) {
-      assertEquals(schema.getFields().get(i).getName(), readedSchema.getFields().get(i).getName());
+      assertEquals(
+          schema.getFields().get(i).getName(), readedSchema.getFields().get(i).getName());
     }
 
     VectorSchemaRoot actualSchemaRoot = VectorSchemaRoot.create(readedSchema, allocator);
@@ -103,7 +99,8 @@ public class ParquetReadTest {
     testFile.delete();
   }
 
-  private static Field field(String name, boolean nullable, ArrowType type, Field... children) {
+  private static Field field(
+      String name, boolean nullable, ArrowType type, Field... children) {
     return new Field(name, new FieldType(nullable, type, null, null), asList(children));
   }
 

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
@@ -171,6 +171,17 @@ std::string GetTempPath() {
   return tmp_dir_;
 }
 
+int GetBatchSize() {
+  int batch_size;
+  const char* env_batch_size = std::getenv("NATIVESQL_BATCH_SIZE");
+  if (env_batch_size != nullptr) {
+    batch_size = atoi(env_batch_size);
+  } else {
+    batch_size = 10000;
+  }
+  return batch_size;
+}
+
 int FileSpinLock() {
   std::string lockfile = GetTempPath() + "/nativesql_compile.lock";
 
@@ -202,6 +213,10 @@ arrow::Status CompileCodes(std::string codes, std::string signature) {
     exit(EXIT_FAILURE);
   }
   out << codes;
+#ifdef DEBUG
+  std::cout << "BatchSize is " << GetBatchSize() << std::endl;
+  std::cout << codes << std::endl;
+#endif
   out.flush();
   out.close();
 

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.h
@@ -34,6 +34,7 @@ int FileSpinLock();
 
 void FileSpinUnLock(int fd);
 
+int GetBatchSize();
 std::string GetArrowTypeDefString(std::shared_ptr<arrow::DataType> type);
 std::string GetCTypeString(std::shared_ptr<arrow::DataType> type);
 std::string GetTypeString(std::shared_ptr<arrow::DataType> type,

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -306,7 +306,9 @@ class TypedSorterImpl : public CodeGenBase {
     }
 
     arrow::Status Next(std::shared_ptr<arrow::RecordBatch>* out) {
-      auto length = (total_length_ - offset_) > 4096 ? 4096 : (total_length_ - offset_);
+      auto length = (total_length_ - offset_) > )" +
+           std::to_string(GetBatchSize()) + R"( ? )" + std::to_string(GetBatchSize()) +
+           R"( : (total_length_ - offset_);
       uint64_t count = 0;
       while (count < length) {
         auto item = indices_begin_ + offset_ + count++;

--- a/oap-native-sql/cpp/src/jni/jni_wrapper.cc
+++ b/oap-native-sql/cpp/src/jni/jni_wrapper.cc
@@ -237,6 +237,12 @@ Java_com_intel_sparkColumnarPlugin_vectorized_ExpressionEvaluatorJniWrapper_nati
   env->ReleaseStringUTFChars(pathObj, path);
 }
 
+JNIEXPORT void JNICALL
+Java_com_intel_sparkColumnarPlugin_vectorized_ExpressionEvaluatorJniWrapper_nativeSetBatchSize(
+    JNIEnv* env, jobject obj, jint batch_size) {
+  setenv("NATIVESQL_BATCH_SIZE", std::to_string(batch_size).c_str(), 1);
+}
+
 JNIEXPORT jlong JNICALL
 Java_com_intel_sparkColumnarPlugin_vectorized_ExpressionEvaluatorJniWrapper_nativeBuild(
     JNIEnv* env, jobject obj, jbyteArray schema_arr, jbyteArray exprs_arr,


### PR DESCRIPTION
This commit add two new configuration in spark config who will be used in nativesql
"spark.sql.execution.arrow.maxRecordsPerBatch" and "spark.sql.columnar.tmp_dir"

Signed-off-by: Chendi Xue <chendi.xue@intel.com>

