### PR TITLE
[oap-native-sql] compression use single thread

### DIFF
--- a/oap-native-sql/cpp/src/shuffle/partition_writer.cc
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.cc
@@ -133,6 +133,7 @@ arrow::Status PartitionWriter::WriteArrowRecordBatch() {
     auto options = arrow::ipc::IpcWriteOptions::Defaults();
     options.allow_64bit = true;
     options.compression = compression_codec_;
+    options.use_threads = false;
 
     auto res = arrow::ipc::NewStreamWriter(file_.get(), schema_, options);
     RETURN_NOT_OK(res.status());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Arrow's RecordBatch compression by default use multi-threads to compress. Need to disable multi-thread compression in our use case due to performance downgrade.

The decompression doesn't call the RecordBatch API and use single thread, so it doesn't need modification.

After disabling multi-thread compression, the native shuffle split + write micro benchmark improve ~60% (1330ms vs 825ms, input file 132M)

## How was this patch tested?

Unit tests. Pass TPCH queries.

