### PR TITLE
[OAP-1651][oap-native-sql] Adding fallback rules for join/shuffle

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -33,7 +33,7 @@ class ColumnarPluginConfig(conf: SparkConf) {
   val enableJoinOptimizationReplace: Boolean =
     conf.getBoolean("spark.oap.sql.columnar.joinOptimizationReplace", defaultValue = false)
   val joinOptimizationThrottle: Integer =
-    conf.getInt("spark.oap.sql.columnar.joinOptimizationLevel", defaultValue = 9)
+    conf.getInt("spark.oap.sql.columnar.joinOptimizationLevel", defaultValue = 6)
   val enableColumnarShuffle: Boolean = conf
     .get("spark.shuffle.manager", "sort")
     .equals("org.apache.spark.shuffle.sort.ColumnarShuffleManager")

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/RowToArrowColumnarExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/RowToArrowColumnarExec.scala
@@ -293,7 +293,7 @@ case class RowToArrowColumnarExec(child: SparkPlan) extends UnaryExecNode {
               elapse += System.nanoTime() - start
               rowCount += 1
             }
-            vectors.foreach(v => v.asInstanceOf[ArrowWritableColumnVector].setValueCount(numRows))
+            vectors.foreach(v => v.asInstanceOf[ArrowWritableColumnVector].setValueCount(rowCount))
             processTime.set(NANOSECONDS.toMillis(elapse))
             numInputRows += rowCount
             numOutputBatches += 1


### PR DESCRIPTION
This patch adds another fallback rule for joins under some special cases.
Native code doesnt support whole stage code generation yet, there's a performance gap w/ vanilla Spark. e.g, Q72.
The shuffle code will be switch back to row-based operator to get better performance, if  we already fall back to row-based execution for joins. 


Signed-off-by: Chendi Xue <chendi.xue@intel.com>

Fixed: https://github.com/Intel-bigdata/OAP/issues/1651

This Commits depends on arrow commit https://github.com/Intel-bigdata/arrow/pull/92