### PR TITLE
[OAP-CACHE][OAP-1690][POAE7-430]cacheFallBackDetect is not called when initializing OapcacheBackend

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -75,17 +75,17 @@ private[sql] class FiberCacheManager(
     }
 
     val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
-     if (cacheName.equals(MIX_CACHE)) {
-     val separateCache = sparkEnv.conf.getBoolean(
-             OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
-             OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
-     )
-     new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
-     indexCacheGuardianMemorySize, separateCache, sparkEnv)
-     } else {
-     OapCache(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY, dataCacheMemorySize,
-     dataCacheGuardianMemorySize, FiberType.DATA)
-     }
+    if (cacheName.equals(MIX_CACHE)) {
+      val seperateCache = sparkEnv.conf.getBoolean(
+        OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
+        OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
+      )
+      new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
+        indexCacheMemorySize, seperateCache, sparkEnv)
+    } else {
+      OapCache(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY, dataCacheMemorySize,
+        dataCacheGuardianMemorySize, FiberType.DATA)
+    }
   }
 
   def stop(): Unit = {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -81,7 +81,7 @@ private[sql] class FiberCacheManager(
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
       )
       new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
-        indexCacheMemorySize, seperateCache, sparkEnv)
+        indexCacheGuardianMemorySize, seperateCache, sparkEnv)
     } else {
       OapCache(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY, dataCacheMemorySize,
         dataCacheGuardianMemorySize, FiberType.DATA)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -75,27 +75,17 @@ private[sql] class FiberCacheManager(
     }
 
     val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
-    if (cacheName.equals(GUAVA_CACHE)) {
-      new GuavaOapCache(dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
-    } else if (cacheName.equals(SIMPLE_CACHE)) {
-      new SimpleOapCache()
-    } else if (cacheName.equals(NO_EVICT_CACHE)) {
-      new NoEvictPMCache(dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
-    } else if (cacheName.equals(VMEM_CACHE)) {
-      new VMemCache(FiberType.DATA)
-    } else if (cacheName.equals(EXTERNAL_CACHE)) {
-      val cache = new ExternalCache(FiberType.DATA)
-      cache
-    } else if (cacheName.equals(MIX_CACHE)) {
-      val separateCache = sparkEnv.conf.getBoolean(
-        OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
-        OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
-      )
-      new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
-        indexCacheGuardianMemorySize, separateCache, sparkEnv)
-    } else {
-      throw new OapException(s"Unsupported cache strategy $cacheName")
-    }
+     if (cacheName.equals(MIX_CACHE)) {
+     val separateCache = sparkEnv.conf.getBoolean(
+             OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
+             OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
+     )
+     new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
+     indexCacheGuardianMemorySize, separateCache, sparkEnv)
+     } else {
+     OapCache(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY, dataCacheMemorySize,
+     dataCacheGuardianMemorySize, FiberType.DATA)
+     }
   }
 
   def stop(): Unit = {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -76,12 +76,12 @@ private[sql] class FiberCacheManager(
 
     val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
     if (cacheName.equals(MIX_CACHE)) {
-      val seperateCache = sparkEnv.conf.getBoolean(
+      val separateCache = sparkEnv.conf.getBoolean(
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
       )
       new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
-        indexCacheGuardianMemorySize, seperateCache, sparkEnv)
+        indexCacheGuardianMemorySize, separateCache, sparkEnv)
     } else {
       OapCache(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY, dataCacheMemorySize,
         dataCacheGuardianMemorySize, FiberType.DATA)


### PR DESCRIPTION
## What changes were proposed in this pull request?

call OapCache.apply method  instead of directly call new specific CacheBackend like (new VMemCache、new ExternalCache)
Then can go cacheDetectFallBack codepath.

## How was this patch tested?

E2E tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

