### PR TITLE
[OAP-1587][oap-native-sql] tpcds enabling (part1)

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
@@ -486,7 +486,8 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
   }
 
   public void appendString(byte[] value, int srcIndex, int count) {
-    writer.appendBytes(value, srcIndex, count);
+    writer.setBytes(elementsAppended, count, value, srcIndex);
+    elementsAppended++;
   }
 
   @Override

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
@@ -168,6 +168,11 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     return vector;
   }
 
+  public void setValueCount(int numRows) {
+    vector.setValueCount(numRows);
+  }
+
+
   private void createVectorAccessor(ValueVector vector, ValueVector dictionary) {
     if (dictionary != null) {
       if (!(vector instanceof IntVector)) {
@@ -422,11 +427,13 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
 
   @Override
   public void putNull(int rowId) {
+    numNulls += 1;
     writer.setNull(rowId);
   }
 
   @Override
   public void putNulls(int rowId, int count) {
+    numNulls += count;
     writer.setNulls(rowId, count);
   }
 

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
@@ -1663,6 +1663,11 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
       BigDecimal v = new BigDecimal(value);
       writer.setSafe(rowId, v.setScale(writer.getScale()));
     }
+    @Override
+    final void setArray(int rowId, int offset, int length) {
+      ArrowBuf buffer = allocator.buffer(16 * rowId + 16L);
+      writer.setSafe(rowId, offset, buffer);
+    }
   }
 
   private static class StringWriter extends ArrowVectorWriter {

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPlugin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPlugin.scala
@@ -245,8 +245,10 @@ case class ColumnarPreOverrides(conf: SparkConf) extends Rule[SparkPlan] {
   }
 
   def applyChildrenWithStrategy(p: SparkPlan): Seq[SparkPlan] = {
-    p.children.map(child =>
-      child match {
+    if (columnarConf.enablePreferColumnar) {
+      p.children.map(replaceWithColumnarPlan)
+    } else {
+      p.children.map(child => child match {
         case project: ProjectExec =>
           val newChild = replaceWithColumnarPlan(project.child)
           if (newChild.supportsColumnar) {
@@ -274,6 +276,7 @@ case class ColumnarPreOverrides(conf: SparkConf) extends Rule[SparkPlan] {
         case _ =>
           replaceWithColumnarPlan(child)
       })
+    }
   }
 }
 

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPlugin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPlugin.scala
@@ -229,6 +229,14 @@ case class ColumnarPreOverrides(conf: SparkConf) extends Rule[SparkPlan] {
               val newProject = project.withNewChildren(List(newChild))
               newProject
             }
+          case filter: FilterExec =>
+            val newChild = replaceWithColumnarPlan(filter.child)
+            if (newChild.supportsColumnar) {
+              replaceWithColumnarPlan(child)
+            } else {
+              val newFilter = filter.withNewChildren(List(newChild))
+              newFilter
+            }
           case _ =>
             replaceWithColumnarPlan(child)
         })

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -28,6 +28,8 @@ class ColumnarPluginConfig(conf: SparkConf) {
     conf.getBoolean("spark.sql.columnar.sort.broadcastJoin", defaultValue = true)
   val enableColumnarSortMergeJoin: Boolean =
     conf.getBoolean("spark.oap.sql.columnar.sortmergejoin", defaultValue = false)
+  val enablePreferColumnar: Boolean =
+    conf.getBoolean("spark.oap.sql.columnar.preferColumnar", defaultValue = false)
   val enableColumnarShuffle: Boolean = conf
     .get("spark.shuffle.manager", "sort")
     .equals("org.apache.spark.shuffle.sort.ColumnarShuffleManager")

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBroadcastHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBroadcastHashJoinExec.scala
@@ -99,12 +99,8 @@ class ColumnarBroadcastHashJoinExec(
   //override def supportCodegen: Boolean = false
 
   val signature =
-    if (resultSchema.size > 0 && !leftKeys
-          .filter(expr => bindReference(expr, left.output, true).isInstanceOf[BoundReference])
-          .isEmpty && !rightKeys
-          .filter(expr => bindReference(expr, right.output, true).isInstanceOf[BoundReference])
-          .isEmpty) {
-
+    if (resultSchema.size > 0 ) {
+      try {
       ColumnarShuffledHashJoin.prebuild(
         leftKeys,
         rightKeys,
@@ -115,6 +111,14 @@ class ColumnarBroadcastHashJoinExec(
         left,
         right,
         sparkConf)
+      } catch {
+        case e: UnsupportedOperationException
+            if e.getMessage == "Unsupport to generate native expression from replaceable expression." =>
+          logWarning(e.getMessage())
+          ""
+        case e =>
+          throw e
+      }
     } else {
       ""
     }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
@@ -137,8 +137,6 @@ class ColumnarHashAggregateExec(
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     child.executeColumnar().mapPartitionsWithIndex { (partIndex, iter) =>
       val hasInput = iter.hasNext
-      logInfo(
-        s"\ngroupingExpressions: $groupingExpressions,\noriginalInputAttributes: ${child.output},\naggregateExpressions: $aggregateExpressions,\naggregateAttributes: $aggregateAttributes,\nresultExpressions: $resultExpressions, \noutput: $output")
       val res = if (!hasInput) {
         // This is a grouped aggregate and the input iterator is empty,
         // so return an empty iterator.
@@ -150,7 +148,7 @@ class ColumnarHashAggregateExec(
           val execTempDir = ColumnarPluginConfig.getTempFile
           val jarList = listJars
             .map(jarUrl => {
-              logWarning(s"Get Codegened library Jar ${jarUrl}")
+              logInfo(s"HashAggregate Get Codegened library Jar ${jarUrl}")
               UserAddedJarUtils.fetchJarFromSpark(
                 jarUrl,
                 execTempDir,

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -105,6 +105,7 @@ class ColumnarShuffledHashJoinExec(
         case e: UnsupportedOperationException
             if e.getMessage == "Unsupport to generate native expression from replaceable expression." =>
           logWarning(e.getMessage())
+          ""
         case e =>
           throw e
       }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -89,22 +89,25 @@ class ColumnarShuffledHashJoinExec(
   //override def supportCodegen: Boolean = false
 
   val signature =
-    if (resultSchema.size > 0 && !leftKeys
-          .filter(expr => bindReference(expr, left.output, true).isInstanceOf[BoundReference])
-          .isEmpty && !rightKeys
-          .filter(expr => bindReference(expr, right.output, true).isInstanceOf[BoundReference])
-          .isEmpty) {
-
-      ColumnarShuffledHashJoin.prebuild(
-        leftKeys,
-        rightKeys,
-        resultSchema,
-        joinType,
-        buildSide,
-        condition,
-        left,
-        right,
-        sparkConf)
+    if (resultSchema.size > 0) {
+      try {
+        ColumnarShuffledHashJoin.prebuild(
+          leftKeys,
+          rightKeys,
+          resultSchema,
+          joinType,
+          buildSide,
+          condition,
+          left,
+          right,
+          sparkConf)
+      } catch {
+        case e: UnsupportedOperationException
+            if e.getMessage == "Unsupport to generate native expression from replaceable expression." =>
+          logWarning(e.getMessage())
+        case e =>
+          throw e
+      }
     } else {
       ""
     }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/RowToArrowColumnarExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/RowToArrowColumnarExec.scala
@@ -294,6 +294,7 @@ case class RowToArrowColumnarExec(child: SparkPlan) extends UnaryExecNode {
               elapse += System.nanoTime() - start
               rowCount += 1
             }
+            vectors.foreach(v => v.asInstanceOf[ArrowWritableColumnVector].setValueCount(numRows))
             processTime.set(NANOSECONDS.toMillis(elapse))
             numInputRows += rowCount
             numOutputBatches += 1

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregateExpression.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregateExpression.scala
@@ -80,7 +80,7 @@ class ColumnarAggregateExpression(
 
   var aggrFieldList: List[Field] = _
   val (funcName, argSize, resSize) = mode match {
-    case Partial | PartialMerge =>
+    case Partial =>
       aggregateFunction.prettyName match {
         case "avg" => ("sum_count", 1, 2)
         case "count" => {
@@ -91,6 +91,12 @@ class ColumnarAggregateExpression(
           }
         }
         case "stddev_samp" => ("stddev_samp_partial", 1, 3)
+        case other => (aggregateFunction.prettyName, 1, 1)
+      }
+    case PartialMerge =>
+      aggregateFunction.prettyName match {
+        case "avg" => ("sum_count_merge", 2, 2)
+        case "count" => ("sum", 1, 1)
         case other => (aggregateFunction.prettyName, 1, 1)
       }
     case Final =>

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
@@ -142,6 +142,8 @@ class ColumnarAggregation(
         val fieldList = if (arg_size > 0) {
           internalExpressionList.map(projectExpr => {
             val attr = ConverterUtils.getResultAttrFromExpr(projectExpr, s"res_$index")
+            if (attr.dataType.isInstanceOf[DecimalType])
+              throw new UnsupportedOperationException(s"Decimal type is not supported in ColumnarAggregation.")
             Field.nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
           })
         } else {
@@ -172,6 +174,8 @@ class ColumnarAggregation(
         non_partial_field_id += arg_size
         val fieldList = ordinalList.map(i => {
           val attr = originalInputAttributes(i)
+          if (attr.dataType.isInstanceOf[DecimalType])
+            throw new UnsupportedOperationException(s"Decimal type is not supported in ColumnarAggregation.")
           Field.nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
         })
         ordinalList.foreach{i => {

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarExpressionConverter.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarExpressionConverter.scala
@@ -156,7 +156,6 @@ object ColumnarExpressionConverter extends Logging {
         replaceWithColumnarExpression(ss.len),
         expr)
     case u: UnaryExpression =>
-      check_if_no_calculation = false
       logInfo(s"${expr.getClass} ${expr} is supported, no_cal is $check_if_no_calculation.")
       ColumnarUnaryOperator.create(replaceWithColumnarExpression(u.child, attributeSeq), expr)
     case s: org.apache.spark.sql.execution.ScalarSubquery =>

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarGroupbyHashAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarGroupbyHashAggregation.scala
@@ -238,8 +238,7 @@ object ColumnarGroupbyHashAggregation extends Logging {
     val mode = if (aggregateExpressions.size > 0) {
       aggregateExpressions(0).mode
     } else {
-      throw new UnsupportedOperationException(
-        s"Unable to handle Aggregation with no aggregate expressions.")
+      null
     }
 
     val originalInputFieldList = originalInputAttributes.toList.map(attr => {

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarGroupbyHashAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarGroupbyHashAggregation.scala
@@ -426,16 +426,17 @@ object ColumnarGroupbyHashAggregation extends Logging {
         TreeBuilder.makeFunction("action_min", childrenColumnarFuncNodeList.asJava, resultType)
       case StddevSamp(_) =>
         mode match {
-          case Partial | PartialMerge =>
+          case Partial =>
             val childrenColumnarFuncNodeList =
               aggregateFunc.children.toList.map(expr => getColumnarFuncNode(expr))
             TreeBuilder.makeFunction("action_stddev_samp_partial",
               childrenColumnarFuncNodeList.asJava, resultType)
+          case PartialMerge =>
+            throw new UnsupportedOperationException("stddev_samp PartialMerge is not supported.")
           case Final =>
             val childrenColumnarFuncNodeList =
               List(inputAttrQueue.dequeue, inputAttrQueue.dequeue, inputAttrQueue.dequeue).map(attr =>
                 getColumnarFuncNode(attr))
-            logInfo(s"childrenColumnarFuncNodeList is ${childrenColumnarFuncNodeList}")
             TreeBuilder.makeFunction("action_stddev_samp_final",
               childrenColumnarFuncNodeList.asJava, resultType)
         }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarGroupbyHashAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarGroupbyHashAggregation.scala
@@ -245,6 +245,8 @@ object ColumnarGroupbyHashAggregation extends Logging {
     aggregateAttributeList = aggregateAttributes
 
     val originalInputFieldList = originalInputAttributes.toList.map(attr => {
+      if (attr.dataType.isInstanceOf[DecimalType])
+        throw new UnsupportedOperationException(s"Decimal type is not supported in ColumnarGroupbyHashAggregation.")
       Field
         .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
     })
@@ -345,6 +347,9 @@ object ColumnarGroupbyHashAggregation extends Logging {
     }
     var columnarExpr: Expression =
       ColumnarExpressionConverter.replaceWithColumnarExpression(expr)
+    if (columnarExpr.dataType.isInstanceOf[DecimalType])
+      throw new UnsupportedOperationException(
+        s"Decimal type is not supported in ColumnarGroupbyHashAggregation.")
     var inputList: java.util.List[Field] = Lists.newArrayList()
     val (node, _resultType) =
       columnarExpr.asInstanceOf[ColumnarExpression].doColumnarCodeGen(inputList)

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarProjection.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarProjection.scala
@@ -85,7 +85,7 @@ class ColumnarProjection (
   }
 
   val (ordinalList, arrowSchema) = if (projPrepareList.size > 0 &&
-    (!check_if_no_calculation || projPrepareList.size != inputList.size)) {
+    (s"${projPrepareList.map(_.toProtobuf)}".contains("fnNode") || projPrepareList.size != inputList.size)) {
     val inputFieldList = inputList.asScala.toList.distinct
     val schema = new Schema(inputFieldList.asJava)
     projector = Projector.make(schema, projPrepareList.toList.asJava)

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarShuffledHashJoin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarShuffledHashJoin.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit._
 
 import com.intel.oap.ColumnarPluginConfig
 import com.intel.oap.vectorized.ArrowWritableColumnVector
-
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -36,7 +35,8 @@ import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, BuildSide}
 import scala.collection.JavaConverters._
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
+
 import scala.collection.mutable.ListBuffer
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
@@ -45,11 +45,9 @@ import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.Schema
 import org.apache.arrow.gandiva.expression._
 import org.apache.arrow.gandiva.evaluator._
-
 import io.netty.buffer.ArrowBuf
-import com.google.common.collect.Lists;
-
-import org.apache.spark.sql.types.{DataType, StructType}
+import com.google.common.collect.Lists
+import org.apache.spark.sql.types.{DataType, DecimalType, StructType}
 import com.intel.oap.vectorized.ExpressionEvaluator
 import com.intel.oap.vectorized.BatchIterator
 
@@ -206,10 +204,14 @@ object ColumnarShuffledHashJoin extends Logging {
       s"\nleft_schema is ${l_input_schema}, right_schema is ${r_input_schema}, \nleftKeys is ${leftKeys}, rightKeys is ${rightKeys}, \nresultSchema is ${resultSchema}, \njoinType is ${joinType}, buildSide is ${buildSide}, condition is ${conditionOption}")
 
     val l_input_field_list: List[Field] = l_input_schema.toList.map(attr => {
+      if (attr.dataType.isInstanceOf[DecimalType])
+        throw new UnsupportedOperationException(s"Decimal type is not supported in ColumnarShuffledHashJoin.")
       Field
         .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
     })
     val r_input_field_list: List[Field] = r_input_schema.toList.map(attr => {
+      if (attr.dataType.isInstanceOf[DecimalType])
+        throw new UnsupportedOperationException(s"Decimal type is not supported in ColumnarShuffledHashJoin.")
       Field
         .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
     })

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarShuffledHashJoin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarShuffledHashJoin.scala
@@ -222,12 +222,22 @@ object ColumnarShuffledHashJoin extends Logging {
 
     logInfo(s"leftKeyExpression is ${leftKeys}, rightKeyExpression is ${rightKeys}")
     val lkeyFieldList: List[Field] = leftKeys.toList.map(expr => {
+      val nativeNode = ConverterUtils.getColumnarFuncNode(expr)
+      if (s"${nativeNode.toProtobuf}".contains("fnNode")) {
+        throw new UnsupportedOperationException(
+          s"expression inside key is not currently supported.")
+      }
       val attr = ConverterUtils.getAttrFromExpr(expr)
       Field
         .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
     })
 
     val rkeyFieldList: List[Field] = rightKeys.toList.map(expr => {
+      val nativeNode = ConverterUtils.getColumnarFuncNode(expr)
+      if (s"${nativeNode.toProtobuf}".contains("fnNode")) {
+        throw new UnsupportedOperationException(
+          s"expression inside key is not currently supported.")
+      }
       val attr = ConverterUtils.getAttrFromExpr(expr)
       Field
         .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -199,6 +199,8 @@ object ColumnarSorter extends Logging {
     /////////////// Prepare ColumnarSorter //////////////
     val keyFieldList: List[Field] = sortOrder.toList.map(sort => {
       val attr = ConverterUtils.getAttrFromExpr(sort.child)
+      if (attr.dataType.isInstanceOf[DecimalType])
+        throw new UnsupportedOperationException(s"Decimal type is not supported in ColumnarSorter.")
       Field
         .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
     });

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -19,7 +19,8 @@ package com.intel.oap.expression
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException}
 import java.nio.channels.Channels
-
+import java.nio.ByteBuffer
+import java.util.ArrayList
 import com.intel.oap.vectorized.ArrowWritableColumnVector
 import io.netty.buffer.{ArrowBuf, ByteBufAllocator, ByteBufOutputStream}
 import org.apache.arrow.gandiva.exceptions.GandivaException
@@ -34,7 +35,10 @@ import org.apache.arrow.vector.ipc.message.{
   IpcOption,
   MessageSerializer
 }
+import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.arrow.gandiva.expression._
+import org.apache.arrow.gandiva.evaluator._
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
@@ -45,6 +49,10 @@ import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+import io.netty.buffer.{ByteBuf, ByteBufAllocator, ByteBufOutputStream}
+import java.nio.channels.{Channels, WritableByteChannel}
+import com.google.common.collect.Lists
 
 object ConverterUtils extends Logging {
   def createArrowRecordBatch(columnarBatch: ColumnarBatch): ArrowRecordBatch = {
@@ -263,6 +271,21 @@ object ConverterUtils extends Logging {
           tmpAttr
         }
     }
+  }
+
+  def getColumnarFuncNode(expr: Expression): TreeNode = {
+    if (expr.isInstanceOf[AttributeReference] && expr
+          .asInstanceOf[AttributeReference]
+          .name == "none") {
+      throw new UnsupportedOperationException(
+        s"Unsupport to generate native expression from replaceable expression.")
+    }
+    var columnarExpr: Expression =
+      ColumnarExpressionConverter.replaceWithColumnarExpression(expr)
+    var inputList: java.util.List[Field] = Lists.newArrayList()
+    val (node, _resultType) =
+      columnarExpr.asInstanceOf[ColumnarExpression].doColumnarCodeGen(inputList)
+    node
   }
 
   def ifEquals(left: Seq[AttributeReference], right: Seq[NamedExpression]): Boolean = {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -304,54 +304,54 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(
         right_field_list, ret_fields, p, &impl_));
     goto finish;
   }
-    if (func_name.compare("conditionedJoinArraysInner") == 0 ||
-        func_name.compare("conditionedJoinArraysOuter") == 0 ||
-        func_name.compare("conditionedJoinArraysAnti") == 0 ||
-        func_name.compare("conditionedJoinArraysSemi") == 0) {
-      // first child is left_key_schema
-      std::vector<std::shared_ptr<arrow::Field>> left_key_list;
-      auto left_func_node =
-          std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[0]);
-      for (auto field : left_func_node->children()) {
-        auto field_node = std::dynamic_pointer_cast<gandiva::FieldNode>(field);
-        left_key_list.push_back(field_node->field());
-      }
-      // second child is right_key_schema
-      std::vector<std::shared_ptr<arrow::Field>> right_key_list;
-      auto right_func_node =
-          std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[1]);
-      for (auto field : right_func_node->children()) {
-        auto field_node = std::dynamic_pointer_cast<gandiva::FieldNode>(field);
-        right_key_list.push_back(field_node->field());
-      }
-      // if there is third child, it should be condition
-      std::shared_ptr<gandiva::Node> condition_node;
-      if (func_node->children().size() > 2) {
-        condition_node = func_node->children()[2];
-      }
-      int join_type = 0;
-      if (func_name.compare("conditionedJoinArraysInner") == 0) {
-        join_type = 0;
-      } else if (func_name.compare("conditionedJoinArraysOuter") == 0) {
-        join_type = 1;
-      } else if (func_name.compare("conditionedJoinArraysAnti") == 0) {
-        join_type = 2;
-      } else if (func_name.compare("conditionedJoinArraysSemi") == 0) {
-        join_type = 3;
-      }
-      RETURN_NOT_OK(ConditionedJoinArraysVisitorImpl::Make(
-          left_key_list, right_key_list, condition_node, join_type, left_field_list,
-          right_field_list, ret_fields, p, &impl_));
-      goto finish;
+  if (func_name.compare("conditionedJoinArraysInner") == 0 ||
+      func_name.compare("conditionedJoinArraysOuter") == 0 ||
+      func_name.compare("conditionedJoinArraysAnti") == 0 ||
+      func_name.compare("conditionedJoinArraysSemi") == 0) {
+    // first child is left_key_schema
+    std::vector<std::shared_ptr<arrow::Field>> left_key_list;
+    auto left_func_node =
+        std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[0]);
+    for (auto field : left_func_node->children()) {
+      auto field_node = std::dynamic_pointer_cast<gandiva::FieldNode>(field);
+      left_key_list.push_back(field_node->field());
     }
-  
-  finish:
-    return arrow::Status::OK();
-
-  unrecognizedFail:
-    return arrow::Status::NotImplemented("Function name ", func_name,
-                                        " is not implemented yet.");
+    // second child is right_key_schema
+    std::vector<std::shared_ptr<arrow::Field>> right_key_list;
+    auto right_func_node =
+        std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[1]);
+    for (auto field : right_func_node->children()) {
+      auto field_node = std::dynamic_pointer_cast<gandiva::FieldNode>(field);
+      right_key_list.push_back(field_node->field());
+    }
+    // if there is third child, it should be condition
+    std::shared_ptr<gandiva::Node> condition_node;
+    if (func_node->children().size() > 2) {
+      condition_node = func_node->children()[2];
+    }
+    int join_type = 0;
+    if (func_name.compare("conditionedJoinArraysInner") == 0) {
+      join_type = 0;
+    } else if (func_name.compare("conditionedJoinArraysOuter") == 0) {
+      join_type = 1;
+    } else if (func_name.compare("conditionedJoinArraysAnti") == 0) {
+      join_type = 2;
+    } else if (func_name.compare("conditionedJoinArraysSemi") == 0) {
+      join_type = 3;
+    }
+    RETURN_NOT_OK(ConditionedJoinArraysVisitorImpl::Make(
+        left_key_list, right_key_list, condition_node, join_type, left_field_list,
+        right_field_list, ret_fields, p, &impl_));
+    goto finish;
   }
+
+finish:
+  return arrow::Status::OK();
+
+unrecognizedFail:
+  return arrow::Status::NotImplemented("Function name ", func_name,
+                                       " is not implemented yet.");
+}
 
 arrow::Status ExprVisitor::MakeExprVisitorImpl(const std::string& func_name,
                                                ExprVisitor* p) {
@@ -362,9 +362,10 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(const std::string& func_name,
   if (func_name.compare("sum") == 0 || func_name.compare("count") == 0 ||
       func_name.compare("unique") == 0 || func_name.compare("append") == 0 ||
       func_name.compare("sum_count") == 0 || func_name.compare("avgByCount") == 0 ||
-      func_name.compare("min") == 0 || func_name.compare("max") == 0 || 
-      func_name.compare("stddev_samp_partial") == 0 || 
-      func_name.compare("stddev_samp_final") == 0) {  
+      func_name.compare("min") == 0 || func_name.compare("max") == 0 ||
+      func_name.compare("stddev_samp_partial") == 0 ||
+      func_name.compare("stddev_samp_final") == 0 ||
+      func_name.compare("sum_count_merge") == 0) {
     RETURN_NOT_OK(AggregateVisitorImpl::Make(p, func_name, &impl_));
     goto finish;
   }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -335,7 +335,7 @@ class EncodeVisitorImpl : public ExprVisitorImpl {
       RETURN_NOT_OK(extra::HashArrayKernel::Make(&p_->ctx_, type_list, &concat_kernel_));
     }
 
-    auto result_field = field("res", arrow::uint32());
+    auto result_field = field("res", arrow::uint64());
     p_->result_fields_.push_back(result_field);
     initialized_ = true;
     return arrow::Status::OK();

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -211,26 +211,42 @@ class AggregateVisitorImpl : public ExprVisitorImpl {
 
     if (func_name_.compare("sum") == 0) {
       RETURN_NOT_OK(extra::SumArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
     } else if (func_name_.compare("count") == 0) {
       RETURN_NOT_OK(extra::CountArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
     } else if (func_name_.compare("sum_count") == 0) {
       p_->result_fields_.push_back(arrow::field("cnt", arrow::int64()));
       RETURN_NOT_OK(extra::SumCountArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
+    } else if (func_name_.compare("sum_count_merge") == 0) {
+      RETURN_NOT_OK(extra::SumArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
+      RETURN_NOT_OK(extra::SumArrayKernel::Make(&p_->ctx_, p_->result_fields_[1]->type(),
+                                                &kernel_));
+      kernel_list_.push_back(kernel_);
     } else if (func_name_.compare("avgByCount") == 0) {
       p_->result_fields_.erase(p_->result_fields_.end() - 1);
       RETURN_NOT_OK(extra::AvgByCountArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
     } else if (func_name_.compare("min") == 0) {
       RETURN_NOT_OK(extra::MinArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
     } else if (func_name_.compare("max") == 0) {
       RETURN_NOT_OK(extra::MaxArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
     } else if (func_name_.compare("stddev_samp_partial") == 0) {
       p_->result_fields_.push_back(arrow::field("avg", arrow::int64()));
       p_->result_fields_.push_back(arrow::field("m2", arrow::int64()));
-      RETURN_NOT_OK(extra::StddevSampPartialArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      RETURN_NOT_OK(
+          extra::StddevSampPartialArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
     } else if (func_name_.compare("stddev_samp_final") == 0) {
       p_->result_fields_.erase(p_->result_fields_.end() - 1);
       p_->result_fields_.erase(p_->result_fields_.end() - 1);
-      RETURN_NOT_OK(extra::StddevSampFinalArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      RETURN_NOT_OK(
+          extra::StddevSampFinalArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+      kernel_list_.push_back(kernel_);
     }
     initialized_ = true;
     return arrow::Status::OK();
@@ -249,7 +265,13 @@ class AggregateVisitorImpl : public ExprVisitorImpl {
           auto col = p_->in_record_batch_->column(col_id);
           in.push_back(col);
         }
-        RETURN_NOT_OK(kernel_->Evaluate(in));
+        for (int i = 0; i < kernel_list_.size(); i++) {
+          if (kernel_list_.size() > 1) {
+            RETURN_NOT_OK(kernel_list_[i]->Evaluate({in[i]}));
+          } else {
+            RETURN_NOT_OK(kernel_list_[i]->Evaluate(in));
+          }
+        }
         finish_return_type_ = ArrowComputeResultType::Batch;
       } break;
       default:
@@ -263,7 +285,9 @@ class AggregateVisitorImpl : public ExprVisitorImpl {
     RETURN_NOT_OK(ExprVisitorImpl::Finish());
     switch (finish_return_type_) {
       case ArrowComputeResultType::Batch: {
-        RETURN_NOT_OK(kernel_->Finish(&p_->result_batch_));
+        for (auto kernel : kernel_list_) {
+          RETURN_NOT_OK(kernel->Finish(&p_->result_batch_));
+        }
         p_->return_type_ = ArrowComputeResultType::Batch;
       } break;
       default: {
@@ -279,6 +303,7 @@ class AggregateVisitorImpl : public ExprVisitorImpl {
  private:
   std::vector<int> col_id_list_;
   std::string func_name_;
+  std::vector<std::shared_ptr<extra::KernalBase>> kernel_list_;
 };
 
 ////////////////////////// EncodeVisitorImpl ///////////////////////

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/action_codegen.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/action_codegen.h
@@ -532,6 +532,8 @@ class SumCountActionCodeGen : public ActionCodeGen {
     }
     prepare_codes_ss << "}" << std::endl;
 
+    // FIXME: spark expect double as sum result type, quick fix here
+    data_type = arrow::float64();
     func_sig_define_codes_list_.push_back(
         GetTypedVectorDefineString(data_type, sig_name) + ";\n");
     on_exists_prepare_codes_list_.push_back(prepare_codes_ss.str() + "\n");

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/action_codegen.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/action_codegen.h
@@ -1420,33 +1420,54 @@ class StddevSampFinalActionCodeGen : public ActionCodeGen {
     on_new_codes_list_.push_back(sig_name + ".push_back(" + tmp_name + ");");    
     ///////////////////////////// Stddev //////////////////////////////////
     sig_name = "action_stddev_" + name + "_";
+    auto validity_name = "action_stddev_" + name + "_validity_";
     data_type = arrow::float64();
     func_sig_list_.push_back(sig_name);
+    func_sig_list_.push_back(validity_name);
+    typed_input_and_prepare_list_.push_back(std::make_pair("", ""));
     typed_input_and_prepare_list_.push_back(std::make_pair("", ""));
     func_sig_define_codes_list_.push_back(
         GetTypedVectorDefineString(data_type, sig_name) + ";\n");
+    func_sig_define_codes_list_.push_back(
+        GetTypedVectorDefineString(arrow::boolean(), validity_name) + ";\n");
+    on_exists_codes_list_.push_back("");
     on_exists_codes_list_.push_back("");
     on_new_codes_list_.push_back("");
+    on_new_codes_list_.push_back("");
     on_finish_codes_list_.push_back("if (" + count_name + "[i] - 1 < 0.00001) {\n"
-      + sig_name + ".push_back(std::numeric_limits<double>::quiet_NaN());}\n" 
+      + validity_name + ".push_back(true);\n"
+      // + sig_name + ".push_back(std::numeric_limits<double>::quiet_NaN());}\n" 
+      + sig_name + ".push_back(std::numeric_limits<double>::infinity());}\n"
       + "else if (" + count_name + "[i] < 0.00001) {\n"
-      + sig_name + ".push_back(std::numeric_limits<double>::quiet_NaN());}\n" 
-      + "else {\n" + sig_name + ".push_back("
+      + validity_name + ".push_back(false);\n"
+      + sig_name + ".push_back(0);}\n" 
+      + "else {\n" 
+      + validity_name + ".push_back(true);\n"
+      + sig_name + ".push_back("
       + "sqrt(" + m2_name + "[i] / (" + count_name + "[i] - 1)));}\n");
+    on_finish_codes_list_.push_back("");
 
     finish_variable_list_.push_back(sig_name);
+    finish_variable_list_.push_back(validity_name);
     finish_var_parameter_codes_list_.push_back(
-        GetTypedVectorDefineString(data_type, sig_name + "_vector_tmp"));
+        GetTypedVectorDefineString(data_type, sig_name + "_vector_tmp", true));
+    finish_var_parameter_codes_list_.push_back(GetTypedVectorDefineString(
+        arrow::boolean(), validity_name + "_vector_tmp", true));
     finish_var_define_codes_list_.push_back(
-        GetTypedVectorAndBuilderDefineString(data_type, sig_name));
+        GetTypedVectorAndBuilderDefineString(data_type, sig_name, true));
     finish_var_prepare_codes_list_.push_back(
-        GetTypedVectorAndBuilderPrepareString(data_type, sig_name));
+        GetTypedVectorAndBuilderPrepareString(data_type, sig_name, true));
     finish_var_to_builder_codes_list_.push_back(
-        GetTypedVectorToBuilderString(data_type, sig_name));
+        GetTypedVectorToBuilderString(data_type, sig_name, true));
     finish_var_to_array_codes_list_.push_back(
         GetTypedResultToArrayString(data_type, sig_name));
     finish_var_array_codes_list_.push_back(
         GetTypedResultArrayString(data_type, sig_name)); 
+    finish_var_define_codes_list_.push_back("");
+    finish_var_prepare_codes_list_.push_back("");
+    finish_var_to_builder_codes_list_.push_back("");
+    finish_var_to_array_codes_list_.push_back("");
+    finish_var_array_codes_list_.push_back("");
   }
 };
 

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
@@ -37,6 +37,8 @@ std::string BaseCodes() {
   return R"(
 #include <arrow/compute/context.h>
 #include <arrow/record_batch.h>
+#include <math.h>
+#include <limits>
 
 #include "codegen/arrow_compute/ext/code_generator_base.h"
 #include "precompile/array.h"

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
@@ -151,22 +151,22 @@ gandiva::ExpressionPtr GetConcatedKernel(std::vector<gandiva::NodePtr> key_list)
   for (auto key : key_list) {
     auto field_node = key;
     auto func_node =
-        gandiva::TreeExprBuilder::MakeFunction("hash32", {field_node}, arrow::int32());
+        gandiva::TreeExprBuilder::MakeFunction("hash64", {field_node}, arrow::int64());
     func_node_list.push_back(func_node);
     if (func_node_list.size() == 2) {
       auto shift_func_node = gandiva::TreeExprBuilder::MakeFunction(
           "multiply",
-          {func_node_list[0], gandiva::TreeExprBuilder::MakeLiteral((int32_t)10)},
-          arrow::int32());
+          {func_node_list[0], gandiva::TreeExprBuilder::MakeLiteral((int64_t)10)},
+          arrow::int64());
       auto tmp_func_node = gandiva::TreeExprBuilder::MakeFunction(
-          "add", {shift_func_node, func_node_list[1]}, arrow::int32());
+          "add", {shift_func_node, func_node_list[1]}, arrow::int64());
       func_node_list.clear();
       func_node_list.push_back(tmp_func_node);
     }
     index++;
   }
   return gandiva::TreeExprBuilder::MakeExpression(
-      func_node_list[0], arrow::field("projection_key", arrow::int32()));
+      func_node_list[0], arrow::field("projection_key", arrow::int64()));
 }
 
 arrow::Status GetIndexList(const std::vector<std::shared_ptr<arrow::Field>>& target_list,

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
@@ -145,17 +145,11 @@ std::string GetTypeString(std::shared_ptr<arrow::DataType> type, std::string tai
   }
 }
 
-gandiva::ExpressionPtr GetConcatedKernel(
-    std::vector<std::shared_ptr<arrow::Field>> key_list) {
+gandiva::ExpressionPtr GetConcatedKernel(std::vector<gandiva::NodePtr> key_list) {
   int index = 0;
   std::vector<std::shared_ptr<gandiva::Node>> func_node_list = {};
-  std::vector<std::shared_ptr<arrow::Field>> field_list = {};
   for (auto key : key_list) {
-    auto type = key->type();
-    auto name = key->name();
-    auto field = arrow::field(name, type);
-    field_list.push_back(field);
-    auto field_node = gandiva::TreeExprBuilder::MakeField(field);
+    auto field_node = key;
     auto func_node =
         gandiva::TreeExprBuilder::MakeFunction("hash32", {field_node}, arrow::int32());
     func_node_list.push_back(func_node);

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_common.h
@@ -42,8 +42,7 @@ std::string GetArrowTypeDefString(std::shared_ptr<arrow::DataType> type);
 std::string GetCTypeString(std::shared_ptr<arrow::DataType> type);
 std::string GetTypeString(std::shared_ptr<arrow::DataType> type,
                           std::string tail = "Type");
-gandiva::ExpressionPtr GetConcatedKernel(
-    std::vector<std::shared_ptr<arrow::Field>> key_list);
+gandiva::ExpressionPtr GetConcatedKernel(std::vector<gandiva::NodePtr> key_list);
 template <typename T>
 std::string GetStringFromList(std::vector<T> list) {
   std::stringstream ss;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/hash_aggregate_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/hash_aggregate_kernel.cc
@@ -292,7 +292,7 @@ class HashAggregateKernel::Impl {
     std::string concat_kernel;
     std::string hash_map_include_str = R"(#include "precompile/sparse_hash_map.h")";
     std::string hash_map_type_str =
-        "SparseHashMap<" + GetCTypeString(arrow::int32()) + ">";
+        "SparseHashMap<" + GetCTypeString(arrow::int64()) + ">";
     std::string hash_map_define_str =
         "std::make_shared<" + hash_map_type_str + ">(ctx_->memory_pool());";
     std::string evaluate_get_typed_key_array_str;
@@ -318,7 +318,7 @@ class HashAggregateKernel::Impl {
     } else {
       evaluate_get_typed_key_array_str =
           "auto typed_array = "
-          "std::make_shared<Int32Array>(projected_batch->GetColumnByName("
+          "std::make_shared<Int64Array>(projected_batch->GetColumnByName("
           "\"projection_key\"));\n";
       evaluate_get_typed_key_method_str = "GetView";
     }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/hash_aggregate_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/hash_aggregate_kernel.cc
@@ -462,8 +462,15 @@ extern "C" void MakeCodeGen(arrow::compute::FunctionContext* ctx,
     return arrow::Status::OK();
   }
 
-  std::string GetParameterList(const std::vector<std::string>& cached_list,
+  std::string GetParameterList(const std::vector<std::string>& cached_list_in,
                                bool pre_comma = true) {
+    // filter not-empty cached_list
+    std::vector<std::string> cached_list;
+    for (auto s : cached_list_in) {
+      if (s != "") {
+        cached_list.push_back(s);
+      }
+    }
     std::stringstream ss;
     for (int i = 0; i < cached_list.size(); i++) {
       if (i != (cached_list.size() - 1)) {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -1274,22 +1274,22 @@ class HashArrayKernel::Impl {
       field_list.push_back(field);
       auto field_node = gandiva::TreeExprBuilder::MakeField(field);
       auto func_node =
-          gandiva::TreeExprBuilder::MakeFunction("hash32", {field_node}, arrow::int32());
+          gandiva::TreeExprBuilder::MakeFunction("hash64", {field_node}, arrow::int64());
       func_node_list.push_back(func_node);
       if (func_node_list.size() == 2) {
         auto shift_func_node = gandiva::TreeExprBuilder::MakeFunction(
             "multiply",
-            {func_node_list[0], gandiva::TreeExprBuilder::MakeLiteral((int32_t)10)},
-            arrow::int32());
+            {func_node_list[0], gandiva::TreeExprBuilder::MakeLiteral((int64_t)10)},
+            arrow::int64());
         auto tmp_func_node = gandiva::TreeExprBuilder::MakeFunction(
-            "add", {shift_func_node, func_node_list[1]}, arrow::int32());
+            "add", {shift_func_node, func_node_list[1]}, arrow::int64());
         func_node_list.clear();
         func_node_list.push_back(tmp_func_node);
       }
       index++;
     }
     expr = gandiva::TreeExprBuilder::MakeExpression(func_node_list[0],
-                                                    arrow::field("res", arrow::int32()));
+                                                    arrow::field("res", arrow::int64()));
 #ifdef DEBUG
     std::cout << expr->ToString() << std::endl;
 #endif

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -497,7 +497,7 @@ class SumCountArrayKernel::Impl {
     using CType = typename arrow::TypeTraits<DataType>::CType;
     using ScalarType = typename arrow::TypeTraits<DataType>::ScalarType;
     using CntScalarType = typename arrow::TypeTraits<arrow::Int64Type>::ScalarType;
-    CType sum_res = 0;
+    double sum_res = 0;
     int64_t cnt_res = 0;
     for (size_t i = 0; i < sum_scalar_list_.size(); i++) {
       auto sum_typed_scalar = std::dynamic_pointer_cast<ScalarType>(sum_scalar_list_[i]);

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
@@ -423,14 +423,20 @@ class ConditionedProbeArraysKernel::Impl {
                            const std::vector<int>& right_shuffle_index_list) {
     std::stringstream ss;
     for (auto i : left_shuffle_index_list) {
-      ss << "RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
-         << "_[tmp.array_id]->GetView(tmp."
-            "id)));"
-         << std::endl;
+      ss << "if (cached_0_" << i << "_[tmp.array_id]->IsNull(tmp.id)) {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
+      ss << "} else {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
+         << "_[tmp.array_id]->GetView(tmp.id)));" << std::endl;
+      ss << "}" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
-      ss << "RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+      ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());" << std::endl;
+      ss << "} else {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
          << "_->GetView(i)));" << std::endl;
+      ss << "}" << std::endl;
     }
     std::string shuffle_str;
     if (cond_check) {
@@ -467,15 +473,24 @@ class ConditionedProbeArraysKernel::Impl {
     std::stringstream left_valid_ss;
     std::stringstream right_valid_ss;
     for (auto i : left_shuffle_index_list) {
-      left_valid_ss << "RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
-                    << "_[tmp.array_id]->GetView(tmp."
-                       "id)));"
+      left_valid_ss << "if (cached_0_" << i << "_[tmp.array_id]->IsNull(tmp.id)) {"
                     << std::endl;
+      left_valid_ss << "  RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());"
+                    << std::endl;
+      left_valid_ss << "} else {" << std::endl;
+      left_valid_ss << "  RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
+                    << "_[tmp.array_id]->GetView(tmp.id)));" << std::endl;
+      left_valid_ss << "}" << std::endl;
       left_null_ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
-      right_valid_ss << "RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+      right_valid_ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());"
+                     << std::endl;
+      right_valid_ss << "} else {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
                      << "_->GetView(i)));" << std::endl;
+      right_valid_ss << "}" << std::endl;
     }
     std::string shuffle_str;
     if (cond_check) {
@@ -521,8 +536,13 @@ class ConditionedProbeArraysKernel::Impl {
       left_null_ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
-      right_valid_ss << "RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+      right_valid_ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());"
+                     << std::endl;
+      right_valid_ss << "} else {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
                      << "_->GetView(i)));" << std::endl;
+      right_valid_ss << "}" << std::endl;
     }
     std::string shuffle_str;
     if (cond_check) {
@@ -566,8 +586,12 @@ class ConditionedProbeArraysKernel::Impl {
       ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
-      ss << "RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+      ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());" << std::endl;
+      ss << "} else {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
          << "_->GetView(i)));" << std::endl;
+      ss << "}" << std::endl;
     }
     std::string shuffle_str;
     if (cond_check) {
@@ -615,8 +639,13 @@ class ConditionedProbeArraysKernel::Impl {
                        << std::endl;
 
     for (auto i : right_shuffle_index_list) {
-      right_valid_ss << "RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+      right_valid_ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());"
+                     << std::endl;
+      right_valid_ss << "} else {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
                      << "_->GetView(i)));" << std::endl;
+      right_valid_ss << "}" << std::endl;
     }
     std::string shuffle_str;
     if (cond_check) {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
@@ -748,7 +748,7 @@ class ConditionedProbeArraysKernel::Impl {
       ss << "std::shared_ptr<arrow::Array> hash_in;" << std::endl;
       ss << "RETURN_NOT_OK(hash_kernel_->Evaluate(concat_kernel_arr_list, &hash_in));"
          << std::endl;
-      ss << "auto typed_array = std::make_shared<Int32Array>(hash_in);" << std::endl;
+      ss << "auto typed_array = std::make_shared<Int64Array>(hash_in);" << std::endl;
     } else {
       ss << "auto typed_array = std::make_shared<" << data_type << ">(in[" << i << "]);"
          << std::endl;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
@@ -190,6 +190,10 @@ class ConditionedProbeArraysKernel::Impl {
     for (auto i : right_shuffle_index_list) {
       func_args_ss << i << ",";
     }
+    func_args_ss << "[ResultOrdinal]";
+    for (auto pair : result_schema_index_list) {
+      func_args_ss << pair.first << "_" << pair.second << ",";
+    }
 
 #ifdef DEBUG
     std::cout << "signature original line is " << func_args_ss.str() << std::endl;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
@@ -803,7 +803,7 @@ class ConditionedProbeArraysKernel::Impl {
     bool multiple_cols = (left_key_index_list.size() > 1);
     std::string hash_map_include_str = R"(#include "precompile/sparse_hash_map.h")";
     std::string hash_map_type_str =
-        "SparseHashMap<" + GetCTypeString(arrow::int32()) + ">";
+        "SparseHashMap<" + GetCTypeString(arrow::int64()) + ">";
     std::string hash_map_define_str =
         "std::make_shared<" + hash_map_type_str + ">(ctx_->memory_pool());";
     if (!multiple_cols) {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/typed_action_codegen_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/typed_action_codegen_impl.h
@@ -185,6 +185,16 @@ class TypedActionCodeGenImpl {
       *action_codegen = std::make_shared<StddevSampPartialActionCodeGen>(
           name, child_list_, input_list_, input_fields_list_, codes_ss_.str(),
           named_projector_);
+    } else if (action_name_.compare("action_stddev_samp_final") == 0) {
+      std::string name;
+      if (input_index_list_.size() == 3) {
+        name = std::to_string(input_index_list_[0]) + "_" +
+               std::to_string(input_index_list_[1]) + "_" +
+               std::to_string(input_index_list_[2]);
+      }
+      *action_codegen = std::make_shared<StddevSampFinalActionCodeGen>(
+          name, child_list_, input_list_, input_fields_list_, codes_ss_.str(),
+          named_projector_);
     } else {
       std::cout << "action_name " << action_name_ << " is unrecognized" << std::endl;
       return arrow::Status::Invalid("Invalid action_name ", action_name_);

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/typed_action_codegen_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/typed_action_codegen_impl.h
@@ -177,6 +177,14 @@ class TypedActionCodeGenImpl {
       *action_codegen = std::make_shared<SumCountMergeActionCodeGen>(
           name, child_list_, input_list_, input_fields_list_, codes_ss_.str(),
           named_projector_);
+    } else if (action_name_.compare("action_stddev_samp_partial") == 0) {
+      std::string name;
+      if (!input_index_list_.empty()) {
+        name = std::to_string(input_index_list_[0]);
+      }
+      *action_codegen = std::make_shared<StddevSampPartialActionCodeGen>(
+          name, child_list_, input_list_, input_fields_list_, codes_ss_.str(),
+          named_projector_);
     } else {
       std::cout << "action_name " << action_name_ << " is unrecognized" << std::endl;
       return arrow::Status::Invalid("Invalid action_name ", action_name_);

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/typed_action_codegen_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/typed_action_codegen_impl.h
@@ -168,6 +168,15 @@ class TypedActionCodeGenImpl {
       *action_codegen = std::make_shared<MaxActionCodeGen>(
           name, child_list_, input_list_, input_fields_list_, codes_ss_.str(),
           named_projector_);
+    } else if (action_name_.compare("action_sum_count_merge") == 0) {
+      std::string name;
+      if (input_index_list_.size() == 2) {
+        name = std::to_string(input_index_list_[0]) + "_" +
+               std::to_string(input_index_list_[1]);
+      }
+      *action_codegen = std::make_shared<SumCountMergeActionCodeGen>(
+          name, child_list_, input_list_, input_fields_list_, codes_ss_.str(),
+          named_projector_);
     } else {
       std::cout << "action_name " << action_name_ << " is unrecognized" << std::endl;
       return arrow::Status::Invalid("Invalid action_name ", action_name_);

--- a/oap-native-sql/cpp/src/precompile/hash_arrays_kernel.cc
+++ b/oap-native-sql/cpp/src/precompile/hash_arrays_kernel.cc
@@ -17,22 +17,22 @@ class HashArraysKernel::Impl {
     for (auto field : field_list) {
       auto field_node = gandiva::TreeExprBuilder::MakeField(field);
       auto func_node =
-          gandiva::TreeExprBuilder::MakeFunction("hash32", {field_node}, arrow::int32());
+          gandiva::TreeExprBuilder::MakeFunction("hash64", {field_node}, arrow::int64());
       func_node_list.push_back(func_node);
       if (func_node_list.size() == 2) {
         auto shift_func_node = gandiva::TreeExprBuilder::MakeFunction(
             "multiply",
-            {func_node_list[0], gandiva::TreeExprBuilder::MakeLiteral((int32_t)10)},
-            arrow::int32());
+            {func_node_list[0], gandiva::TreeExprBuilder::MakeLiteral((int64_t)10)},
+            arrow::int64());
         auto tmp_func_node = gandiva::TreeExprBuilder::MakeFunction(
-            "add", {shift_func_node, func_node_list[1]}, arrow::int32());
+            "add", {shift_func_node, func_node_list[1]}, arrow::int64());
         func_node_list.clear();
         func_node_list.push_back(tmp_func_node);
       }
       index++;
     }
     auto expr = gandiva::TreeExprBuilder::MakeExpression(
-        func_node_list[0], arrow::field("projection_key", arrow::int32()));
+        func_node_list[0], arrow::field("projection_key", arrow::int64()));
     schema_ = arrow::schema(field_list);
     auto configuration = gandiva::ConfigurationBuilder().DefaultConfiguration();
     auto status = gandiva::Projector::Make(schema_, {expr}, configuration, &projector_);

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_hashaggregate.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_hashaggregate.cc
@@ -578,5 +578,88 @@ TEST(TestArrowCompute, GroupByHashAggregateWithProjectedKeyTest) {
   }
 }
 
+TEST(TestArrowCompute, GroupByStddevSampPartialHashAggregateTest) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", float64());
+  auto f2 = field("f2", float64());
+  auto f_unique = field("unique", uint32());
+  auto f_n = field("count", float64());
+  auto f_avg = field("avg", float64());
+  auto f_m2 = field("m2", float64());
+  auto f_res = field("res", uint32());
+
+  auto arg0 = TreeExprBuilder::MakeField(f0);
+  auto arg1 = TreeExprBuilder::MakeField(f1);
+  auto arg2 = TreeExprBuilder::MakeField(f2);
+  auto n_groupby = TreeExprBuilder::MakeFunction("action_groupby", {arg0}, uint32());
+  auto n_stddev_1 = TreeExprBuilder::MakeFunction("action_stddev_samp_partial", {arg1}, uint32());
+  auto n_stddev_2 = TreeExprBuilder::MakeFunction("action_stddev_samp_partial", {arg2}, uint32());
+  auto n_schema = TreeExprBuilder::MakeFunction(
+      "codegen_schema", {TreeExprBuilder::MakeField(f0), TreeExprBuilder::MakeField(f1), 
+      TreeExprBuilder::MakeField(f2)}, uint32());
+  auto n_aggr = TreeExprBuilder::MakeFunction(
+      "hashAggregateArrays",
+      {n_groupby, n_stddev_1, n_stddev_2}, uint32());
+  auto n_codegen_aggr =
+      TreeExprBuilder::MakeFunction("codegen_withOneInput", {n_aggr, n_schema}, uint32());
+
+  auto aggr_expr = TreeExprBuilder::MakeExpression(n_codegen_aggr, f_res);
+
+  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {aggr_expr};
+
+  auto sch = arrow::schema({f0, f1, f2});
+  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_n, f_avg, f_m2, f_n, f_avg, f_m2};
+
+  /////////////////////// Create Expression Evaluator ////////////////////
+  std::shared_ptr<CodeGenerator> expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, expr_vector, ret_types, &expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> output_batch_list;
+
+  ////////////////////// calculation /////////////////////
+  std::vector<std::string> input_data = {
+      "[1, 2, 3, 4, 5, null, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]",
+      "[2, 4, 5, 7, 8, 2, 45, 32, 23, 12, 14, 16, 18, 19, 23, 25, 57, 59, 12, 1]",
+      "[2, 4, 5, 7, 8, 2, 45, 32, 23, 12, 14, 16, 18, 19, 23, 25, 57, 59, 12, 1]"};
+  MakeInputBatch(input_data, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_2 = {
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]",
+      "[7, 8, 4, 5, 6, 1, 34, 54, 65, 66, 78, 12, 32, 24, 32, 45, 12, 24, 35, 46]",
+      "[7, 8, 4, 5, 6, 1, 34, 54, 65, 66, 78, 12, 32, 24, 32, 45, 12, 24, 35, 46]"};
+  MakeInputBatch(input_data_2, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_3 = {
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, null, 8, 5, 5]",
+      "[23, 34, 56, 78, 98, 12, 23, 26, 28, 29, 21, 31, 12, 4, 5, 6, 9, 65, 45, 12]",
+      "[23, 34, 56, 78, 98, 12, 23, 26, 28, 29, 21, 31, 12, 4, 5, 6, 9, 65, 45, 12]"};
+  MakeInputBatch(input_data_3, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  ////////////////////// Finish //////////////////////////
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> aggr_result_iterator;
+  ASSERT_NOT_OK(expr->finish(&aggr_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]", "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",
+      "[17.875, 20.2, 28.6667, 19.8, 33.7778, 33.5714, 42, 48 ,17.5, 21]", 
+      "[596.875, 588.8, 1320.67, 1028.8, 8587.56, 3729.71, 2430, 3134, 995.5, 1540]",
+      "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",
+      "[17.875, 20.2, 28.6667, 19.8, 33.7778, 33.5714, 42, 48 ,17.5, 21]", 
+      "[596.875, 588.8, 1320.67, 1028.8, 8587.56, 3729.71, 2430, 3134, 995.5, 1540]"};
+  auto res_sch =
+      arrow::schema({f_unique, f_n, f_avg, f_m2, f_n, f_avg, f_m2});
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  if (aggr_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(aggr_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
 }  // namespace codegen
 }  // namespace sparkcolumnarplugin

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_hashaggregate.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_hashaggregate.cc
@@ -110,6 +110,170 @@ TEST(TestArrowCompute, GroupByHashAggregateTest) {
   }
 }
 
+TEST(TestArrowCompute, GroupByHashAggregateTest2) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", uint32());
+  auto f_unique = field("unique", uint32());
+  auto f_sum = field("sum", uint64());
+  auto f_count = field("count", int64());
+  auto f_min = field("min", uint32());
+  auto f_max = field("max", uint32());
+  auto f_res = field("res", uint32());
+
+  auto arg0 = TreeExprBuilder::MakeField(f0);
+  auto arg1 = TreeExprBuilder::MakeField(f1);
+  auto n_groupby = TreeExprBuilder::MakeFunction("action_groupby", {arg0}, uint32());
+  auto n_sum_count = TreeExprBuilder::MakeFunction("action_sum_count", {arg1}, uint32());
+  auto n_min = TreeExprBuilder::MakeFunction("action_min", {arg1}, uint32());
+  auto n_max = TreeExprBuilder::MakeFunction("action_max", {arg1}, uint32());
+  auto n_sum = TreeExprBuilder::MakeFunction("action_sum", {arg1}, uint32());
+  auto n_count = TreeExprBuilder::MakeFunction("action_count", {arg1}, uint32());
+  auto n_schema = TreeExprBuilder::MakeFunction(
+      "codegen_schema", {TreeExprBuilder::MakeField(f0), TreeExprBuilder::MakeField(f1)},
+      uint32());
+  auto n_aggr = TreeExprBuilder::MakeFunction(
+      "hashAggregateArrays", {n_groupby, n_sum_count, n_min, n_max, n_sum, n_count},
+      uint32());
+  auto n_codegen_aggr =
+      TreeExprBuilder::MakeFunction("codegen_withOneInput", {n_aggr, n_schema}, uint32());
+
+  auto aggr_expr = TreeExprBuilder::MakeExpression(n_codegen_aggr, f_res);
+
+  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {aggr_expr};
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_sum, f_count, f_min,
+                                                   f_max,    f_sum, f_count};
+
+  /////////////////////// Create Expression Evaluator ////////////////////
+  std::shared_ptr<CodeGenerator> expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, expr_vector, ret_types, &expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> output_batch_list;
+
+  ////////////////////// calculation /////////////////////
+  std::vector<std::string> input_data = {
+      "[1, 2, 3, 4, 5, null, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]",
+      "[1, 2, 3, 4, 5, 5, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]"};
+  MakeInputBatch(input_data, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_2 = {
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]",
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]"};
+  MakeInputBatch(input_data_2, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_3 = {
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, null, 8, 5, 5]",
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, 5, 8, 5, 5]"};
+  MakeInputBatch(input_data_3, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  ////////////////////// Finish //////////////////////////
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> aggr_result_iterator;
+  ASSERT_NOT_OK(expr->finish(&aggr_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]", "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]",
+      "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",  "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
+      "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]", "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]",
+      "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]"};
+  auto res_sch = arrow::schema(ret_types);
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  if (aggr_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(aggr_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowCompute, GroupByHashAggregateTest3) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", uint32());
+  auto f2 = field("f2", uint32());
+  auto f_unique = field("unique", uint32());
+  auto f_sum = field("sum", uint64());
+  auto f_count = field("count", int64());
+  auto f_min = field("min", uint32());
+  auto f_max = field("max", uint32());
+  auto f_res = field("res", uint32());
+
+  auto arg0 = TreeExprBuilder::MakeField(f0);
+  auto arg1 = TreeExprBuilder::MakeField(f1);
+  auto arg2 = TreeExprBuilder::MakeField(f2);
+  auto n_groupby = TreeExprBuilder::MakeFunction("action_groupby", {arg0}, uint32());
+  auto n_min = TreeExprBuilder::MakeFunction("action_min", {arg1}, uint32());
+  auto n_max = TreeExprBuilder::MakeFunction("action_max", {arg1}, uint32());
+  auto n_sum_count_merge =
+      TreeExprBuilder::MakeFunction("action_sum_count_merge", {arg1, arg2}, uint32());
+  auto n_schema = TreeExprBuilder::MakeFunction(
+      "codegen_schema",
+      {TreeExprBuilder::MakeField(f0), TreeExprBuilder::MakeField(f1),
+       TreeExprBuilder::MakeField(f2)},
+      uint32());
+  auto n_aggr = TreeExprBuilder::MakeFunction(
+      "hashAggregateArrays", {n_groupby, n_min, n_max, n_sum_count_merge}, uint32());
+  auto n_codegen_aggr =
+      TreeExprBuilder::MakeFunction("codegen_withOneInput", {n_aggr, n_schema}, uint32());
+
+  auto aggr_expr = TreeExprBuilder::MakeExpression(n_codegen_aggr, f_res);
+
+  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {aggr_expr};
+
+  auto sch = arrow::schema({f0, f1, f2});
+  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_min, f_max, f_sum,
+                                                   f_count};
+
+  /////////////////////// Create Expression Evaluator ////////////////////
+  std::shared_ptr<CodeGenerator> expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, expr_vector, ret_types, &expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> output_batch_list;
+
+  ////////////////////// calculation /////////////////////
+  std::vector<std::string> input_data = {
+      "[1, 2, 3, 4, 5, null, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]",
+      "[1, 2, 3, 4, 5, 5, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]",
+      "[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]"};
+  MakeInputBatch(input_data, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_2 = {
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]",
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]",
+      "[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]"};
+  MakeInputBatch(input_data_2, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_3 = {
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, null, 8, 5, 5]",
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, 5, 8, 5, 5]",
+      "[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]"};
+  MakeInputBatch(input_data_3, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  ////////////////////// Finish //////////////////////////
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> aggr_result_iterator;
+  ASSERT_NOT_OK(expr->finish(&aggr_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]", "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
+      "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]", "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]",
+      "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]"};
+  auto res_sch = arrow::schema(ret_types);
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  if (aggr_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(aggr_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
 TEST(TestArrowCompute, GroupByHashAggregateWithStringTest) {
   ////////////////////// prepare expr_vector ///////////////////////
   auto f_unique = field("unique", utf8());
@@ -593,14 +757,17 @@ TEST(TestArrowCompute, GroupByStddevSampPartialHashAggregateTest) {
   auto arg1 = TreeExprBuilder::MakeField(f1);
   auto arg2 = TreeExprBuilder::MakeField(f2);
   auto n_groupby = TreeExprBuilder::MakeFunction("action_groupby", {arg0}, uint32());
-  auto n_stddev_1 = TreeExprBuilder::MakeFunction("action_stddev_samp_partial", {arg1}, uint32());
-  auto n_stddev_2 = TreeExprBuilder::MakeFunction("action_stddev_samp_partial", {arg2}, uint32());
+  auto n_stddev_1 =
+      TreeExprBuilder::MakeFunction("action_stddev_samp_partial", {arg1}, uint32());
+  auto n_stddev_2 =
+      TreeExprBuilder::MakeFunction("action_stddev_samp_partial", {arg2}, uint32());
   auto n_schema = TreeExprBuilder::MakeFunction(
-      "codegen_schema", {TreeExprBuilder::MakeField(f0), TreeExprBuilder::MakeField(f1), 
-      TreeExprBuilder::MakeField(f2)}, uint32());
+      "codegen_schema",
+      {TreeExprBuilder::MakeField(f0), TreeExprBuilder::MakeField(f1),
+       TreeExprBuilder::MakeField(f2)},
+      uint32());
   auto n_aggr = TreeExprBuilder::MakeFunction(
-      "hashAggregateArrays",
-      {n_groupby, n_stddev_1, n_stddev_2}, uint32());
+      "hashAggregateArrays", {n_groupby, n_stddev_1, n_stddev_2}, uint32());
   auto n_codegen_aggr =
       TreeExprBuilder::MakeFunction("codegen_withOneInput", {n_aggr, n_schema}, uint32());
 
@@ -609,7 +776,8 @@ TEST(TestArrowCompute, GroupByStddevSampPartialHashAggregateTest) {
   std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {aggr_expr};
 
   auto sch = arrow::schema({f0, f1, f2});
-  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_n, f_avg, f_m2, f_n, f_avg, f_m2};
+  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_n,   f_avg, f_m2,
+                                                   f_n,      f_avg, f_m2};
 
   /////////////////////// Create Expression Evaluator ////////////////////
   std::shared_ptr<CodeGenerator> expr;
@@ -646,14 +814,14 @@ TEST(TestArrowCompute, GroupByStddevSampPartialHashAggregateTest) {
 
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string = {
-      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]", "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",
-      "[17.875, 20.2, 28.6667, 19.8, 33.7778, 33.5714, 42, 48 ,17.5, 21]", 
+      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]",
+      "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",
+      "[17.875, 20.2, 28.6667, 19.8, 33.7778, 33.5714, 42, 48 ,17.5, 21]",
       "[596.875, 588.8, 1320.67, 1028.8, 8587.56, 3729.71, 2430, 3134, 995.5, 1540]",
       "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",
-      "[17.875, 20.2, 28.6667, 19.8, 33.7778, 33.5714, 42, 48 ,17.5, 21]", 
+      "[17.875, 20.2, 28.6667, 19.8, 33.7778, 33.5714, 42, 48 ,17.5, 21]",
       "[596.875, 588.8, 1320.67, 1028.8, 8587.56, 3729.71, 2430, 3134, 995.5, 1540]"};
-  auto res_sch =
-      arrow::schema({f_unique, f_n, f_avg, f_m2, f_n, f_avg, f_m2});
+  auto res_sch = arrow::schema({f_unique, f_n, f_avg, f_m2, f_n, f_avg, f_m2});
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
   if (aggr_result_iterator->HasNext()) {
     ASSERT_NOT_OK(aggr_result_iterator->Next(&result_batch));
@@ -676,12 +844,15 @@ TEST(TestArrowCompute, GroupByStddevSampFinalHashAggregateTest) {
   auto arg2 = TreeExprBuilder::MakeField(f2);
   auto arg3 = TreeExprBuilder::MakeField(f3);
   auto n_groupby = TreeExprBuilder::MakeFunction("action_groupby", {arg0}, uint32());
-  auto n_stddev = TreeExprBuilder::MakeFunction("action_stddev_samp_final", {arg1, arg2, arg3}, uint32());
+  auto n_stddev = TreeExprBuilder::MakeFunction("action_stddev_samp_final",
+                                                {arg1, arg2, arg3}, uint32());
   auto n_schema = TreeExprBuilder::MakeFunction(
-      "codegen_schema", {TreeExprBuilder::MakeField(f0), TreeExprBuilder::MakeField(f1), 
-      TreeExprBuilder::MakeField(f2), TreeExprBuilder::MakeField(f3)}, uint32());
-  auto n_aggr = TreeExprBuilder::MakeFunction(
-      "hashAggregateArrays", {n_groupby, n_stddev}, uint32());
+      "codegen_schema",
+      {TreeExprBuilder::MakeField(f0), TreeExprBuilder::MakeField(f1),
+       TreeExprBuilder::MakeField(f2), TreeExprBuilder::MakeField(f3)},
+      uint32());
+  auto n_aggr = TreeExprBuilder::MakeFunction("hashAggregateArrays",
+                                              {n_groupby, n_stddev}, uint32());
   auto n_codegen_aggr =
       TreeExprBuilder::MakeFunction("codegen_withOneInput", {n_aggr, n_schema}, uint32());
 
@@ -722,10 +893,10 @@ TEST(TestArrowCompute, GroupByStddevSampFinalHashAggregateTest) {
 
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string = {
-      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]", 
-      "[8.49255, 6.93137, 7.6489, 13.5708, 17.4668, 8.52779, 6.23633, 5.58903, 12.535, 24.3544]"};
-  auto res_sch =
-      arrow::schema({f_unique, f_stddev});
+      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]",
+      "[8.49255, 6.93137, 7.6489, 13.5708, 17.4668, 8.52779, 6.23633, 5.58903, 12.535, "
+      "24.3544]"};
+  auto res_sch = arrow::schema({f_unique, f_stddev});
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
   if (aggr_result_iterator->HasNext()) {
     ASSERT_NOT_OK(aggr_result_iterator->Next(&result_batch));


### PR DESCRIPTION
This PR adds support for TPCDS workload(part1), major changes are:
- codegen hash aggr will faultily skip null key, now add validity vector to fix this
- add a optimization when project between two RowBased operator 
- switch to hash64 for hashagg/hashjoin
- limited decimal support
- fallback to row-based operator if there are unsupported expressions

as of this patch, TPCDS queries are all working with below configurations:

```
spark.sql.columnar.codegen.hashAggregate true
spark.sql.columnar.sort.broadcastJoin false
#spark.shuffle.manager org.apache.spark.shuffle.sort.ColumnarShuffleManager
spark.sql.adaptive.enabled false

```
remaining issues will be fixed in part2

Fixed: https://github.com/Intel-bigdata/OAP/issues/1587