### PR TITLE
[OAP-1565] [OAP-cache] Modify visibility of FiberCacheManager from private sql to public

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -35,7 +35,7 @@ import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.OapBitSet
 
-private[sql] class FiberCacheManager(
+class FiberCacheManager(
     sparkEnv: SparkEnv) extends Logging {
   private val GUAVA_CACHE = "guava"
   private val SIMPLE_CACHE = "simple"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr to resolve #1565 ,  the main change is modify visibility of `FiberCacheManager` from `private[sql]` to `public`, then `mvn clean install -DskipTests -pl oap-cache/oap -am` can pass

## How was this patch tested?
Manual test(mvn clean install -DskipTests -pl oap-cache/oap -am)