### PR TITLE
[OAP-1512][sql index and data source cache] Fix oap-perf-suite to sync with SparkEnv.scala decouple

### DIFF
--- a/oap-cache/oap/src/test/oap-perf-suite/scala/org/apache/spark/sql/OapPerfSuiteContext.scala
+++ b/oap-cache/oap/src/test/oap-perf-suite/scala/org/apache/spark/sql/OapPerfSuiteContext.scala
@@ -22,6 +22,7 @@ package org.apache.spark.sql
 
 import sys.process._
 import org.apache.spark._
+import org.apache.spark.sql.oap.OapRuntime
 
 trait OapPerfSuiteContext {
 
@@ -82,6 +83,7 @@ trait OapPerfSuiteContext {
   def afterAll(): Unit = {
     if (_spark != null) {
       SparkSession.clearActiveSession()
+      OapRuntime.stop()
       _spark.stop()
       _spark = null
       assert(("rm -f ./metastore_db/db.lck" !) == 0)


### PR DESCRIPTION

## What changes were proposed in this pull request?
Due to #1141  and #1478 , OAP has decoupled SparkEnv.scala since 0.8.2, so oap-perf-suite should sync with this situation, then OapRuntime#stop() will before than SparkEnv#stop()  in OapPerfSuiteContext.scala



## How was this patch tested?

Pass small scale data daily test.

