### PR TITLE
[OAP-1158][OAP-CACHE][POAE7-363] Make Parquet splitable

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OapFileFormat.scala
@@ -181,7 +181,7 @@ private[sql] class OapFileFormat extends FileFormat
             case DataFileVersion.OAP_DATAFILE_V1 =>
               val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
                 filterScanners, requiredIds, None, oapMetrics, conf, false, options,
-                filters, None)
+                filters, None, null)
               reader.read(file)
             // Actually it shouldn't get to this line, because unsupported version will cause
             // exception thrown in readVersion call

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.oap
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.sql.SparkSession
@@ -40,6 +41,11 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
   override def hashCode(): Int = getClass.hashCode()
 
   override def equals(other: Any): Boolean = other.isInstanceOf[OptimizedParquetFileFormat]
+
+  override def isSplitable(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      path: Path): Boolean = true
 
   override def prepareWrite(
       sparkSession: SparkSession,
@@ -128,7 +134,7 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
       }
       val reader = new OapDataReaderV1(file.filePath, m, partitionSchema, requiredSchema,
         filterScanners, requiredIds, pushed, oapMetrics, conf, enableVectorizedReader, options,
-        filters, context)
+        filters, context, file)
       reader.read(file)
     }
   }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -45,7 +45,14 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
   override def isSplitable(
       sparkSession: SparkSession,
       options: Map[String, String],
-      path: Path): Boolean = true
+      path: Path): Boolean = {
+    val isSplitable = sparkSession.sparkContext.conf.getBoolean(OapConf.OAP_PARQUET_SPLIT_ENABLED.key,
+      OapConf.OAP_PARQUET_SPLIT_ENABLED.defaultValue.get)
+    if (isSplitable) {
+      logWarning("Enable Parquet file splitable will conflict with OAP index!")
+    }
+    isSplitable
+  }
 
   override def prepareWrite(
       sparkSession: SparkSession,

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.{OapException, OutputWriterFactory, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.oap.io.{DataFileContext, OapDataReaderV1, ParquetVectorizedContext}
 import org.apache.spark.sql.execution.datasources.oap.utils.FilterHelper
 import org.apache.spark.sql.internal.SQLConf
@@ -50,6 +50,11 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
       OapConf.OAP_PARQUET_SPLIT_ENABLED.defaultValue.get)
     if (isSplitable) {
       logWarning("Enable Parquet file splitable will conflict with OAP index!")
+      if (sparkSession.sparkContext.conf.getBoolean(OapConf.OAP_ENABLE_OINDEX.key,
+          OapConf.OAP_ENABLE_OINDEX.defaultValue.get)) {
+        throw new OapException("Please check configuration. " +
+          "Parquet file splitable conflict with OAP index!")
+      }
     }
     isSplitable
   }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OapDataReaderWriter.scala
