### PR TITLE
[SQL Data Source Cache][POAE7-152] Consistent hash based scheduler

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -535,4 +535,18 @@ object OapConf {
       .doc("The commit algorithm version used by create index job")
       .intConf
       .createWithDefault(2)
+
+  val OAP_CLUSTER_CONSISTENTHASH_SCHEDULER_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.cluster.consistenthash.scheduler.enabled")
+      .internal()
+      .doc("Whether enable consistenthash scheduler in cluster environment")
+      .booleanConf
+      .createWithDefault(false)
+
+  val OAP_CLUSTER_NODE_INFO =
+    SqlConfAdapter.buildConf("spark.sql.oap.cluster.node.info")
+      .internal()
+      .doc("Node info in the cluster")
+      .stringConf
+      .createWithDefault("0:host0;1:host1;2:host2")
 }

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -582,14 +582,18 @@ case class FileSourceScanExec(
         val filePath = file.getPath
         val isSplitable = relation.fileFormat.isSplitable(
           relation.sparkSession, relation.options, filePath)
-        PartitionedFileUtil.splitFiles(
-          sparkSession = relation.sparkSession,
-          file = file,
-          filePath = filePath,
-          isSplitable = isSplitable,
-          maxSplitBytes = maxSplitBytes,
-          partitionValues = partition.values
-        )
+        if (isSplitable) {
+          PartitionedFileUtil.splitFiles(
+            sparkSession = relation.sparkSession,
+            file = file,
+            filePath = filePath,
+            isSplitable = isSplitable,
+            maxSplitBytes = maxSplitBytes,
+            partitionValues = partition.values
+          )
+        } else {
+          CachedPartitionedFileUtil.splitFilesWithCacheLocality(file, filePath, partition.values)
+        }
       }
     }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
     val partitions =

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -596,6 +596,7 @@ case class FileSourceScanExec(
         }
       }
     }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+    
     val partitions =
       FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
 

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -582,21 +582,16 @@ case class FileSourceScanExec(
         val filePath = file.getPath
         val isSplitable = relation.fileFormat.isSplitable(
           relation.sparkSession, relation.options, filePath)
-        if (isSplitable) {
-          PartitionedFileUtil.splitFiles(
-            sparkSession = relation.sparkSession,
-            file = file,
-            filePath = filePath,
-            isSplitable = isSplitable,
-            maxSplitBytes = maxSplitBytes,
-            partitionValues = partition.values
-          )
-        } else {
-          CachedPartitionedFileUtil.splitFilesWithCacheLocality(file, filePath, partition.values)
-        }
+        PartitionedFileUtil.splitFiles(
+          sparkSession = relation.sparkSession,
+          file = file,
+          filePath = filePath,
+          isSplitable = isSplitable,
+          maxSplitBytes = maxSplitBytes,
+          partitionValues = partition.values
+        )
       }
     }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
-
     val partitions =
       FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
 

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -596,7 +596,7 @@ case class FileSourceScanExec(
         }
       }
     }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
-    
+
     val partitions =
       FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
 

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.Partition
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.read.InputPartition
+
+/**
+ * A collection of file blocks that should be read as a single task
+ * (possibly from multiple partitioned directories).
+ */
+case class FilePartition(index: Int, files: Array[PartitionedFile])
+  extends Partition with InputPartition {
+  override def preferredLocations(): Array[String] = {
+    // Computes total number of bytes can be retrieved from each host.
+    val hostToNumBytes = mutable.HashMap.empty[String, Long]
+    files.foreach { file =>
+      file.locations.filter(_ != "localhost").foreach { host =>
+        hostToNumBytes(host) = hostToNumBytes.getOrElse(host, 0L) + file.length
+      }
+    }
+
+    // Takes the first 3 hosts with the most data to be retrieved
+    hostToNumBytes.toSeq.sortBy {
+      case (host, numBytes) => numBytes
+    }.reverse.take(3).map {
+      case (host, numBytes) => host
+    }.toArray
+  }
+}
+
+object FilePartition extends Logging {
+
+  def getFilePartitions(
+                         sparkSession: SparkSession,
+                         partitionedFiles: Seq[PartitionedFile],
+                         maxSplitBytes: Long): Seq[FilePartition] = {
+    val partitions = new ArrayBuffer[FilePartition]
+    val currentFiles = new ArrayBuffer[PartitionedFile]
+    var currentSize = 0L
+
+    /** Close the current partition and move to the next. */
+    def closePartition(): Unit = {
+      if (currentFiles.nonEmpty) {
+        // Copy to a new Array.
+        val newPartition = FilePartition(partitions.size, currentFiles.toArray)
+        partitions += newPartition
+      }
+      currentFiles.clear()
+      currentSize = 0
+    }
+
+    val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
+    // Assign files to partitions using "Next Fit Decreasing"
+    partitionedFiles.foreach { file =>
+      if (currentSize + file.length > maxSplitBytes) {
+        closePartition()
+      }
+      // Add the given file to the current partition.
+      currentSize += file.length + openCostInBytes
+      currentFiles += file
+    }
+    closePartition()
+    partitions
+  }
+
+  def maxSplitBytes(
+                     sparkSession: SparkSession,
+                     selectedPartitions: Seq[PartitionDirectory]): Long = {
+    val defaultMaxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
+    val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
+    val defaultParallelism = sparkSession.sparkContext.defaultParallelism
+    val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
+    val bytesPerCore = totalBytes / defaultParallelism
+
+    Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
+  }
+}

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -41,7 +41,7 @@ case class FilePartition(index: Int, files: Array[PartitionedFile])
     }
     res
   } else {
-    null
+    Array[String]()
   }
   override def preferredLocations(): Array[String] = {
     if (conf.get(OapConf.OAP_CLUSTER_CONSISTENTHASH_SCHEDULER_ENABLED)) {

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -56,9 +56,9 @@ case class FilePartition(index: Int, files: Array[PartitionedFile])
 object FilePartition extends Logging {
 
   def getFilePartitions(
-                         sparkSession: SparkSession,
-                         partitionedFiles: Seq[PartitionedFile],
-                         maxSplitBytes: Long): Seq[FilePartition] = {
+      sparkSession: SparkSession,
+      partitionedFiles: Seq[PartitionedFile],
+      maxSplitBytes: Long): Seq[FilePartition] = {
     val partitions = new ArrayBuffer[FilePartition]
     val currentFiles = new ArrayBuffer[PartitionedFile]
     var currentSize = 0L
@@ -89,8 +89,8 @@ object FilePartition extends Logging {
   }
 
   def maxSplitBytes(
-                     sparkSession: SparkSession,
-                     selectedPartitions: Seq[PartitionDirectory]): Long = {
+      sparkSession: SparkSession,
+      selectedPartitions: Seq[PartitionDirectory]): Long = {
     val defaultMaxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
     val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
     val defaultParallelism = sparkSession.sparkContext.defaultParallelism


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove origin report mechanism cache locality awareness, use consistent hash to calculate task localition.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

