### PR TITLE
[OAP-1531][oap-native-sql] Optimize columnar shuffle metrics

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ShuffleSplitterJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ShuffleSplitterJniWrapper.java
@@ -55,9 +55,10 @@ public class ShuffleSplitterJniWrapper {
    * file. And stop processing splitting
    *
    * @param splitterId
+   * @return SplitResult
    * @throws RuntimeException
    */
-  public native void stop(long splitterId) throws RuntimeException;
+  public native SplitResult stop(long splitterId) throws RuntimeException;
 
   /**
    * Set the output buffer for each partition. Splitter will maintain one buffer for each partition
@@ -76,24 +77,6 @@ public class ShuffleSplitterJniWrapper {
    * @param codec "lz4", "zstd", "uncompressed"
    */
   public native void setCompressionCodec(long splitterId, String codec);
-
-  /**
-   * Get all files information created by the splitter. Used by the {@link
-   * org.apache.spark.shuffle.ColumnarShuffleWriter} These files are temporarily existed and will be
-   * deleted after the combination.
-   *
-   * @param splitterId
-   * @return an array of all files information
-   */
-  public native PartitionFileInfo[] getPartitionFileInfo(long splitterId);
-
-  /**
-   * Get the total bytes written to disk.
-   *
-   * @param splitterId
-   * @return
-   */
-  public native long getTotalBytesWritten(long splitterId);
 
   /**
    * Release resources associated with designated splitter instance.

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SplitResult.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SplitResult.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.vectorized;
+
+public class SplitResult {
+    private final long totalWriteTime;
+    private final long totalBytesWritten;
+    PartitionFileInfo[] partitionFileInfo;
+
+    public SplitResult(
+            long totalWriteTime, long totalBytesWritten, PartitionFileInfo[] partitionFileInfo) {
+        this.totalWriteTime = totalWriteTime;
+        this.totalBytesWritten = totalBytesWritten;
+        this.partitionFileInfo = partitionFileInfo;
+    }
+
+    public long getTotalWriteTime() {
+        return totalWriteTime;
+    }
+
+    public long getTotalBytesWritten() {
+        return totalBytesWritten;
+    }
+
+    public PartitionFileInfo[] getPartitionFileInfo() {
+        return partitionFileInfo;
+    }
+}

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleDependency.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleDependency.scala
@@ -51,7 +51,8 @@ class ColumnarShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     override val shuffleWriterProcessor: ShuffleWriteProcessor = new ShuffleWriteProcessor,
     val serializedSchema: Array[Byte],
     val dataSize: SQLMetric,
-    val splitTime: SQLMetric)
+    val splitTime: SQLMetric,
+    val totalTime: SQLMetric)
     extends ShuffleDependency[K, V, C](
       _rdd,
       partitioner,

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -22,8 +22,11 @@ import java.nio.ByteBuffer
 
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.io.Closeables
-import com.intel.oap.vectorized.{ArrowWritableColumnVector, PartitionFileInfo, ShuffleSplitterJniWrapper, SplitResult}
-import jdk.nashorn.internal.ir.SplitReturn
+import com.intel.oap.vectorized.{
+  ArrowWritableColumnVector,
+  ShuffleSplitterJniWrapper,
+  SplitResult
+}
 import org.apache.arrow.util.SchemaUtils
 import org.apache.arrow.vector.types.pojo.Schema
 import org.apache.spark._
@@ -205,7 +208,12 @@ class ColumnarShuffleWriter[K, V](
       threwException = false
     } finally {
       Closeables.close(out, threwException)
-      writeMetrics.incWriteTime(System.nanoTime - writerStartTime + splitResult.getTotalWriteTime)
+      val writeTime = System.nanoTime - writerStartTime + splitResult.getTotalWriteTime
+      writeMetrics.incWriteTime(writeTime)
+
+      // merge into total time
+      dep.totalTime.add(writeTime)
+      dep.totalTime.merge(dep.splitTime)
     }
     lengths
   }

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/sort/ColumnarShuffleManager.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/sort/ColumnarShuffleManager.scala
@@ -50,11 +50,11 @@ class ColumnarShuffleManager(conf: SparkConf) extends ShuffleManager with Loggin
   override def registerShuffle[K, V, C](
       shuffleId: Int,
       dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
-    if (dependency.isInstanceOf[ColumnarShuffleDependency[K, V, V]]) {
+    if (dependency.isInstanceOf[ColumnarShuffleDependency[_, _, _]]) {
       logInfo(s"Registering ColumnarShuffle shuffleId: ${shuffleId}")
       new ColumnarShuffleHandle[K, V](
         shuffleId,
-        dependency.asInstanceOf[ShuffleDependency[K, V, V]])
+        dependency.asInstanceOf[ColumnarShuffleDependency[K, V, V]])
     } else if (SortShuffleWriter.shouldBypassMergeSort(conf, dependency)) {
       // If there are fewer than spark.shuffle.sort.bypassMergeThreshold partitions and we don't
       // need map-side aggregation, then write numPartitions files directly and just concatenate


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add compute partition id time metric
2. Seperate native split time and write time
3. Add total time metric for ColumnarShuffleExchangeExec and CoalesceBatchesExec

## How was this patch tested?

Manually test TPCH