@@ -229,8 +229,6 @@ private[oap] class OapDataReaderV1(
 
     def fullScan: OapCompletionIterator[Any] = {
       val start = if (log.isDebugEnabled) System.currentTimeMillis else 0
-      logInfo("this file is splitFile, start offset is: " + file.start +
-        ", length is " + file.length + ". However, current impl will read all bytes" )
       val iter = fileScanner.iterator(requiredIds, filters)
       val end = if (log.isDebugEnabled) System.currentTimeMillis else 0
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -26,7 +26,7 @@ import org.apache.parquet.hadoop._
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
-import org.apache.spark.sql.execution.datasources.RecordReader
+import org.apache.spark.sql.execution.datasources.{PartitionedFile, RecordReader}
 import org.apache.spark.sql.execution.datasources.oap.filecache._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportWrapper
 import org.apache.spark.sql.internal.oap.OapConf
@@ -67,6 +67,7 @@ private[oap] case class ParquetDataFile(
     configuration: Configuration) extends DataFile {
 
   private var context: Option[ParquetVectorizedContext] = None
+  private var partitionedFile: PartitionedFile = null
   private lazy val meta =
     OapRuntime.getOrCreate.dataFileMetaCacheManager.get(this).asInstanceOf[ParquetDataFileMeta]
   private val file = new Path(StringUtils.unEscapeString(path))
@@ -118,7 +119,7 @@ private[oap] case class ParquetDataFile(
           addRequestSchemaToConf(configuration, requiredIds)
           initCacheReader(requiredIds, c,
             new VectorizedCacheReader(configuration,
-              meta.footer.toParquetMetadata(), this, requiredIds))
+              meta.footer.toParquetMetadata(), this, requiredIds, partitionedFile))
         } else {
           addRequestSchemaToConf(configuration, requiredIds)
           initVectorizedReader(c,
@@ -169,6 +170,9 @@ private[oap] case class ParquetDataFile(
 
   def setParquetVectorizedContext(context: Option[ParquetVectorizedContext]): Unit =
     this.context = context
+
+  def setPartitionedFile(file: PartitionedFile): Unit =
+    this.partitionedFile = file
 
   private def initRecordReader(reader: RecordReader[InternalRow]) = {
     reader.initialize()

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/VectorizedCacheReader.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/VectorizedCacheReader.scala
@@ -228,10 +228,13 @@ class VectorizedCacheReader(
     this.sparkSchema = StructType.fromString(sparkRequestedSchemaString)
     // we should not get all row Groups here
     val rowGroupMetas = footer.getBlocks.asScala
-//    this.rowGroupMetaIter = rowGroupMetas.iterator
-//    for (block <- rowGroupMetas) {
-//      this.totalRowCount += block.getRowCount
-//    }
+    if (file == null) {
+      this.rowGroupMetaIter = rowGroupMetas.iterator
+      for (block <- rowGroupMetas) {
+        this.totalRowCount += block.getRowCount
+      }
+      return
+    }
 
     var rowGourpList = List[BlockMetaData]()
     var currentOffset : Long = 0

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/VectorizedCacheReader.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/VectorizedCacheReader.scala
@@ -32,7 +32,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.RecordReader
+import org.apache.spark.sql.execution.datasources.{PartitionedFile, RecordReader}
 import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberId, VectorDataFiberId}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupportWrapper
 import org.apache.spark.sql.execution.vectorized._
@@ -44,7 +44,8 @@ class VectorizedCacheReader(
     configuration: Configuration,
     footer: ParquetMetadata,
     dataFile: ParquetDataFile,
-    requiredColumnIds: Array[Int])
+    requiredColumnIds: Array[Int],
+    file: PartitionedFile = null)
   extends RecordReader[AnyRef] with Logging {
 
   protected val defaultCapacity: Int =
@@ -225,11 +226,27 @@ class VectorizedCacheReader(
     val sparkRequestedSchemaString =
       configuration.get(ParquetReadSupportWrapper.SPARK_ROW_REQUESTED_SCHEMA)
     this.sparkSchema = StructType.fromString(sparkRequestedSchemaString)
+    // we should not get all row Groups here
     val rowGroupMetas = footer.getBlocks.asScala
-    this.rowGroupMetaIter = rowGroupMetas.iterator
+//    this.rowGroupMetaIter = rowGroupMetas.iterator
+//    for (block <- rowGroupMetas) {
+//      this.totalRowCount += block.getRowCount
+//    }
+
+    var rowGourpList = List[BlockMetaData]()
+    var currentOffset : Long = 0
+    // refer parquet file format: https://github.com/apache/parquet-format#file-format
+    val PARQUET_MAGIC_NUMBER = 4
+    currentOffset += PARQUET_MAGIC_NUMBER
+    // if a split file include a row group's head, this reader will read this row group.
     for (block <- rowGroupMetas) {
-      this.totalRowCount += block.getRowCount
+      if (file.start <= currentOffset && file.start + file.length >= currentOffset) {
+        rowGourpList +:= block
+        this.totalRowCount += block.getRowCount
+      }
+      currentOffset += block.getTotalByteSize
     }
+    this.rowGroupMetaIter = rowGourpList.iterator
   }
 
   protected def initializeInternal(): Unit = {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -414,8 +414,8 @@ object OapConf {
   val OAP_PARQUET_SPLIT_ENABLED =
     SqlConfAdapter.buildConf("spark.sql.oap.parquet.split.enable")
       .internal()
-      .doc("To indicate if a parquet file could be splitable, default false," +
-        "if set to true, it will conflict with OAP index.")
+      .doc("To indicate if a parquet file could be split. Default is false." +
+        " Warning: OAP index doesn't support file splitting.")
       .booleanConf
       .createWithDefault(false)
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -411,6 +411,14 @@ object OapConf {
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_PARQUET_SPLIT_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.split.enable")
+      .internal()
+      .doc("To indicate if a parquet file could be splitable, default false," +
+        "if set to true, it will conflict with OAP index.")
+      .booleanConf
+      .createWithDefault(false)
+
   val OAP_PARQUET_INDEX_ENABLED =
     SqlConfAdapter.buildConf("spark.sql.oap.parquet.index.enable")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

OAP will process one parquet file with one task, this will influence performance a lot if a file is huge. The reason why OAP file is not splitable is related to index. For data cache, we can make parquet file splitable for better performance. refer Issue [1158](https://github.com/Intel-bigdata/OAP/issues/1588)

## How was this patch tested?

UT passed

