### PR TITLE
[oap-native-sql] Columnar shuffle I/O Use Configured Disks

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ShuffleSplitterJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/sparkColumnarPlugin/vectorized/ShuffleSplitterJniWrapper.java
@@ -16,7 +16,7 @@ public class ShuffleSplitterJniWrapper {
    * @return native splitter instance id if created successfully.
    * @throws RuntimeException
    */
-  public native long make(byte[] schemaBuf, long bufferSize) throws RuntimeException;
+  public native long make(byte[] schemaBuf, long bufferSize, String localDirs) throws RuntimeException;
 
   /**
    * Split one record batch represented by bufAddrs and bufSizes into several batches. The batch is split according to

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -31,7 +31,6 @@ import org.apache.arrow.vector.types.pojo.Schema
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.MapStatus
-import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
 
@@ -81,7 +80,9 @@ class ColumnarShuffleWriter[K, V](
 
     if (nativeSplitter == 0) {
       val schema: Schema = Schema.deserialize(ByteBuffer.wrap(dep.serializedSchema))
-      nativeSplitter = jniWrapper.make(SchemaUtils.get.serialize(schema), nativeBufferSize)
+      val localDirs = Utils.getConfiguredLocalDirs(conf).mkString(",")
+      nativeSplitter =
+        jniWrapper.make(SchemaUtils.get.serialize(schema), nativeBufferSize, localDirs)
       if (compressionEnabled) {
         jniWrapper.setCompressionCodec(nativeSplitter, compressionCodec)
       }

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -31,7 +31,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.ColumnarShuffleDependency
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, LazilyGeneratedOrdering}
+import org.apache.spark.sql.catalyst.expressions.codegen.LazilyGeneratedOrdering
 import org.apache.spark.sql.catalyst.expressions.{
   Attribute,
   AttributeReference,
@@ -59,8 +59,7 @@ class ColumnarShuffleExchangeExec(
     override val outputPartitioning: Partitioning,
     child: SparkPlan,
     canChangeNumPartitions: Boolean = true)
-    extends ShuffleExchangeExec(outputPartitioning, child, canChangeNumPartitions)
-    with CodegenSupport {
+    extends ShuffleExchangeExec(outputPartitioning, child, canChangeNumPartitions) {
 
   private lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
@@ -105,14 +104,6 @@ class ColumnarShuffleExchangeExec(
     }
     cachedShuffleRDD
   }
-
-  override def supportCodegen: Boolean = false
-
-  override def inputRDDs(): Seq[RDD[InternalRow]] =
-    throw new UnsupportedOperationException
-
-  override protected def doProduce(ctx: CodegenContext): String =
-    throw new UnsupportedOperationException
 }
 
 object ColumnarShuffleExchangeExec extends Logging {

--- a/oap-native-sql/core/src/test/scala/org/apache/spark/sql/RepartitionSuite.scala
+++ b/oap-native-sql/core/src/test/scala/org/apache/spark/sql/RepartitionSuite.scala
@@ -39,10 +39,7 @@ class RepartitionSuite extends QueryTest with SharedSparkSession {
       .set("spark.sql.extensions", "com.intel.sparkColumnarPlugin.ColumnarPlugin")
       .set("spark.sql.execution.arrow.maxRecordsPerBatch", "4096")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
-//      .set("spark.sql.codegen.wholeStage", "false")
       .set("spark.shuffle.compress", "false")
-      .set("spark.eventLog.enabled", "true")
-      .set("spark.eventLog.dir", "file:///home/mr/spark/sparklog")
 
   def checkCoulumnarExec(data: DataFrame) = {
     val found = data.queryExecution.executedPlan

--- a/oap-native-sql/cpp/src/jni/jni_wrapper.cc
+++ b/oap-native-sql/cpp/src/jni/jni_wrapper.cc
@@ -1087,9 +1087,15 @@ Java_com_intel_sparkColumnarPlugin_datasource_parquet_ParquetWriterJniWrapper_na
 
 JNIEXPORT jlong JNICALL
 Java_com_intel_sparkColumnarPlugin_vectorized_ShuffleSplitterJniWrapper_make(
-    JNIEnv* env, jobject, jbyteArray schema_arr, jlong buffer_size) {
+    JNIEnv* env, jobject, jbyteArray schema_arr, jlong buffer_size, jstring pathObj) {
   std::shared_ptr<arrow::Schema> schema;
   arrow::Status status;
+
+  // split pathObj to paths
+  auto joined_path = env->GetStringUTFChars(pathObj, JNI_FALSE);
+  setenv("NATIVESQL_SPARK_LOCAL_DIRS", joined_path, 1);
+
+  env->ReleaseStringUTFChars(pathObj, joined_path);
 
   status = MakeSchema(env, schema_arr, &schema);
   if (!status.ok()) {

--- a/oap-native-sql/cpp/src/jni/jni_wrapper.cc
+++ b/oap-native-sql/cpp/src/jni/jni_wrapper.cc
@@ -1091,7 +1091,6 @@ Java_com_intel_sparkColumnarPlugin_vectorized_ShuffleSplitterJniWrapper_make(
   std::shared_ptr<arrow::Schema> schema;
   arrow::Status status;
 
-  // split pathObj to paths
   auto joined_path = env->GetStringUTFChars(pathObj, JNI_FALSE);
   setenv("NATIVESQL_SPARK_LOCAL_DIRS", joined_path, 1);
 

--- a/oap-native-sql/resource/ApacheArrowInstallation.md
+++ b/oap-native-sql/resource/ApacheArrowInstallation.md
@@ -42,7 +42,7 @@ git clone https://github.com/Intel-bigdata/arrow.git
 cd arrow && git checkout native-sql-engine-clean
 mkdir -p arrow/cpp/release-build
 cd arrow/cpp/release-build
-cmake -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_HDFS=ON -DARROW_BOOST_USE_SHARED=ON -DARROW_JNI=ON -DARROW_WITH_SNAPPY=ON -DARROW_FILESYSTEM=ON -DARROW_JSON=ON ..
+cmake -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_HDFS=ON -DARROW_BOOST_USE_SHARED=ON -DARROW_JNI=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_LZ4=ON -DARROW_FILESYSTEM=ON -DARROW_JSON=ON ..
 make -j
 make install
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow spark's rule to chose shuffle disks. Multiple disks configuration is supported.

## How was this patch tested?

unit tests
