### PR TITLE
[oap-native-sql][Scala] fix broadcasthashjoin

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarShuffledHashJoin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarShuffledHashJoin.scala
@@ -84,6 +84,21 @@ class ColumnarShuffledHashJoin(
         build_cb = null
       }
       build_cb = buildIter.next()
+      if (build_cb == null) {
+        val res = new Iterator[ColumnarBatch] {
+          override def hasNext: Boolean = {
+            false
+          }
+
+          override def next(): ColumnarBatch = {
+            val resultColumnVectors = ArrowWritableColumnVector
+              .allocateColumns(0, resultSchema)
+              .toArray
+            new ColumnarBatch(resultColumnVectors.map(_.asInstanceOf[ColumnVector]), 0)
+          }
+        }
+        return res
+      }
       val beforeBuild = System.nanoTime()
       val build_rb = ConverterUtils.createArrowRecordBatch(build_cb)
       (0 until build_cb.numCols).toList.foreach(i =>

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -118,6 +118,7 @@ object ConverterUtils extends Logging {
     val buf = out.buffer
     val bytes = new Array[Byte](buf.readableBytes);
     buf.getBytes(buf.readerIndex, bytes);
+    out.close()
     bytes
   }
 
@@ -127,7 +128,7 @@ object ConverterUtils extends Logging {
       var incorrectInput = false
       var input = new ByteArrayInputStream(data(array_id))
       var reader = new ArrowStreamReader(input, ArrowWritableColumnVector.getNewAllocator)
-      var root = reader.getVectorSchemaRoot()
+      var root :VectorSchemaRoot = null
 
       override def hasNext: Boolean =
         (array_id < (data.size - 1) || input.available > 0) && (!incorrectInput)
@@ -140,6 +141,9 @@ object ConverterUtils extends Logging {
             root = reader.getVectorSchemaRoot()
           }
           reader.loadNextBatch();
+          if (root == null) {
+            root = reader.getVectorSchemaRoot()
+          }
           val length = root.getRowCount
           val vectors = root
             .getFieldVectors()


### PR DESCRIPTION
This patch added a check on hash join, if build iter is empty, we should return immediately. 
Fixes #1599 

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


