### PR TITLE
[OAP-1498][oap-native-sql] adding support for stddev_samp without codegen

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregateExpression.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregateExpression.scala
@@ -90,12 +90,14 @@ class ColumnarAggregateExpression(
             ("count", 1, 1)
           }
         }
+        case "stddev_samp" => ("stddev_samp_partial", 1, 3)
         case other => (aggregateFunction.prettyName, 1, 1)
       }
     case Final =>
       aggregateFunction.prettyName match {
         case "count" => ("sum", 1, 1)
         case "avg" => ("avgByCount", 2, 1)
+        case "stddev_samp" => ("stddev_samp_final", 3, 1)
         case other => (aggregateFunction.prettyName, 1, 1)
       }
     case _ =>

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
@@ -248,6 +248,13 @@ class ColumnarAggregation(
           val aggBufferAttr = min.inputAggBufferAttributes
           val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
           aggregateAttr += attr
+        case StddevSamp(_) =>
+          val stddevSamp = aggregateFunc.asInstanceOf[StddevSamp]
+          val aggBufferAttr = stddevSamp.inputAggBufferAttributes
+          for (index <- 0 until aggBufferAttr.size) {
+            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
+            aggregateAttr += attr
+          }
         case other =>
           throw new UnsupportedOperationException(s"not currently supported: $other.")
       }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarExpressionConverter.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarExpressionConverter.scala
@@ -156,6 +156,7 @@ object ColumnarExpressionConverter extends Logging {
         replaceWithColumnarExpression(ss.len),
         expr)
     case u: UnaryExpression =>
