### PR TITLE
[OAP-1610][Intel-MLlib]Upgrade the mahout-hdfs to version 14.1

### DIFF
--- a/oap-mllib/examples/kmeans-hibench/pom.xml
+++ b/oap-mllib/examples/kmeans-hibench/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.mahout</groupId>
       <artifactId>mahout-hdfs</artifactId>
-      <version>0.13.0</version>
+      <version>14.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade the mahout-hdfs to version 14.1 of mllib-examples to pass Snyk scanning.


## How was this patch tested?

Fix: #1610 
