### PR TITLE
[OAP-MLLIB] support to use batch iterator to set data from jvm to native

### DIFF
--- a/oap-mllib/mllib-dal/src/main/java/org/apache/spark/ml/util/DataBatch.java
+++ b/oap-mllib/mllib-dal/src/main/java/org/apache/spark/ml/util/DataBatch.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+ 
+package org.apache.spark.ml.util;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A mini-batch of data that can be converted to DALMatrix.
+ */
+public class DataBatch {
+  
+  /** The offset of each rows in the matrix */
+  final long[] rowOffset;
+  /** value of each non-missing entry in the matrix */
+  final double[] values ;
+  /** feature columns */
+  final int numCols;
+
+  DataBatch(long[] rowOffset,
+            double[] values, int numCols) {
+    this.rowOffset = rowOffset;
+    this.values = values;
+    this.numCols = numCols;
+  }
+
+  static public class BatchIterator implements Iterator<DataBatch> {
+    private final Iterator<double[]> base;
+    private final int batchSize;
+
+    public BatchIterator(Iterator<double[]> base, int batchSize) {
+      this.base = base;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return base.hasNext();
+    }
+
+    @Override
+    public DataBatch next() {
+      try {
+        int numRows = 0;
+        int numCols  = -1;
+        List<double[]> batch = new ArrayList<>(batchSize);
+        while (base.hasNext() && batch.size() < batchSize) {
+          double[] curValue = base.next();
+          if (numCols == -1) {
+            numCols = curValue.length;
+          } else if (numCols != curValue.length) {
+            throw new RuntimeException("Feature size is not the same");
+          }
+          batch.add(curValue);
+		  
+          numRows++;
+        }
+
+        long[] rowOffset = new long[numRows];
+        double[] values = new double[numRows * numCols];
+
+        int offset = 0;
+        for (int i = 0; i < batch.size(); i++) {
+          double[] curValue = batch.get(i);
+          rowOffset[i] = i;
+          System.arraycopy(curValue, 0, values, offset,
+            curValue.length);
+          offset += curValue.length;
+        }
+
+        return new DataBatch(rowOffset, values, numCols);
+      } catch (RuntimeException runtimeError) {
+     
+        return null;
+      }
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException("DataBatch.BatchIterator.remove");
+    }
+  }
+}

--- a/oap-mllib/mllib-dal/src/main/native/javah/org_apache_spark_ml_util_OneDAL__.h
+++ b/oap-mllib/mllib-dal/src/main/native/javah/org_apache_spark_ml_util_OneDAL__.h
@@ -14,6 +14,9 @@ extern "C" {
  */
 JNIEXPORT void JNICALL Java_org_apache_spark_ml_util_OneDAL_00024_setNumericTableValue
   (JNIEnv *, jobject, jlong, jint, jint, jdouble);
+  
+JNIEXPORT void JNICALL Java_org_apache_spark_ml_util_OneDAL_00024_cSetDoubleIterator
+  (JNIEnv *env, jobject,jlong numTableAddr, jobject jiter);
 
 #ifdef __cplusplus
 }

--- a/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/clustering/KMeansDALImpl.scala
+++ b/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/clustering/KMeansDALImpl.scala
@@ -61,15 +61,15 @@ class KMeansDALImpl (
     LibLoader.loadLibrary()
 
     println(s"KMeansDALImpl: Start data conversion")
+    import scala.collection.JavaConverters._
 
     val start = System.nanoTime
-    it.zipWithIndex.foreach {
-      case (v, rowIndex) =>
-        for (colIndex <- 0 until numCols)
-          // TODO: Add matrix.set API in DAL to replace this
-          // matrix.set(rowIndex, colIndex, row.getString(colIndex).toDouble)
-          OneDAL.setNumericTableValue(localData.getCNumericTable, rowIndex, colIndex, v(colIndex))
+    val iter = it.map{
+                curVector => curVector.toArray
     }
+    val batchSize = 8 << 10;
+    val batchIter = new DataBatch.BatchIterator(iter.asJava, batchSize)
+    OneDAL.cSetDoubleIterator(localData.getCNumericTable, batchIter)
 
     val duration = (System.nanoTime - start) / 1E9
 

--- a/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/util/OneDAL.scala
+++ b/oap-mllib/mllib-dal/src/main/scala/org/apache/spark/ml/util/OneDAL.scala
@@ -70,4 +70,6 @@ object OneDAL {
   }
 
   @native def setNumericTableValue(numTableAddr: Long, rowIndex: Int, colIndex: Int, value: Double)
+  
+  @native def cSetDoubleIterator(numTableAddr: Long, iter: java.util.Iterator[DataBatch])
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When convert the RDD[Vector] to RDD[HomogenNumericTable], the native set method will be called for each value. This PR aims to use the batch iterator and batch size to control the calls number of the native set method.


## How was this patch tested?
Manual test the kmeans-hibench and compared the results