+      check_if_no_calculation = false
       logInfo(s"${expr.getClass} ${expr} is supported, no_cal is $check_if_no_calculation.")
       ColumnarUnaryOperator.create(replaceWithColumnarExpression(u.child, attributeSeq), expr)
     case s: org.apache.spark.sql.execution.ScalarSubquery =>

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -321,7 +321,9 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(const std::string& func_name,
   if (func_name.compare("sum") == 0 || func_name.compare("count") == 0 ||
       func_name.compare("unique") == 0 || func_name.compare("append") == 0 ||
       func_name.compare("sum_count") == 0 || func_name.compare("avgByCount") == 0 ||
-      func_name.compare("min") == 0 || func_name.compare("max") == 0) {
+      func_name.compare("min") == 0 || func_name.compare("max") == 0 || 
+      func_name.compare("stddev_samp_partial") == 0 || 
+      func_name.compare("stddev_samp_final") == 0) {  
     RETURN_NOT_OK(AggregateVisitorImpl::Make(p, func_name, &impl_));
     goto finish;
   }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -47,7 +47,7 @@ class ExprVisitorImpl {
   }
 
   virtual arrow::Status SetMember() {
-    return arrow::Status::NotImplemented("ExprVisitorImpl Init is abstract.");
+    return arrow::Status::NotImplemented("ExprVisitorImpl SetMember is abstract.");
   }
 
   virtual arrow::Status SetDependency(
@@ -223,6 +223,14 @@ class AggregateVisitorImpl : public ExprVisitorImpl {
       RETURN_NOT_OK(extra::MinArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
     } else if (func_name_.compare("max") == 0) {
       RETURN_NOT_OK(extra::MaxArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+    } else if (func_name_.compare("stddev_samp_partial") == 0) {
+      p_->result_fields_.push_back(arrow::field("avg", arrow::int64()));
+      p_->result_fields_.push_back(arrow::field("m2", arrow::int64()));
+      RETURN_NOT_OK(extra::StddevSampPartialArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
+    } else if (func_name_.compare("stddev_samp_final") == 0) {
+      p_->result_fields_.erase(p_->result_fields_.end() - 1);
+      p_->result_fields_.erase(p_->result_fields_.end() - 1);
+      RETURN_NOT_OK(extra::StddevSampFinalArrayKernel::Make(&p_->ctx_, data_type, &kernel_));
     }
     initialized_ = true;
     return arrow::Status::OK();

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
@@ -24,6 +24,8 @@
 #include <arrow/type_fwd.h>
 #include <arrow/type_traits.h>
 #include <arrow/util/checked_cast.h>
+#include <math.h>
+#include <limits>
 
 #include <iostream>
 #include <memory>
@@ -1050,6 +1052,299 @@ class AvgByCountAction : public ActionBase {
   std::vector<bool> cache_validity_;
 };
 
+//////////////// StddevSampPartialAction ///////////////
+template <typename DataType>
+class StddevSampPartialAction : public ActionBase {
+ public:
+  StddevSampPartialAction(arrow::compute::FunctionContext* ctx) : ctx_(ctx) {
+#ifdef DEBUG
+    std::cout << "Construct StddevSampPartialAction" << std::endl;
+#endif
+  }
+  ~StddevSampPartialAction() {
+#ifdef DEBUG
+    std::cout << "Destruct StddevSampPartialAction" << std::endl;
+#endif
+  }
+
+  int RequiredColNum() { return 1; }
+
+  arrow::Status Submit(ArrayList in_list, int max_group_id,
+                       std::function<arrow::Status(int)>* on_valid,
+                       std::function<arrow::Status()>* on_null) override {
+    // resize result data
+    if (cache_validity_.size() <= max_group_id) {
+      cache_validity_.resize(max_group_id + 1, false);
+      cache_sum_.resize(max_group_id + 1, 0);
+      cache_count_.resize(max_group_id + 1, 0);
+      cache_m2_.resize(max_group_id + 1, 0);
+    }
+
+    in_ = in_list[0];
+    // prepare evaluate lambda
+    data_ = const_cast<CType*>(in_->data()->GetValues<CType>(1));
+    row_id = 0;
+    if (in_->null_count()) {
+      *on_valid = [this](int dest_group_id) {
+        const bool is_null = in_->IsNull(row_id);
+        if (!is_null) {
+          cache_validity_[dest_group_id] = true;
+          double pre_avg = cache_sum_[dest_group_id] * 1.0 / 
+            (cache_count_[dest_group_id] > 0 ? cache_count_[dest_group_id] : 1);
+          double delta = data_[row_id] * 1.0 - pre_avg;
+          double deltaN = delta / (cache_count_[dest_group_id] + 1);
+          cache_m2_[dest_group_id] += delta * deltaN * cache_count_[dest_group_id];
+          cache_sum_[dest_group_id] += data_[row_id] * 1.0;
+          cache_count_[dest_group_id] += 1.0;
+        }
+        row_id++;
+        return arrow::Status::OK();
+      };
+    } else {
+      *on_valid = [this](int dest_group_id) {
+        cache_validity_[dest_group_id] = true;
+        double pre_avg = cache_sum_[dest_group_id] * 1.0 / 
+            (cache_count_[dest_group_id] > 0 ? cache_count_[dest_group_id] : 1);
+        double delta = data_[row_id] * 1.0 - pre_avg;
+        double deltaN = delta / (cache_count_[dest_group_id] + 1);
+        cache_m2_[dest_group_id] += delta * deltaN * cache_count_[dest_group_id];
+        cache_sum_[dest_group_id] += data_[row_id] * 1.0;
+        cache_count_[dest_group_id] += 1.0;
+        row_id++;
+        return arrow::Status::OK();
+      };
+    }
+    *on_null = [this]() {
+      row_id++;
+      return arrow::Status::OK();
+    };
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Finish(ArrayList* out) override {
+    // get count
+    std::shared_ptr<arrow::Array> count_array;
+    auto count_builder = new arrow::DoubleBuilder(ctx_->memory_pool());
+    RETURN_NOT_OK(count_builder->AppendValues(cache_count_, cache_validity_));
+    RETURN_NOT_OK(count_builder->Finish(&count_array));
+    // get avg
+    std::shared_ptr<arrow::Array> avg_array;
+    for (uint64_t i = 0; i < cache_sum_.size(); i++) {
+      if (cache_count_[i] < 0.0001) {
+        cache_sum_[i] = 0;
+      } else {
+        cache_sum_[i] /= cache_count_[i] * 1.0;
+      }  
+    }
+    auto avg_builder = new arrow::DoubleBuilder(ctx_->memory_pool());
+    RETURN_NOT_OK(avg_builder->AppendValues(cache_sum_, cache_validity_));
+    RETURN_NOT_OK(avg_builder->Finish(&avg_array));
+    //get m2
+    std::shared_ptr<arrow::Array> m2_array;
+    auto m2_builder = new arrow::DoubleBuilder(ctx_->memory_pool());
+    RETURN_NOT_OK(m2_builder->AppendValues(cache_m2_, cache_validity_));
+    RETURN_NOT_OK(m2_builder->Finish(&m2_array));
+
+    out->push_back(count_array);
+    out->push_back(avg_array);
+    out->push_back(m2_array);
+    return arrow::Status::OK();
+  }
+
+  uint64_t GetResultLength() { return cache_sum_.size(); }
+
+  arrow::Status Finish(uint64_t offset, uint64_t length, ArrayList* out) override {
+    for (uint64_t i = 0; i < length; i++) {
+      if (cache_count_[i + offset] < 0.00001) {
+        cache_sum_[i + offset] = 0;
+      } else {
+        cache_sum_[i + offset] /= cache_count_[i + offset] * 1.0;
+      }
+    }
+    auto count_builder = new arrow::DoubleBuilder(ctx_->memory_pool());
+    auto avg_builder = new arrow::DoubleBuilder(ctx_->memory_pool());
+    auto m2_builder = new arrow::DoubleBuilder(ctx_->memory_pool());
+    for (uint64_t i = 0; i < length; i++) {
+      if (cache_validity_[offset + i]) {
+        RETURN_NOT_OK(count_builder->Append(cache_count_[offset + i]));
+        RETURN_NOT_OK(avg_builder->Append(cache_sum_[offset + i]));
+        RETURN_NOT_OK(m2_builder->Append(cache_m2_[offset + i]));
+      } else {
+        // append zero to count_builder if all values in this group are null
+        double zero = 0;
+        RETURN_NOT_OK(count_builder->Append(zero));
+        RETURN_NOT_OK(avg_builder->Append(zero));
+        RETURN_NOT_OK(m2_builder->Append(zero));
+      }
+    }
+
+    std::shared_ptr<arrow::Array> count_array;
+    std::shared_ptr<arrow::Array> avg_array;
+    std::shared_ptr<arrow::Array> m2_array;
+    RETURN_NOT_OK(count_builder->Finish(&count_array));
+    RETURN_NOT_OK(avg_builder->Finish(&avg_array));
+    RETURN_NOT_OK(m2_builder->Finish(&m2_array));
+    out->push_back(count_array);
+    out->push_back(avg_array);
+    out->push_back(m2_array);
+    return arrow::Status::OK();
+  }
+
+ private:
+  using CType = typename arrow::TypeTraits<DataType>::CType;
+  using ResDataType = typename FindAccumulatorType<DataType>::Type;
+  using ResCType = typename arrow::TypeTraits<ResDataType>::CType;
+  using ResArrayType = typename arrow::TypeTraits<ResDataType>::ArrayType;
+  // input
+  arrow::compute::FunctionContext* ctx_;
+  CType* data_;
+  std::shared_ptr<arrow::Array> in_;
+  int row_id;
+  // result
+  std::vector<double> cache_sum_;
+  std::vector<double> cache_count_;
+  std::vector<double> cache_m2_;
+  std::vector<bool> cache_validity_;
+};
+
+//////////////// StddevSampFinalAction ///////////////
+template <typename DataType>
+class StddevSampFinalAction : public ActionBase {
+ public:
+  StddevSampFinalAction(arrow::compute::FunctionContext* ctx) : ctx_(ctx) {
+#ifdef DEBUG
+    std::cout << "Construct StddevSampFinalAction" << std::endl;
+#endif
+  }
+  ~StddevSampFinalAction() {
+#ifdef DEBUG
+    std::cout << "Destruct StddevSampFinalAction" << std::endl;
+#endif
+  }
+
+  int RequiredColNum() { return 3; }
+
+  arrow::Status Submit(ArrayList in_list, int max_group_id,
+                       std::function<arrow::Status(int)>* on_valid,
+                       std::function<arrow::Status()>* on_null) override {
+    // resize result data
+    if (cache_validity_.size() <= max_group_id) {
+      cache_validity_.resize(max_group_id + 1, false);
+      cache_count_.resize(max_group_id + 1, 0);
+      cache_avg_.resize(max_group_id + 1, 0);
+      cache_m2_.resize(max_group_id + 1, 0);
+    }
+    in_count_ = in_list[0];
+    in_avg_ = in_list[1];
+    in_m2_ = in_list[2];
+    // prepare evaluate lambda
+    data_count_ = const_cast<double*>(in_count_->data()->GetValues<double>(1));
+    data_avg_ = const_cast<double*>(in_avg_->data()->GetValues<double>(1));
+    data_m2_ = const_cast<double*>(in_m2_->data()->GetValues<double>(1));
+    row_id = 0;
+    if (in_m2_->null_count()) {
+      *on_valid = [this](int dest_group_id) {
+        const bool is_null = in_m2_->IsNull(row_id);
+        if (!is_null && data_count_[row_id] > 0) {
+          cache_validity_[dest_group_id] = true;
+          double pre_avg = cache_avg_[dest_group_id];
+          double delta = data_avg_[row_id] - pre_avg;
+          double n1 = cache_count_[dest_group_id];
+          double n2 = data_count_[row_id];
+          double deltaN = (n1 + n2) > 0 ? delta / (n1 + n2) : 0;
+          cache_m2_[dest_group_id] += (data_m2_[row_id] + delta * deltaN * n1 * n2);
+          cache_avg_[dest_group_id] += deltaN * n2;
+          cache_count_[dest_group_id] += n2;
+        }
+        row_id++;
+        return arrow::Status::OK();
+      };
+    } else {
+      *on_valid = [this](int dest_group_id) {
+        if (data_count_[row_id] > 0) {
+           cache_validity_[dest_group_id] = true;
+           double pre_avg = cache_avg_[dest_group_id];
+           double delta = data_avg_[row_id] - pre_avg;
+           double n1 = cache_count_[dest_group_id];
+           double n2 = data_count_[row_id];
+           double deltaN = (n1 + n2) > 0 ? delta / (n1 + n2) : 0;
+           cache_m2_[dest_group_id] += (data_m2_[row_id] + delta * deltaN * n1 * n2);
+           cache_avg_[dest_group_id] += deltaN * n2;
+           cache_count_[dest_group_id] += n2;
+        }
+        row_id++;
+        return arrow::Status::OK();
+      };
+    }
+    *on_null = [this]() {
+      row_id++;
+      return arrow::Status::OK();
+    };
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Finish(ArrayList* out) override {
+    std::shared_ptr<arrow::Array> out_arr;
+    for (int i = 0; i < cache_count_.size(); i++) {
+      cache_m2_[i] = sqrt(cache_m2_[i] / (cache_count_[i] > 1 ? 
+        (cache_count_[i] - 1) : 1));
+    }
+    auto builder = new arrow::DoubleBuilder(ctx_->memory_pool());
+    RETURN_NOT_OK(builder->AppendValues(cache_m2_, cache_validity_));
+    RETURN_NOT_OK(builder->Finish(&out_arr));
+    out->push_back(out_arr);
+
+    return arrow::Status::OK();
+  }
+
+  uint64_t GetResultLength() { return cache_count_.size(); }
+
+  arrow::Status Finish(uint64_t offset, uint64_t length, ArrayList* out) override {
+    for (int i = 0; i < length; i++) {
+      cache_m2_[i + offset] = sqrt(cache_m2_[i + offset] / 
+        (cache_count_[i + offset] > 1 ? (cache_count_[i + offset] - 1) : 1));
+    }
+    auto builder = new arrow::DoubleBuilder(ctx_->memory_pool());
+    for (uint64_t i = 0; i < length; i++) {
+      if (cache_count_[offset + i] - 1 < 0.00001) {
+        // append NaN if only one non-null value exists
+        RETURN_NOT_OK(builder->Append(std::numeric_limits<double>::quiet_NaN()));
+      } else if (cache_validity_[offset + i]) {
+        RETURN_NOT_OK(builder->Append(cache_m2_[offset + i]));
+      } else {
+        // append null if all values are null 
+        RETURN_NOT_OK(builder->AppendNull());
+      }
+    }
+
+    std::shared_ptr<arrow::Array> out_array;
+    RETURN_NOT_OK(builder->Finish(&out_array));
+    out->push_back(out_array);
+    return arrow::Status::OK();
+  }
+
+ private:
+  using CType = typename arrow::TypeTraits<DataType>::CType;
+  using ArrayType = typename arrow::TypeTraits<DataType>::ArrayType;
+  using ResDataType = typename FindAccumulatorType<DataType>::Type;
+  using ResCType = typename arrow::TypeTraits<ResDataType>::CType;
+  using ResArrayType = typename arrow::TypeTraits<ResDataType>::ArrayType;
+  // input
+  arrow::compute::FunctionContext* ctx_;
+  double* data_count_;
+  double* data_avg_;
+  double* data_m2_;
+  int row_id;
+  std::shared_ptr<arrow::Array> in_count_;
+  std::shared_ptr<arrow::Array> in_avg_;
+  std::shared_ptr<arrow::Array> in_m2_;
+  // result
+  std::vector<double> cache_count_;
+  std::vector<double> cache_avg_;
+  std::vector<double> cache_m2_;
+  std::vector<bool> cache_validity_;
+};
+
 ///////////////////// Public Functions //////////////////
 #define PROCESS_SUPPORTED_TYPES(PROCESS) \
   PROCESS(arrow::UInt8Type)              \
@@ -1200,6 +1495,40 @@ arrow::Status MakeAvgByCountAction(arrow::compute::FunctionContext* ctx,
 #define PROCESS(InType)                                                \
   case InType::type_id: {                                              \
     auto action_ptr = std::make_shared<AvgByCountAction<InType>>(ctx); \
+    *out = std::dynamic_pointer_cast<ActionBase>(action_ptr);          \
+  } break;
+    PROCESS_SUPPORTED_TYPES(PROCESS)
+#undef PROCESS
+    default:
+      break;
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status MakeStddevSampPartialAction(arrow::compute::FunctionContext* ctx,
+                                   std::shared_ptr<arrow::DataType> type,
+                                   std::shared_ptr<ActionBase>* out) {
+  switch (type->id()) {
+#define PROCESS(InType)                                                \
+  case InType::type_id: {                                              \
+    auto action_ptr = std::make_shared<StddevSampPartialAction<InType>>(ctx); \
+    *out = std::dynamic_pointer_cast<ActionBase>(action_ptr);          \
+  } break;
+    PROCESS_SUPPORTED_TYPES(PROCESS)
+#undef PROCESS
+    default:
+      break;
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status MakeStddevSampFinalAction(arrow::compute::FunctionContext* ctx,
+                                   std::shared_ptr<arrow::DataType> type,
+                                   std::shared_ptr<ActionBase>* out) {
+  switch (type->id()) {
+#define PROCESS(InType)                                                \
+  case InType::type_id: {                                              \
+    auto action_ptr = std::make_shared<StddevSampFinalAction<InType>>(ctx); \
     *out = std::dynamic_pointer_cast<ActionBase>(action_ptr);          \
   } break;
     PROCESS_SUPPORTED_TYPES(PROCESS)

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -225,6 +225,38 @@ class MaxArrayKernel : public KernalBase {
   arrow::compute::FunctionContext* ctx_;
 };
 
+class StddevSampPartialArrayKernel : public KernalBase {
+ public:
+  static arrow::Status Make(arrow::compute::FunctionContext* ctx,
+                            std::shared_ptr<arrow::DataType> data_type,
+                            std::shared_ptr<KernalBase>* out);
+  StddevSampPartialArrayKernel(arrow::compute::FunctionContext* ctx,
+                 std::shared_ptr<arrow::DataType> data_type);
+  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status Finish(ArrayList* out) override;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+  arrow::compute::FunctionContext* ctx_;
+};
+
+class StddevSampFinalArrayKernel : public KernalBase {
+ public:
+  static arrow::Status Make(arrow::compute::FunctionContext* ctx,
+                            std::shared_ptr<arrow::DataType> data_type,
+                            std::shared_ptr<KernalBase>* out);
+  StddevSampFinalArrayKernel(arrow::compute::FunctionContext* ctx,
+                 std::shared_ptr<arrow::DataType> data_type);
+  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status Finish(ArrayList* out) override;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+  arrow::compute::FunctionContext* ctx_;
+};
+
 class SortArraysToIndicesKernel : public KernalBase {
  public:
   static arrow::Status Make(arrow::compute::FunctionContext* ctx,

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_aggregate.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_aggregate.cc
@@ -43,6 +43,7 @@ TEST(TestArrowCompute, AggregatewithMultipleBatchTest) {
   auto n_avg = TreeExprBuilder::MakeFunction("avgByCount", {arg_2, arg_1}, uint64());
   auto n_min = TreeExprBuilder::MakeFunction("min", {arg_0}, uint64());
   auto n_max = TreeExprBuilder::MakeFunction("max", {arg_0}, uint64());
+  auto n_stddev_samp_partial = TreeExprBuilder::MakeFunction("stddev_samp_partial", {arg_0}, float64());
 
   auto sum_expr = TreeExprBuilder::MakeExpression(n_sum, f_res);
   auto count_expr = TreeExprBuilder::MakeExpression(n_count, f_res);
@@ -50,12 +51,13 @@ TEST(TestArrowCompute, AggregatewithMultipleBatchTest) {
   auto avg_expr = TreeExprBuilder::MakeExpression(n_avg, f_res);
   auto min_expr = TreeExprBuilder::MakeExpression(n_min, f_res);
   auto max_expr = TreeExprBuilder::MakeExpression(n_max, f_res);
+  auto stddev_samp_partial_expr = TreeExprBuilder::MakeExpression(n_stddev_samp_partial, f_res);
 
   std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {
-      sum_expr, count_expr, sum_count_expr, avg_expr, min_expr, max_expr};
+      sum_expr, count_expr, sum_count_expr, avg_expr, min_expr, max_expr, stddev_samp_partial_expr};
   auto sch = arrow::schema({f0, f1, f2});
-  std::vector<std::shared_ptr<Field>> ret_types = {f_sum,   f_count, f_sum, f_count,
-                                                   f_float, f_res,   f_res};
+  std::vector<std::shared_ptr<Field>> ret_types = {f_sum, f_count, f_sum, f_count,
+                                                   f_float, f_res, f_res, f_float, f_float, f_float};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> expr;
   ASSERT_NOT_OK(CreateCodeGenerator(sch, expr_vector, ret_types, &expr, true));
@@ -74,9 +76,10 @@ TEST(TestArrowCompute, AggregatewithMultipleBatchTest) {
   ASSERT_NOT_OK(expr->finish(&result_batch));
 
   std::shared_ptr<arrow::RecordBatch> expected_result;
-  std::vector<std::string> expected_result_string = {"[601]",   "[19]", "[601]", "[19]",
-                                                     "[30.05]", "[8]",  "[70]"};
-  auto res_sch = arrow::schema({f_sum, f_count, f_sum, f_count, f_float, f_res, f_res});
+  std::vector<std::string> expected_result_string = {"[601]",   "[19]", "[601]", "[19]", "[30.05]",
+                                                      "[8]", "[70]", "[19]", "[31.6316]", "[8080.42]"};
+  auto res_sch = arrow::schema({f_sum, f_count, f_sum, f_count, f_float, f_res, 
+                                f_res, f_float, f_float, f_float});
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
   ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
 }
@@ -90,6 +93,7 @@ TEST(TestArrowCompute, GroupByAggregateWithMultipleBatchTest) {
   auto f_count = field("count", uint32());
   auto f_avg = field("avg", uint32());
   auto f_res = field("res", uint32());
+  auto f_m2 = field("m2", uint32());
 
   auto arg_pre = TreeExprBuilder::MakeField(f0);
   auto n_pre = TreeExprBuilder::MakeFunction("encodeArray", {arg_pre}, uint32());
@@ -108,6 +112,8 @@ TEST(TestArrowCompute, GroupByAggregateWithMultipleBatchTest) {
       TreeExprBuilder::MakeFunction("action_sum_count", {n_split, arg1}, uint32());
   auto n_min = TreeExprBuilder::MakeFunction("action_min", {n_split, arg1}, uint32());
   auto n_max = TreeExprBuilder::MakeFunction("action_max", {n_split, arg1}, uint32());
+  auto n_stddev_samp_partial = TreeExprBuilder::MakeFunction("action_stddev_samp_partial", 
+                                                            {n_split, arg1}, uint32());
 
   auto unique_expr = TreeExprBuilder::MakeExpression(n_unique, f_res);
   auto sum_expr = TreeExprBuilder::MakeExpression(n_sum, f_res);
@@ -116,12 +122,13 @@ TEST(TestArrowCompute, GroupByAggregateWithMultipleBatchTest) {
   auto sum_count_expr = TreeExprBuilder::MakeExpression(n_sum_count, f_res);
   auto avg_min = TreeExprBuilder::MakeExpression(n_min, f_res);
   auto avg_max = TreeExprBuilder::MakeExpression(n_max, f_res);
+  auto stddev_samp_partial_expr = TreeExprBuilder::MakeExpression(n_stddev_samp_partial, f_res);
 
-  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {
-      unique_expr, sum_expr, count_expr, avg_expr, sum_count_expr, avg_min, avg_max};
+  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {unique_expr, sum_expr, 
+        count_expr, avg_expr, sum_count_expr, avg_min, avg_max, stddev_samp_partial_expr};
   auto sch = arrow::schema({f0, f1});
-  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_sum,   f_count, f_avg,
-                                                   f_sum,    f_count, f_res,   f_res};
+  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_sum, f_count, f_avg,
+                                                   f_sum, f_count, f_res, f_res, f_count, f_avg, f_m2};
 
   /////////////////////// Create Expression Evaluator ////////////////////
   std::shared_ptr<CodeGenerator> expr;
@@ -157,9 +164,11 @@ TEST(TestArrowCompute, GroupByAggregateWithMultipleBatchTest) {
       "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]",        "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]",
       "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",         "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
       "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]", "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",
-      "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",        "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"};
-  auto res_sch =
-      arrow::schema({f_unique, f_sum, f_count, f_avg, f_sum, f_count, f_res, f_res});
+      "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",        "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
+      "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]", "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
+      "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"};
+  auto res_sch = arrow::schema({f_unique, f_sum, f_count, f_avg, f_sum, f_count, 
+                                f_res, f_res, f_count, f_avg, f_m2});
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
   ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
 }
@@ -498,6 +507,184 @@ TEST(TestArrowCompute, GroupByAggregateWithMultipleBatchOutputWoKeyTest) {
   std::vector<std::string> expected_result_string = {
       "[8, 10, 9, 20, 55, 42, 28, 32, 54, 70]", "[8, 5, 3, 5, 11, 7, 4, 4, 6, 7]"};
   auto res_sch = arrow::schema({f_sum, f_count});
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
+}
+
+TEST(TestArrowCompute, StddevSampFinalTest) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", float64());
+  auto f2 = field("f2", float64());
+
+  auto f_float = field("float", float64());
+  auto f_res = field("res", uint32());
+
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto arg_2 = TreeExprBuilder::MakeField(f2);
+
+  auto n_stddev_samp_final = TreeExprBuilder::MakeFunction("stddev_samp_final", {arg_0, arg_1, arg_2}, float64());
+  auto final_expr = TreeExprBuilder::MakeExpression(n_stddev_samp_final, f_res);
+
+  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {final_expr};
+  auto sch = arrow::schema({f0, f1, f2});
+  std::vector<std::shared_ptr<Field>> ret_types = {f_float};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, expr_vector, ret_types, &expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> result_batch;
+  std::vector<std::string> input_data_string = {"[2, 32, 14, 16, 18, 3, 4, 7, 9, 10]", 
+  "[2, 32, 14, 16, 18, 12, 32, 11, 12, 14]", "[2, 16, 14, 16, 18, 23, 32, 45, 43, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &result_batch));
+  std::vector<std::string> input_data_2_string = {"[8, 57, 59, 12, 1, 12, 3, 5, 7, 8]", 
+  "[8, 57, 59, 12, 1, 15, 21, 13, 15, 6]", "[8, 57, 59, 12, 1, 8, 6, 3, 6, 12]"};
+  MakeInputBatch(input_data_2_string, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &result_batch));
+  ASSERT_NOT_OK(expr->finish(&result_batch));
+
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {"[21.0435]"};
+  auto res_sch = arrow::schema({f_float});
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
+}
+
+TEST(TestArrowCompute, GroupByStddevSampPartialWithMultipleBatchTest) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", utf8());
+  auto f_1 = field("f1", float64());
+  auto f_2 = field("f2", int64());
+  auto f_unique = field("unique", utf8());
+  auto f_count = field("count", int64());
+  auto f_avg = field("avg", float64());
+  auto f_res = field("res", uint32());
+  auto f_m2 = field("m2", float64());
+
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto n_pre = TreeExprBuilder::MakeFunction("encodeArray", {arg_0}, utf8());
+  auto arg_1 = TreeExprBuilder::MakeField(f_1);
+  auto arg_2 = TreeExprBuilder::MakeField(f_2);
+  auto n_split = TreeExprBuilder::MakeFunction(
+      "splitArrayListWithAction", {n_pre, arg_0, arg_1, arg_2}, uint32());
+  auto arg_res = TreeExprBuilder::MakeField(f_res);
+
+  auto n_unique = TreeExprBuilder::MakeFunction("action_unique", {n_split, arg_0}, utf8());
+  auto n_stddev_samp_partial = TreeExprBuilder::MakeFunction("action_stddev_samp_partial", {n_split, arg_1}, uint32());
+
+  auto unique_expr = TreeExprBuilder::MakeExpression(n_unique, f_res);
+  auto stddev_samp_partial_expr = TreeExprBuilder::MakeExpression(n_stddev_samp_partial, f_res);
+
+  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {unique_expr, stddev_samp_partial_expr};
+  auto sch = arrow::schema({f0, f_1, f_2});
+  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_count, f_avg, f_m2};
+
+  /////////////////////// Create Expression Evaluator ////////////////////
+  std::shared_ptr<CodeGenerator> expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, expr_vector, ret_types, &expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> output_batch_list;
+
+  ////////////////////// calculation /////////////////////
+  std::vector<std::string> input_data = {
+      R"(["BJ", "SH", "SZ", "HZ", "WH", "WH", "HZ", "BJ", "SH", "SH", "BJ", "BJ", "BJ", "HZ", "HZ", "SZ", "WH", "WH", "WH", "WH"])",
+      "[2, 4, 9, 11, 12, 25, 12, 7, 5, 9, 9, 15, 23, 32, 2, 12, 23, 56, 35, 68]",
+      "[1, 2, 3, 4, 5, 5, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]"};
+  MakeInputBatch(input_data, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_2 = {
+      R"(["CD", "DL", "NY", "LA", "AU", "AU", "LA", "CD", "DL", "DL", "CD", "CD", "CD", "LA", "LA", "NY", "AU", "AU", "AU", "AU"])",
+      "[12, 49, 64, 18, 20, 100, 81, 36, 12, 24, 23, 12, 6, 22, 12, 12, 12, 35, 76, 24]",
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]"};
+  MakeInputBatch(input_data_2, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_3 = {
+      R"(["BJ", "SH", "SZ", "NY", "WH", "WH", "AU", "BJ", "SH", "DL", "CD", "CD", "BJ", "LA", "HZ", "LA", "WH", "NY", "WH", "WH"])",
+      "[1, 12, 1, 25, 12, 9, 78, 10, 8, 15, 3, 7, 3, 1, 5, 6, 16, 25, 30, 22]",
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, 5, 8, 5, 5]"};
+  MakeInputBatch(input_data_3, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  ////////////////////// Finish //////////////////////////
+  std::vector<std::shared_ptr<arrow::RecordBatch>> result_batch;
+  ASSERT_NOT_OK(expr->finish(&result_batch));
+
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      R"(["BJ", "SH", "SZ", "HZ", "WH", "CD", "DL", "NY" ,"LA", "AU"])",
+      "[8, 5, 3, 5, 11, 7, 4, 4, 6, 7]", "[8.75, 7.6, 7.33333, 12.4, 28, 14.1429, 25, 31.5, 23.3333, 49.2857]",
+      "[385.5, 41.2, 64.6667, 549.2, 3524, 806.857, 846, 1521, 4283.33, 7201.43]"};
+  auto res_sch = arrow::schema({f_unique, f_count, f_avg, f_m2});
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
+}
+
+TEST(TestArrowCompute, GroupByStddevSampFinalWithMultipleBatchTest) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", float64());
+  auto f2 = field("f2", float64());
+  auto f3 = field("f3", float64());
+  auto f_unique = field("unique", uint32());
+  auto f_stddev = field("stddev", float64());
+  auto f_res = field("res", uint32());
+
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto n_pre = TreeExprBuilder::MakeFunction("encodeArray", {arg_0}, uint32());
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto arg_2 = TreeExprBuilder::MakeField(f2);
+  auto arg_3 = TreeExprBuilder::MakeField(f3);
+  auto n_split = TreeExprBuilder::MakeFunction(
+      "splitArrayListWithAction", {n_pre, arg_0, arg_1, arg_2, arg_3}, uint32());
+  auto arg_res = TreeExprBuilder::MakeField(f_res);
+
+  auto n_unique = TreeExprBuilder::MakeFunction("action_unique", {n_split, arg_0}, uint32());
+  auto n_stddev = TreeExprBuilder::MakeFunction("action_stddev_samp_final", 
+    {n_split, arg_1, arg_2, arg_3}, uint32());
+
+  auto unique_expr = TreeExprBuilder::MakeExpression(n_unique, f_res);
+  auto stddev_expr = TreeExprBuilder::MakeExpression(n_stddev, f_res);
+
+  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {unique_expr, stddev_expr};
+  auto sch = arrow::schema({f0, f1, f2, f3});
+  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_stddev};
+
+  /////////////////////// Create Expression Evaluator ////////////////////
+  std::shared_ptr<CodeGenerator> expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, expr_vector, ret_types, &expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> output_batch_list;
+
+  ////////////////////// calculation /////////////////////
+  std::vector<std::string> input_data = {
+      "[1, 2, 3, 4, 5, null, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]",
+      "[2, 4, 5, 7, 8, 2, 45, 32, 23, 12, 14, 16, 18, 19, 23, 25, 57, 59, 12, 1]",
+      "[2, 4, 5, 7, 8, 2, 45, 32, 23, 12, 14, 16, 18, 19, 23, 25, 57, 59, 12, 1]",
+      "[2, 4, 5, 7, 8, 2, 45, 32, 23, 12, 14, 16, 18, 19, 23, 25, 57, 59, 12, 1]"};
+  MakeInputBatch(input_data, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_2 = {
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]",
+      "[7, 8, 4, 5, 6, 1, 34, 54, 65, 66, 78, 12, 32, 24, 32, 45, 12, 24, 35, 46]",
+      "[2, 4, 5, 7, 8, 2, 45, 32, 23, 12, 14, 16, 18, 19, 23, 25, 57, 59, 12, 1]",
+      "[2, 4, 5, 7, 8, 2, 45, 32, 23, 12, 14, 16, 18, 19, 23, 25, 57, 59, 12, 1]"};
+  MakeInputBatch(input_data_2, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  ////////////////////// Finish //////////////////////////
+  std::vector<std::shared_ptr<arrow::RecordBatch>> result_batch;
+  ASSERT_NOT_OK(expr->finish(&result_batch));
+
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]", 
+      "[8.49255, 6.93137, 7.6489, 13.5708, 17.4668, 8.52779, 6.23633, 5.58903, 12.535, 24.3544]"};
+  auto res_sch = arrow::schema({f_unique, f_stddev});
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
   ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
 }


### PR DESCRIPTION
This pr contains the support for stddev_samp without codegen.
Fixes #1498
