### PR TITLE
[OAP-1682][oap-native-sql] fix aggregate without codegen

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
@@ -384,8 +384,10 @@ class ColumnarAggregation(
     val aggregateCols : List[ArrowWritableColumnVector]= if (beforeAggregateProjector != null && beforeAggregateProjector.needEvaluate) {
       val res = beforeAggregateProjector.evaluate(numRows, aggregateProjectCols.map(_.getValueVector()))
       aggregateProjectCols.foreach(_.close())
+      aggregateFullCols.foreach(_.close())
       res
     } else {
+      aggregateProjectCols.foreach(_.close())
       aggregateFullCols
     }
 

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
@@ -106,10 +106,11 @@ class ColumnarAggregation(
   })
 
   // 3. map original input to aggregate input
+  val aggregateAttributeList : Seq[Attribute] = aggregateAttributes
   val beforeAggregateExprListBuffer = ListBuffer[Expression]()
   val projectOrdinalListBuffer = ListBuffer[Int]()
   val aggregateFieldListBuffer = ListBuffer[Field]()
-  var aggregateResultAttributesBuffer = ListBuffer[Attribute]()
+  var aggregateResultAttributesBuffer = getAttrForAggregateExpr(aggregateExpressions)
   // we need to remove ordinal used in partial mode expression
   val nonPartialProjectOrdinalList = (0 until originalInputAttributes.size).toList.filter(i => !groupingOrdinalList.contains(i)).to[ListBuffer]
   aggregateExpressions.zipWithIndex.foreach{case(expr, index) => expr.mode match {
@@ -136,7 +137,6 @@ class ColumnarAggregation(
           expr.isDistinct,
           expr.resultId)
         val arg_size = res.requiredColNum
-        val res_size = res.expectedResColNum
         val internalExpressionList = expr.aggregateFunction.children
         val ordinalList = ColumnarProjection.binding(originalInputAttributes, internalExpressionList, index, skipLiteral = true)
         val fieldList = if (arg_size > 0) {
@@ -156,9 +156,7 @@ class ColumnarAggregation(
         fieldList.foreach{field => {
           aggregateFieldListBuffer += field
         }}
-        getAttrForAggregateExpr(expr).foreach(e => aggregateResultAttributesBuffer += e)
         expr.aggregateFunction.children.foreach(e => beforeAggregateExprListBuffer += e)
-        res_field_id += res_size
         res.setInputFields(fieldList.toList)
         res
       }
@@ -169,7 +167,6 @@ class ColumnarAggregation(
           expr.isDistinct,
           expr.resultId)
         val arg_size = res.requiredColNum
-        val res_size = res.expectedResColNum
         val ordinalList = (non_partial_field_id until (non_partial_field_id + arg_size)).map(i => nonPartialProjectOrdinalList(i))
         non_partial_field_id += arg_size
         val fieldList = ordinalList.map(i => {
@@ -185,8 +182,6 @@ class ColumnarAggregation(
         fieldList.foreach{field => {
           aggregateFieldListBuffer += field
         }}
-        (res_field_id until (res_field_id + res_size)).foreach(i => aggregateResultAttributesBuffer += aggregateAttributes(i))
-        res_field_id += res_size
         res.setInputFields(fieldList.toList)
         res
       }
@@ -198,7 +193,8 @@ class ColumnarAggregation(
 
   // 4. create aggregate native Expression
 
-  var projectOrdinalList = projectOrdinalListBuffer.toList.distinct
+  val aggregateOrdinalList = projectOrdinalListBuffer.toList
+  var projectOrdinalList = aggregateOrdinalList.distinct
   val aggregateFieldList = aggregateFieldListBuffer.toList
 
   // 5. create nativeAggregate evaluator
@@ -252,48 +248,114 @@ class ColumnarAggregation(
     elapseTime.merge(aggrTime)
   }
 
-  def getAttrForAggregateExpr(exp: AggregateExpression): List[Attribute] = {
+  def getAttrForAggregateExpr(aggregateExpressions: Seq[AggregateExpression]): ListBuffer[Attribute] = {
     var aggregateAttr = new ListBuffer[Attribute]()
+    val size = aggregateExpressions.size
+    var res_index = 0
+    for (expIdx <- 0 until size) {
+      val exp: AggregateExpression = aggregateExpressions(expIdx)
+      val mode = exp.mode
       val aggregateFunc = exp.aggregateFunction
       aggregateFunc match {
-        case Average(_) =>
-          val avg = aggregateFunc.asInstanceOf[Average]
-          val aggBufferAttr = avg.inputAggBufferAttributes
-          for (index <- 0 until aggBufferAttr.size) {
-            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
-            aggregateAttr += attr
+        case Average(_) => mode match {
+          case Partial => {
+            val avg = aggregateFunc.asInstanceOf[Average]
+            val aggBufferAttr = avg.inputAggBufferAttributes
+            for (index <- 0 until aggBufferAttr.size) {
+              val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
+              aggregateAttr += attr
+            }
+            res_index += 2
           }
-        case Sum(_) =>
-          val sum = aggregateFunc.asInstanceOf[Sum]
-          val aggBufferAttr = sum.inputAggBufferAttributes
-          val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
-          aggregateAttr += attr
-        case Count(_) =>
-          val count = aggregateFunc.asInstanceOf[Count]
-          val aggBufferAttr = count.inputAggBufferAttributes
-          val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
-          aggregateAttr += attr
-        case Max(_) =>
-          val max = aggregateFunc.asInstanceOf[Max]
-          val aggBufferAttr = max.inputAggBufferAttributes
-          val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
-          aggregateAttr += attr
-        case Min(_) =>
-          val min = aggregateFunc.asInstanceOf[Min]
-          val aggBufferAttr = min.inputAggBufferAttributes
-          val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
-          aggregateAttr += attr
-        case StddevSamp(_) =>
-          val stddevSamp = aggregateFunc.asInstanceOf[StddevSamp]
-          val aggBufferAttr = stddevSamp.inputAggBufferAttributes
-          for (index <- 0 until aggBufferAttr.size) {
-            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
-            aggregateAttr += attr
+          case PartialMerge => {
+            val avg = aggregateFunc.asInstanceOf[Average]
+            val aggBufferAttr = avg.inputAggBufferAttributes
+            for (index <- 0 until aggBufferAttr.size) {
+              val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
+              aggregateAttr += attr
+            }
+            res_index += 1
           }
+          case Final => {
+            aggregateAttr += aggregateAttributeList(res_index)
+            res_index += 1
+          }
+        }
+        case Sum(_) => mode match {
+          case Partial | PartialMerge => {
+            val sum = aggregateFunc.asInstanceOf[Sum]
+            val aggBufferAttr = sum.inputAggBufferAttributes
+            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
+            aggregateAttr += attr
+            res_index += 1
+          }
+          case _ => {
+            aggregateAttr += aggregateAttributeList(res_index)
+            res_index += 1
+          }
+        }
+        case Count(_) => mode match {
+          case Partial | PartialMerge => {
+            val count = aggregateFunc.asInstanceOf[Count]
+            val aggBufferAttr = count.inputAggBufferAttributes
+            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
+            aggregateAttr += attr
+            res_index += 1
+          }
+          case _ => {
+            aggregateAttr += aggregateAttributeList(res_index)
+            res_index += 1
+          }
+        }
+        case Max(_) => mode match {
+          case Partial | PartialMerge => {
+            val max = aggregateFunc.asInstanceOf[Max]
+            val aggBufferAttr = max.inputAggBufferAttributes
+            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
+            aggregateAttr += attr
+            res_index += 1
+          }
+          case _ => {
+            aggregateAttr += aggregateAttributeList(res_index)
+            res_index += 1
+          }
+        }
+        case Min(_) => mode match {
+          case Partial | PartialMerge => {
+            val min = aggregateFunc.asInstanceOf[Min]
+            val aggBufferAttr = min.inputAggBufferAttributes
+            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(0))
+            aggregateAttr += attr
+            res_index += 1
+          }
+          case _ => {
+            aggregateAttr += aggregateAttributeList(res_index)
+            res_index += 1
+          }
+        }
+        case StddevSamp(_) => mode match {
+          case Partial => {
+            val stddevSamp = aggregateFunc.asInstanceOf[StddevSamp]
+            val aggBufferAttr = stddevSamp.inputAggBufferAttributes
+            for (index <- 0 until aggBufferAttr.size) {
+              val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
+              aggregateAttr += attr
+            }
+            res_index += 3
+          }
+          case PartialMerge => {
+            throw new UnsupportedOperationException("stddev_samp PartialMerge is not supported.")
+          }
+          case Final => {
+            aggregateAttr += aggregateAttributeList(res_index)
+            res_index += 1
+          }
+        }
         case other =>
           throw new UnsupportedOperationException(s"not currently supported: $other.")
       }
-    aggregateAttr.toList
+    }
+    aggregateAttr
   }
 
   def updateAggregationResult(columnarBatch: ColumnarBatch): Unit = {
@@ -303,6 +365,10 @@ class ColumnarAggregation(
       columnarBatch.column(i).asInstanceOf[ArrowWritableColumnVector]
     })
     val aggregateProjectCols = projectOrdinalList.map(i => {
+      columnarBatch.column(i).asInstanceOf[ArrowWritableColumnVector].retain()
+      columnarBatch.column(i).asInstanceOf[ArrowWritableColumnVector]
+    })
+    val aggregateFullCols = aggregateOrdinalList.map(i => {
       columnarBatch.column(i).asInstanceOf[ArrowWritableColumnVector].retain()
       columnarBatch.column(i).asInstanceOf[ArrowWritableColumnVector]
     })
@@ -320,7 +386,7 @@ class ColumnarAggregation(
       aggregateProjectCols.foreach(_.close())
       res
     } else {
-      aggregateProjectCols
+      aggregateFullCols
     }
 
     val combinedAggregateCols = groupingAggregateCols ::: aggregateCols

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarGroupbyHashAggregation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarGroupbyHashAggregation.scala
@@ -470,9 +470,13 @@ object ColumnarGroupbyHashAggregation extends Logging {
             res_index += 2
           }
           case PartialMerge => {
-            aggregateAttr += aggregateAttributeList(res_index)
-            aggregateAttr += aggregateAttributeList(res_index + 1)
-            res_index += 2
+            val avg = aggregateFunc.asInstanceOf[Average]
+            val aggBufferAttr = avg.inputAggBufferAttributes
+            for (index <- 0 until aggBufferAttr.size) {
+              val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
+              aggregateAttr += attr
+            }
+            res_index += 1
           }
           case Final => {
             aggregateAttr += aggregateAttributeList(res_index)

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
@@ -1437,8 +1437,9 @@ class StddevSampFinalAction : public ActionBase {
     auto builder = new arrow::DoubleBuilder(ctx_->memory_pool());
     for (uint64_t i = 0; i < length; i++) {
       if (cache_count_[offset + i] - 1 < 0.00001) {
-        // append NaN if only one non-null value exists
-        RETURN_NOT_OK(builder->Append(std::numeric_limits<double>::quiet_NaN()));
+        // append Infinity if only one non-null value exists
+        // RETURN_NOT_OK(builder->Append(std::numeric_limits<double>::quiet_NaN()));
+        RETURN_NOT_OK(builder->Append(std::numeric_limits<double>::infinity()));
       } else if (cache_validity_[offset + i]) {
         RETURN_NOT_OK(builder->Append(cache_m2_[offset + i]));
       } else {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/actions_impl.h
@@ -58,6 +58,8 @@ struct FindAccumulatorType<I, arrow::enable_if_floating_point<I>> {
 
 class ActionBase {
  public:
+  virtual ~ActionBase() {}
+
   virtual int RequiredColNum() { return 1; }
 
   virtual arrow::Status Submit(ArrayList in, int max_group_id,

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -95,6 +95,8 @@ class SplitArrayListWithActionKernel::Impl {
         RETURN_NOT_OK(MakeMaxAction(ctx_, type_list[type_id], &action));
       } else if (action_name_list_[action_id].compare("action_sum_count") == 0) {
         RETURN_NOT_OK(MakeSumCountAction(ctx_, type_list[type_id], &action));
+      } else if (action_name_list_[action_id].compare("action_sum_count_merge") == 0) {
+        RETURN_NOT_OK(MakeSumCountMergeAction(ctx_, type_list[type_id], &action));
       } else if (action_name_list_[action_id].compare("action_avgByCount") == 0) {
         RETURN_NOT_OK(MakeAvgByCountAction(ctx_, type_list[type_id], &action));
       } else if (action_name_list_[action_id].compare(0, 20, "action_countLiteral_") ==

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -1108,7 +1108,8 @@ class StddevSampFinalArrayKernel::Impl {
     std::shared_ptr<arrow::Array> stddev_samp_out;
     std::shared_ptr<arrow::Scalar> stddev_samp_scalar_out;
     if (cnt_res - 1 < 0.00001) {
-      double stddev_samp = std::numeric_limits<double>::quiet_NaN();
+      //double stddev_samp = std::numeric_limits<double>::quiet_NaN();
+      double stddev_samp = std::numeric_limits<double>::infinity();
       stddev_samp_scalar_out = arrow::MakeScalar(stddev_samp);
     } else if (cnt_res < 0.00001) {
       stddev_samp_scalar_out = MakeNullScalar(arrow::float64());

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -1188,7 +1188,7 @@ class EncodeArrayTypedImpl : public EncodeArrayKernel::Impl {
     } else {
       for (; cur_id < typed_array->length(); cur_id++) {
         if (typed_array->IsNull(cur_id)) {
-          RETURN_NOT_OK(builder_->AppendNull());
+          hash_table_->GetOrInsertNull(insert_on_found, insert_on_not_found);
         } else {
           hash_table_->GetOrInsert(typed_array->GetView(cur_id), insert_on_found,
                                    insert_on_not_found, &memo_index);

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -35,7 +35,7 @@ namespace extra {
 class KernalBase {
  public:
   KernalBase() {}
-  ~KernalBase() {}
+  virtual ~KernalBase() {}
   virtual arrow::Status Evaluate(const ArrayList& in) {
     return arrow::Status::NotImplemented("Evaluate is abstract interface for ",
                                          kernel_name_, ", input is arrayList.");

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_aggregate.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_aggregate.cc
@@ -161,12 +161,12 @@ TEST(TestArrowCompute, GroupByAggregateWithMultipleBatchTest) {
 
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string = {
-      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]",        "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]",
-      "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",         "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
-      "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]", "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]",
-      "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",        "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
-      "[8, 5, 3, 5, 9, 7, 4, 4, 6, 7]", "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
-      "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"};
+      "[1, 2, 3, 4, 5, null, 6, 7, 8 ,9, 10]",        "[8, 10, 9, 20, 45, 10, 42, 28, 32, 54, 70]",
+      "[8, 5, 3, 5, 9, 2, 7, 4, 4, 6, 7]",         "[1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10]",
+      "[8, 10, 9, 20, 45, 10, 42, 28, 32, 54, 70]", "[8, 5, 3, 5, 9, 2, 7, 4, 4, 6, 7]",
+      "[1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10]",        "[1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10]",
+      "[8, 5, 3, 5, 9, 2, 7, 4, 4, 6, 7]", "[1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10]",
+      "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"};
   auto res_sch = arrow::schema({f_unique, f_sum, f_count, f_avg, f_sum, f_count, 
                                 f_res, f_res, f_count, f_avg, f_m2});
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
@@ -682,8 +682,8 @@ TEST(TestArrowCompute, GroupByStddevSampFinalWithMultipleBatchTest) {
 
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string = {
-      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]", 
-      "[8.49255, 6.93137, 7.6489, 13.5708, 17.4668, 8.52779, 6.23633, 5.58903, 12.535, 24.3544]"};
+      "[1, 2, 3, 4, 5, null, 6, 7, 8 ,9, 10]", 
+      "[8.49255, 6.93137, 7.6489, 13.5708, 17.4668, 1.41421, 8.52779, 6.23633, 5.58903, 12.535, 24.3544]"};
   auto res_sch = arrow::schema({f_unique, f_stddev});
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
   ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
@@ -754,8 +754,8 @@ TEST(TestArrowCompute, GroupbySumCountMergeTest) {
 
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string = {
-      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]",        "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]",
-      "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]"};
+      "[1, 2, 3, 4, 5, null, 6, 7, 8 ,9, 10]",        "[8, 10, 9, 20, 45, 10, 42, 28, 32, 54, 70]",
+      "[8, 10, 9, 20, 45, 10, 42, 28, 32, 54, 70]"};
   auto res_sch = arrow::schema({f_unique, f_sum, f_count});
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
   ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_aggregate.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_aggregate.cc
@@ -689,5 +689,77 @@ TEST(TestArrowCompute, GroupByStddevSampFinalWithMultipleBatchTest) {
   ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
 }
 
+TEST(TestArrowCompute, GroupbySumCountMergeTest) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", float64());
+  auto f2 = field("f2", int64());
+  auto f_unique = field("unique", uint32());
+  auto f_sum = field("sum", float64());
+  auto f_count = field("count", int64());
+  auto f_res = field("res", uint32());
+
+  auto arg_pre = TreeExprBuilder::MakeField(f0);
+  auto n_pre = TreeExprBuilder::MakeFunction("encodeArray", {arg_pre}, uint32());
+
+  auto arg0 = TreeExprBuilder::MakeField(f0);
+  auto arg1 = TreeExprBuilder::MakeField(f1);
+  auto arg2 = TreeExprBuilder::MakeField(f2);
+  auto n_split = TreeExprBuilder::MakeFunction("splitArrayListWithAction",
+                                               {n_pre, arg0, arg1, arg2}, uint32());
+  auto arg_res = TreeExprBuilder::MakeField(f_res);
+  auto n_unique =
+      TreeExprBuilder::MakeFunction("action_unique", {n_split, arg0}, uint32());
+  auto n_merge = TreeExprBuilder::MakeFunction("action_sum_count_merge", 
+                                                {n_split, arg1, arg2}, uint32());
+
+  auto unique_expr = TreeExprBuilder::MakeExpression(n_unique, f_res);
+  auto merge_expr = TreeExprBuilder::MakeExpression(n_merge, f_res);
+
+  std::vector<std::shared_ptr<::gandiva::Expression>> expr_vector = {unique_expr, merge_expr};
+  auto sch = arrow::schema({f0, f1, f2});
+  std::vector<std::shared_ptr<Field>> ret_types = {f_unique, f_sum, f_count};
+
+  /////////////////////// Create Expression Evaluator ////////////////////
+  std::shared_ptr<CodeGenerator> expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, expr_vector, ret_types, &expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> output_batch_list;
+
+  ////////////////////// calculation /////////////////////
+  std::vector<std::string> input_data = {
+      "[1, 2, 3, 4, 5, null, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]",
+      "[1, 2, 3, 4, 5, 5, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]",
+      "[1, 2, 3, 4, 5, 5, 4, 1, 2, 2, 1, 1, 1, 4, 4, 3, 5, 5, 5, 5]"};
+  MakeInputBatch(input_data, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_2 = {
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]",
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]",
+      "[6, 7, 8, 9, 10, 10, 9, 6, 7, 7, 6, 6, 6, 9, 9, 8, 10, 10, 10, 10]"};
+  MakeInputBatch(input_data_2, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  std::vector<std::string> input_data_3 = {
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, null, 8, 5, 5]",
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, 5, 8, 5, 5]",
+      "[1, 2, 3, 8, 5, 5, 10, 1, 2, 7, 6, 6, 1, 9, 4, 9, 5, 8, 5, 5]"};
+  MakeInputBatch(input_data_3, sch, &input_batch);
+  ASSERT_NOT_OK(expr->evaluate(input_batch, &output_batch_list));
+
+  ////////////////////// Finish //////////////////////////
+  std::vector<std::shared_ptr<arrow::RecordBatch>> result_batch;
+  ASSERT_NOT_OK(expr->finish(&result_batch));
+
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 5, 6, 7, 8 ,9, 10]",        "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]",
+      "[8, 10, 9, 20, 45, 42, 28, 32, 54, 70]"};
+  auto res_sch = arrow::schema({f_unique, f_sum, f_count});
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  ASSERT_NOT_OK(Equals(*expected_result.get(), *(result_batch[0]).get()));
+}
+
 }  // namespace codegen
 }  // namespace sparkcolumnarplugin


### PR DESCRIPTION
Fixed query failing and result mismatch when setting "spark.sql.columnar.codegen.hashAggregate" as false.

fixed: https://github.com/Intel-bigdata/OAP/issues/1682

