### PR TITLE
[OAP-1460][rpmem-shuffle]Bug fix to support decision support query

### DIFF
--- a/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmofShuffleManager.scala
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmofShuffleManager.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.pmof.PmofTransferService
 import org.apache.spark.shuffle._
+import org.apache.spark.util.collection.OpenHashSet
 import org.apache.spark.util.configuration.pmof.PmofConf
 import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv, TaskContext}
 
@@ -15,7 +16,11 @@ private[spark] class PmofShuffleManager(conf: SparkConf) extends ShuffleManager 
     logWarning("spark.shuffle.spill was set to false")
   }
 
-  private[this] val numMapsForShuffle = new ConcurrentHashMap[Int, Int]()
+  /**
+   * A mapping from shuffle ids to the task ids of mappers producing output for those shuffles.
+   */
+  private[this] val taskIdMapsForShuffle = new ConcurrentHashMap[Int, OpenHashSet[Long]]()
+
   private[this] val pmofConf = new PmofConf(conf)
   var metadataResolver: MetadataResolver = _
 
@@ -32,8 +37,9 @@ private[spark] class PmofShuffleManager(conf: SparkConf) extends ShuffleManager 
   }
 
   override def getWriter[K, V](handle: ShuffleHandle, mapId: Long, context: TaskContext, metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
-    assert(handle.isInstanceOf[BaseShuffleHandle[_, _, _]])
-
+    val mapTaskIds = taskIdMapsForShuffle.computeIfAbsent(
+      handle.shuffleId, _ => new OpenHashSet[Long](16))
+    mapTaskIds.synchronized { mapTaskIds.add(context.taskAttemptId()) }
     val env: SparkEnv = SparkEnv.get
     val blockManager = SparkEnv.get.blockManager
     val serializerManager = SparkEnv.get.serializerManager
@@ -53,20 +59,31 @@ private[spark] class PmofShuffleManager(conf: SparkConf) extends ShuffleManager 
     }
   }
 
-  override def getReader[K, C](handle: _root_.org.apache.spark.shuffle.ShuffleHandle, startPartition: Int, endPartition: Int, context: _root_.org.apache.spark.TaskContext, metrics: ShuffleReadMetricsReporter): _root_.org.apache.spark.shuffle.ShuffleReader[K, C] = {
+  override def getReader[K, C](handle: _root_.org.apache.spark.shuffle.ShuffleHandle, startPartition: Int, endPartition: Int, context: _root_.org.apache.spark.TaskContext, readMetrics: ShuffleReadMetricsReporter): _root_.org.apache.spark.shuffle.ShuffleReader[K, C] = {
+    val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
+      handle.shuffleId, startPartition, endPartition)
     if (pmofConf.enableRdma) {
       new RdmaShuffleReader(handle.asInstanceOf[BaseShuffleHandle[K, _, C]],
         startPartition, endPartition, context, pmofConf)
     } else {
       new BaseShuffleReader(
-        handle.asInstanceOf[BaseShuffleHandle[K, _, C]], startPartition, endPartition, context, pmofConf)
+        handle.asInstanceOf[BaseShuffleHandle[K, _, C]], blocksByAddress, startPartition, endPartition, context, readMetrics, pmofConf)
     }
   }
 
   override def unregisterShuffle(shuffleId: Int): Boolean = {
+    /**
+     * Previous implementation about remove map metadata
     Option(numMapsForShuffle.remove(shuffleId)).foreach { numMaps =>
       (0 until numMaps).foreach { mapId =>
         shuffleBlockResolver.asInstanceOf[IndexShuffleBlockResolver].removeDataByMap(shuffleId, mapId)
+      }
+    }
+     */
+
+    Option(taskIdMapsForShuffle.remove(shuffleId)).foreach { mapTaskIds =>
+      mapTaskIds.iterator.foreach { mapTaskId =>
+        shuffleBlockResolver.removeDataByMap(shuffleId, mapTaskId)
       }
     }
     true
@@ -76,7 +93,7 @@ private[spark] class PmofShuffleManager(conf: SparkConf) extends ShuffleManager 
     shuffleBlockResolver.stop()
   }
 
-  override val shuffleBlockResolver: ShuffleBlockResolver = {
+  override val shuffleBlockResolver: IndexShuffleBlockResolver = {
     if (pmofConf.enablePmem)
       new PmemShuffleBlockResolver(conf)
     else


### PR DESCRIPTION
The shuffle behavior of Spark3.0 has some changes due to https://issues.apache.org/jira/browse/SPARK-25341, it's used to better support rolling back a shuffle map stage and recover environment.
Some interfaces of RPMem shuffle plugin needs to be changed correspondingly.

This PR has been tested by 500GB decision support benchmark