### PR TITLE
[OAP-1484][OAP-CACHE]Supported DPP for OAP DATA SOURCE CACHE

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{DynamicPruningSubquery, Expression}
 import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OptimizedOrcFileFormat, OptimizedParquetFileFormat}
 import org.apache.spark.sql.execution.datasources.orc.ReadOnlyNativeOrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ReadOnlyParquetFileFormat}
@@ -40,8 +40,10 @@ object HadoopFsRelationOptimizer extends Logging {
       dataFilters: Seq[Expression],
       outputSchema: StructType): (HadoopFsRelation, Boolean) = {
 
-    def selectedPartitions: Seq[PartitionDirectory] =
-      relation.location.listFiles(partitionKeyFilters, Nil)
+    def selectedPartitions: Seq[PartitionDirectory] = {
+      relation.location.listFiles(
+        partitionKeyFilters.filter(p => !p.isInstanceOf[DynamicPruningSubquery]), Nil)
+    }
 
     relation.fileFormat match {
       case _: ReadOnlyParquetFileFormat =>

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
@@ -42,7 +42,7 @@ object HadoopFsRelationOptimizer extends Logging {
 
     def selectedPartitions: Seq[PartitionDirectory] = {
       relation.location.listFiles(
-        partitionKeyFilters.filter(p => !p.isInstanceOf[DynamicPruningSubquery]), Nil)
+        partitionKeyFilters.filterNot(p => p.isInstanceOf[DynamicPruningSubquery]), Nil)
     }
 
     relation.fileFormat match {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
@@ -178,10 +178,7 @@ object OapFileSourceStrategy extends Strategy with Logging {
     plan match {
       case PhysicalOperation(_, _, LogicalRelation(_: HadoopFsRelation, _, _, _)) =>
         FileSourceStrategy(plan).headOption match {
-          case Some(head) =>
-            val PlanDynamicPruningFiltersPlan =
-              PlanDynamicPruningFilters(SparkSession.getActiveSession.get).apply(head)
-            tryOptimize(PlanDynamicPruningFiltersPlan) :: Nil
+          case Some(head) => tryOptimize(head) :: Nil
           case _ => Nil
         }
       case _ => Nil

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategySuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapStrategySuite.scala
@@ -30,7 +30,6 @@ import org.apache.spark.sql.catalyst.plans.logical.CatalystSerde
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources.oap.adapter.WholeStageCodeGenAdapter
 import org.apache.spark.sql.execution.datasources.oap.utils.OapUtils
-import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.test.SQLTestUtils
@@ -290,33 +289,6 @@ class OapStrategySuite
     } finally {
       spark.sqlContext.setConf(OapConf.OAP_ENABLE_EXECUTOR_INDEX_SELECTION.key, "false")
       sql("drop oindex index1 on oap_fix_length_schema_table")
-    }
-  }
-
-  test("simple inner join triggers DPP with mock-up tables") {
-    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
-      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true",
-      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true") {
-      withTable("df1", "df2") {
-        spark.range(1000)
-          .select(col("id"), col("id").as("k"))
-          .write
-          .partitionBy("k")
-          .format("parquet")
-          .mode("overwrite")
-          .saveAsTable("df1")
-
-        spark.range(100)
-          .select(col("id"), col("id").as("k"))
-          .write
-          .partitionBy("k")
-          .format("parquet")
-          .mode("overwrite")
-          .saveAsTable("df2")
-
-        val df = sql("SELECT df1.id, df2.k FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id < 2")
-        checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
-      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use PlanDynamicPruningFilters in OapFileSourceStrategy to transfer DynamicPruningSubquery into DynamicPruningExpression.

Fixed: #1484


