### PR TITLE
[OAP-RPMemshuffle] Rename RPMem shuffle jar file

### DIFF
--- a/oap-shuffle/RPMem-shuffle/core/pom.xml
+++ b/oap-shuffle/RPMem-shuffle/core/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <packaging>jar</packaging>
 
-    <artifactId>java</artifactId>
+    <artifactId>oap-rpmem-shuffle</artifactId>
     <version>1.0</version>
 
     <dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename RPMem shuffle jar file. 


## How was this patch tested?

Tested locally. 