### PR TITLE
[OAP-1468][oap-native-sql][CI] update to depends on oap-0.9 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
       before_script:
       - cd /tmp
       - git clone https://github.com/intel-bigdata/arrow.git
-      - cd arrow && git checkout oap-master && cd cpp
+      - cd arrow && git checkout branch-0.17.0-oap-0.9 && cd cpp
       - sed -i "s/\${Python3_EXECUTABLE}/\/opt\/pyenv\/shims\/python3/g" CMakeLists.txt
       - mkdir build && cd build 
       - cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON && make 


### PR DESCRIPTION
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## What changes were proposed in this pull request?

Update travis CI to depends on arrow oap-0.9 branch since oap-master branch will be modified
Fixes #1468 

## How was this patch tested?

Travis + local jenkins
