### PR TITLE
[OAP-1508][oap-native-sql] Clean java tmp dir when doing compilation

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ExpressionEvaluator.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ExpressionEvaluator.java
@@ -48,8 +48,9 @@ public class ExpressionEvaluator implements AutoCloseable {
       tmp_dir = System.getProperty("java.io.tmpdir");
     }
     jniWrapper = new ExpressionEvaluatorJniWrapper(tmp_dir, listJars);
-    jniWrapper.nativeSetJavaTmpDir(tmp_dir);
+    jniWrapper.nativeSetJavaTmpDir(jniWrapper.tmp_dir_path);
     jniWrapper.nativeSetBatchSize(ColumnarPluginConfig.getBatchSize());
+    ColumnarPluginConfig.setRandomTempDir(jniWrapper.tmp_dir_path);
   }
 
   /** Convert ExpressionTree into native function. */

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -26,12 +26,15 @@ import java.util.List;
  * jni. Avoid all external dependencies in this file.
  */
 public class ExpressionEvaluatorJniWrapper {
+        public String tmp_dir_path;
+
         /** Wrapper for native API. */
         public ExpressionEvaluatorJniWrapper(String tmp_dir, List<String> listJars)
                         throws IOException, IllegalAccessException, IllegalStateException {
                 JniUtils jni = JniUtils.getInstance(tmp_dir);
-                jni.setTempDir(tmp_dir);
+                jni.setTempDir();
                 jni.setJars(listJars);
+                tmp_dir_path = jni.getTempDir();
         }
 
         /**

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
@@ -26,6 +26,8 @@ import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -62,8 +64,11 @@ public class JniUtils {
     return INSTANCE;
   }
 
-  private JniUtils(String tmp_dir) throws IOException, IllegalAccessException, IllegalStateException {
+  private JniUtils(String _tmp_dir) throws IOException, IllegalAccessException, IllegalStateException {
     if (!isLoaded) {
+      Path folder = Paths.get(_tmp_dir);
+      Path path = Files.createTempDirectory(folder, "spark_columnar_plugin_");
+      tmp_dir = path.toAbsolutePath().toString();
       try {
         loadLibraryFromJar(tmp_dir);
       } catch (IOException ex) {
@@ -73,12 +78,15 @@ public class JniUtils {
     }
   }
 
-  public void setTempDir(String _tmp_dir) throws IOException, IllegalAccessException {
+  public void setTempDir() throws IOException, IllegalAccessException {
     if (isCodegenDependencyLoaded == false) {
-      tmp_dir = _tmp_dir;
       loadIncludeFromJar(tmp_dir);
       isCodegenDependencyLoaded = true;
     }
+  }
+
+  public String getTempDir() {
+    return tmp_dir;
   }
 
   public void setJars(List<String> list_jars) throws IOException, IllegalAccessException {

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
@@ -109,7 +109,6 @@ public class JniUtils {
       }
       final String libraryToLoad = System.mapLibraryName(LIBRARY_NAME);
       final File libraryFile = moveFileFromJarToTemp(tmp_dir, libraryToLoad);
-      System.out.println("loadLibraryFromJar " + libraryFile.getAbsolutePath());
       System.load(libraryFile.getAbsolutePath());
     }
   }
@@ -118,7 +117,6 @@ public class JniUtils {
     synchronized (JniUtils.class) {
       if (tmp_dir == null) {
         tmp_dir = System.getProperty("java.io.tmpdir");
-        System.out.println("loadLibraryFromJar " + tmp_dir);
       }
       final String folderToLoad = "";
       URL url = new URL("jar:file:" + source_jar + "!/");
@@ -146,7 +144,6 @@ public class JniUtils {
     synchronized (JniUtils.class) {
       if (tmp_dir == null) {
         tmp_dir = System.getProperty("java.io.tmpdir");
-        System.out.println("loadIncludeFromJar " + tmp_dir);
       }
       final String folderToLoad = "include";
       final URLConnection urlConnection = JniUtils.class.getClassLoader().getResource("include").openConnection();

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -35,6 +35,7 @@ class ColumnarPluginConfig(conf: SparkConf) {
 
 object ColumnarPluginConfig {
   var ins: ColumnarPluginConfig = null
+  var random_temp_dir_path: String = null
   def getConf(conf: SparkConf): ColumnarPluginConfig = synchronized {
     if (ins == null) {
       ins = new ColumnarPluginConfig(conf)
@@ -63,5 +64,11 @@ object ColumnarPluginConfig {
     } else {
       System.getProperty("java.io.tmpdir")
     }
+  }
+  def setRandomTempDir(path: String) = synchronized {
+    random_temp_dir_path = path
+  }
+  def getRandomTempDir = synchronized {
+    random_temp_dir_path
   }
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
@@ -123,7 +123,7 @@ class ColumnarHashAggregateExec(
     } else {
       (List(), "")
     }
-  listJars.foreach(jar => logWarning(s"Uploaded ${jar}"))
+  listJars.foreach(jar => logInfo(s"Uploaded ${jar}"))
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     child.executeColumnar().mapPartitionsWithIndex { (partIndex, iter) =>

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
@@ -111,7 +111,7 @@ class ColumnarHashAggregateExec(
         sparkConf)
       if (signature != "") {
         if (sparkContext.listJars.filter(path => path.contains(s"${signature}.jar")).isEmpty) {
-          val tempDir = ColumnarPluginConfig.getTempFile
+          val tempDir = ColumnarPluginConfig.getRandomTempDir
           val jarFileName =
             s"${tempDir}/tmp/spark-columnar-plugin-codegen-precompile-${signature}.jar"
           sparkContext.addJar(jarFileName)

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -118,7 +118,7 @@ class ColumnarShuffledHashJoinExec(
   } else {
     List()
   }
-  listJars.foreach(jar => logWarning(s"Uploaded ${jar}"))
+  listJars.foreach(jar => logInfo(s"Uploaded ${jar}"))
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     streamedPlan.executeColumnar().zipPartitions(buildPlan.executeColumnar()) {

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -109,7 +109,7 @@ class ColumnarShuffledHashJoinExec(
     }
   val listJars = if (signature != "") {
     if (sparkContext.listJars.filter(path => path.contains(s"${signature}.jar")).isEmpty) {
-      val tempDir = ColumnarPluginConfig.getTempFile
+      val tempDir = ColumnarPluginConfig.getRandomTempDir
       val jarFileName =
         s"${tempDir}/tmp/spark-columnar-plugin-codegen-precompile-${signature}.jar"
       sparkContext.addJar(jarFileName)

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
@@ -85,7 +85,7 @@ class ColumnarSortExec(
     }
   val listJars = if (signature != "") {
     if (sparkContext.listJars.filter(path => path.contains(s"${signature}.jar")).isEmpty) {
-      val tempDir = ColumnarPluginConfig.getTempFile
+      val tempDir = ColumnarPluginConfig.getRandomTempDir
       val jarFileName =
         s"${tempDir}/tmp/spark-columnar-plugin-codegen-precompile-${signature}.jar"
       sparkContext.addJar(jarFileName)

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
@@ -94,7 +94,7 @@ class ColumnarSortExec(
   } else {
     List()
   }
-  listJars.foreach(jar => logWarning(s"Uploaded ${jar}"))
+  listJars.foreach(jar => logInfo(s"Uploaded ${jar}"))
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     child.executeColumnar().mapPartitions { iter =>

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarShuffledHashJoin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarShuffledHashJoin.scala
@@ -204,7 +204,7 @@ object ColumnarShuffledHashJoin extends Logging {
       })
       .toList
 
-    logWarning(s"leftKeyExpression is ${leftKeys}, rightKeyExpression is ${rightKeys}")
+    logInfo(s"leftKeyExpression is ${leftKeys}, rightKeyExpression is ${rightKeys}")
     val lkeyFieldList: List[Field] = leftKeys.toList.map(expr => {
       val attr = ConverterUtils.getAttrFromExpr(expr)
       Field

--- a/oap-native-sql/cpp/src/jni/jni_wrapper.cc
+++ b/oap-native-sql/cpp/src/jni/jni_wrapper.cc
@@ -25,15 +25,16 @@
 #include <arrow/record_batch.h>
 #include <arrow/util/compression.h>
 #include <jni.h>
+
 #include <iostream>
 #include <string>
-#include "data_source/parquet/adapter.h"
-#include "proto/protobuf_utils.h"
 
 #include "codegen/code_generator_factory.h"
 #include "codegen/common/result_iterator.h"
+#include "data_source/parquet/adapter.h"
 #include "jni/concurrent_map.h"
 #include "jni/jni_common.h"
+#include "proto/protobuf_utils.h"
 #include "shuffle/splitter.h"
 
 namespace types {
@@ -275,9 +276,11 @@ Java_com_intel_oap_vectorized_ExpressionEvaluatorJniWrapper_nativeBuild(
     ret_types = resSchema->fields();
   }
 
+#ifdef DEBUG
   for (auto expr : expr_vector) {
     std::cerr << expr->ToString() << std::endl;
   }
+#endif
 
   std::shared_ptr<CodeGenerator> handler;
   msg = sparkcolumnarplugin::codegen::CreateCodeGenerator(schema, expr_vector, ret_types,


### PR DESCRIPTION
Signed-off-by: Chendi Xue <chendi.xue@intel.com>

This PR is aim to clean java tmp dir in compilation, since we now do runtime codegen compile in driver side, and driver uses /tmp dir and won't clean this folder after test, we will try clean this DIR at next time codes compilation.

fixes #1508 