### PR TITLE
[OAP-MLLIB] combine the multi numeric tables to one in executor process

### DIFF
--- a/oap-mllib/mllib-dal/src/main/native/OneDAL.cpp
+++ b/oap-mllib/mllib-dal/src/main/native/OneDAL.cpp
@@ -33,3 +33,11 @@ JNIEXPORT void JNICALL Java_org_apache_spark_ml_util_OneDAL_00024_setNumericTabl
 
 }
 
+JNIEXPORT void JNICALL Java_org_apache_spark_ml_util_OneDAL_00024_cAddNumericTable
+  (JNIEnv *, jobject,  jlong rowMergedNumericTableAddr, jlong numericTableAddr) {
+    
+    data_management::RowMergedNumericTablePtr pRowMergedNumericTable = (*(data_management::RowMergedNumericTablePtr *)rowMergedNumericTableAddr); 
+    data_management::NumericTablePtr pNumericTable = (*(data_management::NumericTablePtr *)numericTableAddr);
+    pRowMergedNumericTable->addNumericTable(pNumericTable);
+
+  }

--- a/oap-mllib/mllib-dal/src/main/native/javah/org_apache_spark_ml_util_OneDAL__.h
+++ b/oap-mllib/mllib-dal/src/main/native/javah/org_apache_spark_ml_util_OneDAL__.h
@@ -15,6 +15,9 @@ extern "C" {
 JNIEXPORT void JNICALL Java_org_apache_spark_ml_util_OneDAL_00024_setNumericTableValue
   (JNIEnv *, jobject, jlong, jint, jint, jdouble);
 
+JNIEXPORT void JNICALL Java_org_apache_spark_ml_util_OneDAL_00024_cAddNumericTable
+	  (JNIEnv *, jobject, jlong, jlong);
+
 #ifdef __cplusplus
 }
 #endif

