### PR TITLE
Modify pom.xml to add RPMem shuffle as a sub project

### DIFF
--- a/oap-shuffle/RPMem-shuffle/core/pom.xml
+++ b/oap-shuffle/RPMem-shuffle/core/pom.xml
@@ -5,14 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>com.intel.spark-pmof</groupId>
-      <artifactId>spark-pmof</artifactId>
-      <version>1.0</version>
+      <groupId>com.intel.oap</groupId>
+      <artifactId>oap-rpmem-shuffle</artifactId>
+      <version>0.8.0</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
-    <groupId>com.intel.spark-pmof.java</groupId>
     <artifactId>java</artifactId>
     <version>1.0</version>
 

--- a/oap-shuffle/RPMem-shuffle/native/pom.xml
+++ b/oap-shuffle/RPMem-shuffle/native/pom.xml
@@ -5,14 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>com.intel.spark-pmof</groupId>
-      <artifactId>spark-pmof</artifactId>
-      <version>1.0</version>
+      <groupId>com.intel.oap</groupId>
+      <artifactId>oap-rpmem-shuffle</artifactId>
+      <version>0.8.0</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
 
-    <groupId>com.intel.spark-pmof.native</groupId>
     <artifactId>native</artifactId>
     <version>1.0</version>
     <build>

--- a/oap-shuffle/RPMem-shuffle/pom.xml
+++ b/oap-shuffle/RPMem-shuffle/pom.xml
@@ -1,23 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.intel.spark-pmof</groupId>
-    <artifactId>spark-pmof</artifactId>
-    <version>1.0</version>
-    <packaging>pom</packaging>
-    <name>Spark-PMoF</name>
-    <licenses>
-      <license>
-        <name>Apache 2.0 License</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-        <distribution>repo</distribution>
-      </license>
-    </licenses>
-    <modules>
-      <module>native</module>
-      <module>core</module>
-    </modules>
+
+<parent>
+	<groupId>com.intel.oap</groupId>
+	<artifactId>oap-parent</artifactId>
+	<version>0.8.0</version>
+	<relativePath>../../pom.xml</relativePath>
+</parent>
+
+<artifactId>oap-rpmem-shuffle</artifactId>
+<packaging>pom</packaging>
+<name>OAP Project RPMem Shuffle</name>
+
+<licenses>
+	<license>
+		<name>Apache 2.0 License</name>
+		<url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+		<distribution>repo</distribution>
+	</license>
+</licenses>
+<modules>
+	<module>native</module>
+	<module>core</module>
+</modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>oap-cache/oap</module>
         <module>oap-shuffle/remote-shuffle</module>
         <module>oap-spark</module>
+        <module>oap-shuffle/RPMem-shuffle</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Add RPMem shuffle as a sub project in OAP's pom

The RPMem is added as a module. 
For now, the RPMem shuffle can be packaged specifically with:

```mvn package -pl com.intel.oap:oap-rpmem-shuffle -amd package -DskipTests```




