### PR TITLE
[oap-1406][rpmem-shuffle]Add shuffle block removing operation in one Spark context

### DIFF
--- a/oap-shuffle/RPMem-shuffle/core/src/main/java/org/apache/spark/storage/pmof/PersistentMemoryPool.java
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/java/org/apache/spark/storage/pmof/PersistentMemoryPool.java
@@ -12,6 +12,7 @@ public class PersistentMemoryPool {
     private static native void nativeDeleteBlock(long deviceHandler, String key);
     private static native long nativeGetRoot(long deviceHandler);
     private static native int nativeCloseDevice(long deviceHandler);
+    private static native long nativeRemoveBlock(long deviceHandler, String key);
   
     private static final long DEFAULT_PMPOOL_SIZE = 0L;
 
@@ -39,6 +40,10 @@ public class PersistentMemoryPool {
 
     public void deletePartition(String key) {
       nativeDeleteBlock(this.deviceHandler, key);
+    }
+
+    public long removeBlock(String key) {
+        return nativeRemoveBlock(this.deviceHandler, key);
     }
 
     public long getRootAddr() {

--- a/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmemShuffleBlockResolver.scala
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmemShuffleBlockResolver.scala
@@ -24,4 +24,14 @@ private[spark] class PmemShuffleBlockResolver(
     PersistentMemoryHandler.stop()
     super.stop()
   }
+
+  override def removeDataByMap(shuffleId: ShuffleId, mapId: Long): Unit ={
+    val partitionNumber = conf.get("spark.sql.shuffle.partitions")
+    val persistentMemoryHandler = PersistentMemoryHandler.getPersistentMemoryHandler
+
+    for (i <- 0 to partitionNumber.toInt){
+      val key = "shuffle_" + shuffleId + "_" + mapId + "_" + i
+      persistentMemoryHandler.removeBlock(key)
+    }
+  }
 }

--- a/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
@@ -75,6 +75,10 @@ private[spark] class PersistentMemoryHandler(
     pmpool.deletePartition(blockId)
   }
 
+  def removeBlock(blockId: String): Long = {
+    pmpool.removeBlock(blockId)
+  }
+
   def getPartitionManagedBuffer(blockId: String): ManagedBuffer = {
     new PmemManagedBuffer(this, blockId)
   }

--- a/oap-shuffle/RPMem-shuffle/native/src/010-TestCasePersistentMemoryPool.cpp
+++ b/oap-shuffle/RPMem-shuffle/native/src/010-TestCasePersistentMemoryPool.cpp
@@ -75,6 +75,7 @@ TEST_CASE( "PmemBuffer operations", "[PmemBuffer]" ) {
 
 
 TEST_CASE("pmemkv operations", "[pmemkv]") {
+
   SECTION("test open and close") {
     std::string key = "1";
     pmemkv* kv = new pmemkv("/dev/dax0.0");
@@ -194,7 +195,7 @@ TEST_CASE("pmemkv operations", "[pmemkv]") {
 SECTION("test put and remove multiple elements with same key"){
   pmemkv* kv = new pmemkv("/dev/dax0.0");
   std::string key = "key-multiple-objects";
-  int size = 1000000;
+  int size = 100;
   int length = 5;
   for(int i = 0; i < size; i++){
       kv->put(key, "first", length);
@@ -217,7 +218,7 @@ SECTION("test put and remove multiple elements with same key"){
   SECTION("test multithreaded remove") {
     std::vector<std::thread> threads;
     pmemkv* kv = new pmemkv("/dev/dax0.0");
-    int size = 5;
+    int size = 10;
     for (uint64_t i = 0; i < size; i++) {
       threads.emplace_back(test_multithread_put, i, kv);
     }
@@ -229,21 +230,13 @@ SECTION("test put and remove multiple elements with same key"){
     assert(kv->getBytesWritten() != 0);
     kv->dump_all();
 
-    for (uint64_t i = 0; i < size; i++){
-        std::string key = std::to_string(i);
-        kv->remove(key);
-    }
-    std::cout<<"mark2. kv->getBytesWritten()="<<kv->getBytesWritten()<<std::endl;
-    kv->dump_all();
-
     std::vector<std::thread> removeThreads;
-    for (uint64_t i = 0; i < 20; i++) {
+    for (uint64_t i = 0; i < size; i++) {
       removeThreads.emplace_back(test_multithread_remove, i, kv);
     }
-    for (uint64_t i = 0; i < 20; i++) {
+    for (uint64_t i = 0; i < size; i++) {
       removeThreads[i].join();
     }
-
     std::cout<<"mark2. kv->getBytesWritten()="<<kv->getBytesWritten()<<std::endl;
     assert(kv->getBytesWritten() == 0);
     kv->dump_all();

--- a/oap-shuffle/RPMem-shuffle/native/src/010-TestCasePersistentMemoryPool.cpp
+++ b/oap-shuffle/RPMem-shuffle/native/src/010-TestCasePersistentMemoryPool.cpp
@@ -108,6 +108,80 @@ TEST_CASE("pmemkv operations", "[pmemkv]") {
     delete kv;
   }
 
+  SECTION("test remove element from an empty list"){
+    std::string key = "remove-element-from-empty-list";
+    pmemkv* kv = new pmemkv("/dev/dax0.0");
+    int result = kv->remove(key);
+    REQUIRE(result == -1);
+    kv->free_all();
+    delete kv;
+  }
+
+  SECTION("test remove an non-existed element"){
+    std::string key = "key";
+    pmemkv* kv = new pmemkv("/dev/dax0.0");
+    int length = 5;
+    kv->put(key, "first", length);
+    string non_existed_key = "non-exist-key";
+    int result = kv->remove(non_existed_key);
+    REQUIRE(result == -1);
+    kv->free_all();
+    delete kv;
+  }
+
+  SECTION("test remove an element from a single node list"){
+    std::string key = "key-single";
+    pmemkv* kv = new pmemkv("/dev/dax0.0");
+    int length = 5;
+    kv->put(key, "first", length);
+    std::cout<<"Before remove a single node, dump all: "<<std::endl;
+    kv->dump_all();
+    int result = kv->remove(key);
+    std::cout<<"After remove a single node, dump all: "<<std::endl;
+    kv->dump_all();
+    REQUIRE(result == 0);
+    kv->free_all();
+    delete kv;
+  }
+
+  SECTION("test remove an element from a middle of a list"){
+    pmemkv* kv = new pmemkv("/dev/dax0.0");
+    std::string key1 = "first-key";
+    int length1 = 5;
+    kv->put(key1, "first", length1);
+
+    std::string key2 = "second-key";
+    int length2 = 6;
+    kv->put(key2, "second", length2);
+
+    std::string key3 = "third-key";
+    int length3 = 5;
+    kv->put(key3, "third", length3);
+
+    std::string key4 = "forth-key";
+    int length4 = 5;
+    kv->put(key4, "forth", length4);
+
+    kv->dump_all();
+    long r1 = kv->remove(key4);
+    std::cout<<"The forth is removed, dump:"<<std::endl;
+    kv->dump_all();
+
+    long r2 = kv->remove(key2);
+    std::cout<<"The second is removed, dump:"<<std::endl;
+    kv->dump_all();
+    long r3 = kv->remove(key1);
+    std::cout<<"The first is removed, dump:"<<std::endl;
+    kv->dump_all();
+    long r4 = kv->remove(key3);
+    std::cout<<"The third is removed, dump:"<<std::endl;
+    kv->dump_all();
+    REQUIRE((r1 + r2 + r3 + r4) == 0);
+
+    kv->free_all();
+    delete kv;
+  }
+/**
   SECTION("test multithreaded put and get") {
     std::vector<std::thread> threads;
     pmemkv* kv = new pmemkv("/dev/dax0.0");
@@ -193,4 +267,5 @@ TEST_CASE("pmemkv operations", "[pmemkv]") {
     kv->free_all();
     delete kv;
   }
+  **/
 }

--- a/oap-shuffle/RPMem-shuffle/native/src/lib_jni_pmdk.cpp
+++ b/oap-shuffle/RPMem-shuffle/native/src/lib_jni_pmdk.cpp
@@ -47,7 +47,16 @@ JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_
   uint64_t value_size;
   pmkv->get_value_size(key_str, &value_size);
   return value_size;
-  }
+}
+
+JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_nativeRemoveBlock
+  (JNIEnv *env, jclass obj, jlong kv, jstring key){
+  const char *CStr = env->GetStringUTFChars(key, 0);
+  string key_str(CStr);
+  pmemkv *pmkv = static_cast<pmemkv*>((void*)kv);
+  long result = pmkv->remove(key_str);
+  return result;
+}
 
 JNIEXPORT jint JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_nativeCloseDevice
   (JNIEnv *env, jclass obj, jlong kv) {

--- a/oap-shuffle/RPMem-shuffle/native/src/lib_jni_pmdk.cpp
+++ b/oap-shuffle/RPMem-shuffle/native/src/lib_jni_pmdk.cpp
@@ -61,7 +61,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_
 JNIEXPORT jint JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_nativeCloseDevice
   (JNIEnv *env, jclass obj, jlong kv) {
   pmemkv *pmkv = static_cast<pmemkv*>((void*)kv);
-  //pmkv->free_all();
+  pmkv->free_all();
   delete pmkv;
 }
 

--- a/oap-shuffle/RPMem-shuffle/native/src/lib_jni_pmdk.h
+++ b/oap-shuffle/RPMem-shuffle/native/src/lib_jni_pmdk.h
@@ -49,6 +49,14 @@ JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_
 
 /*
  * Class:     lib_jni_pmdk
+ * Method:    nativeRemoveBlock
+ * Signature: (JLjava/lang/String;)J
+ */
+JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_nativeRemoveBlock
+  (JNIEnv *, jclass, jlong, jstring);
+
+/*
+ * Class:     lib_jni_pmdk
  * Method:    nativeGetRoot
  * Signature: (J)J
  */

--- a/oap-shuffle/RPMem-shuffle/native/src/pmemkv.h
+++ b/oap-shuffle/RPMem-shuffle/native/src/pmemkv.h
@@ -254,7 +254,7 @@ class pmemkv {
                 std::free(cur);
                 cur = next;
                 bytes_allocated -= sizeof(block_meta);
-                std::cout<<"Only key in head is removed. key="<<key<<std::endl;
+                //std::cout<<"Only key in head is removed. key="<<key<<std::endl;
                 continue;
             }
 
@@ -270,18 +270,18 @@ class pmemkv {
             std::free(cur);
             cur = next;
             bytes_allocated -= sizeof(block_meta);
-            std::cout<<"Key in head is removed. key="<<key<<std::endl;
+            //std::cout<<"Key in head is removed. key="<<key<<std::endl;
             continue;
         }
         //Node to be deleted is at the tail
         if (pmemobj_direct(bep->hdr.next) == nullptr){
             //The one node scenario is already covered in head judgement, there are two or more nodes here
+            struct block_entry* prebep = (struct block_entry*)pmemobj_direct(bep->hdr.pre);
+            prebep->hdr.next = OID_NULL;
             bp->tail = bep->hdr.pre;
             if((struct block_entry*)pmemobj_direct(bp->tail) == nullptr){
                 std::cout<<"Error. The bp->tail should not be nullptr"<<std::endl;
             }
-            struct block_entry* prebep = (struct block_entry*)pmemobj_direct(bep->hdr.pre);
-            prebep->hdr.next = OID_NULL;
             bp->bytes_written = bp->bytes_written - bep->hdr.size;
             pmemobj_free(&bep->data);
             pmemobj_free(&cur->beo);
@@ -290,13 +290,15 @@ class pmemkv {
             std::free(cur);
             cur = next;
             bytes_allocated -= sizeof(block_meta);
-            std::cout<<"Key in tail is removed. key="<<key<<std::endl;
+            //std::cout<<"Key in tail is removed. key="<<key<<std::endl;
             continue;
         }
 
         //Node to be deleted is at the middle, no head or tail, there are at least three nodes
         struct block_entry* prebep = (struct block_entry*)pmemobj_direct(bep->hdr.pre);
         prebep->hdr.next = bep->hdr.next;
+        struct block_entry* nextbep = (struct block_entry*)pmemobj_direct(bep->hdr.next);
+        nextbep->hdr.pre = bep->hdr.pre;
         bp->bytes_written = bp->bytes_written - bep->hdr.size;
         pmemobj_free(&bep->data);
         pmemobj_free(&cur->beo);
@@ -305,7 +307,7 @@ class pmemkv {
         std::free(cur);
         cur = next;
         bytes_allocated -= sizeof(block_meta);
-        std::cout<<"Key neither in head nor in tail is removed. key="<<key<<std::endl;
+        //std::cout<<"Key neither in head nor in tail is removed. key="<<key<<std::endl;
       }
 
       bytes_allocated -= sizeof(block_meta_list);


### PR DESCRIPTION
Add block removing operations within one spark context, it will help to release PMem spaces. 