--- a/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -424,15 +424,14 @@ class KMeans @Since("1.5.0") (
     val strInitMode = $(initMode)
     logInfo(f"Initialization with $strInitMode took $initTimeInSeconds%.3f seconds.")
 
-    // Repartition and convert to RDD[HomogenNumericTable]
-    val repartitioned = instances.map {
+    val inputData = instances.map {
       case (point: Vector, weight: Double) => point
-    }.repartition(executor_num).setName("Repartitioned for conversion").cache()
+    }
 
     val kmeansDAL = new KMeansDALImpl(getK, getMaxIter, getTol,
       DistanceMeasure.EUCLIDEAN, centers, executor_num, executor_cores)
 
-    val parentModel = kmeansDAL.runWithRDDVector(repartitioned, Option(instr))
+    val parentModel = kmeansDAL.runWithRDDVector(inputData, Option(instr))
 
     val model = copyValues(new KMeansModel(uid, parentModel).setParent(this))
 

--- a/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/clustering/KMeansDALImpl.scala
+++ b/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/clustering/KMeansDALImpl.scala
@@ -18,14 +18,16 @@
 package org.apache.spark.ml.clustering
 
 import com.intel.daal.algorithms.KMeansResult
-import com.intel.daal.data_management.data.{NumericTable, Matrix => DALMatrix}
+import com.intel.daal.data_management.data.{NumericTable, HomogenNumericTable, RowMergedNumericTable, Matrix => DALMatrix}
 import com.intel.daal.services.DaalContext
 import org.apache.spark.ml.util._
 import org.apache.spark.mllib.clustering.{DistanceMeasure, KMeansModel => MLlibKMeansModel}
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.util.OneDAL._
 import org.apache.spark.mllib.linalg.{Vector => OldVector, Vectors => OldVectors}
-import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.{ExecutorInProcessCoalescePartitioner, RDD}
+
+import scala.collection.mutable.ArrayBuffer
 
 class KMeansDALImpl (
   var nClusters : Int = 4,
@@ -43,55 +45,87 @@ class KMeansDALImpl (
 
     val partitionDims = Utils.getPartitionDims(data)
     val executorIPAddress = Utils.sparkFirstExecutorIP(data.sparkContext)
+    
+	// convert RDD[Vector] to RDD[HomogenNumericTable]
+    val numericTables = data.mapPartitionsWithIndex { (index: Int, it: Iterator[Vector]) =>
+      val tables = new ArrayBuffer[HomogenNumericTable]()
 
-    val results = data.mapPartitionsWithIndex { (index: Int, it: Iterator[Vector]) =>
+      val numRows = partitionDims(index)._1
+      val numCols = partitionDims(index)._2
 
-    val numRows = partitionDims(index)._1
-    val numCols = partitionDims(index)._2
+      println(s"KMeansDALImpl: Partition index: $index, numCols: $numCols, numRows: $numRows")
 
-    println(s"KMeansDALImpl: Partition index: $index, numCols: $numCols, numRows: $numRows")
+      // Build DALMatrix, this will load libJavaAPI, libtbb, libtbbmalloc
+      val context = new DaalContext()
+      val matrix = new DALMatrix(context, classOf[java.lang.Double],
+        numCols.toLong, numRows.toLong, NumericTable.AllocationFlag.DoAllocate)
 
-    // Build DALMatrix, this will load libJavaAPI, libtbb, libtbbmalloc
-    val context = new DaalContext()
-    val localData = new DALMatrix(context, classOf[java.lang.Double],
-      numCols.toLong, numRows.toLong, NumericTable.AllocationFlag.DoAllocate)
+      println("KMeansDALImpl: Loading libMLlibDAL.so" )
+      // oneDAL libs should be loaded by now, extract libMLlibDAL.so to temp file and load
+      LibLoader.loadLibrary()
 
-    println("KMeansDALImpl: Loading libMLlibDAL.so" )
-    // oneDAL libs should be loaded by now, extract libMLlibDAL.so to temp file and load
-    LibLoader.loadLibrary()
+      println(s"KMeansDALImpl: Start data conversion")
 
-    println(s"KMeansDALImpl: Start data conversion")
-
-    val start = System.nanoTime
-    it.zipWithIndex.foreach {
-      case (v, rowIndex) =>
-        for (colIndex <- 0 until numCols)
+      val start = System.nanoTime
+      it.zipWithIndex.foreach {
+        case (v, rowIndex) =>
+          for (colIndex <- 0 until numCols)
           // TODO: Add matrix.set API in DAL to replace this
           // matrix.set(rowIndex, colIndex, row.getString(colIndex).toDouble)
-          OneDAL.setNumericTableValue(localData.getCNumericTable, rowIndex, colIndex, v(colIndex))
-    }
+            OneDAL.setNumericTableValue(matrix.getCNumericTable, rowIndex, colIndex, v(colIndex))
+      }
 
-    val duration = (System.nanoTime - start) / 1E9
+      val duration = (System.nanoTime - start) / 1E9
 
-    println(s"KMeansDALImpl: Data conversion takes $duration seconds")
+      println(s"KMeansDALImpl: Data conversion takes $duration seconds")
+      matrix.pack()
+      tables += matrix
+      
+      context.dispose()
+      tables.iterator
+    }.cache()
+    
+    val inputRDD = numericTables.mapPartitions( (tables: Iterator[HomogenNumericTable]) => {
+      val context = new DaalContext()
+      tables.map { table =>
+          table.unpack(context)
+          table.getCNumericTable}
+    }).cache()
 
-    OneCCL.init(executorNum, executorIPAddress, OneCCL.KVS_PORT)
+    inputRDD.count()
+	
+    val coalescedrdd = inputRDD.coalesce(1,
+      partitionCoalescer = Some(new ExecutorInProcessCoalescePartitioner()))
 
-    val initCentroids = OneDAL.makeNumericTable(centers)
-    var result = new KMeansResult()
-    val cCentroids = cKMeansDALComputeWithInitCenters(
-      localData.getCNumericTable,
-      initCentroids.getCNumericTable,
-      nClusters,
-      maxIterations,
-      executorNum,
-      executorCores,
-      result
-    )
+    val coalescedTables = coalescedrdd.mapPartitions { iter =>
+      val matcharr = iter.toArray
+      val context = new DaalContext()
+      val mergedData = new RowMergedNumericTable(context)
+	  
+      matcharr.foreach(OneDAL.cAddNumericTable(mergedData.getCNumericTable, _))
+      
+      Iterator(mergedData.getCNumericTable)
+    
+    }.cache()
 
-    val ret = if (OneCCL.isRoot()) {
+    val results = coalescedTables.mapPartitions { table =>
+      val tableArr = table.next()
+      OneCCL.init(executorNum, executorIPAddress, OneCCL.KVS_PORT)
+
+      val initCentroids = OneDAL.makeNumericTable(centers)
+      var result = new KMeansResult()
+      val cCentroids = cKMeansDALComputeWithInitCenters(
+        tableArr,
+        initCentroids.getCNumericTable,
+        nClusters,
+        maxIterations,
+        executorNum,
+        executorCores,
+        result
+      )
+
+      val ret = if (OneCCL.isRoot()) {
         assert(cCentroids != 0)
-
         val centerVectors = OneDAL.numericTableToVectors(OneDAL.makeNumericTable(cCentroids))
         Iterator((centerVectors, result.totalCost))
       } else {
@@ -101,7 +135,6 @@ class KMeansDALImpl (
       OneCCL.cleanup()
 
       ret
-
     }.collect()
 
     // Make sure there is only one result from rank 0

--- a/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/clustering/KMeansDALImpl.scala
+++ b/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/clustering/KMeansDALImpl.scala
@@ -91,7 +91,8 @@ class KMeansDALImpl (
           table.unpack(context)
           table.getCNumericTable}
     }).cache()
-
+    
+    inputRDD.foreachPartition(() => _)
     inputRDD.count()
 	
     val coalescedrdd = inputRDD.coalesce(1,
@@ -136,6 +137,11 @@ class KMeansDALImpl (
 
       ret
     }.collect()
+
+    // release the native memory allocated by NumericTable.
+    numericTables.mapPartitions( (tables: Iterator[HomogenNumericTable]) =>
+        tables.map (_.freeDataMemory())
+    )
 
     // Make sure there is only one result from rank 0
     assert(results.length == 1)

--- a/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/util/OneDAL.scala
+++ b/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/util/OneDAL.scala
@@ -70,4 +70,6 @@ object OneDAL {
   }
 
   @native def setNumericTableValue(numTableAddr: Long, rowIndex: Int, colIndex: Int, value: Double)
+
+  @native def cAddNumericTable(cObject: Long, numericTableAddr: Long)
 }

--- a/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/rdd/ExecutorInProcessCoalescePartitioner.scala
+++ b/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/rdd/ExecutorInProcessCoalescePartitioner.scala
@@ -1,0 +1,80 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import org.apache.commons.logging.LogFactory
+
+import org.apache.spark.Partition
+import org.apache.spark.SparkException
+import org.apache.spark.scheduler.ExecutorCacheTaskLocation
+import org.apache.spark.scheduler.TaskLocation
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+class ExecutorInProcessCoalescePartitioner(val balanceSlack: Double = 0.10)
+  extends PartitionCoalescer with Serializable {
+  private val logger = LogFactory.getLog("ExecutorInProcessCoalescePartitioner")
+
+  def coalesce(maxPartitions: Int, prev: RDD[_]): Array[PartitionGroup] = {
+    val map = new mutable.HashMap[String, mutable.HashSet[Partition]]()
+
+    // System.out.println("xgbtck rddname " + prev.getClass.getName
+    //  + "\n " + prev.toDebugString)
+    // System.out.println("xgbtck rddname " + prev.prev().getClass.getName)
+    // System.out.println("xgbtck rddname " + prev.prev().prev().getClass.getName)
+
+    val groupArr = ArrayBuffer[PartitionGroup]()
+    prev.partitions.foreach(p => {
+      val loc = prev.context.getPreferredLocs(prev, p.index)
+      loc.foreach{
+      case location : ExecutorCacheTaskLocation =>
+        // System.out.println("xgbtck partitionloc " + location.getClass.getName)
+        val execLoc = "executor_" + location.host + "_" + location.executorId
+        val partValue = map.getOrElse(execLoc, new mutable.HashSet[Partition]())
+        partValue.add(p)
+        map.put(execLoc, partValue)
+        // System.out.println("xgbtck coalescePartitioner partid"
+        //  +  String.valueOf(p.index)
+        //  + " location = " + execLoc)
+
+      case loc : TaskLocation =>
+        System.out.println("xgbtck partitionloc " + loc.getClass.getName)
+        System.out.println("xgbtck partitionloc " + loc.host)
+        logger.error("Invalid location : ")
+      }
+    })
+    map.foreach(x => {
+      val pg = new PartitionGroup(Some(x._1))
+      val list = x._2.toList.sortWith(_.index < _.index);
+      list.foreach(part => pg.partitions += part)
+      groupArr += pg
+    })
+    if (groupArr.length == 0) throw new SparkException("No partitions or" +
+      " no locations for partitions found.")
+
+    val sortedGroupArr = groupArr.sortWith(_.partitions(0).index < _.partitions(0).index)
+
+    sortedGroupArr.foreach(pg => {
+      System.out.print(" xgbtck executorcoalesce " + pg.prefLoc + " : ")
+      pg.partitions.foreach(part => System.out.print(String.valueOf(part.index) + " "))
+      System.out.print("\n")
+    })
+    return sortedGroupArr.toArray
+  }
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?
 Combine the multi tasks to one task by combining the multi numeric tables into one before training. 


## How was this patch tested?
Manual test the kmeans-hibench and compared the results

