### PR TITLE
[OAP-1618][oap-native-sql] Fix columnar reuse exchange

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/CoalesceBatchesExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/CoalesceBatchesExec.scala
@@ -17,8 +17,6 @@
 
 package com.intel.oap.execution
 
-import java.util.concurrent.TimeUnit
-
 import com.intel.oap.vectorized.ArrowWritableColumnVector
 import org.apache.arrow.vector.util.VectorBatchAppender
 import org.apache.spark.TaskContext

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBatchScanExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBatchScanExec.scala
@@ -52,9 +52,7 @@ class ColumnarBatchScanExec(output: Seq[AttributeReference], @transient scan: Sc
 
   override def equals(other: Any): Boolean = other match {
     case that: ColumnarBatchScanExec =>
-      (that canEqual this) && (that eq this)
+      (that canEqual this) && super.equals(that)
     case _ => false
   }
-
-  override def hashCode(): Int = System.identityHashCode(this)
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBroadcastHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBroadcastHashJoinExec.scala
@@ -181,9 +181,7 @@ class ColumnarBroadcastHashJoinExec(
 
   override def equals(other: Any): Boolean = other match {
     case that: ColumnarBroadcastHashJoinExec =>
-      (that canEqual this) && (that eq this)
+      (that canEqual this) && super.equals(that)
     case _ => false
   }
-
-  override def hashCode(): Int = System.identityHashCode(this)
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashAggregateExec.scala
@@ -209,10 +209,7 @@ class ColumnarHashAggregateExec(
 
   override def equals(other: Any): Boolean = other match {
     case that: ColumnarHashAggregateExec =>
-      (that canEqual this) && (that eq this)
+      (that canEqual this) && super.equals(that)
     case _ => false
   }
-
-  override def hashCode(): Int = System.identityHashCode(this)
-
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -168,9 +168,7 @@ class ColumnarShuffledHashJoinExec(
 
   override def equals(other: Any): Boolean = other match {
     case that: ColumnarShuffledHashJoinExec =>
-      (that canEqual this) && (that eq this)
+      (that canEqual this) && super.equals(that)
     case _ => false
   }
-
-  override def hashCode(): Int = System.identityHashCode(this)
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
@@ -140,9 +140,7 @@ class ColumnarSortExec(
 
   override def equals(other: Any): Boolean = other match {
     case that: ColumnarSortExec =>
-      (that canEqual this) && (that eq this)
+      (that canEqual this) && super.equals(that)
     case _ => false
   }
-
-  override def hashCode(): Int = System.identityHashCode(this)
 }

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -133,6 +133,14 @@ class ColumnarShuffleExchangeExec(
 
       override val shuffleHandle: ShuffleHandle = columnarShuffleDependency.shuffleHandle
     }
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[ColumnarShuffleExchangeExec]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ColumnarShuffleExchangeExec =>
+      (that canEqual this) && super.equals(that)
+    case _ => false
+  }
 }
 
 object ColumnarShuffleExchangeExec extends Logging {


### PR DESCRIPTION
## What changes were proposed in this pull request?
ReuseExchange is a spark rule that is used to detect same shuffle map stages by analysing the canonicalized spark plan. It will convert the repeated nodes as a single ReusedExchange leaf node. Thus the shuffle map stage will only compute once and other reduce stages can reuse it's output.
Currently, `equals` method in columnar operators determine whether references are equal but not values, which leads to SparkPlan `this.canonicalized == other.canonicalized` always return false. So ReuseExchange cannot correctly identify the same shuffle map stages.



## How was this patch tested?
Add Scala unit test and manually tested TPCH q18
before
![image](https://user-images.githubusercontent.com/52736607/90505574-6b944300-e185-11ea-95bf-2ee208b6222e.png)

after
![image](https://user-images.githubusercontent.com/52736607/90505447-3ab40e00-e185-11ea-9940-44f92575f220.png)

