### PR TITLE
[OAP-1541][oap-native-sql] TreeNode children not replaced by columnar…

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBatchScanExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBatchScanExec.scala
@@ -47,4 +47,14 @@ class ColumnarBatchScanExec(output: Seq[AttributeReference], @transient scan: Sc
       r
     }
   }
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[ColumnarBatchScanExec]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ColumnarBatchScanExec =>
+      (that canEqual this) && (that eq this)
+    case _ => false
+  }
+
+  override def hashCode(): Int = System.identityHashCode(this)
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBroadcastHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBroadcastHashJoinExec.scala
@@ -176,4 +176,14 @@ class ColumnarBroadcastHashJoinExec(
       new CloseableColumnBatchIterator(vjoinResult)
     }
   }
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[ColumnarBroadcastHashJoinExec]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ColumnarBroadcastHashJoinExec =>
+      (that canEqual this) && (that eq this)
+    case _ => false
+  }
+
+  override def hashCode(): Int = System.identityHashCode(this)
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
@@ -194,4 +194,14 @@ class ColumnarHashAggregateExec(
     }
   }
 
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[ColumnarHashAggregateExec]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ColumnarHashAggregateExec =>
+      (that canEqual this) && (that eq this)
+    case _ => false
+  }
+
+  override def hashCode(): Int = System.identityHashCode(this)
+
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -163,4 +163,14 @@ class ColumnarShuffledHashJoinExec(
         new CloseableColumnBatchIterator(vjoinResult)
     }
   }
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[ColumnarShuffledHashJoinExec]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ColumnarShuffledHashJoinExec =>
+      (that canEqual this) && (that eq this)
+    case _ => false
+  }
+
+  override def hashCode(): Int = System.identityHashCode(this)
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
@@ -135,4 +135,14 @@ class ColumnarSortExec(
       res
     }
   }
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[ColumnarSortExec]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ColumnarSortExec =>
+      (that canEqual this) && (that eq this)
+    case _ => false
+  }
+
+  override def hashCode(): Int = System.identityHashCode(this)
 }


### PR DESCRIPTION
… operators

Also, add ColumnarPluginTest.

Closes #1541

