### PR TITLE
[OAP-1464][SQL-Data-Source-Cache]Disable OAP Orc Column VecotorCache

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
@@ -126,19 +126,24 @@ object HadoopFsRelationOptimizer extends Logging {
             relation.options,
             selectedPartitions.flatMap(p => p.files))
 
+  /**
+   * Spark-3.0 has removed internal ORC configuration "spark.sql.orc.copyBatchToSpark"
+   * to simplify the code path, so it won't copy the ORC columnar batch to Spark columnar batch
+   * in the vectorized ORC reader. Then OAP does not support orc columnVectorCache for now
+   */
         def canUseCache: Boolean = {
           val runtimeConf = relation.sparkSession.conf
-          var vectorCacheEnabled = runtimeConf.get(OapConf.OAP_ORC_DATA_CACHE_ENABLED)
-          logDebug(s"config - ${OapConf.OAP_ORC_DATA_CACHE_ENABLED.key} is $vectorCacheEnabled")
-          vectorCacheEnabled = vectorCacheEnabled &&
-            runtimeConf.get(SQLConf.ORC_VECTORIZED_READER_ENABLED) &&
-            runtimeConf.get(SQLConf.WHOLESTAGE_CODEGEN_ENABLED) &&
-            // runtimeConf.get(SQLConf.ORC_COPY_BATCH_TO_SPARK) &&
-            outputSchema.forall(_.dataType.isInstanceOf[AtomicType])
+//          var vectorCacheEnabled = runtimeConf.get(OapConf.OAP_ORC_DATA_CACHE_ENABLED)
+//          logDebug(s"config - ${OapConf.OAP_ORC_DATA_CACHE_ENABLED.key} is $vectorCacheEnabled")
+//          vectorCacheEnabled = vectorCacheEnabled &&
+//            runtimeConf.get(SQLConf.ORC_VECTORIZED_READER_ENABLED) &&
+//            runtimeConf.get(SQLConf.WHOLESTAGE_CODEGEN_ENABLED) &&
+//            runtimeConf.get(SQLConf.ORC_COPY_BATCH_TO_SPARK) &&
+//            outputSchema.forall(_.dataType.isInstanceOf[AtomicType])
           val binaryCacheEnabled = runtimeConf.get(OapConf.OAP_ORC_BINARY_DATA_CACHE_ENABLED)
           logDebug(s"config - ${OapConf.OAP_ORC_BINARY_DATA_CACHE_ENABLED.key}" +
             s"is $binaryCacheEnabled")
-          val ret = vectorCacheEnabled || binaryCacheEnabled
+          val ret = binaryCacheEnabled
           if (ret) {
             logInfo("data cache enable and suitable for use , " +
               "will replace with optimizedOrcFileFormat.")

--- a/oap-cache/oap/src/test/oap-perf-suite/scala/org/apache/spark/sql/BenchmarkConfig.scala
+++ b/oap-cache/oap/src/test/oap-perf-suite/scala/org/apache/spark/sql/BenchmarkConfig.scala
@@ -181,24 +181,10 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true"),
         new BenchmarkConfig()
-          .setBenchmarkConfName("Orc w/ index oap cache enabled")
-          .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
-          .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.data.cache.enable", "true")
-          .setSparkConf("spark.sql.orc.copyBatchToSpark", "true"),
-        new BenchmarkConfig()
           .setBenchmarkConfName("Orc w/ index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
           .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true"),
-        new BenchmarkConfig()
-          .setBenchmarkConfName("orc w/ index data cache separation same medium enabled")
-          .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
-          .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.data.cache.enable", "true")
-          .setSparkConf("spark.sql.orc.copyBatchToSpark", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
-          .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
           .setBenchmarkConfName("orc w/ index binary data cache separation same medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
@@ -210,12 +196,6 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("Orc w/o index")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false"),
-        new BenchmarkConfig()
-          .setBenchmarkConfName("Orc w/o index oap cache enabled")
-          .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
-          .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false")
-          .setSparkConf("spark.sql.oap.orc.data.cache.enable", "true")
-          .setSparkConf("spark.sql.orc.copyBatchToSpark", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("Orc w/o index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
@@ -271,39 +251,16 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true"),
         new BenchmarkConfig()
-          .setBenchmarkConfName("Orc w/ index oap cache enabled")
-          .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
-          .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.data.cache.enable", "true")
-          .setSparkConf("spark.sql.orc.copyBatchToSpark", "true"),
-        new BenchmarkConfig()
           .setBenchmarkConfName("Orc w/ index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
           .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true"),
-        new BenchmarkConfig()
-          .setBenchmarkConfName("orc w/ index data cache separation same medium enabled")
-          .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
-          .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.data.cache.enable", "true")
-          .setSparkConf("spark.sql.orc.copyBatchToSpark", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
-          .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
           .setBenchmarkConfName("orc w/ index binary data cache separation same medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
           .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true")
           .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
-          .setSparkConf("spark.oap.cache.strategy", "mix"),
-        new BenchmarkConfig()
-          .setBenchmarkConfName("Orc w/ index data cache separation different medium enabled")
-          .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
-          .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.data.cache.enable", "true")
-          .setSparkConf("spark.sql.orc.copyBatchToSpark", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
-          .setSparkConf("spark.sql.oap.fiberCache.memory.manager", "mix")
           .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
           .setBenchmarkConfName("Orc w/ index data binary cache separation different medium enabled")
@@ -317,12 +274,6 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("Orc w/o index")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false"),
-        new BenchmarkConfig()
-          .setBenchmarkConfName("Orc w/o index oap cache enabled")
-          .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
-          .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false")
-          .setSparkConf("spark.sql.oap.orc.data.cache.enable", "true")
-          .setSparkConf("spark.sql.orc.copyBatchToSpark", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("Orc w/o index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Spark-3.0 has removed internal ORC configuration "spark.sql.orc.copyBatchToSpark" to simplify the code path, so it won't copy the ORC columnar batch to Spark columnar bath in the vectorized ORC batch. Then OAP for now does not support ORC colunmnVectorCache, so made corresponding change and remove related tests.



## How was this patch tested?

Passed unit tests.




