### PR TITLE
[OAP-Cache][POAE7-348]Fix OAP not apply ReuseExchange Optimization

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -44,6 +44,12 @@ private[sql] class OapFileFormat extends FileFormat
   with Logging
   with Serializable {
 
+  override def toString: String = "OAP"
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def equals(other: Any): Boolean = other.isInstanceOf[OapFileFormat]
+
   // exposed for test
   private[oap] lazy val oapMetrics = OapRuntime.getOrCreate.oapMetricsManager
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -44,12 +44,6 @@ private[sql] class OapFileFormat extends FileFormat
   with Logging
   with Serializable {
 
-  override def toString: String = "OAP"
-
-  override def hashCode(): Int = getClass.hashCode()
-
-  override def equals(other: Any): Boolean = other.isInstanceOf[OapFileFormat]
-
   // exposed for test
   private[oap] lazy val oapMetrics = OapRuntime.getOrCreate.oapMetricsManager
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedOrcFileFormat.scala
@@ -35,6 +35,14 @@ import org.apache.spark.util.SerializableConfiguration
 
 private[sql] class OptimizedOrcFileFormat extends OapFileFormat {
 
+  override def shortName(): String = "OAP_ORC"
+
+  override def toString: String = "OAP_ORC"
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def equals(other: Any): Boolean = other.isInstanceOf[OptimizedOrcFileFormat]
+
   override def prepareWrite(
       sparkSession: SparkSession,
       job: Job,

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -33,6 +33,14 @@ import org.apache.spark.util.SerializableConfiguration
 
 private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
 
+  override def shortName(): String = "OAP_Parquet"
+
+  override def toString: String = "OAP_Parquet"
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def equals(other: Any): Boolean = other.isInstanceOf[OptimizedParquetFileFormat]
+
   override def prepareWrite(
       sparkSession: SparkSession,
       job: Job,

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -74,6 +74,7 @@ class DataFrameSuite extends QueryTest
         join2.queryExecution.executedPlan
           .collect { case _: ReusedExchangeExec => true }.size == 4)
     }
+    sqlContext.dropTempTable("parquet_test")
   }
 
   test("reuse exchange") {

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.io.{ByteArrayOutputStream, File}
+import java.nio.charset.StandardCharsets
+import java.sql.{Date, Timestamp}
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.reflect.runtime.universe.TypeTag
+import scala.util.Random
+
+import org.scalatest.Matchers._
+
+import org.apache.spark.SparkException
+import org.apache.spark.scheduler.{SparkListener, SparkListenerJobEnd}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.catalyst.expressions.Uuid
+import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, OneRowRelation}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.execution.{FilterExec, QueryExecution, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchangeExec}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSparkSession}
+import org.apache.spark.sql.test.SQLTestData.{DecimalData, TestData2}
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.CalendarInterval
+import org.apache.spark.util.Utils
+import org.apache.spark.util.random.XORShiftRandom
+
+class DataFrameSuite extends QueryTest
+  with SharedSparkSession
+  with AdaptiveSparkPlanHelper {
+  import testImplicits._
+
+  test("reuse exchange OAP") {
+    val path = Utils.createTempDir().getAbsolutePath
+    sql(s"""CREATE TEMPORARY VIEW parquet_test (a INT, b STRING)
+           | USING parquet
+           | OPTIONS (path '$path')""".stripMargin)
+    withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "2",
+      OapConf.OAP_PARQUET_BINARY_DATA_CACHE_ENABLED.key -> "true") {
+      val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+      data.toDF("key", "value").createOrReplaceTempView("t")
+      sql("insert overwrite table parquet_test select * from t")
+      val df = sql("select * from parquet_test")
+      val join = df.join(df, "a")
+      val broadcasted = broadcast(join)
+      val join2 = join.join(broadcasted, "a").join(broadcasted, "a")
+      join2.explain()
+      assert(
+        join2.queryExecution.executedPlan
+          .collect { case _: ReusedExchangeExec => true }.size == 4)
+    }
+  }
+
+  test("reuse exchange") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2") {
+      val df = spark.range(100).toDF()
+      val join = df.join(df, "id")
+      val plan = join.queryExecution.executedPlan
+      checkAnswer(join, df)
+      assert(
+        collect(join.queryExecution.executedPlan) {
+          case e: ShuffleExchangeExec => true }.size === 1)
+      assert(
+        collect(join.queryExecution.executedPlan) { case e: ReusedExchangeExec => true }.size === 1)
+      val broadcasted = broadcast(join)
+      val join2 = join.join(broadcasted, "id").join(broadcasted, "id")
+      checkAnswer(join2, df)
+      assert(
+        collect(join2.queryExecution.executedPlan) {
+          case e: ShuffleExchangeExec => true }.size == 1)
+      assert(
+        collect(join2.queryExecution.executedPlan) {
+          case e: BroadcastExchangeExec => true }.size === 1)
+      assert(
+        collect(join2.queryExecution.executedPlan) { case e: ReusedExchangeExec => true }.size == 4)
+    }
+  }
+
+}
+
+

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.datasources.oap
 
 import org.scalatest.BeforeAndAfterEach
-
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.oap.OapConf
@@ -163,11 +162,12 @@ class OapMetricsSuite extends QueryTest with SharedOapContext with BeforeAndAfte
     checkAnswer(df, Row(1, "this is row 1") :: Nil)
 
     // rowsRead = 2 && rowsSkipped = 2 * 99
+    // ReuseExchange optimization
     val fileFormats = getOapFileFormat(df.queryExecution.sparkPlan)
     fileFormats.foreach(f => assert(f.orNull != null))
     assertAccumulators(fileFormats,
-      Some(RowMetrics(2 * 100, 0, 2 * 1, 2 * 99, 0, 0)),
-      Some(TaskMetrics(2 * 3, 0, 2 * 3, 0, 0)))
+      Some(RowMetrics(100, 0, 1, 99, 0, 0)),
+      Some(TaskMetrics(3, 0, 3, 0, 0)))
 
     sql("drop oindex idx1 on parquet_test")
   }

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapMetricsSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.oap
 
 import org.scalatest.BeforeAndAfterEach
+
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.oap.OapConf


### PR DESCRIPTION
## What changes were proposed in this pull request?

OAP  will not apply ReuseExchange optimization due to `OAPFileFormat` didn't override `equals`, `hashcode`, `shortName`, `toString` method. 

Related issue: [1110](https://github.com/Intel-bigdata/OAP/issues/1110), [1423](https://github.com/Intel-bigdata/OAP/issues/1423)

## How was this patch tested?

add a UT, and run TPC-DS query64 , get about more than 2x performance gain(632s -> 289s, lower better).


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

