### PR TITLE
[OAP-MLlib] Clean up POM to remove unnecessaries for examples and mllib-dal

### DIFF
--- a/oap-mllib/examples/kmeans-hibench/pom.xml
+++ b/oap-mllib/examples/kmeans-hibench/pom.xml
@@ -26,22 +26,15 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-    </dependency>    
-
-     <dependency>
       <groupId>com.github.scopt</groupId>
       <artifactId>scopt_2.12</artifactId>
       <version>3.7.0</version>      
     </dependency>
 
     <dependency>
-      <groupId>com.github.fommil.netlib</groupId>
-      <artifactId>all</artifactId>
-      <version>1.1.2</version>      
-      <type>pom</type>
+      <groupId>org.apache.mahout</groupId>
+      <artifactId>mahout-hdfs</artifactId>
+      <version>0.13.0</version>
     </dependency>
 
     <dependency>
@@ -58,24 +51,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.mahout</groupId>
-      <artifactId>mahout-core</artifactId>
-      <version>0.9</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.intel.daal</groupId>
-      <artifactId>daal</artifactId>
-      <version>2021.1-beta</version>
-      <scope>system</scope>
-      <systemPath>${env.ONEAPI_ROOT}/daal/latest/lib/daal.jar</systemPath>
-    </dependency>
   </dependencies>
 
   <build>

--- a/oap-mllib/examples/kmeans/pom.xml
+++ b/oap-mllib/examples/kmeans/pom.xml
@@ -26,22 +26,9 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-    </dependency>    
-
-     <dependency>
       <groupId>com.github.scopt</groupId>
       <artifactId>scopt_2.12</artifactId>
       <version>3.7.0</version>      
-    </dependency>
-
-    <dependency>
-      <groupId>com.github.fommil.netlib</groupId>
-      <artifactId>all</artifactId>
-      <version>1.1.2</version>      
-      <type>pom</type>
     </dependency>
 
     <dependency>
@@ -58,24 +45,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.mahout</groupId>
-      <artifactId>mahout-core</artifactId>
-      <version>0.9</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.intel.daal</groupId>
-      <artifactId>daal</artifactId>
-      <version>2021.1-beta</version>
-      <scope>system</scope>
-      <systemPath>${env.ONEAPI_ROOT}/daal/latest/lib/daal.jar</systemPath>
-    </dependency>
   </dependencies>
 
   <build>

--- a/oap-mllib/mllib-dal/pom.xml
+++ b/oap-mllib/mllib-dal/pom.xml
@@ -29,12 +29,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.github.scopt</groupId>
             <artifactId>scopt_2.12</artifactId>
             <version>3.7.0</version>
@@ -69,6 +63,13 @@
             <systemPath>${env.ONEAPI_ROOT}/daal/latest/lib/daal.jar</systemPath>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>     
+        </dependency>
+             
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.12</artifactId>

--- a/oap-mllib/mllib-dal/pom.xml
+++ b/oap-mllib/mllib-dal/pom.xml
@@ -35,13 +35,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.fommil.netlib</groupId>
-            <artifactId>all</artifactId>
-            <version>1.1.2</version>
-            <type>pom</type>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
             <version>${spark.version}</version>
@@ -67,9 +60,9 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
-            <scope>test</scope>     
+            <scope>test</scope>
         </dependency>
-             
+
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.12</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Move junit to test scope to prevent including it in the release jar
- Use mahout-hdfs instead
- Remove netlib and unnecessaries from pom

## How was this patch tested?

CI
