### PR TITLE
[SQL Data Source Cache][POAE7-412]Bug fix: can't find OapRpcManagerMaster when restart sparkSession

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
@@ -93,6 +93,7 @@ private[spark] class OapRpcManagerSlave(
 
   override private[spark] def stop(): Unit = {
     oapHeartbeater.shutdown()
+    rpcEnv.shutdown()
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

 can't find OapRpcManagerMaster when restart sparkSession

## How was this patch tested?

e2e test

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

