### PR TITLE
[OAP-1522][OAP-SQL-Data-Source-Cache]Modify Spark OAP TAB  webUI

### DIFF
--- a/oap-cache/oap/src/main/resources/oap/static/oap.js
+++ b/oap-cache/oap/src/main/resources/oap/static/oap.js
@@ -259,8 +259,10 @@ $(document).ready(function () {
                             },
                             {
                                 data: function (row, type) {
-                                    return type === 'display' ? (row.dataFiberHitCount * 100
-                                        / (row.dataFiberHitCount + row.dataFiberMissCount)).toFixed(2)
+                                    return type === 'display' ? (((row.dataFiberHitCount * 100
+                                        / (row.dataFiberHitCount + row.dataFiberMissCount)).toFixed(2)) === 'NaN' ?
+                                        '0' : (row.dataFiberHitCount * 100 / (row.dataFiberHitCount +
+                                        row.dataFiberMissCount)).toFixed(2))
                                         + '% (' + formatCount(row.dataFiberHitCount, type) + '/'
                                         + formatCount(row.dataFiberMissCount, type) + ')' : 'Nan'
                                 }
@@ -274,7 +276,9 @@ $(document).ready(function () {
                             {
                                 data: function (row, type) {
                                     return type === 'display' ?
-                                        formatDuration((row.dataTotalLoadTime / 1000000 / row.dataFiberLoadCount).toFixed(2)) : 'Nan'
+                                        (formatDuration((row.dataTotalLoadTime / 1000000 / row.dataFiberLoadCount).toFixed(2))
+                                         === 'NaN h' ? '0': formatDuration((row.dataTotalLoadTime / 1000000 /
+                                         row.dataFiberLoadCount).toFixed(2))): 'Nan'
                                 }
                             },
                             {
@@ -285,8 +289,10 @@ $(document).ready(function () {
                             },
                             {
                                 data: function (row, type) {
-                                    return type === 'display' ? (row.indexFiberHitCount * 100
-                                        / (row.indexFiberHitCount + row.indexFiberMissCount)).toFixed(2)
+                                    return type === 'display' ? (((row.indexFiberHitCount * 100
+                                        / (row.indexFiberHitCount + row.indexFiberMissCount)).toFixed(2)) === 'NaN' ?
+                                        '0' : (row.indexFiberHitCount * 100 / (row.indexFiberHitCount +
+                                        row.indexFiberMissCount)).toFixed(2))
                                         + '% (' + formatCount(row.indexFiberHitCount, type) + '/'
                                         + formatCount(row.indexFiberMissCount, type) + ')' : 'Nan'
                                 }
@@ -300,7 +306,9 @@ $(document).ready(function () {
                             {
                                 data: function (row, type) {
                                     return type === 'display' ?
-                                        formatDuration((row.indexTotalLoadTime / 1000000 / row.indexFiberLoadCount).toFixed(2)) : 'Nan'
+                                        (formatDuration((row.indexTotalLoadTime / 1000000 / row.indexFiberLoadCount).toFixed(2))
+                                         === 'NaN h' ? '0' : formatDuration((row.indexTotalLoadTime / 1000000 /
+                                         row.indexFiberLoadCount).toFixed(2))): 'Nan'
                                 }
                             },
                             {
@@ -314,6 +322,7 @@ $(document).ready(function () {
                     };
 
                     $(selector).DataTable(conf);
+                    $("#cache-separation-active-cms-table tr:not(:first):first").remove();
                     $('#active-cms [data-toggle="tooltip"]').tooltip();
 
                     var sumSelector = "#cache-separation-summary-cms-table";
@@ -352,8 +361,10 @@ $(document).ready(function () {
                             },
                             {
                                 data: function (row, type) {
-                                    return type === 'display' ? (row.allDataFiberHitCount * 100
-                                        / (row.allDataFiberHitCount + row.allDataFiberMissCount)).toFixed(2)
+                                    return type === 'display' ? (((row.allDataFiberHitCount * 100
+                                        / (row.allDataFiberHitCount + row.allDataFiberMissCount)).toFixed(2)) === 'NaN' ?
+                                        '0' : (row.allDataFiberHitCount * 100 / (row.allDataFiberHitCount +
+                                         row.allDataFiberMissCount)).toFixed(2))
                                         + '% (' + formatCount(row.allDataFiberHitCount, type) + '/'
                                         + formatCount(row.allDataFiberMissCount, type) + ')' : 'Nan'
                                 }
@@ -367,7 +378,9 @@ $(document).ready(function () {
                             {
                                 data: function (row, type) {
                                     return type === 'display' ?
-                                        formatDuration((row.allDataLoadTime / 1000000 / row.allDataFiberLoadCount).toFixed(2)) : 'Nan'
+                                        (formatDuration((row.allDataLoadTime / 1000000 / row.allDataFiberLoadCount).toFixed(2))
+                                        === 'NaN h' ? '0' : formatDuration((row.allDataLoadTime / 1000000 /
+                                        row.allDataFiberLoadCount).toFixed(2))) : 'Nan'
                                 }
                             },
                             {
@@ -378,8 +391,10 @@ $(document).ready(function () {
                             },
                             {
                                 data: function (row, type) {
-                                    return type === 'display' ? (row.allIndexFiberHitCount * 100
-                                        / (row.allIndexFiberHitCount + row.allIndexFiberMissCount)).toFixed(2)
+                                    return type === 'display' ? (((row.allIndexFiberHitCount * 100
+                                        / (row.allIndexFiberHitCount + row.allIndexFiberMissCount)).toFixed(2)) === 'NaN' ?
+                                        '0' : (row.allIndexFiberHitCount * 100  / (row.allIndexFiberHitCount +
+                                         row.allIndexFiberMissCount)).toFixed(2))
                                         + '% (' + formatCount(row.allIndexFiberHitCount, type) + '/'
                                         + formatCount(row.allIndexFiberMissCount, type) + ')' : 'Nan'
                                 }
@@ -393,7 +408,9 @@ $(document).ready(function () {
                             {
                                 data: function (row, type) {
                                     return type === 'display' ?
-                                        formatDuration((row.allIndexLoadTime / 1000000 / row.allIndexFiberLoadCount).toFixed(2)) : 'Nan'
+                                        (formatDuration((row.allIndexLoadTime / 1000000 / row.allIndexFiberLoadCount).toFixed(2))
+                                        === 'NaN h' ? '0': formatDuration((row.allIndexLoadTime / 1000000 /
+                                         row.allIndexFiberLoadCount).toFixed(2))) : 'Nan'
                                 }
                             },
                             {
@@ -462,8 +479,10 @@ $(document).ready(function () {
                             },
                             {
                                 data: function (row, type) {
-                                    return type === 'display' ? (row.dataFiberHitCount * 100
-                                        / (row.dataFiberHitCount + row.dataFiberMissCount)).toFixed(2)
+                                    return type === 'display' ? (((row.dataFiberHitCount * 100
+                                        / (row.dataFiberHitCount + row.dataFiberMissCount)).toFixed(2)) === 'NaN' ?
+                                        '0' : (row.dataFiberHitCount * 100  / (row.dataFiberHitCount +
+                                         row.dataFiberMissCount)).toFixed(2))
                                         + '% (' + formatCount(row.dataFiberHitCount, type) + '/'
                                         + formatCount(row.dataFiberMissCount, type) + ')' : 'Nan'
                                 }
@@ -472,7 +491,9 @@ $(document).ready(function () {
                             {
                                 data: function (row, type) {
                                     return type === 'display' ?
-                                        formatDuration((row.dataTotalLoadTime / 1000000 / row.dataFiberLoadCount).toFixed(2)) : 'Nan'
+                                        (formatDuration((row.dataTotalLoadTime / 1000000 / row.dataFiberLoadCount).toFixed(2))
+                                         === 'NaN h' ? '0': formatDuration((row.dataTotalLoadTime / 1000000 /
+                                          row.dataFiberLoadCount).toFixed(2))): 'Nan'
                                 }
                             },
                             {data: 'dataEvictionCount', render: formatCount}
@@ -481,6 +502,7 @@ $(document).ready(function () {
                     };
 
                     $(selector).DataTable(conf);
+                    $("#active-cms-table tr:not(:first):first").remove();
                     $('#active-cms [data-toggle="tooltip"]').tooltip();
 
                     var sumSelector = "#summary-cms-table";
@@ -531,8 +553,10 @@ $(document).ready(function () {
                             },
                             {
                                 data: function (row, type) {
-                                    return type === 'display' ? (row.allDataFiberHitCount * 100
-                                        / (row.allDataFiberHitCount + row.allDataFiberMissCount)).toFixed(2)
+                                    return type === 'display' ? (((row.allDataFiberHitCount * 100
+                                        / (row.allDataFiberHitCount + row.allDataFiberMissCount)).toFixed(2)) === 'NaN' ?
+                                        '0' : (row.allDataFiberHitCount * 100 / (row.allDataFiberHitCount +
+                                        row.allDataFiberMissCount)).toFixed(2))
                                         + '% (' + formatCount(row.allDataFiberHitCount, type) + '/'
                                         + formatCount(row.allDataFiberMissCount, type) + ')' : 'Nan'
                                 }
@@ -541,7 +565,9 @@ $(document).ready(function () {
                             {
                                 data: function (row, type) {
                                     return type === 'display' ?
-                                        formatDuration((row.allDataLoadTime / 1000000 / row.allDataFiberLoadCount).toFixed(2)) : 'Nan'
+                                        (formatDuration((row.allDataLoadTime / 1000000 / row.allDataFiberLoadCount).toFixed(2))
+                                         === 'NaN h' ? '0' : formatDuration((row.allDataLoadTime / 1000000 /
+                                         row.allDataFiberLoadCount).toFixed(2))) : 'Nan'
                                 }
                             },
                             {data: "allDataEvictionCount", render: formatCount}

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/oap/ui/FiberCacheManagerPage.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/oap/ui/FiberCacheManagerPage.scala
@@ -40,7 +40,7 @@ private[ui] class FiberCacheManagerPage(parent: OapTab) extends WebUIPage("") wi
         }
       </div>
 
-    UIUtils.headerSparkPage(request, "FiberCacheManager", content, parent, useDataTables = true)
+    UIUtils.headerSparkPage(request, "OAP Cache Metrics", content, parent, useDataTables = true)
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark webUI OAP tab used to have misleading information, such as 'NaN' , ‘FiberCacheManager’ and when OAP sql data source cache enables, driver doesn't cache , we' better remove its statistics. So, this PR submitted 3 modifications:
1. Remove driver statistics in Executors table.
2. Change the presentation 'NaN' to '0' when no data cached
3. Change 'FiberCacheManager' to 'OAP Cache Metrics'

Former OAP tab webUI:

Thriftserver start, but queries not running
<img width="946" alt="1" src="https://user-images.githubusercontent.com/30172512/87763591-9c602000-c847-11ea-8a09-c5653f59941c.png">

After queries finish
<img width="954" alt="2" src="https://user-images.githubusercontent.com/30172512/87763323-3378a800-c847-11ea-8e2d-d2bc0835e506.png">


## How was this patch tested?

Now the OAP tab webUI changes as below, the third is in mix mode and no data cached.

<img width="950" alt="3" src="https://user-images.githubusercontent.com/30172512/87901946-ec7af480-ca8a-11ea-9449-f3650827278c.png">

<img width="949" alt="3-1" src="https://user-images.githubusercontent.com/30172512/87901948-ee44b800-ca8a-11ea-8b9f-8445d5bb34ff.png">

 
<img width="948" alt="4" src="https://user-images.githubusercontent.com/30172512/87901955-f0a71200-ca8a-11ea-9872-84bee8ff8e15.png">

Fix #1522 