### PR TITLE
[POAE7-334][OAP-Cache-oap][DO NOT MERGE]Remove extra memcopy in OAP plasma code path

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 import com.google.common.primitives.Ints
+import org.apache.arrow.plasma.PlasmaClient
 import scala.collection.mutable
 
 import org.apache.spark.internal.Logging
@@ -55,6 +56,8 @@ case class FiberCache(fiberType: FiberType.FiberType, fiberData: MemoryBlockHold
 
   // This suppose to be used when index cache allocation failed
   var originByteArray: Array[Byte] = null
+
+  var plasmaClient: PlasmaClient = null
 
   // We use readLock to lock occupy. _refCount need be atomic to make sure thread-safe
   protected val _refCount = new AtomicLong(0)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -209,6 +209,10 @@ private[sql] class FiberCacheManager(
     FiberCache(FiberType.DATA, allocateFiberMemory(FiberType.DATA, length))
   }
 
+  def getEmptyDataFiberCache(length: Long, fiberId: FiberId = null): FiberCache = {
+    cacheBackend.getEmptyFiber(length, fiberId)
+  }
+
   def releaseIndexCache(indexName: String): Unit = {
     logDebug(s"Going to remove all index cache of $indexName")
     val fiberToBeRemoved = cacheBackend.getFibers.filter {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -232,6 +232,9 @@ private[sql] class FiberCacheManager(
     cacheAllocator.isDcpmmUsed()
   }
 
+  // TODO: for multithreadCacheGuardian, we need refactor releaseFiberCache method,
+  // dead lock will happen in some case. For now, we can increase dcpmmWaitingThreshold
+  // here
   def isNeedWaitForFree(): Boolean = {
     logDebug(
       s"dcpmm wait threshold: " +

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -73,7 +73,7 @@ case class BinaryDataFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) 
     val data = new Array[Byte](length)
     input.seek(offset)
     input.readFully(data)
-    val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length)
+    val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length, this)
     Platform.copyMemory(data,
       Platform.BYTE_ARRAY_OFFSET, null, fiber.getBaseOffset, length)
     fiber
@@ -122,7 +122,7 @@ case class OrcBinaryFiberId(file: DataFile, columnIndex: Int, rowGroupId: Int) e
       "Illegal condition when load ORCColumn Fiber to cache.")
     val data = new Array[Byte](length)
     input.readFully((offset), data, 0, data.length);
-    val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length)
+    val fiber = OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(length, this)
     Platform.copyMemory(data,
       Platform.BYTE_ARRAY_OFFSET, null, fiber.getBaseOffset, length)
     fiber

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -57,7 +57,7 @@ case class MemoryBlockHolder(
                               length: Long,
                               occupiedSize: Long,
                               source: SourceEnum.SourceEnum,
-                              fiberId: FiberId = null,
+                              obejctId: Array[Byte] = null,
                               client: PlasmaClient = null)
 
 private[sql] abstract class MemoryManager {
@@ -133,6 +133,7 @@ private[sql] object MemoryManager extends Logging {
       case "hybrid" => new HybridMemoryManager(sparkEnv)
       case "tmp" => new TmpDramMemoryManager(sparkEnv)
       case "kmem" => new DaxKmemMemoryManager(sparkEnv)
+      case "plasma" => new PlasmaMemoryManager(sparkEnv)
       case _ => throw new UnsupportedOperationException(
         s"The memory manager: ${memoryManagerOpt} is not supported now")
     }
@@ -152,7 +153,7 @@ private[sql] object MemoryManager extends Logging {
       case "guava" => apply(sparkEnv, memoryManagerOpt)
       case "noevict" => new HybridMemoryManager(sparkEnv)
       case "vmem" => new TmpDramMemoryManager(sparkEnv)
-      case "external" => new TmpDramMemoryManager(sparkEnv)
+      case "external" => new PlasmaMemoryManager(sparkEnv)
       case "mix" =>
         if (!memoryManagerOpt.equals("mix")) {
           apply(sparkEnv, memoryManagerOpt)
@@ -416,7 +417,7 @@ private[filecache] class PlasmaMemoryManager(sparkEnv: SparkEnv)
   }
 
   override private[filecache] def free(block: MemoryBlockHolder): Unit = {
-    throw new OapException("Unsupported Exception!!")
+    block.client.release(block.obejctId)
   }
 
   override def isDcpmmUsed(): Boolean = true

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.util.Success
 
 import com.intel.oap.common.unsafe.PersistentMemoryPlatform
+import org.apache.arrow.plasma.PlasmaClient
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
@@ -55,7 +56,9 @@ case class MemoryBlockHolder(
                               baseOffset: Long,
                               length: Long,
                               occupiedSize: Long,
-                              source: SourceEnum.SourceEnum)
+                              source: SourceEnum.SourceEnum,
+                              fiberId: FiberId = null,
+                              client: PlasmaClient = null)
 
 private[sql] abstract class MemoryManager {
   /**
@@ -404,6 +407,23 @@ private[filecache] class DaxKmemMemoryManager(sparkEnv: SparkEnv)
 
   override def memorySize: Long = _memorySize
 
+}
+
+private[filecache] class PlasmaMemoryManager(sparkEnv: SparkEnv)
+  extends MemoryManager with Logging {
+  override private[filecache] def allocate(size: Long) = {
+    throw new OapException("Unsupported Exception!!")
+  }
+
+  override private[filecache] def free(block: MemoryBlockHolder): Unit = {
+    throw new OapException("Unsupported Exception!!")
+  }
+
+  override def isDcpmmUsed(): Boolean = true
+
+  override def memorySize: Long = 0
+
+  override def memoryUsed: Long = 0
 }
 
 private[filecache] class HybridMemoryManager(sparkEnv: SparkEnv)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -911,7 +911,6 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
   private val externalStoreCacheSocket: String = "/tmp/plasmaStore"
   private var cacheInit: Boolean = false
   def init(): Unit = {
-    logInfo("just a test log")
     if (!cacheInit) {
       try {
         System.loadLibrary("plasma_java")
@@ -945,6 +944,7 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
   override def getEmptyFiber(fiberLength: Long, fiberId: FiberId = null ): FiberCache = {
     val objectId = hash(fiberId.toString)
     val plasmaClient = plasmaClientPool(clientRoundRobin.getAndAdd(1) % clientPoolSize)
+    // TODO: may throw ObjectDuplicateException here
     val buf: ByteBuffer = plasmaClient.create(objectId, fiberLength.toInt)
     DataFiber(buf, objectId, plasmaClient)
   }
@@ -1018,7 +1018,7 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
         cacheMissCount.addAndGet(1)
         fiberSet.add(fiberId)
         fiberCache.occupy()
-         cacheGuardian.addRemovalFiber(fiberId, fiberCache)
+        cacheGuardian.addRemovalFiber(fiberId, fiberCache)
         fiberCache
       } else {
         val fiberCache = super.cache(fiberId)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -340,7 +340,8 @@ trait OapCache {
     val cache = fiber match {
       case binary: BinaryDataFiberId => binary.doCache()
       case orcChunk: OrcBinaryFiberId => orcChunk.doCache()
-      case VectorDataFiberId(file, columnIndex, rowGroupId) => file.cache(rowGroupId, columnIndex)
+      case VectorDataFiberId(file, columnIndex, rowGroupId) =>
+        file.cache(rowGroupId, columnIndex, fiber)
       case BTreeFiberId(getFiberData, _, _, _) => getFiberData.apply()
       case BitmapFiberId(getFiberData, _, _, _) => getFiberData.apply()
       case TestDataFiberId(getFiberData, _) => getFiberData.apply()

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/DataFile.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.FSDataInputStream
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.{OapException, RecordReader}
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberId}
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
@@ -46,7 +46,8 @@ abstract class DataFile {
   def totalRows(): Long
 
   def getDataFileMeta(): DataFileMeta
-  def cache(groupId: Int, fiberId: Int): FiberCache
+  // FIXME: the first 'fiberId' should be renamed as 'columnId'
+  def cache(groupId: Int, fiberId: Int, fiber: FiberId = null): FiberCache
   override def hashCode(): Int = path.hashCode
   override def equals(other: Any): Boolean = other match {
     case df: DataFile => path.equals(df.path)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataFile.scala
@@ -92,7 +92,7 @@ private[oap] case class OapDataFileV1(
     }
   }
 
-  def cache(groupId: Int, fiberId: Int): FiberCache = {
+  def cache(groupId: Int, fiberId: Int, fiber: FiberId = null): FiberCache = {
     val groupMeta = meta.rowGroupsMeta(groupId)
     val decompressor: BytesDecompressor = codecFactory.getDecompressor(meta.codec)
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
@@ -238,6 +238,6 @@ private[oap] case class OrcDataFile(
     else {
       OrcCacheReader.putValues(rowCount, field, fromColumn, toColumn)
     }
-    ParquetDataFiberWriter.dumpToCache(toColumn, rowCount)
+    ParquetDataFiberWriter.dumpToCache(toColumn, rowCount, fiber)
   }
 }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
@@ -213,7 +213,7 @@ private[oap] case class OrcDataFile(
   override def getDataFileMeta(): DataFileMeta =
     new OrcDataFileMeta(filePath, configuration)
 
-  override def cache(groupId: Int, fiberId: Int): FiberCache = {
+  override def cache(groupId: Int, fiberId: Int, fiber: FiberId = null): FiberCache = {
     val fileSchema = fileReader.getSchema
     val columnTypeDesc = TypeDescription.createStruct()
       .addField(fileSchema.getFieldNames.get(fiberId), fileSchema.getChildren.get(fiberId))

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberCompressedReaderWriter.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberCompressedReaderWriter.scala
@@ -53,7 +53,7 @@ object ParquetDataFiberCompressedWriter extends Logging {
   val compressionCodec = SparkCompressionCodec.createCodec(new SparkConf(), codecName)
 
   def dumpToCache(reader: VectorizedColumnReader,
-      total: Int, dataType: DataType): FiberCache = {
+      total: Int, dataType: DataType, fiberId: FiberId = null): FiberCache = {
     // For the dictionary case, the column vector occurs some batch has dictionary
     // and some no dictionary. Therefore we still read the total value to cv instead of batch.
     // TODO: Next can split the read to column vector from total to batch?

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberReaderWriter.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberReaderWriter.scala
@@ -306,7 +306,7 @@ object ParquetDataFiberWriter extends Logging {
   }
 
   private def emptyDataFiber(fiberLength: Long, fiberId: FiberId = null): FiberCache =
-    OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(fiberLength)
+    OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(fiberLength, fiberId)
 }
 
 /**

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberReaderWriter.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberReaderWriter.scala
@@ -23,7 +23,7 @@ import org.apache.parquet.it.unimi.dsi.fastutil.ints.IntList
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.OapException
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberId}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetDictionaryWrapper
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
 import org.apache.spark.sql.oap.OapRuntime
@@ -41,7 +41,7 @@ import org.apache.spark.unsafe.Platform
  */
 object ParquetDataFiberWriter extends Logging {
 
-  def dumpToCache(column: OnHeapColumnVector, total: Int): FiberCache = {
+  def dumpToCache(column: OnHeapColumnVector, total: Int, fiberId: FiberId = null): FiberCache = {
     val header = ParquetDataFiberHeader(column, total)
     logDebug(s"will dump column to data fiber dataType = ${column.dataType()}, " +
       s"total = $total, header is $header")
@@ -49,7 +49,7 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(true, false, 0) =>
         val length = fiberLength(column, total, 0 )
         logDebug(s"will apply $length bytes off heap memory for data fiber.")
-        val fiber = emptyDataFiber(length)
+        val fiber = emptyDataFiber(length, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           val nativeAddress = header.writeToCache(fiber.getBaseOffset)
           dumpDataToFiber(nativeAddress, column, total)
@@ -60,7 +60,7 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(true, false, dicLength) =>
         val length = fiberLength(column, total, 0, dicLength)
         logDebug(s"will apply $length bytes off heap memory for data fiber.")
-        val fiber = emptyDataFiber(length)
+        val fiber = emptyDataFiber(length, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           val nativeAddress = header.writeToCache(fiber.getBaseOffset)
           dumpDataAndDicToFiber(nativeAddress, column, total, dicLength)
@@ -71,7 +71,7 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(false, true, _) =>
         logDebug(s"will apply ${ParquetDataFiberHeader.defaultSize} " +
           s"bytes off heap memory for data fiber.")
-        val fiber = emptyDataFiber(ParquetDataFiberHeader.defaultSize)
+        val fiber = emptyDataFiber(ParquetDataFiberHeader.defaultSize, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           header.writeToCache(fiber.getBaseOffset)
         } else {
@@ -81,7 +81,7 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(false, false, 0) =>
         val length = fiberLength(column, total, 1)
         logDebug(s"will apply $length bytes off heap memory for data fiber.")
-        val fiber = emptyDataFiber(length)
+        val fiber = emptyDataFiber(length, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           val nativeAddress =
             dumpNullsToFiber(header.writeToCache(fiber.getBaseOffset), column, total)
@@ -93,7 +93,7 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(false, false, dicLength) =>
         val length = fiberLength(column, total, 1, dicLength)
         logDebug(s"will apply $length bytes off heap memory for data fiber.")
-        val fiber = emptyDataFiber(length)
+        val fiber = emptyDataFiber(length, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           val nativeAddress =
             dumpNullsToFiber(header.writeToCache(fiber.getBaseOffset), column, total)
@@ -305,7 +305,7 @@ object ParquetDataFiberWriter extends Logging {
     case other => throw new OapException(s"$other data type is not implemented for cache.")
   }
 
-  private def emptyDataFiber(fiberLength: Long): FiberCache =
+  private def emptyDataFiber(fiberLength: Long, fiberId: FiberId = null): FiberCache =
     OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(fiberLength)
 }
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -92,7 +92,7 @@ private[oap] case class ParquetDataFile(
     inUseFiberCache.indices.foreach(release)
   }
 
-  def cache(groupId: Int, fiberId: Int): FiberCache = {
+  def cache(groupId: Int, fiberId: Int, fiber: FiberId = null): FiberCache = {
     if (fiberDataReader == null) {
       fiberDataReader =
         ParquetFiberDataReader.open(configuration, file, meta.footer.toParquetMetadata)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -102,7 +102,7 @@ private[oap] case class ParquetDataFile(
     // setting required column to conf enables us to
     // Vectorized read & cache certain(not all) columns
     addRequestSchemaToConf(conf, Array(fiberId))
-    ParquetFiberDataLoader(conf, fiberDataReader, groupId).loadSingleColumn
+    ParquetFiberDataLoader(conf, fiberDataReader, groupId).loadSingleColumn(fiber)
   }
 
   def iterator(

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -1617,7 +1617,7 @@ class ParquetFiberDataLoaderSuite extends ParquetDataFileSuite {
   private def loadSingleColumn(requiredId: Array[Int]): FiberCache = {
     val conf = new Configuration(configuration)
     addRequestSchemaToConf(conf, requiredId)
-    ParquetFiberDataLoader(conf, reader, 0).loadSingleColumn
+    ParquetFiberDataLoader(conf, reader, 0).loadSingleColumn()
   }
 
   test("test loadSingleColumn with reuse reader") {

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/TestDataFile.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/TestDataFile.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution.datasources.oap.io
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.sql.execution.datasources.oap.filecache.FiberCache
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberId}
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 
@@ -41,6 +41,6 @@ private[oap] case class TestDataFile(path: String, schema: StructType, configura
   override def getDataFileMeta(): DataFileMeta =
     throw new UnsupportedOperationException
 
-  override def cache(groupId: Int, fiberId: Int): FiberCache =
+  override def cache(groupId: Int, fiberId: Int, fiber: FiberId = null): FiberCache =
     throw new UnsupportedOperationException
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can remove extra memcopy (from plasma share memory to tmpMemory) since plasma can mmap /mnt/pmem directly.




## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

