### PR TITLE
[oap-native-sql]Add ColumnarBatch Combination on Shuffle Read Side

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/AdaptorReferenceManager.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/AdaptorReferenceManager.java
@@ -29,8 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A simple reference manager implementation for memory allocated by native
- * code. The underlying memory will be released when reference count reach zero.
+ * A simple reference manager implementation for memory allocated by native code. The underlying
+ * memory will be released when reference count reach zero.
  */
 public class AdaptorReferenceManager implements ReferenceManager {
   private native void nativeRelease(long nativeMemoryHolder);
@@ -62,7 +62,8 @@ public class AdaptorReferenceManager implements ReferenceManager {
 
   @Override
   public boolean release(int decrement) {
-    Preconditions.checkState(decrement >= 1, "ref count decrement should be greater than or equal to 1");
+    Preconditions.checkState(
+        decrement >= 1, "ref count decrement should be greater than or equal to 1");
     // decrement the ref count
     final int refCnt;
     synchronized (this) {
@@ -106,7 +107,8 @@ public class AdaptorReferenceManager implements ReferenceManager {
   }
 
   @Override
-  public OwnershipTransferResult transferOwnership(ArrowBuf sourceBuffer, BufferAllocator targetAllocator) {
+  public OwnershipTransferResult transferOwnership(
+      ArrowBuf sourceBuffer, BufferAllocator targetAllocator) {
     return NO_OP.transferOwnership(sourceBuffer, targetAllocator);
   }
 

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/CompressedVectorLoader.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/CompressedVectorLoader.java
@@ -28,36 +28,36 @@ import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 
 import io.netty.buffer.ArrowBuf;
 
-/**
- * Loads compressed buffers into vectors.
- */
+/** Loads compressed buffers into vectors. */
 public class CompressedVectorLoader extends VectorLoader {
 
-    /**
-     * Construct with a root to load and will create children in root based on schema.
-     *
-     * @param root the root to add vectors to based on schema
-     */
-    public CompressedVectorLoader(VectorSchemaRoot root) {
-        super(root);
-    }
+  /**
+   * Construct with a root to load and will create children in root based on schema.
+   *
+   * @param root the root to add vectors to based on schema
+   */
+  public CompressedVectorLoader(VectorSchemaRoot root) {
+    super(root);
+  }
 
-    /**
-     * Loads the record batch in the vectors.
-     * will not close the record batch
-     *
-     * @param recordBatch the batch to load
-     */
-    public void loadCompressed(ArrowRecordBatch recordBatch) {
-        Iterator<ArrowBuf> buffers = recordBatch.getBuffers().iterator();
-        Iterator<ArrowFieldNode> nodes = recordBatch.getNodes().iterator();
-        for (FieldVector fieldVector : root.getFieldVectors()) {
-            loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes);
-        }
-        root.setRootRowCount(recordBatch.getLength());
-        if (nodes.hasNext() || buffers.hasNext()) {
-            throw new IllegalArgumentException("not all nodes and buffers were consumed. nodes: " +
-                    Collections2.toList(nodes).toString() + " buffers: " + Collections2.toList(buffers).toString());
-        }
+  /**
+   * Loads the record batch in the vectors. will not close the record batch
+   *
+   * @param recordBatch the batch to load
+   */
+  public void loadCompressed(ArrowRecordBatch recordBatch) {
+    Iterator<ArrowBuf> buffers = recordBatch.getBuffers().iterator();
+    Iterator<ArrowFieldNode> nodes = recordBatch.getNodes().iterator();
+    for (FieldVector fieldVector : root.getFieldVectors()) {
+      loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes);
     }
+    root.setRootRowCount(recordBatch.getLength());
+    if (nodes.hasNext() || buffers.hasNext()) {
+      throw new IllegalArgumentException(
+          "not all nodes and buffers were consumed. nodes: "
+              + Collections2.toList(nodes).toString()
+              + " buffers: "
+              + Collections2.toList(buffers).toString());
+    }
+  }
 }

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/PartitionFileInfo.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/PartitionFileInfo.java
@@ -1,19 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.intel.sparkColumnarPlugin.vectorized;
 
 public class PartitionFileInfo {
-    private int pid;
-    private String filePath;
+  private int pid;
+  private String filePath;
 
-    public PartitionFileInfo(int pid, String filePath) {
-        this.pid = pid;
-        this.filePath = filePath;
-    }
+  public PartitionFileInfo(int pid, String filePath) {
+    this.pid = pid;
+    this.filePath = filePath;
+  }
 
-    public int getPid() {
-        return pid;
-    }
+  public int getPid() {
+    return pid;
+  }
 
-    public String getFilePath() {
-        return filePath;
-    }
+  public String getFilePath() {
+    return filePath;
+  }
 }

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ShuffleDecompressionJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ShuffleDecompressionJniWrapper.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.intel.sparkColumnarPlugin.vectorized;
 
 import java.io.IOException;
@@ -18,7 +35,12 @@ public class ShuffleDecompressionJniWrapper {
   public native long make(byte[] schemaBuf) throws RuntimeException;
 
   public native ArrowRecordBatchBuilder decompress(
-      long schemaHolderId, String compressionCodec, int numRows, long[] bufAddrs, long[] bufSizes, long[] bufMask)
+      long schemaHolderId,
+      String compressionCodec,
+      int numRows,
+      long[] bufAddrs,
+      long[] bufSizes,
+      long[] bufMask)
       throws RuntimeException;
 
   /**

--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ShuffleSplitterJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ShuffleSplitterJniWrapper.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.intel.sparkColumnarPlugin.vectorized;
 
 import java.io.IOException;
@@ -16,12 +33,14 @@ public class ShuffleSplitterJniWrapper {
    * @return native splitter instance id if created successfully.
    * @throws RuntimeException
    */
-  public native long make(byte[] schemaBuf, long bufferSize, String localDirs) throws RuntimeException;
+  public native long make(byte[] schemaBuf, long bufferSize, String localDirs)
+      throws RuntimeException;
 
   /**
-   * Split one record batch represented by bufAddrs and bufSizes into several batches. The batch is split according to
-   * the first column as partition id. During splitting, the data in native buffers will be write to disk when
-   * the buffers are full.
+   * Split one record batch represented by bufAddrs and bufSizes into several batches. The batch is
+   * split according to the first column as partition id. During splitting, the data in native
+   * buffers will be write to disk when the buffers are full.
+   *
    * @param splitterId
    * @param numRows Rows per batch
    * @param bufAddrs Addresses of buffers
@@ -42,7 +61,8 @@ public class ShuffleSplitterJniWrapper {
 
   /**
    * Set the output buffer for each partition. Splitter will maintain one buffer for each partition
-   * id occurred, and write data to file when buffer is full. Default buffer size will be set to 4096 rows.
+   * id occurred, and write data to file when buffer is full. Default buffer size will be set to
+   * 4096 rows.
    *
    * @param splitterId
    * @param bufferSize In row, not bytes. Default buffer size will be set to 4096 rows.
@@ -69,6 +89,7 @@ public class ShuffleSplitterJniWrapper {
 
   /**
    * Get the total bytes written to disk.
+   *
    * @param splitterId
    * @return
    */

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/CoalesceBatchesExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/CoalesceBatchesExec.scala
@@ -1,12 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.intel.sparkColumnarPlugin.execution
 
+import java.util.concurrent.TimeUnit
+
+import com.intel.sparkColumnarPlugin.vectorized.ArrowWritableColumnVector
+import org.apache.arrow.vector.util.VectorBatchAppender
+import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+import scala.collection.mutable.ListBuffer
+
 case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
+
+  override def output: Seq[Attribute] = child.output
 
   override def supportsColumnar: Boolean = true
 
@@ -14,10 +41,112 @@ case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
 
   override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException
 
+  override lazy val metrics: Map[String, SQLMetric] = Map(
+    "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
+    "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "number of input batches"),
+    "numOutputBatches" -> SQLMetrics.createMetric(sparkContext, "number of output batches"),
+    "concatTime" -> SQLMetrics.createTimingMetric(sparkContext, "concat batch time total"),
+    "collectTime" -> SQLMetrics.createTimingMetric(sparkContext, "collect batch time total"),
+    "avgCoalescedNumRows" -> SQLMetrics
+      .createAverageMetric(sparkContext, "avg coalesced batch num rows"))
+  // TODO: peak device memory total
+
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    child.executeColumnar()
+    import CoalesceBatchesExec._
+
+    val recordsPerBatch = conf.arrowMaxRecordsPerBatch
+    val numInputRows = longMetric("numInputRows")
+    val numInputBatches = longMetric("numInputBatches")
+    val numOutputBatches = longMetric("numOutputBatches")
+    val concatTime = longMetric("concatTime")
+    val collectTime = longMetric("collectTime")
+    val avgCoalescedNumRows = longMetric("avgCoalescedNumRows")
+
+    child.executeColumnar().mapPartitions { iter =>
+      if (iter.hasNext) {
+        new Iterator[ColumnarBatch] {
+          var target: ColumnarBatch = _
+          var numBatchesTotal: Long = _
+          var numRowsTotal: Long = _
+
+          TaskContext.get().addTaskCompletionListener[Unit] { _ =>
+            closePrevious()
+            if (numBatchesTotal > 0) {
+              avgCoalescedNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
+            }
+          }
+
+          private def closePrevious(): Unit = {
+            if (target != null) {
+              target.close()
+              target = null
+            }
+          }
+
+          override def hasNext: Boolean = {
+            iter.hasNext
+          }
+
+          override def next(): ColumnarBatch = {
+            closePrevious()
+            var rowCount = 0
+            val batchesToAppend = ListBuffer[ColumnarBatch]()
+
+            val beforeCollect = System.nanoTime
+            target = iter.next()
+            target.retain()
+            rowCount += target.numRows
+
+            while (iter.hasNext && rowCount < recordsPerBatch) {
+              val delta = iter.next()
+              delta.retain()
+              rowCount += delta.numRows
+              batchesToAppend += delta
+            }
+
+            val beforeConcat = System.nanoTime
+            collectTime += TimeUnit.NANOSECONDS.toMillis(beforeConcat - beforeCollect)
+
+            coalesce(target, batchesToAppend.toList)
+            target.setNumRows(rowCount)
+
+            concatTime += TimeUnit.NANOSECONDS.toMillis(System.nanoTime - beforeConcat)
+            numInputRows += rowCount
+            numInputBatches += (1 + batchesToAppend.length)
+            numOutputBatches += 1
+
+            // used for calculating avgCoalescedNumRows
+            numRowsTotal += rowCount
+            numBatchesTotal += 1
+
+            batchesToAppend.foreach(cb => cb.close())
+
+            target
+          }
+        }
+      } else {
+        Iterator.empty
+      }
+    }
+  }
+}
+
+object CoalesceBatchesExec {
+  implicit class ArrowColumnarBatchRetainer(val cb: ColumnarBatch) {
+    def retain(): Unit = {
+      (0 until cb.numCols).toList.foreach(i =>
+        cb.column(i).asInstanceOf[ArrowWritableColumnVector].retain())
+    }
   }
 
-  override def output: Seq[Attribute] = child.output
-
+  def coalesce(targetBatch: ColumnarBatch, batchesToAppend: List[ColumnarBatch]): Unit = {
+    (0 until targetBatch.numCols).toList.foreach { i =>
+      val targetVector =
+        targetBatch.column(i).asInstanceOf[ArrowWritableColumnVector].getValueVector
+      val vectorsToAppend = batchesToAppend.map { cb =>
+        cb.column(i).asInstanceOf[ArrowWritableColumnVector].getValueVector
+      }
+      VectorBatchAppender.batchAppend(targetVector, vectorsToAppend: _*)
+    }
+  }
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/CoalesceBatchesExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/execution/CoalesceBatchesExec.scala
@@ -45,8 +45,8 @@ case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
     "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
     "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "number of input batches"),
     "numOutputBatches" -> SQLMetrics.createMetric(sparkContext, "number of output batches"),
-    "concatTime" -> SQLMetrics.createTimingMetric(sparkContext, "concat batch time total"),
-    "collectTime" -> SQLMetrics.createTimingMetric(sparkContext, "collect batch time total"),
+    "concatTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "concat batch time total"),
+    "collectTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "collect batch time total"),
     "avgCoalescedNumRows" -> SQLMetrics
       .createAverageMetric(sparkContext, "avg coalesced batch num rows"))
   // TODO: peak device memory total
@@ -105,12 +105,12 @@ case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
             }
 
             val beforeConcat = System.nanoTime
-            collectTime += TimeUnit.NANOSECONDS.toMillis(beforeConcat - beforeCollect)
+            collectTime += beforeConcat - beforeCollect
 
             coalesce(target, batchesToAppend.toList)
             target.setNumRows(rowCount)
 
-            concatTime += TimeUnit.NANOSECONDS.toMillis(System.nanoTime - beforeConcat)
+            concatTime += System.nanoTime - beforeConcat
             numInputRows += rowCount
             numInputBatches += (1 + batchesToAppend.length)
             numOutputBatches += 1

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ConverterUtils.scala
@@ -18,16 +18,15 @@
 package com.intel.sparkColumnarPlugin.expression
 
 import java.util.concurrent.atomic.AtomicLong
+
 import io.netty.buffer.ArrowBuf
-
 import com.intel.sparkColumnarPlugin.vectorized.ArrowWritableColumnVector
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.optimizer._
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
@@ -35,6 +34,8 @@ import org.apache.arrow.vector.types.pojo.Schema
 import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.ColumnarShuffleExchangeExec.fromAttributes
+import org.apache.spark.sql.internal.SQLConf
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -75,7 +76,9 @@ object ConverterUtils extends Logging {
     new ArrowRecordBatch(numRowsInBatch, fieldNodes.toList.asJava, inputData.toList.asJava)
   }
 
-  def fromArrowRecordBatch(recordBatchSchema: Schema, recordBatch: ArrowRecordBatch): Array[ArrowWritableColumnVector] = {
+  def fromArrowRecordBatch(
+      recordBatchSchema: Schema,
+      recordBatch: ArrowRecordBatch): Array[ArrowWritableColumnVector] = {
     val numRows = recordBatch.getLength()
     ArrowWritableColumnVector.loadColumns(numRows, recordBatchSchema, recordBatch)
   }
@@ -124,7 +127,8 @@ object ConverterUtils extends Logging {
       case ss: Substring =>
         getAttrFromExpr(ss.children(0))
       case other =>
-        throw new UnsupportedOperationException(s"makeStructField is unable to parse from $other (${other.getClass}).")
+        throw new UnsupportedOperationException(
+          s"makeStructField is unable to parse from $other (${other.getClass}).")
     }
   }
 
@@ -142,9 +146,15 @@ object ConverterUtils extends Logging {
         //TODO: a walkaround since we didn't support cast yet
         if (a.child.isInstanceOf[Cast]) {
           val tmp = if (name != "None") {
-            new Alias(a.child.asInstanceOf[Cast].child, name)(a.exprId, a.qualifier, a.explicitMetadata)
+            new Alias(a.child.asInstanceOf[Cast].child, name)(
+              a.exprId,
+              a.qualifier,
+              a.explicitMetadata)
           } else {
-            new Alias(a.child.asInstanceOf[Cast].child, a.name)(a.exprId, a.qualifier, a.explicitMetadata)
+            new Alias(a.child.asInstanceOf[Cast].child, a.name)(
+              a.exprId,
+              a.qualifier,
+              a.explicitMetadata)
           }
           tmp.toAttribute.asInstanceOf[AttributeReference]
         } else {
@@ -178,15 +188,21 @@ object ConverterUtils extends Logging {
   }
 
   def combineArrowRecordBatch(rb1: ArrowRecordBatch, rb2: ArrowRecordBatch): ArrowRecordBatch = {
-     val numRows = rb1.getLength()
-     val rb1_nodes = rb1.getNodes()
-     val rb2_nodes = rb2.getNodes()
-     val rb1_bufferlist = rb1.getBuffers()
-     val rb2_bufferlist = rb2.getBuffers()
+    val numRows = rb1.getLength()
+    val rb1_nodes = rb1.getNodes()
+    val rb2_nodes = rb2.getNodes()
+    val rb1_bufferlist = rb1.getBuffers()
+    val rb2_bufferlist = rb2.getBuffers()
 
-     val combined_nodes = rb1_nodes.addAll(rb2_nodes)
-     val combined_bufferlist = rb1_bufferlist.addAll(rb2_bufferlist)
-     new ArrowRecordBatch(numRows, rb1_nodes, rb1_bufferlist)
+    val combined_nodes = rb1_nodes.addAll(rb2_nodes)
+    val combined_bufferlist = rb1_bufferlist.addAll(rb2_bufferlist)
+    new ArrowRecordBatch(numRows, rb1_nodes, rb1_bufferlist)
+  }
+
+  def toArrowSchema(attributes: Seq[Attribute]): Schema = {
+    def fromAttributes(attributes: Seq[Attribute]): StructType =
+      StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
+    ArrowUtils.toArrowSchema(fromAttributes(attributes), SQLConf.get.sessionLocalTimeZone)
   }
 
   override def toString(): String = {
@@ -194,4 +210,3 @@ object ConverterUtils extends Logging {
   }
 
 }
-

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/expression/ConverterUtils.scala
@@ -17,25 +17,19 @@
 
 package com.intel.sparkColumnarPlugin.expression
 
-import java.util.concurrent.atomic.AtomicLong
-
-import io.netty.buffer.ArrowBuf
 import com.intel.sparkColumnarPlugin.vectorized.ArrowWritableColumnVector
+import io.netty.buffer.ArrowBuf
+import org.apache.arrow.vector._
+import org.apache.arrow.vector.ipc.message.{ArrowFieldNode, ArrowRecordBatch}
+import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.optimizer._
-import org.apache.spark.sql.util.ArrowUtils
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
-import org.apache.arrow.vector._
-import org.apache.arrow.vector.ipc.message.ArrowFieldNode
-import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
-import org.apache.arrow.vector.types.pojo.Schema
-import org.apache.arrow.vector.types.pojo.Field
-import org.apache.arrow.vector.types.pojo.ArrowType
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql.execution.ColumnarShuffleExchangeExec.fromAttributes
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.ArrowUtils
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer

--- a/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/vectorized/ArrowColumnarBatchSerializer.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/sparkColumnarPlugin/vectorized/ArrowColumnarBatchSerializer.scala
@@ -153,7 +153,9 @@ private class ArrowColumnarBatchSerializerInstance(readBatchNumRows: SQLMetric)
       }
 
       override def close(): Unit = {
-        readBatchNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
+        if (numBatchesTotal > 0) {
+          readBatchNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
+        }
         if (cb != null) cb.close()
         if (reader != null) reader.close(true)
         if (jniWrapper != null) jniWrapper.close(schemaHolderId)

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleDependency.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleDependency.scala
@@ -50,7 +50,8 @@ class ColumnarShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     override val mapSideCombine: Boolean = false,
     override val shuffleWriterProcessor: ShuffleWriteProcessor = new ShuffleWriteProcessor,
     val serializedSchema: Array[Byte],
-    val dataSize: SQLMetric)
+    val dataSize: SQLMetric,
+    val splitTime: SQLMetric)
     extends ShuffleDependency[K, V, C](
       _rdd,
       partitioner,

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -108,14 +108,14 @@ class ColumnarShuffleWriter[K, V](
 
         val startTime = System.nanoTime()
         jniWrapper.split(nativeSplitter, cb.numRows, bufAddrs.toArray, bufSizes.toArray)
-        writeMetrics.incWriteTime(System.nanoTime() - startTime)
+        dep.splitTime.add(System.nanoTime() - startTime)
         writeMetrics.incRecordsWritten(1)
       }
     }
 
     val startTime = System.nanoTime()
     jniWrapper.stop(nativeSplitter)
-    writeMetrics.incWriteTime(System.nanoTime() - startTime)
+    dep.splitTime.add(System.nanoTime() - startTime)
     writeMetrics.incBytesWritten(jniWrapper.getTotalBytesWritten(nativeSplitter))
 
     val output = shuffleBlockResolver.getDataFile(dep.shuffleId, mapId)

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -50,7 +50,6 @@ import org.apache.spark.sql.execution.metric.{
 }
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
-import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.MutablePair
 
@@ -67,8 +66,8 @@ class ColumnarShuffleExchangeExec(
   override private[sql] lazy val readMetrics =
     SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
   override lazy val metrics: Map[String, SQLMetric] = Map(
-    "dataSize" -> SQLMetrics
-      .createSizeMetric(sparkContext, "data size"),
+    "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),
+    "splitTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "split time"),
     "avgReadBatchNumRows" -> SQLMetrics
       .createAverageMetric(sparkContext, "avg read batch num rows")) ++ readMetrics ++ writeMetrics
 
@@ -89,7 +88,8 @@ class ColumnarShuffleExchangeExec(
       outputPartitioning,
       serializer,
       writeMetrics,
-      longMetric("dataSize"))
+      longMetric("dataSize"),
+      longMetric("splitTime"))
   }
 
   def createColumnarShuffledRDD(
@@ -109,16 +109,14 @@ class ColumnarShuffleExchangeExec(
 
 object ColumnarShuffleExchangeExec extends Logging {
 
-  private def fromAttributes(attributes: Seq[Attribute]): StructType =
-    StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
-
   def prepareShuffleDependency(
       rdd: RDD[ColumnarBatch],
       outputAttributes: Seq[Attribute],
       newPartitioning: Partitioning,
       serializer: Serializer,
       writeMetrics: Map[String, SQLMetric],
-      dataSize: SQLMetric): ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
+      dataSize: SQLMetric,
+      splitTime: SQLMetric): ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
 
     val arrowSchema: Schema =
       ConverterUtils.toArrowSchema(
@@ -238,7 +236,8 @@ object ColumnarShuffleExchangeExec extends Logging {
         serializer,
         shuffleWriterProcessor = createShuffleWriteProcessor(writeMetrics),
         serializedSchema = arrowSchema.toByteArray,
-        dataSize = dataSize)
+        dataSize = dataSize,
+        splitTime = splitTime)
 
     dependency
   }

--- a/oap-native-sql/core/src/test/scala/org/apache/spark/shuffle/ColumnarShuffleWriterSuite.scala
+++ b/oap-native-sql/core/src/test/scala/org/apache/spark/shuffle/ColumnarShuffleWriterSuite.scala
@@ -85,6 +85,8 @@ class ColumnarShuffleWriterSuite extends SharedSparkSession {
     when(dependency.serializedSchema).thenReturn(schema.toByteArray)
     when(dependency.dataSize)
       .thenReturn(SQLMetrics.createSizeMetric(spark.sparkContext, "data size"))
+    when(dependency.splitTime)
+      .thenReturn(SQLMetrics.createNanoTimingMetric(spark.sparkContext, "split time"))
     when(taskContext.taskMetrics()).thenReturn(taskMetrics)
     when(blockResolver.getDataFile(0, 0)).thenReturn(outputFile)
 

--- a/oap-native-sql/core/src/test/scala/org/apache/spark/sql/RepartitionSuite.scala
+++ b/oap-native-sql/core/src/test/scala/org/apache/spark/sql/RepartitionSuite.scala
@@ -35,7 +35,6 @@ class RepartitionSuite extends QueryTest with SharedSparkSession {
       .setAppName("test repartition")
       .set("spark.sql.parquet.columnarReaderBatchSize", "4096")
       .set("spark.sql.sources.useV1SourceList", "avro")
-      .set("spark.sql.join.preferSortMergeJoin", "false")
       .set("spark.sql.extensions", "com.intel.sparkColumnarPlugin.ColumnarPlugin")
       .set("spark.sql.execution.arrow.maxRecordsPerBatch", "4096")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new operator CoalesceBatch to support ColumnarBatch combination on shuffle read side.

## How was this patch tested?

Existing unit tests. Manually test and pass all tpch queries.