### PR TITLE
[OAP-1706][oap-native-sql] Optimize shuffle write

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ShuffleSplitterJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ShuffleSplitterJniWrapper.java
@@ -32,9 +32,17 @@ public class ShuffleSplitterJniWrapper {
    * @param bufferSize size of native buffers hold by each partition writer
    * @param codec compression codec
    * @param dataFile acquired from spark IndexShuffleBlockResolver
+   * @param subDirsPerLocalDir SparkConf spark.diskStore.subDirectories
+   * @param localDirs configured local directories where Spark can write files
    * @return native splitter instance id if created successfully.
    */
-  public long make(NativePartitioning part, int bufferSize, String codec, String dataFile) {
+  public long make(
+      NativePartitioning part,
+      int bufferSize,
+      String codec,
+      String dataFile,
+      int subDirsPerLocalDir,
+      String localDirs) {
     return nativeMake(
         part.getShortName(),
         part.getNumPartitions(),
@@ -42,7 +50,9 @@ public class ShuffleSplitterJniWrapper {
         part.getExprList(),
         bufferSize,
         codec,
-        dataFile);
+        dataFile,
+        subDirsPerLocalDir,
+        localDirs);
   }
 
   public native long nativeMake(
@@ -52,7 +62,9 @@ public class ShuffleSplitterJniWrapper {
       byte[] exprList,
       int bufferSize,
       String codec,
-      String dataFile);
+      String dataFile,
+      int subDirsPerLocalDir,
+      String localDirs);
 
   /**
    * Split one record batch represented by bufAddrs and bufSizes into several batches. The batch is

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ShuffleSplitterJniWrapper.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/ShuffleSplitterJniWrapper.java
@@ -30,28 +30,19 @@ public class ShuffleSplitterJniWrapper {
    *
    * @param part contains the partitioning parameter needed by native splitter
    * @param bufferSize size of native buffers hold by each partition writer
-   * @param subDirsPerLocalDir SparkConf spark.diskStore.subDirectories
-   * @param localDirs configured local directories where Spark can write files
    * @param codec compression codec
+   * @param dataFile acquired from spark IndexShuffleBlockResolver
    * @return native splitter instance id if created successfully.
-   * @throws RuntimeException
    */
-  public long make(
-      NativePartitioning part,
-      int bufferSize,
-      int subDirsPerLocalDir,
-      String localDirs,
-      String codec)
-      throws RuntimeException {
+  public long make(NativePartitioning part, int bufferSize, String codec, String dataFile) {
     return nativeMake(
         part.getShortName(),
         part.getNumPartitions(),
         part.getSchema(),
         part.getExprList(),
         bufferSize,
-        subDirsPerLocalDir,
-        localDirs,
-        codec);
+        codec,
+        dataFile);
   }
 
   public native long nativeMake(
@@ -60,10 +51,8 @@ public class ShuffleSplitterJniWrapper {
       byte[] schema,
       byte[] exprList,
       int bufferSize,
-      int subDirsPerLocalDir,
-      String localDirs,
-      String codec)
-      throws RuntimeException;
+      String codec,
+      String dataFile);
 
   /**
    * Split one record batch represented by bufAddrs and bufSizes into several batches. The batch is
@@ -74,10 +63,9 @@ public class ShuffleSplitterJniWrapper {
    * @param numRows Rows per batch
    * @param bufAddrs Addresses of buffers
    * @param bufSizes Sizes of buffers
-   * @throws RuntimeException
    */
   public native void split(long splitterId, int numRows, long[] bufAddrs, long[] bufSizes)
-      throws RuntimeException;
+      throws IOException;
 
   /**
    * Write the data remained in the buffers hold by native splitter to each partition's temporary
@@ -85,9 +73,8 @@ public class ShuffleSplitterJniWrapper {
    *
    * @param splitterId splitter instance id
    * @return SplitResult
-   * @throws RuntimeException
    */
-  public native SplitResult stop(long splitterId) throws RuntimeException;
+  public native SplitResult stop(long splitterId) throws IOException;
 
   /**
    * Release resources associated with designated splitter instance.

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SplitResult.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SplitResult.java
@@ -22,17 +22,17 @@ public class SplitResult {
   private final long totalComputePidTime;
   private final long totalWriteTime;
   private final long totalBytesWritten;
-  private final PartitionFileInfo[] partitionFileInfo;
+  private final long[] partitionLengths;
 
   public SplitResult(
       long totalComputePidTime,
       long totalWriteTime,
       long totalBytesWritten,
-      PartitionFileInfo[] partitionFileInfo) {
+      long[] partitionLengths) {
     this.totalComputePidTime = totalComputePidTime;
     this.totalWriteTime = totalWriteTime;
     this.totalBytesWritten = totalBytesWritten;
-    this.partitionFileInfo = partitionFileInfo;
+    this.partitionLengths = partitionLengths;
   }
 
   public long getTotalComputePidTime() {
@@ -47,7 +47,7 @@ public class SplitResult {
     return totalBytesWritten;
   }
 
-  public PartitionFileInfo[] getPartitionFileInfo() {
-    return partitionFileInfo;
+  public long[] getPartitionLengths() {
+    return partitionLengths;
   }
 }

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SplitResult.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SplitResult.java
@@ -21,16 +21,19 @@ package com.intel.oap.vectorized;
 public class SplitResult {
   private final long totalComputePidTime;
   private final long totalWriteTime;
+  private final long totalSpillTime;
   private final long totalBytesWritten;
   private final long[] partitionLengths;
 
   public SplitResult(
       long totalComputePidTime,
       long totalWriteTime,
+      long totalSpillTime,
       long totalBytesWritten,
       long[] partitionLengths) {
     this.totalComputePidTime = totalComputePidTime;
     this.totalWriteTime = totalWriteTime;
+    this.totalSpillTime = totalSpillTime;
     this.totalBytesWritten = totalBytesWritten;
     this.partitionLengths = partitionLengths;
   }
@@ -41,6 +44,10 @@ public class SplitResult {
 
   public long getTotalWriteTime() {
     return totalWriteTime;
+  }
+
+  public long getTotalSpillTime() {
+    return totalSpillTime;
   }
 
   public long getTotalBytesWritten() {

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SplitResult.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SplitResult.java
@@ -23,6 +23,7 @@ public class SplitResult {
   private final long totalWriteTime;
   private final long totalSpillTime;
   private final long totalBytesWritten;
+  private final long totalBytesSpilled;
   private final long[] partitionLengths;
 
   public SplitResult(
@@ -30,11 +31,13 @@ public class SplitResult {
       long totalWriteTime,
       long totalSpillTime,
       long totalBytesWritten,
+      long totalBytesSpilled,
       long[] partitionLengths) {
     this.totalComputePidTime = totalComputePidTime;
     this.totalWriteTime = totalWriteTime;
     this.totalSpillTime = totalSpillTime;
     this.totalBytesWritten = totalBytesWritten;
+    this.totalBytesSpilled = totalBytesSpilled;
     this.partitionLengths = partitionLengths;
   }
 
@@ -52,6 +55,10 @@ public class SplitResult {
 
   public long getTotalBytesWritten() {
     return totalBytesWritten;
+  }
+
+  public long getTotalBytesSpilled() {
+    return totalBytesSpilled;
   }
 
   public long[] getPartitionLengths() {

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleDependency.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleDependency.scala
@@ -41,6 +41,7 @@ import scala.reflect.ClassTag
  * @param shuffleWriterProcessor the processor to control the write behavior in ShuffleMapTask
  * @param nativePartitioning     hold partitioning parameters needed by native splitter
  * @param dataSize for shuffle data size tracking
+ * @param bytesSpilled for shuffle spill size tracking
  * @param computePidTime partition id computation time metric
  * @param splitTime native split time metric
  */
@@ -54,6 +55,7 @@ class ColumnarShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     override val shuffleWriterProcessor: ShuffleWriteProcessor = new ShuffleWriteProcessor,
     val nativePartitioning: NativePartitioning,
     val dataSize: SQLMetric,
+    val bytesSpilled: SQLMetric,
     val numInputRows: SQLMetric,
     val computePidTime: SQLMetric,
     val splitTime: SQLMetric,

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleDependency.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleDependency.scala
@@ -56,7 +56,8 @@ class ColumnarShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     val dataSize: SQLMetric,
     val numInputRows: SQLMetric,
     val computePidTime: SQLMetric,
-    val splitTime: SQLMetric)
+    val splitTime: SQLMetric,
+    val spillTime: SQLMetric)
     extends ShuffleDependency[K, V, C](
       _rdd,
       partitioner,

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -127,8 +127,9 @@ class ColumnarShuffleWriter[K, V](
       .nanoTime() - startTime - splitResult.getTotalSpillTime - splitResult.getTotalWriteTime - splitResult.getTotalComputePidTime)
     dep.spillTime.add(splitResult.getTotalSpillTime)
     dep.computePidTime.add(splitResult.getTotalComputePidTime)
+    dep.bytesSpilled.add(splitResult.getTotalBytesSpilled)
     writeMetrics.incBytesWritten(splitResult.getTotalBytesWritten)
-    writeMetrics.incWriteTime(splitResult.getTotalWriteTime)
+    writeMetrics.incWriteTime(splitResult.getTotalWriteTime + splitResult.getTotalSpillTime)
 
     partitionLengths = splitResult.getPartitionLengths
     try {

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -29,7 +29,9 @@ import com.intel.oap.vectorized.{
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.shuffle.IndexShuffleBlockResolver.NOOP_REDUCE_ID
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.storage.ShuffleIndexBlockId
 import org.apache.spark.util.Utils
 
 import scala.collection.mutable.ListBuffer
@@ -55,10 +57,8 @@ class ColumnarShuffleWriter[K, V](
 
   private var mapStatus: MapStatus = _
 
-  private val localDirs = blockManager.diskBlockManager.localDirs.mkString(",")
   private val nativeBufferSize =
     conf.getInt("spark.sql.execution.arrow.maxRecordsPerBatch", 4096)
-  private val transeferToEnabled = conf.getBoolean("spark.file.transferTo", true)
   private val compressionCodec = if (conf.getBoolean("spark.shuffle.compress", true)) {
     conf.get("spark.io.compression.codec", "lz4")
   } else {
@@ -82,13 +82,13 @@ class ColumnarShuffleWriter[K, V](
       return
     }
 
+    val dataTmp = Utils.tempFileWith(shuffleBlockResolver.getDataFile(dep.shuffleId, mapId))
     if (nativeSplitter == 0) {
       nativeSplitter = jniWrapper.make(
         dep.nativePartitioning,
         nativeBufferSize,
-        blockManager.subDirsPerLocalDir,
-        localDirs,
-        compressionCodec)
+        compressionCodec,
+        dataTmp.getAbsolutePath)
     }
 
     while (records.hasNext) {
@@ -119,26 +119,29 @@ class ColumnarShuffleWriter[K, V](
 
     val startTime = System.nanoTime()
     splitResult = jniWrapper.stop(nativeSplitter)
+
     dep.splitTime.add(System
       .nanoTime() - startTime - splitResult.getTotalWriteTime - splitResult.getTotalComputePidTime)
     dep.computePidTime.add(splitResult.getTotalComputePidTime)
     writeMetrics.incBytesWritten(splitResult.getTotalBytesWritten)
+    writeMetrics.incWriteTime(splitResult.getTotalWriteTime)
 
-    val output = shuffleBlockResolver.getDataFile(dep.shuffleId, mapId)
-    val tmp = Utils.tempFileWith(output)
+    partitionLengths = splitResult.getPartitionLengths
     try {
-      partitionLengths = writePartitionedFile(tmp)
-      shuffleBlockResolver.writeIndexFileAndCommit(dep.shuffleId, mapId, partitionLengths, tmp)
+      shuffleBlockResolver.writeIndexFileAndCommit(
+        dep.shuffleId,
+        mapId,
+        partitionLengths,
+        dataTmp)
     } finally {
-      if (tmp.exists() && !tmp.delete()) {
-        logError(s"Error while deleting temp file ${tmp.getAbsolutePath}")
+      if (dataTmp.exists() && !dataTmp.delete()) {
+        logError(s"Error while deleting temp file ${dataTmp.getAbsolutePath}")
       }
     }
     mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
   }
 
   override def stop(success: Boolean): Option[MapStatus] = {
-
     try {
       if (stopping) {
         None
@@ -150,71 +153,11 @@ class ColumnarShuffleWriter[K, V](
         None
       }
     } finally {
-      // delete the temporary files hold by native splitter
       if (nativeSplitter != 0) {
-        try {
-          splitResult.getPartitionFileInfo.foreach { fileInfo =>
-            {
-              val pid = fileInfo.getPartitionId
-              val file = new File(fileInfo.getFilePath)
-              if (file.exists()) {
-                if (!file.delete()) {
-                  logError(s"Unable to delete file for partition ${pid}")
-                }
-              }
-            }
-          }
-        } finally {
-          jniWrapper.close(nativeSplitter)
-          nativeSplitter = 0
-        }
+        jniWrapper.close(nativeSplitter)
+        nativeSplitter = 0
       }
     }
-  }
-
-  @throws[IOException]
-  private def writePartitionedFile(outputFile: File): Array[Long] = {
-
-    val lengths = new Array[Long](dep.partitioner.numPartitions)
-    val out = new FileOutputStream(outputFile, true)
-    val writerStartTime = System.nanoTime()
-    var threwException = true
-
-    try {
-      splitResult.getPartitionFileInfo.foreach { fileInfo =>
-        {
-          val pid = fileInfo.getPartitionId
-          val filePath = fileInfo.getFilePath
-
-          val file = new File(filePath)
-          if (file.exists()) {
-            val in = new FileInputStream(file)
-            var copyThrewException = true
-
-            try {
-              lengths(pid) = Utils.copyStream(in, out, false, transeferToEnabled)
-              copyThrewException = false
-            } finally {
-              Closeables.close(in, copyThrewException)
-            }
-            if (!file.delete()) {
-              logError(s"Unable to delete file for partition ${pid}")
-            } else {
-              logDebug(s"Deleting temporary shuffle file ${filePath} for partition ${pid}")
-            }
-          } else {
-            logWarning(
-              s"Native shuffle writer temporary file ${filePath} for partition ${pid} not exists")
-          }
-        }
-      }
-      threwException = false
-    } finally {
-      Closeables.close(out, threwException)
-      val writeTime = System.nanoTime - writerStartTime + splitResult.getTotalWriteTime
-      writeMetrics.incWriteTime(writeTime)
-    }
-    lengths
   }
 
   @VisibleForTesting

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -57,6 +57,7 @@ class ColumnarShuffleWriter[K, V](
 
   private var mapStatus: MapStatus = _
 
+  private val localDirs = blockManager.diskBlockManager.localDirs.mkString(",")
   private val nativeBufferSize =
     conf.getInt("spark.sql.execution.arrow.maxRecordsPerBatch", 4096)
   private val compressionCodec = if (conf.getBoolean("spark.shuffle.compress", true)) {
@@ -88,7 +89,9 @@ class ColumnarShuffleWriter[K, V](
         dep.nativePartitioning,
         nativeBufferSize,
         compressionCodec,
-        dataTmp.getAbsolutePath)
+        dataTmp.getAbsolutePath,
+        blockManager.subDirsPerLocalDir,
+        localDirs)
     }
 
     while (records.hasNext) {

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -121,7 +121,8 @@ class ColumnarShuffleWriter[K, V](
     splitResult = jniWrapper.stop(nativeSplitter)
 
     dep.splitTime.add(System
-      .nanoTime() - startTime - splitResult.getTotalWriteTime - splitResult.getTotalComputePidTime)
+      .nanoTime() - startTime - splitResult.getTotalSpillTime - splitResult.getTotalWriteTime - splitResult.getTotalComputePidTime)
+    dep.spillTime.add(splitResult.getTotalSpillTime)
     dep.computePidTime.add(splitResult.getTotalComputePidTime)
     writeMetrics.incBytesWritten(splitResult.getTotalBytesWritten)
     writeMetrics.incWriteTime(splitResult.getTotalWriteTime)

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -116,8 +116,8 @@ class ColumnarShuffleWriter[K, V](
         jniWrapper.split(nativeSplitter, cb.numRows, bufAddrs.toArray, bufSizes.toArray)
         dep.splitTime.add(System.nanoTime() - startTime)
         dep.numInputRows.add(cb.numRows)
+        writeMetrics.incRecordsWritten(1)
       }
-      writeMetrics.incRecordsWritten(1)
     }
 
     val startTime = System.nanoTime()

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -72,6 +72,7 @@ class ColumnarShuffleExchangeExec(
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),
     "computePidTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_computepid"),
     "splitTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_split"),
+    "spillTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_spill"),
     "avgReadBatchNumRows" -> SQLMetrics
       .createAverageMetric(sparkContext, "avg read batch num rows"),
     "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
@@ -113,7 +114,8 @@ class ColumnarShuffleExchangeExec(
       longMetric("dataSize"),
       longMetric("numInputRows"),
       longMetric("computePidTime"),
-      longMetric("splitTime"))
+      longMetric("splitTime"),
+      longMetric("spillTime"))
   }
 
   private var cachedShuffleRDD: ShuffledColumnarBatchRDD = _
@@ -174,7 +176,8 @@ object ColumnarShuffleExchangeExec extends Logging {
       dataSize: SQLMetric,
       numInputRows: SQLMetric,
       computePidTime: SQLMetric,
-      splitTime: SQLMetric): ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
+      splitTime: SQLMetric,
+      spillTime: SQLMetric): ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
 
     val arrowFields = outputAttributes.map(attr => {
       Field
@@ -325,7 +328,8 @@ object ColumnarShuffleExchangeExec extends Logging {
         dataSize = dataSize,
         numInputRows = numInputRows,
         computePidTime = computePidTime,
-        splitTime = splitTime)
+        splitTime = splitTime,
+        spillTime = spillTime)
 
     dependency
   }

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -70,9 +70,10 @@ class ColumnarShuffleExchangeExec(
     SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),
+    "bytesSpilled" -> SQLMetrics.createSizeMetric(sparkContext, "shuffle bytes spilled"),
     "computePidTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_computepid"),
     "splitTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_split"),
-    "spillTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_spill"),
+    "spillTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "shuffle spill time"),
     "avgReadBatchNumRows" -> SQLMetrics
       .createAverageMetric(sparkContext, "avg read batch num rows"),
     "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
@@ -112,6 +113,7 @@ class ColumnarShuffleExchangeExec(
       serializer,
       writeMetrics,
       longMetric("dataSize"),
+      longMetric("bytesSpilled"),
       longMetric("numInputRows"),
       longMetric("computePidTime"),
       longMetric("splitTime"),
@@ -174,6 +176,7 @@ object ColumnarShuffleExchangeExec extends Logging {
       serializer: Serializer,
       writeMetrics: Map[String, SQLMetric],
       dataSize: SQLMetric,
+      bytesSpilled: SQLMetric,
       numInputRows: SQLMetric,
       computePidTime: SQLMetric,
       splitTime: SQLMetric,
@@ -326,6 +329,7 @@ object ColumnarShuffleExchangeExec extends Logging {
         shuffleWriterProcessor = createShuffleWriteProcessor(writeMetrics),
         nativePartitioning = nativePartitioning,
         dataSize = dataSize,
+        bytesSpilled = bytesSpilled,
         numInputRows = numInputRows,
         computePidTime = computePidTime,
         splitTime = splitTime,

--- a/oap-native-sql/core/src/test/scala/org/apache/spark/shuffle/ColumnarShuffleWriterSuite.scala
+++ b/oap-native-sql/core/src/test/scala/org/apache/spark/shuffle/ColumnarShuffleWriterSuite.scala
@@ -90,6 +90,8 @@ class ColumnarShuffleWriterSuite extends SharedSparkSession {
       .thenReturn(SQLMetrics.createMetric(spark.sparkContext, "number of input rows"))
     when(dependency.splitTime)
       .thenReturn(SQLMetrics.createNanoTimingMetric(spark.sparkContext, "totaltime_split"))
+    when(dependency.spillTime)
+      .thenReturn(SQLMetrics.createNanoTimingMetric(spark.sparkContext, "totaltime_spill"))
     when(dependency.computePidTime)
       .thenReturn(SQLMetrics.createNanoTimingMetric(spark.sparkContext, "totaltime_computepid"))
     when(taskContext.taskMetrics()).thenReturn(taskMetrics)

--- a/oap-native-sql/core/src/test/scala/org/apache/spark/shuffle/ColumnarShuffleWriterSuite.scala
+++ b/oap-native-sql/core/src/test/scala/org/apache/spark/shuffle/ColumnarShuffleWriterSuite.scala
@@ -52,7 +52,6 @@ class ColumnarShuffleWriterSuite extends SharedSparkSession {
   override def sparkConf: SparkConf =
     super.sparkConf
       .setAppName("test ColumnarShuffleWriter")
-      .set("spark.file.transferTo", "true")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set("spark.sql.execution.arrow.maxRecordsPerBatch", "4096")
 

--- a/oap-native-sql/core/src/test/scala/org/apache/spark/shuffle/ColumnarShuffleWriterSuite.scala
+++ b/oap-native-sql/core/src/test/scala/org/apache/spark/shuffle/ColumnarShuffleWriterSuite.scala
@@ -86,6 +86,8 @@ class ColumnarShuffleWriterSuite extends SharedSparkSession {
       new NativePartitioning("rr", numPartitions, ConverterUtils.getSchemaBytesBuf(schema)))
     when(dependency.dataSize)
       .thenReturn(SQLMetrics.createSizeMetric(spark.sparkContext, "data size"))
+    when(dependency.bytesSpilled)
+      .thenReturn(SQLMetrics.createSizeMetric(spark.sparkContext, "shuffle bytes spilled"))
     when(dependency.numInputRows)
       .thenReturn(SQLMetrics.createMetric(spark.sparkContext, "number of input rows"))
     when(dependency.splitTime)

--- a/oap-native-sql/cpp/src/jni/jni_wrapper.cc
+++ b/oap-native-sql/cpp/src/jni/jni_wrapper.cc
@@ -67,6 +67,7 @@ static arrow::jni::ConcurrentMap<std::shared_ptr<CodeGenerator>> handler_holder_
 static arrow::jni::ConcurrentMap<std::shared_ptr<ResultIterator<arrow::RecordBatch>>>
     batch_iterator_holder_;
 
+using sparkcolumnarplugin::shuffle::SplitOptions;
 using sparkcolumnarplugin::shuffle::Splitter;
 static arrow::jni::ConcurrentMap<std::shared_ptr<Splitter>> shuffle_splitter_holder_;
 static arrow::jni::ConcurrentMap<std::shared_ptr<arrow::Schema>>
@@ -89,15 +90,6 @@ std::shared_ptr<ResultIterator<arrow::RecordBatch>> GetBatchIterator(JNIEnv* env
     env->ThrowNew(illegal_argument_exception_class, error_message.c_str());
   }
   return handler;
-}
-
-std::shared_ptr<Splitter> GetShuffleSplitter(JNIEnv* env, jlong id) {
-  auto splitter = shuffle_splitter_holder_.Lookup(id);
-  if (!splitter) {
-    std::string error_message = "invalid reader id " + std::to_string(id);
-    env->ThrowNew(illegal_argument_exception_class, error_message.c_str());
-  }
-  return splitter;
 }
 
 jobject MakeRecordBatchBuilder(JNIEnv* env, std::shared_ptr<arrow::Schema> schema,
@@ -205,16 +197,9 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   arrowbuf_builder_constructor =
       GetMethodID(env, arrowbuf_builder_class, "<init>", "(JJIJ)V");
 
-  partition_file_info_class =
-      CreateGlobalClassReference(env, "Lcom/intel/oap/vectorized/PartitionFileInfo;");
-  partition_file_info_constructor =
-      GetMethodID(env, partition_file_info_class, "<init>", "(ILjava/lang/String;)V");
-
   split_result_class =
       CreateGlobalClassReference(env, "Lcom/intel/oap/vectorized/SplitResult;");
-  split_result_constructor =
-      GetMethodID(env, split_result_class, "<init>",
-                  "(JJJ[Lcom/intel/oap/vectorized/PartitionFileInfo;)V");
+  split_result_constructor = GetMethodID(env, split_result_class, "<init>", "(JJJ[J)V");
 
   return JNI_VERSION;
 }
@@ -232,7 +217,6 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   env->DeleteGlobalRef(arrow_field_node_builder_class);
   env->DeleteGlobalRef(arrowbuf_builder_class);
   env->DeleteGlobalRef(arrow_record_batch_builder_class);
-  env->DeleteGlobalRef(partition_file_info_class);
   env->DeleteGlobalRef(split_result_class);
 
   buffer_holder_.Clear();
@@ -1124,78 +1108,69 @@ Java_com_intel_oap_datasource_parquet_ParquetWriterJniWrapper_nativeWriteNext(
 JNIEXPORT jlong JNICALL
 Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_nativeMake(
     JNIEnv* env, jobject, jstring partitioning_name_jstr, jint num_partitions,
-    jbyteArray schema_arr, jbyteArray expr_arr, jint buffer_size, jint num_sub_dirs,
-    jstring local_dirs_jstr, jstring codec_jstr) {
-  std::shared_ptr<arrow::Schema> schema;
-
-  auto status = MakeSchema(env, schema_arr, &schema);
-  if (!status.ok()) {
-    env->ThrowNew(
-        io_exception_class,
-        std::string("Failed to readSchema, err msg is " + status.message()).c_str());
-  }
-
-  auto local_dirs = env->GetStringUTFChars(local_dirs_jstr, JNI_FALSE);
-  setenv("NATIVESQL_SPARK_LOCAL_DIRS", local_dirs, 1);
-  env->ReleaseStringUTFChars(local_dirs_jstr, local_dirs);
-
-  auto compression_type = arrow::Compression::UNCOMPRESSED;
-  if (codec_jstr != NULL) {
-    auto codec_l = env->GetStringUTFChars(codec_jstr, JNI_FALSE);
-    std::string codec_u;
-    std::transform(codec_l, codec_l + std::strlen(codec_l), std::back_inserter(codec_u),
-                   ::toupper);
-
-    auto codec_result = arrow::util::Codec::GetCompressionType(codec_u);
-    if (!codec_result.ok()) {
-      std::string error_message = "Failed to get arrow compression type, err msg is " +
-                                  codec_result.status().message();
-      env->ThrowNew(io_exception_class, std::string("").c_str());
-    }
-    compression_type = *codec_result;
-
-    if (compression_type == arrow::Compression::LZ4) {
-      compression_type = arrow::Compression::LZ4_FRAME;
-    }
-    env->ReleaseStringUTFChars(codec_jstr, codec_l);
-  }
-
+    jbyteArray schema_arr, jbyteArray expr_arr, jint buffer_size,
+    jstring compression_type_jstr, jstring data_file_jstr) {
   if (partitioning_name_jstr == NULL) {
-    env->ThrowNew(io_exception_class,
-                  std::string("short partitioning name is null").c_str());
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Short partitioning name can't be null").c_str());
+    return 0;
   }
+  if (schema_arr == NULL) {
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Make splitter schema can't be null").c_str());
+    return 0;
+  }
+  if (data_file_jstr == NULL) {
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Shuffle DataFile can't be null").c_str());
+    return 0;
+  }
+
   auto partitioning_name_c = env->GetStringUTFChars(partitioning_name_jstr, JNI_FALSE);
   auto partitioning_name = std::string(partitioning_name_c);
-
-  arrow::Result<std::shared_ptr<Splitter>> make_result;
-
-  if (expr_arr != NULL) {
-    gandiva::ExpressionVector expr_vector;
-    gandiva::FieldVector ret_types;
-    auto msg = MakeExprVector(env, expr_arr, &expr_vector, &ret_types);
-    if (!msg.ok()) {
-      std::string error_message =
-          "Failed to parse expressions protobuf, err msg is " + msg.message();
-      env->ThrowNew(io_exception_class, error_message.c_str());
-    }
-    make_result = Splitter::Make(partitioning_name, std::move(schema),
-                                 (int32_t)num_partitions, std::move(expr_vector));
-  } else {
-    make_result =
-        Splitter::Make(partitioning_name, std::move(schema), (int32_t)num_partitions);
-  }
-
-  if (!make_result.ok()) {
-    std::string error_message = "Failed create native shuffle splitter, err msg is " +
-                                make_result.status().message();
-    env->ThrowNew(io_exception_class, std::string("").c_str());
-  }
-  auto splitter = std::move(*make_result);
-  splitter->set_compression_type(compression_type);
-  splitter->set_buffer_size((int32_t)buffer_size);
-  splitter->set_num_sub_dirs((int32_t)num_sub_dirs);
-
   env->ReleaseStringUTFChars(partitioning_name_jstr, partitioning_name_c);
+
+  auto splitOptions = SplitOptions::Defaults();
+  splitOptions.buffer_size = buffer_size;
+
+  if (compression_type_jstr != NULL) {
+    auto compression_type_result = GetCompressionType(env, compression_type_jstr);
+    if (compression_type_result.status().ok()) {
+      splitOptions.compression_type = compression_type_result.MoveValueUnsafe();
+    }
+  }
+
+  auto data_file_c = env->GetStringUTFChars(data_file_jstr, JNI_FALSE);
+  splitOptions.data_file = std::string(data_file_c);
+  env->ReleaseStringUTFChars(data_file_jstr, data_file_c);
+
+  std::shared_ptr<arrow::Schema> schema;
+  // ValueOrDie in MakeSchema
+  MakeSchema(env, schema_arr, &schema);
+
+  gandiva::ExpressionVector expr_vector = {};
+  if (expr_arr != NULL) {
+    gandiva::FieldVector ret_types;
+    auto status = MakeExprVector(env, expr_arr, &expr_vector, &ret_types);
+    if (!status.ok()) {
+      env->ThrowNew(
+          illegal_argument_exception_class,
+          std::string("Failed to parse expressions protobuf, error message is " +
+                      status.message())
+              .c_str());
+      return 0;
+    }
+  }
+  auto make_result = Splitter::Make(partitioning_name, std::move(schema), num_partitions,
+                                    expr_vector, std::move(splitOptions));
+  if (!make_result.ok()) {
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Failed create native shuffle splitter, error message is " +
+                              make_result.status().message())
+                      .c_str());
+    return 0;
+  }
+  auto splitter = make_result.MoveValueUnsafe();
 
   return shuffle_splitter_holder_.Insert(std::shared_ptr<Splitter>(splitter));
 }
@@ -1203,14 +1178,31 @@ Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_nativeMake(
 JNIEXPORT void JNICALL Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_split(
     JNIEnv* env, jobject, jlong splitter_id, jint num_rows, jlongArray buf_addrs,
     jlongArray buf_sizes) {
-  auto splitter = GetShuffleSplitter(env, splitter_id);
+  auto splitter = shuffle_splitter_holder_.Lookup(splitter_id);
+  if (!splitter) {
+    std::string error_message = "Invalid splitter id " + std::to_string(splitter_id);
+    env->ThrowNew(illegal_argument_exception_class, error_message.c_str());
+    return;
+  }
+  if (buf_addrs == NULL) {
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Native split: buf_addrs can't be null").c_str());
+    return;
+  }
+  if (buf_sizes == NULL) {
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Native split: buf_sizes can't be null").c_str());
+    return;
+  }
 
   int in_bufs_len = env->GetArrayLength(buf_addrs);
   if (in_bufs_len != env->GetArrayLength(buf_sizes)) {
-    std::string error_message =
-        "native split: mismatch in arraylen of buf_addrs and buf_sizes";
-    env->ThrowNew(io_exception_class, error_message.c_str());
+    env->ThrowNew(
+        illegal_argument_exception_class,
+        std::string("Native split: length of buf_addrs and buf_sizes mismatch").c_str());
+    return;
   }
+
   jlong* in_buf_addrs = env->GetLongArrayElements(buf_addrs, JNI_FALSE);
   jlong* in_buf_sizes = env->GetLongArrayElements(buf_sizes, JNI_FALSE);
 
@@ -1222,58 +1214,52 @@ JNIEXPORT void JNICALL Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_s
   env->ReleaseLongArrayElements(buf_sizes, in_buf_sizes, JNI_ABORT);
 
   if (!status.ok()) {
-    env->ThrowNew(io_exception_class,
-                  std::string("native split: make record batch failed").c_str());
+    env->ThrowNew(
+        illegal_argument_exception_class,
+        std::string("Native split: make record batch failed, error message is " +
+                    status.message())
+            .c_str());
+    return;
   }
 
   status = splitter->Split(*in);
 
   if (!status.ok()) {
+    // Throw IOException
     env->ThrowNew(io_exception_class,
-                  std::string("native split: splitter split failed").c_str());
+                  std::string("Native split: splitter split failed, error message is " +
+                              status.message())
+                      .c_str());
   }
 }
 
 JNIEXPORT jobject JNICALL Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_stop(
     JNIEnv* env, jobject, jlong splitter_id) {
-  auto splitter = GetShuffleSplitter(env, splitter_id);
-  auto stop_status = splitter->Stop();
+  auto splitter = shuffle_splitter_holder_.Lookup(splitter_id);
+  if (!splitter) {
+    std::string error_message = "Invalid splitter id " + std::to_string(splitter_id);
+    env->ThrowNew(illegal_argument_exception_class, error_message.c_str());
+    return nullptr;
+  }
 
-  if (!stop_status.ok()) {
+  auto status = splitter->Stop();
+
+  if (!status.ok()) {
+    // Throw IOException
     env->ThrowNew(io_exception_class,
-                  std::string("native split: splitter stop failed, error message is " +
-                              stop_status.message())
+                  std::string("Native split: splitter stop failed, error message is " +
+                              status.message())
                       .c_str());
+    return nullptr;
   }
 
-  // TotalComputePidTime
-  auto compute_pid_time = static_cast<jlong>(splitter->TotalComputePidTime());
-
-  // TotalWriteTime
-  auto write_time = static_cast<jlong>(splitter->TotalWriteTime());
-
-  // TotalBytesWritten
-  auto bytes_written = static_cast<jlong>(splitter->TotalBytesWritten());
-
-  // GetPartitionFileInfo
-  const auto& partition_file_info = splitter->GetPartitionFileInfo();
-  auto valid_num_partitions = partition_file_info.size();
-
-  jobjectArray partition_file_info_array =
-      env->NewObjectArray(valid_num_partitions, partition_file_info_class, nullptr);
-
-  for (auto i = 0; i < valid_num_partitions; ++i) {
-    jobject file_info_obj =
-        env->NewObject(partition_file_info_class, partition_file_info_constructor,
-                       partition_file_info[i].first,
-                       env->NewStringUTF(partition_file_info[i].second.c_str()));
-    env->SetObjectArrayElement(partition_file_info_array, i, file_info_obj);
-  }
-
-  // build SplitResult
-  jobject split_result =
-      env->NewObject(split_result_class, split_result_constructor, compute_pid_time,
-                     write_time, bytes_written, partition_file_info_array);
+  const auto& partition_length = splitter->PartitionLengths();
+  auto partition_length_arr = env->NewLongArray(partition_length.size());
+  auto src = reinterpret_cast<const jlong*>(partition_length.data());
+  env->SetLongArrayRegion(partition_length_arr, 0, partition_length.size(), src);
+  jobject split_result = env->NewObject(
+      split_result_class, split_result_constructor, splitter->TotalComputePidTime(),
+      splitter->TotalWriteTime(), splitter->TotalBytesWritten(), partition_length_arr);
 
   return split_result;
 }
@@ -1286,51 +1272,54 @@ JNIEXPORT void JNICALL Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_c
 JNIEXPORT jlong JNICALL Java_com_intel_oap_vectorized_ShuffleDecompressionJniWrapper_make(
     JNIEnv* env, jobject, jbyteArray schema_arr) {
   std::shared_ptr<arrow::Schema> schema;
-  arrow::Status status;
-
-  status = MakeSchema(env, schema_arr, &schema);
-  if (!status.ok()) {
-    env->ThrowNew(
-        io_exception_class,
-        std::string("failed to readSchema, err msg is " + status.message()).c_str());
-  }
+  // ValueOrDie in MakeSchema
+  MakeSchema(env, schema_arr, &schema);
 
   return decompression_schema_holder_.Insert(schema);
 }
 
 JNIEXPORT jobject JNICALL
 Java_com_intel_oap_vectorized_ShuffleDecompressionJniWrapper_decompress(
-    JNIEnv* env, jobject obj, jlong schema_holder_id, jstring codec_jstr, jint num_rows,
-    jlongArray buf_addrs, jlongArray buf_sizes, jlongArray buf_mask) {
+    JNIEnv* env, jobject obj, jlong schema_holder_id, jstring compression_type_jstr,
+    jint num_rows, jlongArray buf_addrs, jlongArray buf_sizes, jlongArray buf_mask) {
   auto schema = decompression_schema_holder_.Lookup(schema_holder_id);
+  if (!schema) {
+    std::string error_message =
+        "Invalid schema holder id " + std::to_string(schema_holder_id);
+    env->ThrowNew(illegal_argument_exception_class, error_message.c_str());
+    return nullptr;
+  }
+  if (buf_addrs == NULL) {
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Native decompress: buf_addrs can't be null").c_str());
+    return nullptr;
+  }
+  if (buf_sizes == NULL) {
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Native decompress: buf_sizes can't be null").c_str());
+    return nullptr;
+  }
+  if (buf_mask == NULL) {
+    env->ThrowNew(illegal_argument_exception_class,
+                  std::string("Native decompress: buf_mask can't be null").c_str());
+    return nullptr;
+  }
 
   int in_bufs_len = env->GetArrayLength(buf_addrs);
   if (in_bufs_len != env->GetArrayLength(buf_sizes)) {
-    std::string error_message =
-        "native decompress: mismatch in arraylen of buf_addrs and buf_sizes";
-    env->ThrowNew(io_exception_class, error_message.c_str());
+    env->ThrowNew(
+        illegal_argument_exception_class,
+        std::string("Native decompress: length of buf_addrs and buf_sizes mismatch")
+            .c_str());
+    return nullptr;
   }
 
-  // get decompression compression_codec
-  auto compression_codec = arrow::Compression::UNCOMPRESSED;
-  if (codec_jstr != NULL) {
-    auto codec_l = env->GetStringUTFChars(codec_jstr, JNI_FALSE);
-    std::string codec_u;
-    std::transform(codec_l, codec_l + std::strlen(codec_l), std::back_inserter(codec_u),
-                   ::toupper);
-    auto result = arrow::util::Codec::GetCompressionType(codec_u);
-    if (result.ok()) {
-      compression_codec = *result;
-    } else {
-      env->ThrowNew(io_exception_class,
-                    std::string("failed to get compression codec, error message is " +
-                                result.status().message())
-                        .c_str());
+  auto compression_type = arrow::Compression::UNCOMPRESSED;
+  if (compression_type_jstr != NULL) {
+    auto compression_type_result = GetCompressionType(env, compression_type_jstr);
+    if (compression_type_result.status().ok()) {
+      compression_type = compression_type_result.MoveValueUnsafe();
     }
-    if (compression_codec == arrow::Compression::LZ4) {
-      compression_codec = arrow::Compression::LZ4_FRAME;
-    }
-    env->ReleaseStringUTFChars(codec_jstr, codec_l);
   }
 
   // make buffers from raws
@@ -1356,7 +1345,7 @@ Java_com_intel_oap_vectorized_ShuffleDecompressionJniWrapper_decompress(
   auto options = arrow::ipc::IpcReadOptions::Defaults();
   options.use_threads = false;
   auto status =
-      DecompressBuffers(compression_codec, options, (uint8_t*)in_buf_mask, input_buffers);
+      DecompressBuffers(compression_type, options, (uint8_t*)in_buf_mask, input_buffers);
   if (!status.ok()) {
     env->ThrowNew(
         io_exception_class,

--- a/oap-native-sql/cpp/src/jni/jni_wrapper.cc
+++ b/oap-native-sql/cpp/src/jni/jni_wrapper.cc
@@ -51,9 +51,6 @@ static jmethodID arrow_field_node_builder_constructor;
 static jclass arrowbuf_builder_class;
 static jmethodID arrowbuf_builder_constructor;
 
-static jclass partition_file_info_class;
-static jmethodID partition_file_info_constructor;
-
 static jclass split_result_class;
 static jmethodID split_result_constructor;
 
@@ -199,7 +196,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   split_result_class =
       CreateGlobalClassReference(env, "Lcom/intel/oap/vectorized/SplitResult;");
-  split_result_constructor = GetMethodID(env, split_result_class, "<init>", "(JJJ[J)V");
+  split_result_constructor = GetMethodID(env, split_result_class, "<init>", "(JJJJ[J)V");
 
   return JNI_VERSION;
 }
@@ -1259,7 +1256,7 @@ JNIEXPORT jobject JNICALL Java_com_intel_oap_vectorized_ShuffleSplitterJniWrappe
   env->SetLongArrayRegion(partition_length_arr, 0, partition_length.size(), src);
   jobject split_result = env->NewObject(
       split_result_class, split_result_constructor, splitter->TotalComputePidTime(),
-      splitter->TotalWriteTime(), splitter->TotalBytesWritten(), partition_length_arr);
+      splitter->TotalWriteTime(), splitter->TotalSpillTime(), splitter->TotalBytesWritten(), partition_length_arr);
 
   return split_result;
 }

--- a/oap-native-sql/cpp/src/jni/jni_wrapper.cc
+++ b/oap-native-sql/cpp/src/jni/jni_wrapper.cc
@@ -196,7 +196,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   split_result_class =
       CreateGlobalClassReference(env, "Lcom/intel/oap/vectorized/SplitResult;");
-  split_result_constructor = GetMethodID(env, split_result_class, "<init>", "(JJJJ[J)V");
+  split_result_constructor = GetMethodID(env, split_result_class, "<init>", "(JJJJJ[J)V");
 
   return JNI_VERSION;
 }
@@ -1272,7 +1272,7 @@ JNIEXPORT jobject JNICALL Java_com_intel_oap_vectorized_ShuffleSplitterJniWrappe
   jobject split_result = env->NewObject(
       split_result_class, split_result_constructor, splitter->TotalComputePidTime(),
       splitter->TotalWriteTime(), splitter->TotalSpillTime(),
-      splitter->TotalBytesWritten(), partition_length_arr);
+      splitter->TotalBytesWritten(), splitter->TotalBytesSpilled(), partition_length_arr);
 
   return split_result;
 }

--- a/oap-native-sql/cpp/src/shuffle/partition_writer.cc
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.cc
@@ -15,26 +15,28 @@
  * limitations under the License.
  */
 
-#include <arrow/array.h>
-#include <arrow/io/file.h>
-#include <arrow/ipc/options.h>
-#include <arrow/ipc/writer.h>
-#include <arrow/record_batch.h>
 #include <chrono>
 #include <memory>
 
+#include <arrow/array.h>
+#include <arrow/io/file.h>
+#include <arrow/ipc/api.h>
+#include <arrow/record_batch.h>
+
 #include "shuffle/partition_writer.h"
 #include "shuffle/utils.h"
-#include "utils/macros.h"
 
 namespace sparkcolumnarplugin {
 namespace shuffle {
 
 arrow::Result<std::shared_ptr<PartitionWriter>> PartitionWriter::Create(
-    int32_t pid, int64_t capacity, Type::typeId last_type,
-    const std::vector<Type::typeId>& column_type_id,
-    const std::shared_ptr<arrow::Schema>& schema, const std::string& temp_file_path,
-    arrow::Compression::type compression_type) {
+    int32_t partition_id, int64_t capacity, arrow::Compression::type compression_type,
+    Type::typeId last_type, const std::vector<Type::typeId>& column_type_id,
+    const std::shared_ptr<arrow::Schema>& schema,
+    const std::shared_ptr<arrow::io::OutputStream>& data_file_os,
+    const std::shared_ptr<arrow::ipc::RecordBatchWriter>& spilled_file_writer,
+    const std::shared_ptr<arrow::ipc::RecordBatchFileReader>& spilled_file_reader,
+    int32_t* spilled_batch_index) {
   auto buffers = TypeBufferInfos(Type::NUM_TYPES);
   auto binary_bulders = BinaryBuilders();
   auto large_binary_bulders = LargeBinaryBuilders();
@@ -78,33 +80,57 @@ arrow::Result<std::shared_ptr<PartitionWriter>> PartitionWriter::Create(
       } break;
     }
   }
-
-  ARROW_ASSIGN_OR_RAISE(auto file_os,
-                        arrow::io::FileOutputStream::Open(temp_file_path, true));
-
   return std::make_shared<PartitionWriter>(
-      pid, capacity, last_type, column_type_id, schema, std::move(file_os),
-      std::move(buffers), std::move(binary_bulders), std::move(large_binary_bulders),
-      compression_type);
+      partition_id, capacity, compression_type, last_type, column_type_id, schema,
+      data_file_os, spilled_file_writer, spilled_file_reader, spilled_batch_index,
+      std::move(buffers), std::move(binary_bulders), std::move(large_binary_bulders));
 }
 
 arrow::Status PartitionWriter::Stop() {
-  if (write_offset_[last_type_] != 0) {
-    TIME_NANO_OR_RAISE(write_time_, WriteArrowRecordBatch());
-    std::fill(std::begin(write_offset_), std::end(write_offset_), 0);
+  auto start = std::chrono::steady_clock::now();
+  ARROW_ASSIGN_OR_RAISE(auto before_write, data_file_os_->Tell())
+  ARROW_ASSIGN_OR_RAISE(
+      auto data_file_writer,
+      arrow::ipc::NewStreamWriter(data_file_os_.get(), schema_,
+                                  SplitterIpcWriteOptions(compression_type_)));
+  // copy spilled data blocks
+  if (!spilled_index_.empty()) {
+    for (auto index : spilled_index_) {
+      ARROW_ASSIGN_OR_RAISE(auto batch, spilled_file_reader_->ReadRecordBatch(index));
+      RETURN_NOT_OK(data_file_writer->WriteRecordBatch(*batch));
+    }
   }
-  if (file_writer_opened_) {
-    RETURN_NOT_OK(file_writer_->Close());
-    file_writer_opened_ = false;
+  // write the last record batch
+  ARROW_ASSIGN_OR_RAISE(auto batch, MakeRecordBatchAndReset());
+  if (batch != nullptr) {
+    RETURN_NOT_OK(data_file_writer->WriteRecordBatch(*batch));
   }
-  if (!file_os_->closed()) {
-    ARROW_ASSIGN_OR_RAISE(file_footer_, file_os_->Tell());
-    return file_os_->Close();
+  // write EOS
+  RETURN_NOT_OK(data_file_writer->Close());
+  ARROW_ASSIGN_OR_RAISE(auto after_write, data_file_os_->Tell());
+  partition_length_ = after_write - before_write;
+  // count write time
+  auto end = std::chrono::steady_clock::now();
+  write_time_ +=
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+  return arrow::Status::OK();
+}
+
+arrow::Status PartitionWriter::Spill() {
+  ARROW_ASSIGN_OR_RAISE(auto batch, MakeRecordBatchAndReset());
+  if (batch != nullptr) {
+    RETURN_NOT_OK(spilled_file_writer_->WriteRecordBatch(*batch));
+    spilled_index_.push_back(*spilled_batch_index_);
+    (*spilled_batch_index_)++;
   }
   return arrow::Status::OK();
 }
 
-arrow::Status PartitionWriter::WriteArrowRecordBatch() {
+arrow::Result<std::shared_ptr<arrow::RecordBatch>>
+PartitionWriter::MakeRecordBatchAndReset() {
+  if (write_offset_[last_type_] == 0) {
+    return nullptr;
+  }
   std::vector<std::shared_ptr<arrow::Array>> arrays(schema_->num_fields());
   for (int i = 0; i < schema_->num_fields(); ++i) {
     auto type_id = column_type_id_[i];
@@ -129,19 +155,10 @@ arrow::Status PartitionWriter::WriteArrowRecordBatch() {
       buffers_[type_id].push_back(std::move(buf_info_ptr));
     }
   }
-  auto record_batch =
-      arrow::RecordBatch::Make(schema_, write_offset_[last_type_], std::move(arrays));
-
-  if (!file_writer_opened_) {
-    auto res = arrow::ipc::NewStreamWriter(file_os_.get(), schema_,
-                                           GetIpcWriteOptions(compression_type_));
-    RETURN_NOT_OK(res.status());
-    file_writer_ = *res;
-    file_writer_opened_ = true;
-  }
-  RETURN_NOT_OK(file_writer_->WriteRecordBatch(*record_batch));
-
-  return arrow::Status::OK();
+  auto rb = std::move(
+      arrow::RecordBatch::Make(schema_, write_offset_[last_type_], std::move(arrays)));
+  std::fill(std::begin(write_offset_), std::end(write_offset_), 0);
+  return rb;
 }
 
 }  // namespace shuffle

--- a/oap-native-sql/cpp/src/shuffle/partition_writer.cc
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.cc
@@ -102,6 +102,7 @@ arrow::Status PartitionWriter::Stop() {
     RETURN_NOT_OK(spilled_file_is_->Close());
     auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
     RETURN_NOT_OK(fs->DeleteFile(spilled_file_));
+    bytes_spilled_ += nbytes;
 
     // write last record batch if it's not null
     ARROW_ASSIGN_OR_RAISE(auto batch, MakeRecordBatchAndReset());

--- a/oap-native-sql/cpp/src/shuffle/partition_writer.h
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.h
@@ -139,6 +139,8 @@ class PartitionWriter {
 
   int64_t GetPartitionLength() const { return partition_length_; }
 
+  int64_t GetBytesSpilled() const { return bytes_spilled_; }
+
   arrow::Result<bool> inline CheckTypeWriteEnds(const Type::typeId& type_id) {
     if (write_offset_[type_id] == capacity_) {
       if (type_id == last_type_) {
@@ -256,6 +258,7 @@ class PartitionWriter {
   int64_t write_time_ = 0;
   int64_t spill_time_ = 0;
   int64_t partition_length_ = 0;
+  int64_t bytes_spilled_ = 0;
 
   std::string spilled_file_;
   std::shared_ptr<arrow::io::FileOutputStream> spilled_file_os_;

--- a/oap-native-sql/cpp/src/shuffle/partition_writer.h
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.h
@@ -140,6 +140,8 @@ class PartitionWriter {
 
   int64_t GetWriteTime() const { return write_time_; }
 
+  int64_t GetSpillTime() const { return spill_time_; }
+
   int64_t GetPartitionLength() const { return partition_length_; }
 
   arrow::Result<bool> inline CheckTypeWriteEnds(const Type::typeId& type_id) {
@@ -147,7 +149,7 @@ class PartitionWriter {
       if (type_id == last_type_) {
         // Write to spilled file, close the file but don't call RecordBatchWriter.Close()
         // since it may not be the last batch to write
-        TIME_NANO_OR_RAISE(write_time_, Spill());
+        TIME_NANO_OR_RAISE(spill_time_, Spill());
       }
       return true;
     }
@@ -263,6 +265,7 @@ class PartitionWriter {
   std::vector<int32_t> spilled_index_;
 
   int64_t write_time_ = 0;
+  int64_t spill_time_ = 0;
   int64_t partition_length_ = 0;
 };
 

--- a/oap-native-sql/cpp/src/shuffle/partition_writer.h
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.h
@@ -103,15 +103,14 @@ arrow::enable_if_binary_like<T, arrow::Status> inline WriteBinary(
 }  // namespace detail
 class PartitionWriter {
  public:
-  PartitionWriter(
-      int32_t partition_id, int64_t capacity, arrow::Compression::type compression_type,
-      Type::typeId last_type, const std::vector<Type::typeId>& column_type_id,
-      const std::shared_ptr<arrow::Schema>& schema,
-      const std::shared_ptr<arrow::io::OutputStream>& data_file_os,
-      const std::shared_ptr<arrow::ipc::RecordBatchWriter>& spilled_file_writer,
-      const std::shared_ptr<arrow::ipc::RecordBatchFileReader>& spilled_file_reader,
-      int32_t* spilled_batch_index, TypeBufferInfos buffers,
-      BinaryBuilders binary_builders, LargeBinaryBuilders large_binary_builders)
+  PartitionWriter(int32_t partition_id, int64_t capacity,
+                  arrow::Compression::type compression_type, Type::typeId last_type,
+                  const std::vector<Type::typeId>& column_type_id,
+                  const std::shared_ptr<arrow::Schema>& schema,
+                  const std::shared_ptr<arrow::io::OutputStream>& data_file_os,
+                  std::string spilled_file, TypeBufferInfos buffers,
+                  BinaryBuilders binary_builders,
+                  LargeBinaryBuilders large_binary_builders)
       : partition_id_(partition_id),
         capacity_(capacity),
         compression_type_(compression_type),
@@ -119,9 +118,7 @@ class PartitionWriter {
         column_type_id_(column_type_id),
         schema_(schema),
         data_file_os_(data_file_os),
-        spilled_file_writer_(spilled_file_writer),
-        spilled_file_reader_(spilled_file_reader),
-        spilled_batch_index_(spilled_batch_index),
+        spilled_file_(std::move(spilled_file)),
         buffers_(std::move(buffers)),
         binary_builders_(std::move(binary_builders)),
         large_binary_builders_(std::move(large_binary_builders)),
@@ -132,9 +129,7 @@ class PartitionWriter {
       Type::typeId last_type, const std::vector<Type::typeId>& column_type_id,
       const std::shared_ptr<arrow::Schema>& schema,
       const std::shared_ptr<arrow::io::OutputStream>& data_file_os,
-      const std::shared_ptr<arrow::ipc::RecordBatchWriter>& spilled_file_writer,
-      const std::shared_ptr<arrow::ipc::RecordBatchFileReader>& spilled_file_reader,
-      int32_t* spilled_batch_index);
+      std::string spilled_file);
 
   arrow::Status Stop();
 
@@ -248,11 +243,10 @@ class PartitionWriter {
   const std::vector<Type::typeId>& column_type_id_;
   const std::shared_ptr<arrow::Schema>& schema_;
   const std::shared_ptr<arrow::io::OutputStream>& data_file_os_;
-  const std::shared_ptr<arrow::ipc::RecordBatchWriter>& spilled_file_writer_;
-  const std::shared_ptr<arrow::ipc::RecordBatchFileReader>& spilled_file_reader_;
 
-  // can be used and modified across different PartitionWriter
-  int32_t* spilled_batch_index_;
+  std::string spilled_file_;
+  std::shared_ptr<arrow::io::OutputStream> spilled_file_os_;
+  std::shared_ptr<arrow::ipc::RecordBatchWriter> spilled_file_writer_;
 
   TypeBufferInfos buffers_;
   BinaryBuilders binary_builders_;
@@ -261,8 +255,6 @@ class PartitionWriter {
   arrow::Compression::type compression_type_;
 
   std::vector<int64_t> write_offset_;
-
-  std::vector<int32_t> spilled_index_;
 
   int64_t write_time_ = 0;
   int64_t spill_time_ = 0;

--- a/oap-native-sql/cpp/src/shuffle/partition_writer.h
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.h
@@ -108,7 +108,7 @@ class PartitionWriter {
                   const std::vector<Type::typeId>& column_type_id,
                   const std::shared_ptr<arrow::Schema>& schema,
                   const std::shared_ptr<arrow::io::FileOutputStream>& data_file_os,
-                  std::string spilled_file, TypeBufferInfos buffers,
+                  std::string spilled_file_dir, TypeBufferInfos buffers,
                   BinaryBuilders binary_builders,
                   LargeBinaryBuilders large_binary_builders)
       : partition_id_(partition_id),
@@ -118,7 +118,7 @@ class PartitionWriter {
         column_type_id_(column_type_id),
         schema_(schema),
         data_file_os_(data_file_os),
-        spilled_file_(std::move(spilled_file)),
+        spilled_file_dir_(std::move(spilled_file_dir)),
         buffers_(std::move(buffers)),
         binary_builders_(std::move(binary_builders)),
         large_binary_builders_(std::move(large_binary_builders)),
@@ -129,7 +129,7 @@ class PartitionWriter {
       Type::typeId last_type, const std::vector<Type::typeId>& column_type_id,
       const std::shared_ptr<arrow::Schema>& schema,
       const std::shared_ptr<arrow::io::FileOutputStream>& data_file_os,
-      std::string spilled_file);
+      std::string spilled_file_dir);
 
   arrow::Status Stop();
 
@@ -237,6 +237,7 @@ class PartitionWriter {
 
   const int32_t partition_id_;
   const int64_t capacity_;
+  const arrow::Compression::type compression_type_;
   const Type::typeId last_type_;
 
   // hold references to splitter
@@ -244,21 +245,21 @@ class PartitionWriter {
   const std::shared_ptr<arrow::Schema>& schema_;
   const std::shared_ptr<arrow::io::FileOutputStream>& data_file_os_;
 
-  std::string spilled_file_;
-  std::shared_ptr<arrow::io::FileOutputStream> spilled_file_os_;
-  std::shared_ptr<arrow::ipc::RecordBatchWriter> spilled_file_writer_;
+  std::string spilled_file_dir_;
 
   TypeBufferInfos buffers_;
   BinaryBuilders binary_builders_;
   LargeBinaryBuilders large_binary_builders_;
-
-  arrow::Compression::type compression_type_;
 
   std::vector<int64_t> write_offset_;
 
   int64_t write_time_ = 0;
   int64_t spill_time_ = 0;
   int64_t partition_length_ = 0;
+
+  std::string spilled_file_;
+  std::shared_ptr<arrow::io::FileOutputStream> spilled_file_os_;
+  std::shared_ptr<arrow::ipc::RecordBatchWriter> spilled_file_writer_;
 };
 
 }  // namespace shuffle

--- a/oap-native-sql/cpp/src/shuffle/partition_writer.h
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.h
@@ -17,14 +17,16 @@
 
 #pragma once
 
+#include <chrono>
+#include <vector>
+
 #include <arrow/array/builder_binary.h>
 #include <arrow/buffer.h>
 #include <arrow/io/file.h>
 #include <arrow/ipc/writer.h>
 #include <arrow/status.h>
 #include <arrow/util/compression.h>
-#include <chrono>
-#include <vector>
+
 #include "shuffle/type.h"
 #include "utils/macros.h"
 
@@ -101,51 +103,51 @@ arrow::enable_if_binary_like<T, arrow::Status> inline WriteBinary(
 }  // namespace detail
 class PartitionWriter {
  public:
-  explicit PartitionWriter(int32_t pid, int64_t capacity, Type::typeId last_type,
-                           const std::vector<Type::typeId>& column_type_id,
-                           const std::shared_ptr<arrow::Schema>& schema,
-                           std::shared_ptr<arrow::io::FileOutputStream> file_os,
-                           TypeBufferInfos buffers, BinaryBuilders binary_builders,
-                           LargeBinaryBuilders large_binary_builders,
-                           arrow::Compression::type compression_codec)
-      : pid_(pid),
+  PartitionWriter(
+      int32_t partition_id, int64_t capacity, arrow::Compression::type compression_type,
+      Type::typeId last_type, const std::vector<Type::typeId>& column_type_id,
+      const std::shared_ptr<arrow::Schema>& schema,
+      const std::shared_ptr<arrow::io::OutputStream>& data_file_os,
+      const std::shared_ptr<arrow::ipc::RecordBatchWriter>& spilled_file_writer,
+      const std::shared_ptr<arrow::ipc::RecordBatchFileReader>& spilled_file_reader,
+      int32_t* spilled_batch_index, TypeBufferInfos buffers,
+      BinaryBuilders binary_builders, LargeBinaryBuilders large_binary_builders)
+      : partition_id_(partition_id),
         capacity_(capacity),
+        compression_type_(compression_type),
         last_type_(last_type),
         column_type_id_(column_type_id),
         schema_(schema),
-        file_os_(std::move(file_os)),
+        data_file_os_(data_file_os),
+        spilled_file_writer_(spilled_file_writer),
+        spilled_file_reader_(spilled_file_reader),
+        spilled_batch_index_(spilled_batch_index),
         buffers_(std::move(buffers)),
         binary_builders_(std::move(binary_builders)),
         large_binary_builders_(std::move(large_binary_builders)),
-        compression_type_(compression_codec),
-        write_offset_(Type::typeId::NUM_TYPES),
-        file_footer_(0),
-        file_writer_opened_(false),
-        file_writer_(nullptr),
-        write_time_(0) {}
+        write_offset_(Type::typeId::NUM_TYPES) {}
 
   static arrow::Result<std::shared_ptr<PartitionWriter>> Create(
-      int32_t pid, int64_t capacity, Type::typeId last_type,
-      const std::vector<Type::typeId>& column_type_id,
-      const std::shared_ptr<arrow::Schema>& schema, const std::string& temp_file_path,
-      arrow::Compression::type compression_type);
+      int32_t partition_id, int64_t capacity, arrow::Compression::type compression_type,
+      Type::typeId last_type, const std::vector<Type::typeId>& column_type_id,
+      const std::shared_ptr<arrow::Schema>& schema,
+      const std::shared_ptr<arrow::io::OutputStream>& data_file_os,
+      const std::shared_ptr<arrow::ipc::RecordBatchWriter>& spilled_file_writer,
+      const std::shared_ptr<arrow::ipc::RecordBatchFileReader>& spilled_file_reader,
+      int32_t* spilled_batch_index);
 
   arrow::Status Stop();
 
   int64_t GetWriteTime() const { return write_time_; }
 
-  arrow::Result<int64_t> GetBytesWritten() {
-    if (!file_os_->closed()) {
-      ARROW_ASSIGN_OR_RAISE(file_footer_, file_os_->Tell());
-    }
-    return file_footer_;
-  }
+  int64_t GetPartitionLength() const { return partition_length_; }
 
   arrow::Result<bool> inline CheckTypeWriteEnds(const Type::typeId& type_id) {
     if (write_offset_[type_id] == capacity_) {
       if (type_id == last_type_) {
-        TIME_NANO_OR_RAISE(write_time_, WriteArrowRecordBatch());
-        std::fill(std::begin(write_offset_), std::end(write_offset_), 0);
+        // Write to spilled file, close the file but don't call RecordBatchWriter.Close()
+        // since it may not be the last batch to write
+        TIME_NANO_OR_RAISE(write_time_, Spill());
       }
       return true;
     }
@@ -232,14 +234,23 @@ class PartitionWriter {
   }
 
  private:
-  arrow::Status WriteArrowRecordBatch();
+  arrow::Status Spill();
 
-  const int32_t pid_;
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> MakeRecordBatchAndReset();
+
+  const int32_t partition_id_;
   const int64_t capacity_;
   const Type::typeId last_type_;
+
+  // hold references to splitter
   const std::vector<Type::typeId>& column_type_id_;
   const std::shared_ptr<arrow::Schema>& schema_;
-  std::shared_ptr<arrow::io::FileOutputStream> file_os_;
+  const std::shared_ptr<arrow::io::OutputStream>& data_file_os_;
+  const std::shared_ptr<arrow::ipc::RecordBatchWriter>& spilled_file_writer_;
+  const std::shared_ptr<arrow::ipc::RecordBatchFileReader>& spilled_file_reader_;
+
+  // can be used and modified across different PartitionWriter
+  int32_t* spilled_batch_index_;
 
   TypeBufferInfos buffers_;
   BinaryBuilders binary_builders_;
@@ -248,11 +259,11 @@ class PartitionWriter {
   arrow::Compression::type compression_type_;
 
   std::vector<int64_t> write_offset_;
-  int64_t file_footer_;
-  bool file_writer_opened_;
-  std::shared_ptr<arrow::ipc::RecordBatchWriter> file_writer_;
 
-  int64_t write_time_;
+  std::vector<int32_t> spilled_index_;
+
+  int64_t write_time_ = 0;
+  int64_t partition_length_ = 0;
 };
 
 }  // namespace shuffle

--- a/oap-native-sql/cpp/src/shuffle/partition_writer.h
+++ b/oap-native-sql/cpp/src/shuffle/partition_writer.h
@@ -107,7 +107,7 @@ class PartitionWriter {
                   arrow::Compression::type compression_type, Type::typeId last_type,
                   const std::vector<Type::typeId>& column_type_id,
                   const std::shared_ptr<arrow::Schema>& schema,
-                  const std::shared_ptr<arrow::io::OutputStream>& data_file_os,
+                  const std::shared_ptr<arrow::io::FileOutputStream>& data_file_os,
                   std::string spilled_file, TypeBufferInfos buffers,
                   BinaryBuilders binary_builders,
                   LargeBinaryBuilders large_binary_builders)
@@ -128,7 +128,7 @@ class PartitionWriter {
       int32_t partition_id, int64_t capacity, arrow::Compression::type compression_type,
       Type::typeId last_type, const std::vector<Type::typeId>& column_type_id,
       const std::shared_ptr<arrow::Schema>& schema,
-      const std::shared_ptr<arrow::io::OutputStream>& data_file_os,
+      const std::shared_ptr<arrow::io::FileOutputStream>& data_file_os,
       std::string spilled_file);
 
   arrow::Status Stop();
@@ -242,10 +242,10 @@ class PartitionWriter {
   // hold references to splitter
   const std::vector<Type::typeId>& column_type_id_;
   const std::shared_ptr<arrow::Schema>& schema_;
-  const std::shared_ptr<arrow::io::OutputStream>& data_file_os_;
+  const std::shared_ptr<arrow::io::FileOutputStream>& data_file_os_;
 
   std::string spilled_file_;
-  std::shared_ptr<arrow::io::OutputStream> spilled_file_os_;
+  std::shared_ptr<arrow::io::FileOutputStream> spilled_file_os_;
   std::shared_ptr<arrow::ipc::RecordBatchWriter> spilled_file_writer_;
 
   TypeBufferInfos buffers_;

--- a/oap-native-sql/cpp/src/shuffle/splitter.cc
+++ b/oap-native-sql/cpp/src/shuffle/splitter.cc
@@ -212,8 +212,8 @@ arrow::Status Splitter::Stop() {
 arrow::Result<std::shared_ptr<PartitionWriter>> Splitter::GetPartitionWriter(
     int32_t partition_id) {
   if (partition_writer_[partition_id] == nullptr) {
-    ARROW_ASSIGN_OR_RAISE(auto spilled_file,
-                          CreateSpilledShuffleFile(configured_dirs_[dir_selection_],
+    ARROW_ASSIGN_OR_RAISE(auto spilled_file_dir,
+                          GetSpilledShuffleFileDir(configured_dirs_[dir_selection_],
                                                    sub_dir_selection_[dir_selection_]))
     sub_dir_selection_[dir_selection_] =
         (sub_dir_selection_[dir_selection_] + 1) % options_.num_sub_dirs;
@@ -222,7 +222,7 @@ arrow::Result<std::shared_ptr<PartitionWriter>> Splitter::GetPartitionWriter(
         partition_writer_[partition_id],
         PartitionWriter::Create(partition_id, options_.buffer_size,
                                 options_.compression_type, last_type_id_, column_type_id_,
-                                schema_, data_file_os_, spilled_file));
+                                schema_, data_file_os_, spilled_file_dir));
   }
   return partition_writer_[partition_id];
 }

--- a/oap-native-sql/cpp/src/shuffle/splitter.cc
+++ b/oap-native-sql/cpp/src/shuffle/splitter.cc
@@ -187,7 +187,7 @@ arrow::Status Splitter::Split(const arrow::RecordBatch& rb) {
 arrow::Status Splitter::Stop() {
   // open data file output stream
   ARROW_ASSIGN_OR_RAISE(data_file_os_,
-                        arrow::io::FileOutputStream::Open(options_.data_file, false));
+                        arrow::io::FileOutputStream::Open(options_.data_file, true));
 
   // stop PartitionWriter and collect metrics
   for (const auto& writer : partition_writer_) {

--- a/oap-native-sql/cpp/src/shuffle/splitter.cc
+++ b/oap-native-sql/cpp/src/shuffle/splitter.cc
@@ -220,6 +220,7 @@ arrow::Status Splitter::Stop() {
       partition_lengths_.push_back(length);
       total_bytes_written_ += length;
       total_write_time_ += writer->GetWriteTime();
+      total_spill_time_ += writer->GetSpillTime();
     } else {
       partition_lengths_.push_back(0);
     }

--- a/oap-native-sql/cpp/src/shuffle/splitter.cc
+++ b/oap-native-sql/cpp/src/shuffle/splitter.cc
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <memory>
 #include <utility>
 
@@ -87,7 +88,7 @@ arrow::Status Splitter::Init() {
 }
 
 arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb,
-                                std::vector<std::shared_ptr<PartitionWriter>> writers) {
+                                const std::vector<int32_t>& writer_idx) {
   auto num_rows = rb.num_rows();
   auto num_cols = rb.num_columns();
   auto src_addr = std::vector<SrcBuffers>(Type::NUM_TYPES);
@@ -127,36 +128,38 @@ arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb,
 
   auto read_offset = 0;
 
-#define WRITE_FIXEDWIDTH(TYPE_ID, T)                                             \
-  if (!src_addr[TYPE_ID].empty()) {                                              \
-    for (i = read_offset; i < num_rows; ++i) {                                   \
-      ARROW_ASSIGN_OR_RAISE(auto result,                                         \
-                            writers[i]->Write<T>(TYPE_ID, src_addr[TYPE_ID], i)) \
-      if (!result) {                                                             \
-        break;                                                                   \
-      }                                                                          \
-    }                                                                            \
-  }
-
-#define WRITE_DECIMAL                                                                \
-  if (!src_addr[Type::SHUFFLE_DECIMAL128].empty()) {                                 \
+#define WRITE_FIXEDWIDTH(TYPE_ID, T)                                                 \
+  if (!src_addr[TYPE_ID].empty()) {                                                  \
     for (i = read_offset; i < num_rows; ++i) {                                       \
-      ARROW_ASSIGN_OR_RAISE(auto result, writers[i]->WriteDecimal128(                \
-                                             src_addr[Type::SHUFFLE_DECIMAL128], i)) \
+      ARROW_ASSIGN_OR_RAISE(auto result, partition_writer_[writer_idx[i]]->Write<T>( \
+                                             TYPE_ID, src_addr[TYPE_ID], i))         \
       if (!result) {                                                                 \
         break;                                                                       \
       }                                                                              \
     }                                                                                \
   }
 
-#define WRITE_BINARY(func, T, src_arr)                                 \
-  if (!src_arr.empty()) {                                              \
-    for (i = read_offset; i < num_rows; ++i) {                         \
-      ARROW_ASSIGN_OR_RAISE(auto result, writers[i]->func(src_arr, i)) \
-      if (!result) {                                                   \
-        break;                                                         \
-      }                                                                \
-    }                                                                  \
+#define WRITE_DECIMAL                                                          \
+  if (!src_addr[Type::SHUFFLE_DECIMAL128].empty()) {                           \
+    for (i = read_offset; i < num_rows; ++i) {                                 \
+      ARROW_ASSIGN_OR_RAISE(auto result,                                       \
+                            partition_writer_[writer_idx[i]]->WriteDecimal128( \
+                                src_addr[Type::SHUFFLE_DECIMAL128], i))        \
+      if (!result) {                                                           \
+        break;                                                                 \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define WRITE_BINARY(func, T, src_arr)                                          \
+  if (!src_arr.empty()) {                                                       \
+    for (i = read_offset; i < num_rows; ++i) {                                  \
+      ARROW_ASSIGN_OR_RAISE(auto result,                                        \
+                            partition_writer_[writer_idx[i]]->func(src_arr, i)) \
+      if (!result) {                                                            \
+        break;                                                                  \
+      }                                                                         \
+    }                                                                           \
   }
 
   while (read_offset < num_rows) {
@@ -180,8 +183,8 @@ arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb,
 }  // namespace shuffle
 
 arrow::Status Splitter::Split(const arrow::RecordBatch& rb) {
-  ARROW_ASSIGN_OR_RAISE(auto writers, GetNextBatchPartitionWriter(rb));
-  return DoSplit(rb, std::move(writers));
+  ARROW_ASSIGN_OR_RAISE(auto writer_idx, GetNextBatchPartitionWriterIndex(rb));
+  return DoSplit(rb, writer_idx);
 }
 
 arrow::Status Splitter::Stop() {
@@ -209,8 +212,7 @@ arrow::Status Splitter::Stop() {
   return arrow::Status::OK();
 }
 
-arrow::Result<std::shared_ptr<PartitionWriter>> Splitter::GetPartitionWriter(
-    int32_t partition_id) {
+arrow::Status Splitter::CreatePartitionWriter(int32_t partition_id) {
   if (partition_writer_[partition_id] == nullptr) {
     ARROW_ASSIGN_OR_RAISE(auto spilled_file_dir,
                           GetSpilledShuffleFileDir(configured_dirs_[dir_selection_],
@@ -224,7 +226,7 @@ arrow::Result<std::shared_ptr<PartitionWriter>> Splitter::GetPartitionWriter(
                                 options_.compression_type, last_type_id_, column_type_id_,
                                 schema_, data_file_os_, spilled_file_dir));
   }
-  return partition_writer_[partition_id];
+  return arrow::Status::OK();
 }
 
 // ----------------------------------------------------------------------
@@ -238,15 +240,15 @@ arrow::Result<std::shared_ptr<RoundRobinSplitter>> RoundRobinSplitter::Create(
   return res;
 }
 
-arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
-RoundRobinSplitter::GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) {
+arrow::Result<std::vector<int32_t>> RoundRobinSplitter::GetNextBatchPartitionWriterIndex(
+    const arrow::RecordBatch& rb) {
   auto num_rows = rb.num_rows();
 
-  std::vector<std::shared_ptr<PartitionWriter>> res;
+  std::vector<int32_t> res;
   res.reserve(num_rows);
   for (auto i = 0; i < num_rows; ++i) {
-    ARROW_ASSIGN_OR_RAISE(auto writer, GetPartitionWriter(pid_selection_));
-    res.push_back(std::move(writer));
+    RETURN_NOT_OK(CreatePartitionWriter(pid_selection_));
+    res.push_back(pid_selection_);
     pid_selection_ = (pid_selection_ + 1) % num_partitions_;
   }
   return res;
@@ -303,8 +305,8 @@ arrow::Status HashSplitter::CreateProjector(
   return gandiva::Projector::Make(schema_, {hash_expr}, &projector_);
 }
 
-arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
-HashSplitter::GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) {
+arrow::Result<std::vector<int32_t>> HashSplitter::GetNextBatchPartitionWriterIndex(
+    const arrow::RecordBatch& rb) {
   arrow::ArrayVector outputs;
   TIME_NANO_OR_RAISE(total_compute_pid_time_,
                      projector_->Evaluate(rb, arrow::default_memory_pool(), &outputs));
@@ -315,14 +317,14 @@ HashSplitter::GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) {
 
   auto num_rows = rb.num_rows();
   auto pid_arr = std::dynamic_pointer_cast<arrow::Int32Array>(outputs.at(0));
-  std::vector<std::shared_ptr<PartitionWriter>> res;
+  std::vector<int32_t> res;
   res.reserve(num_rows);
   for (auto i = 0; i < num_rows; ++i) {
     // positive mod
     auto pid = pid_arr->Value(i) % num_partitions_;
     if (pid < 0) pid = (pid + num_partitions_) % num_partitions_;
-    ARROW_ASSIGN_OR_RAISE(auto writer, GetPartitionWriter(pid));
-    res.push_back(std::move(writer));
+    RETURN_NOT_OK(CreatePartitionWriter(pid));
+    res.push_back(pid);
   }
   return res;
 }
@@ -345,15 +347,15 @@ arrow::Status FallbackRangeSplitter::Init() {
 }
 
 arrow::Status FallbackRangeSplitter::Split(const arrow::RecordBatch& rb) {
-  ARROW_ASSIGN_OR_RAISE(auto writers, GetNextBatchPartitionWriter(rb));
+  ARROW_ASSIGN_OR_RAISE(auto writer_idx, GetNextBatchPartitionWriterIndex(rb));
   ARROW_ASSIGN_OR_RAISE(auto remove_pid, rb.RemoveColumn(0));
-  return DoSplit(*remove_pid, std::move(writers));
+  return DoSplit(*remove_pid, writer_idx);
 }
 
-arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
-FallbackRangeSplitter::GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) {
+arrow::Result<std::vector<int32_t>>
+FallbackRangeSplitter::GetNextBatchPartitionWriterIndex(const arrow::RecordBatch& rb) {
   auto num_rows = rb.num_rows();
-  std::vector<std::shared_ptr<PartitionWriter>> res;
+  std::vector<int32_t> res;
   res.reserve(num_rows);
 
   if (rb.column(0)->type_id() != arrow::Type::INT32) {
@@ -369,8 +371,8 @@ FallbackRangeSplitter::GetNextBatchPartitionWriter(const arrow::RecordBatch& rb)
                                     " is equal or greater than ",
                                     std::to_string(num_partitions_));
     }
-    ARROW_ASSIGN_OR_RAISE(auto writer, GetPartitionWriter(pid));
-    res.push_back(std::move(writer));
+    RETURN_NOT_OK(CreatePartitionWriter(pid));
+    res.push_back(pid);
   }
   return res;
 }

--- a/oap-native-sql/cpp/src/shuffle/splitter.cc
+++ b/oap-native-sql/cpp/src/shuffle/splitter.cc
@@ -14,32 +14,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "shuffle/splitter.h"
+#include <memory>
+#include <utility>
 
+#include <arrow/filesystem/path_util.h>
+#include <arrow/ipc/reader.h>
 #include <gandiva/node.h>
 #include <gandiva/projector.h>
 #include <gandiva/tree_expr_builder.h>
 
-#include <memory>
-#include <utility>
+#include "shuffle/splitter.h"
 
 namespace sparkcolumnarplugin {
 namespace shuffle {
+
+SplitOptions SplitOptions::Defaults() { return SplitOptions(); }
 
 // ----------------------------------------------------------------------
 // Splitter
 
 arrow::Result<std::shared_ptr<Splitter>> Splitter::Make(
     const std::string& short_name, std::shared_ptr<arrow::Schema> schema,
-    int num_partitions, const gandiva::ExpressionVector& expr_vector) {
+    int num_partitions, const gandiva::ExpressionVector& expr_vector,
+    SplitOptions options) {
   if (short_name == "hash") {
-    return HashSplitter::Create(num_partitions, std::move(schema), expr_vector);
+    return HashSplitter::Create(num_partitions, std::move(schema), expr_vector,
+                                std::move(options));
   } else if (short_name == "rr") {
-    return RoundRobinSplitter::Create(num_partitions, std::move(schema));
+    return RoundRobinSplitter::Create(num_partitions, std::move(schema),
+                                      std::move(options));
   } else if (short_name == "range") {
-    return FallbackRangeSplitter::Create(num_partitions, std::move(schema));
+    return FallbackRangeSplitter::Create(num_partitions, std::move(schema),
+                                         std::move(options));
   } else if (short_name == "single") {
-    return RoundRobinSplitter::Create(1, std::move(schema));
+    return RoundRobinSplitter::Create(1, std::move(schema), std::move(options));
   }
   return arrow::Status::NotImplemented("Partitioning " + short_name +
                                        " not supported yet.");
@@ -47,11 +55,9 @@ arrow::Result<std::shared_ptr<Splitter>> Splitter::Make(
 
 arrow::Result<std::shared_ptr<Splitter>> Splitter::Make(
     const std::string& short_name, std::shared_ptr<arrow::Schema> schema,
-    int num_partitions) {
-  return Make(short_name, std::move(schema), num_partitions, {});
+    int num_partitions, SplitOptions options) {
+  return Make(short_name, std::move(schema), num_partitions, {}, std::move(options));
 }
-
-Splitter::~Splitter() = default;
 
 arrow::Status Splitter::Init() {
   const auto& fields = schema_->fields();
@@ -65,18 +71,33 @@ arrow::Status Splitter::Init() {
   last_type_id_ =
       *std::max_element(std::cbegin(remove_null_id), std::cend(remove_null_id));
 
-  ARROW_ASSIGN_OR_RAISE(configured_dirs_, GetConfiguredLocalDirs())
-  sub_dir_selection_.assign(configured_dirs_.size(), 0);
-
+  partition_lengths_.reserve(num_partitions_);
   partition_writer_.resize(num_partitions_);
 
-  fs_ = std::make_shared<arrow::fs::LocalFileSystem>();
+  // Both data_file and shuffle_index_file should be set through jni.
+  // For test purpose, Create a temporary subdirectory in the system temporary dir with
+  // prefix "columnar-shuffle"
+  if (options_.data_file.length() == 0) {
+    ARROW_ASSIGN_OR_RAISE(auto dir, CreateTempShuffleDir());
+    ARROW_ASSIGN_OR_RAISE(options_.data_file, CreateTempShuffleFile(dir));
+  }
+
+  ARROW_ASSIGN_OR_RAISE(
+      spilled_file_,
+      CreateTempShuffleFile(
+          arrow::fs::internal::GetAbstractPathParent(options_.data_file).first));
+  ARROW_ASSIGN_OR_RAISE(spilled_file_os_,
+                        arrow::io::FileOutputStream::Open(spilled_file_, false));
+  ARROW_ASSIGN_OR_RAISE(spilled_file_writer_,
+                        arrow::ipc::NewFileWriter(
+                            spilled_file_os_.get(), schema_,
+                            SplitterIpcWriteOptions(arrow::Compression::UNCOMPRESSED)));
 
   return arrow::Status::OK();
 }
 
 arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb,
-                                std::vector<int32_t> writer_idx) {
+                                std::vector<std::shared_ptr<PartitionWriter>> writers) {
   auto num_rows = rb.num_rows();
   auto num_cols = rb.num_columns();
   auto src_addr = std::vector<SrcBuffers>(Type::NUM_TYPES);
@@ -116,38 +137,36 @@ arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb,
 
   auto read_offset = 0;
 
-#define WRITE_FIXEDWIDTH(TYPE_ID, T)                                                 \
-  if (!src_addr[TYPE_ID].empty()) {                                                  \
+#define WRITE_FIXEDWIDTH(TYPE_ID, T)                                             \
+  if (!src_addr[TYPE_ID].empty()) {                                              \
+    for (i = read_offset; i < num_rows; ++i) {                                   \
+      ARROW_ASSIGN_OR_RAISE(auto result,                                         \
+                            writers[i]->Write<T>(TYPE_ID, src_addr[TYPE_ID], i)) \
+      if (!result) {                                                             \
+        break;                                                                   \
+      }                                                                          \
+    }                                                                            \
+  }
+
+#define WRITE_DECIMAL                                                                \
+  if (!src_addr[Type::SHUFFLE_DECIMAL128].empty()) {                                 \
     for (i = read_offset; i < num_rows; ++i) {                                       \
-      ARROW_ASSIGN_OR_RAISE(auto result, partition_writer_[writer_idx[i]]->Write<T>( \
-                                             TYPE_ID, src_addr[TYPE_ID], i))         \
+      ARROW_ASSIGN_OR_RAISE(auto result, writers[i]->WriteDecimal128(                \
+                                             src_addr[Type::SHUFFLE_DECIMAL128], i)) \
       if (!result) {                                                                 \
         break;                                                                       \
       }                                                                              \
     }                                                                                \
   }
 
-#define WRITE_DECIMAL                                                          \
-  if (!src_addr[Type::SHUFFLE_DECIMAL128].empty()) {                           \
-    for (i = read_offset; i < num_rows; ++i) {                                 \
-      ARROW_ASSIGN_OR_RAISE(auto result,                                       \
-                            partition_writer_[writer_idx[i]]->WriteDecimal128( \
-                                src_addr[Type::SHUFFLE_DECIMAL128], i))        \
-      if (!result) {                                                           \
-        break;                                                                 \
-      }                                                                        \
-    }                                                                          \
-  }
-
-#define WRITE_BINARY(func, T, src_arr)                                          \
-  if (!src_arr.empty()) {                                                       \
-    for (i = read_offset; i < num_rows; ++i) {                                  \
-      ARROW_ASSIGN_OR_RAISE(auto result,                                        \
-                            partition_writer_[writer_idx[i]]->func(src_arr, i)) \
-      if (!result) {                                                            \
-        break;                                                                  \
-      }                                                                         \
-    }                                                                           \
+#define WRITE_BINARY(func, T, src_arr)                                 \
+  if (!src_arr.empty()) {                                              \
+    for (i = read_offset; i < num_rows; ++i) {                         \
+      ARROW_ASSIGN_OR_RAISE(auto result, writers[i]->func(src_arr, i)) \
+      if (!result) {                                                   \
+        break;                                                         \
+      }                                                                \
+    }                                                                  \
   }
 
   while (read_offset < num_rows) {
@@ -168,66 +187,88 @@ arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb,
 #undef WRITE_BINARY
 
   return arrow::Status::OK();
+}  // namespace shuffle
+
+arrow::Status Splitter::Split(const arrow::RecordBatch& rb) {
+  ARROW_ASSIGN_OR_RAISE(auto writers, GetNextBatchPartitionWriter(rb));
+  return DoSplit(rb, std::move(writers));
 }
 
 arrow::Status Splitter::Stop() {
+  // write EOF to spilled file
+  RETURN_NOT_OK(spilled_file_writer_->Close());
+  // close spilled file output stream
+  RETURN_NOT_OK(spilled_file_os_->Close());
+
+  auto reader_options = arrow::ipc::IpcReadOptions::Defaults();
+  reader_options.use_threads = false;
+  // open spilled file input stream
+  ARROW_ASSIGN_OR_RAISE(auto spilled_file_is_,
+                        arrow::io::ReadableFile::Open(spilled_file_));
+  // create record batch file reader, no need to close
+  ARROW_ASSIGN_OR_RAISE(spilled_file_reader_, arrow::ipc::RecordBatchFileReader::Open(
+                                                  spilled_file_is_, reader_options));
+  // open data file output stream
+  ARROW_ASSIGN_OR_RAISE(data_file_os_,
+                        arrow::io::FileOutputStream::Open(options_.data_file, false));
+
+  // stop PartitionWriter and collect metrics
   for (const auto& writer : partition_writer_) {
     if (writer != nullptr) {
       RETURN_NOT_OK(writer->Stop());
-      ARROW_ASSIGN_OR_RAISE(auto b, writer->GetBytesWritten());
-      total_bytes_written_ += b;
+      auto length = writer->GetPartitionLength();
+      partition_lengths_.push_back(length);
+      total_bytes_written_ += length;
       total_write_time_ += writer->GetWriteTime();
+    } else {
+      partition_lengths_.push_back(0);
     }
   }
-  std::sort(std::begin(partition_file_info_), std::end(partition_file_info_));
+
+  // close spilled file input stream
+  RETURN_NOT_OK(spilled_file_is_->Close());
+  // close data file output Stream
+  RETURN_NOT_OK(data_file_os_->Close());
+
+  auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
+  RETURN_NOT_OK(fs->DeleteFile(spilled_file_));
+
   return arrow::Status::OK();
 }
 
-arrow::Result<std::string> Splitter::CreateDataFile() {
-  int m = configured_dirs_.size();
-  ARROW_ASSIGN_OR_RAISE(auto data_file,
-                        CreateTempShuffleFile(fs_, configured_dirs_[dir_selection_],
-                                              sub_dir_selection_[dir_selection_]))
-  sub_dir_selection_[dir_selection_] =
-      (sub_dir_selection_[dir_selection_] + 1) % num_sub_dirs_;
-  dir_selection_ = (dir_selection_ + 1) % m;
-  return data_file;
-}
-
-arrow::Status Splitter::Split(const arrow::RecordBatch& rb) {
-  ARROW_ASSIGN_OR_RAISE(auto writers, GetNextBatchPartitionWriterIndex(rb));
-  return DoSplit(rb, std::move(writers));
+arrow::Result<std::shared_ptr<PartitionWriter>> Splitter::GetPartitionWriter(
+    int32_t partition_id) {
+  if (partition_writer_[partition_id] == nullptr) {
+    ARROW_ASSIGN_OR_RAISE(
+        partition_writer_[partition_id],
+        PartitionWriter::Create(partition_id, options_.buffer_size,
+                                options_.compression_type, last_type_id_, column_type_id_,
+                                schema_, data_file_os_, spilled_file_writer_,
+                                spilled_file_reader_, &spilled_batch_index));
+  }
+  return partition_writer_[partition_id];
 }
 
 // ----------------------------------------------------------------------
 // RoundRobinSplitter
 
 arrow::Result<std::shared_ptr<RoundRobinSplitter>> RoundRobinSplitter::Create(
-    int32_t num_partitions, std::shared_ptr<arrow::Schema> schema) {
+    int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options) {
   std::shared_ptr<RoundRobinSplitter> res(
-      new RoundRobinSplitter(num_partitions, std::move(schema)));
+      new RoundRobinSplitter(num_partitions, std::move(schema), std::move(options)));
   RETURN_NOT_OK(res->Init());
   return res;
 }
 
-arrow::Result<std::vector<int>> RoundRobinSplitter::GetNextBatchPartitionWriterIndex(
-    const arrow::RecordBatch& rb) {
+arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
+RoundRobinSplitter::GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) {
   auto num_rows = rb.num_rows();
 
-  std::vector<int32_t> res;
+  std::vector<std::shared_ptr<PartitionWriter>> res;
   res.reserve(num_rows);
   for (auto i = 0; i < num_rows; ++i) {
-    if (partition_writer_[pid_selection_] == nullptr) {
-      ARROW_ASSIGN_OR_RAISE(auto file_path, CreateDataFile())
-      partition_file_info_.emplace_back(pid_selection_, std::move(file_path));
-
-      ARROW_ASSIGN_OR_RAISE(
-          partition_writer_[pid_selection_],
-          PartitionWriter::Create(pid_selection_, buffer_size_, last_type_id_,
-                                  column_type_id_, schema_,
-                                  partition_file_info_.back().second, compression_type_));
-    }
-    res.push_back(pid_selection_);
+    ARROW_ASSIGN_OR_RAISE(auto writer, GetPartitionWriter(pid_selection_));
+    res.push_back(std::move(writer));
     pid_selection_ = (pid_selection_ + 1) % num_partitions_;
   }
   return res;
@@ -238,8 +279,9 @@ arrow::Result<std::vector<int>> RoundRobinSplitter::GetNextBatchPartitionWriterI
 
 arrow::Result<std::shared_ptr<HashSplitter>> HashSplitter::Create(
     int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
-    const gandiva::ExpressionVector& expr_vector) {
-  std::shared_ptr<HashSplitter> res(new HashSplitter(num_partitions, std::move(schema)));
+    const gandiva::ExpressionVector& expr_vector, SplitOptions options) {
+  std::shared_ptr<HashSplitter> res(
+      new HashSplitter(num_partitions, std::move(schema), std::move(options)));
   RETURN_NOT_OK(res->Init());
   RETURN_NOT_OK(res->CreateProjector(expr_vector));
   return res;
@@ -283,8 +325,8 @@ arrow::Status HashSplitter::CreateProjector(
   return gandiva::Projector::Make(schema_, {hash_expr}, &projector_);
 }
 
-arrow::Result<std::vector<int32_t>> HashSplitter::GetNextBatchPartitionWriterIndex(
-    const arrow::RecordBatch& rb) {
+arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
+HashSplitter::GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) {
   arrow::ArrayVector outputs;
   TIME_NANO_OR_RAISE(total_compute_pid_time_,
                      projector_->Evaluate(rb, arrow::default_memory_pool(), &outputs));
@@ -295,23 +337,14 @@ arrow::Result<std::vector<int32_t>> HashSplitter::GetNextBatchPartitionWriterInd
 
   auto num_rows = rb.num_rows();
   auto pid_arr = std::dynamic_pointer_cast<arrow::Int32Array>(outputs.at(0));
-  std::vector<int32_t> res;
+  std::vector<std::shared_ptr<PartitionWriter>> res;
   res.reserve(num_rows);
   for (auto i = 0; i < num_rows; ++i) {
     // positive mod
     auto pid = pid_arr->Value(i) % num_partitions_;
     if (pid < 0) pid = (pid + num_partitions_) % num_partitions_;
-    if (partition_writer_[pid] == nullptr) {
-      ARROW_ASSIGN_OR_RAISE(auto file_path, CreateDataFile())
-      partition_file_info_.emplace_back(pid, std::move(file_path));
-
-      ARROW_ASSIGN_OR_RAISE(
-          partition_writer_[pid],
-          PartitionWriter::Create(pid, buffer_size_, last_type_id_, column_type_id_,
-                                  schema_, partition_file_info_.back().second,
-                                  compression_type_))
-    }
-    res.push_back(pid);
+    ARROW_ASSIGN_OR_RAISE(auto writer, GetPartitionWriter(pid));
+    res.push_back(std::move(writer));
   }
   return res;
 }
@@ -320,9 +353,9 @@ arrow::Result<std::vector<int32_t>> HashSplitter::GetNextBatchPartitionWriterInd
 // FallBackRangeSplitter
 
 arrow::Result<std::shared_ptr<FallbackRangeSplitter>> FallbackRangeSplitter::Create(
-    int32_t num_partitions, std::shared_ptr<arrow::Schema> schema) {
+    int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options) {
   auto res = std::shared_ptr<FallbackRangeSplitter>(
-      new FallbackRangeSplitter(num_partitions, std::move(schema)));
+      new FallbackRangeSplitter(num_partitions, std::move(schema), std::move(options)));
   RETURN_NOT_OK(res->Init());
   return res;
 }
@@ -334,15 +367,15 @@ arrow::Status FallbackRangeSplitter::Init() {
 }
 
 arrow::Status FallbackRangeSplitter::Split(const arrow::RecordBatch& rb) {
-  ARROW_ASSIGN_OR_RAISE(auto writers, GetNextBatchPartitionWriterIndex(rb));
+  ARROW_ASSIGN_OR_RAISE(auto writers, GetNextBatchPartitionWriter(rb));
   ARROW_ASSIGN_OR_RAISE(auto remove_pid, rb.RemoveColumn(0));
   return DoSplit(*remove_pid, std::move(writers));
 }
 
-arrow::Result<std::vector<int32_t>>
-FallbackRangeSplitter::GetNextBatchPartitionWriterIndex(const arrow::RecordBatch& rb) {
+arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
+FallbackRangeSplitter::GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) {
   auto num_rows = rb.num_rows();
-  std::vector<int32_t> res;
+  std::vector<std::shared_ptr<PartitionWriter>> res;
   res.reserve(num_rows);
 
   if (rb.column(0)->type_id() != arrow::Type::INT32) {
@@ -358,17 +391,8 @@ FallbackRangeSplitter::GetNextBatchPartitionWriterIndex(const arrow::RecordBatch
                                     " is equal or greater than ",
                                     std::to_string(num_partitions_));
     }
-    if (partition_writer_[pid] == nullptr) {
-      ARROW_ASSIGN_OR_RAISE(auto file_path, CreateDataFile())
-      partition_file_info_.emplace_back(pid, std::move(file_path));
-
-      ARROW_ASSIGN_OR_RAISE(
-          partition_writer_[pid],
-          PartitionWriter::Create(pid, buffer_size_, last_type_id_, column_type_id_,
-                                  schema_, partition_file_info_.back().second,
-                                  compression_type_))
-    }
-    res.push_back(pid);
+    ARROW_ASSIGN_OR_RAISE(auto writer, GetPartitionWriter(pid));
+    res.push_back(std::move(writer));
   }
   return res;
 }

--- a/oap-native-sql/cpp/src/shuffle/splitter.cc
+++ b/oap-native-sql/cpp/src/shuffle/splitter.cc
@@ -199,6 +199,7 @@ arrow::Status Splitter::Stop() {
       auto length = writer->GetPartitionLength();
       partition_lengths_.push_back(length);
       total_bytes_written_ += length;
+      total_bytes_spilled_ += writer->GetBytesSpilled();
       total_write_time_ += writer->GetWriteTime();
       total_spill_time_ += writer->GetSpillTime();
     } else {

--- a/oap-native-sql/cpp/src/shuffle/splitter.h
+++ b/oap-native-sql/cpp/src/shuffle/splitter.h
@@ -88,14 +88,13 @@ class Splitter {
 
   virtual arrow::Status Init();
 
-  virtual arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
-  GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) = 0;
+  virtual arrow::Result<std::vector<int32_t>> GetNextBatchPartitionWriterIndex(
+      const arrow::RecordBatch& rb) = 0;
 
   arrow::Status DoSplit(const arrow::RecordBatch& rb,
-                        std::vector<std::shared_ptr<PartitionWriter>> writer_idx);
+                        const std::vector<int32_t>& writer_idx);
 
-  arrow::Result<std::shared_ptr<PartitionWriter>> GetPartitionWriter(
-      int32_t partition_id);
+  arrow::Status CreatePartitionWriter(int32_t partition_id);
 
   int32_t num_partitions_;
   std::shared_ptr<arrow::Schema> schema_;
@@ -127,8 +126,8 @@ class RoundRobinSplitter : public Splitter {
       SplitOptions options);
 
  protected:
-  arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
-  GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) override;
+  arrow::Result<std::vector<int32_t>> GetNextBatchPartitionWriterIndex(
+      const arrow::RecordBatch& rb) override;
 
  private:
   RoundRobinSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
@@ -151,8 +150,8 @@ class HashSplitter : public Splitter {
 
   arrow::Status CreateProjector(const gandiva::ExpressionVector& expr_vector);
 
-  arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
-  GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) override;
+  arrow::Result<std::vector<int32_t>> GetNextBatchPartitionWriterIndex(
+      const arrow::RecordBatch& rb) override;
 
   std::shared_ptr<gandiva::Projector> projector_;
 };
@@ -174,8 +173,8 @@ class FallbackRangeSplitter : public Splitter {
 
   arrow::Status Init() override;
 
-  arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
-  GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) override;
+  arrow::Result<std::vector<int32_t>> GetNextBatchPartitionWriterIndex(
+      const arrow::RecordBatch& rb) override;
 
   std::shared_ptr<arrow::Schema> input_schema_;
 };

--- a/oap-native-sql/cpp/src/shuffle/splitter.h
+++ b/oap-native-sql/cpp/src/shuffle/splitter.h
@@ -35,6 +35,7 @@ namespace shuffle {
 
 struct SplitOptions {
   int32_t buffer_size = kDefaultSplitterBufferSize;
+  int32_t num_sub_dirs = kDefaultNumSubDirs;
   arrow::Compression::type compression_type = arrow::Compression::UNCOMPRESSED;
 
   std::string data_file;
@@ -100,10 +101,6 @@ class Splitter {
   std::shared_ptr<arrow::Schema> schema_;
   SplitOptions options_;
 
-  // Temporary file to hold all spilled data, which shares the same directory of
-  // options_.data_file
-  std::string spilled_file_;
-
   int64_t total_bytes_written_ = 0;
   int64_t total_write_time_ = 0;
   int64_t total_spill_time_ = 0;
@@ -115,11 +112,12 @@ class Splitter {
   Type::typeId last_type_id_ = Type::SHUFFLE_NOT_IMPLEMENTED;
   std::vector<Type::typeId> column_type_id_;
 
-  std::shared_ptr<arrow::io::OutputStream> spilled_file_os_;
-  std::shared_ptr<arrow::ipc::RecordBatchWriter> spilled_file_writer_;
-  std::shared_ptr<arrow::ipc::RecordBatchFileReader> spilled_file_reader_;
+  // configured local dirs for spilled file
+  int32_t dir_selection_ = 0;
+  std::vector<int32_t> sub_dir_selection_;
+  std::vector<std::string> configured_dirs_;
+
   std::shared_ptr<arrow::io::OutputStream> data_file_os_;
-  int32_t spilled_batch_index = 0;
 };
 
 class RoundRobinSplitter : public Splitter {

--- a/oap-native-sql/cpp/src/shuffle/splitter.h
+++ b/oap-native-sql/cpp/src/shuffle/splitter.h
@@ -117,7 +117,7 @@ class Splitter {
   std::vector<int32_t> sub_dir_selection_;
   std::vector<std::string> configured_dirs_;
 
-  std::shared_ptr<arrow::io::OutputStream> data_file_os_;
+  std::shared_ptr<arrow::io::FileOutputStream> data_file_os_;
 };
 
 class RoundRobinSplitter : public Splitter {

--- a/oap-native-sql/cpp/src/shuffle/splitter.h
+++ b/oap-native-sql/cpp/src/shuffle/splitter.h
@@ -69,6 +69,8 @@ class Splitter {
 
   int64_t TotalWriteTime() const { return total_write_time_; }
 
+  int64_t TotalSpillTime() const { return total_spill_time_; }
+
   int64_t TotalComputePidTime() const { return total_compute_pid_time_; }
 
   const std::vector<int64_t>& PartitionLengths() const { return partition_lengths_; }
@@ -104,6 +106,7 @@ class Splitter {
 
   int64_t total_bytes_written_ = 0;
   int64_t total_write_time_ = 0;
+  int64_t total_spill_time_ = 0;
   int64_t total_compute_pid_time_ = 0;
   std::vector<int64_t> partition_lengths_;
 

--- a/oap-native-sql/cpp/src/shuffle/splitter.h
+++ b/oap-native-sql/cpp/src/shuffle/splitter.h
@@ -33,17 +33,25 @@
 namespace sparkcolumnarplugin {
 namespace shuffle {
 
+struct SplitOptions {
+  int32_t buffer_size = kDefaultSplitterBufferSize;
+  arrow::Compression::type compression_type = arrow::Compression::UNCOMPRESSED;
+
+  std::string data_file;
+
+  static SplitOptions Defaults();
+};
+
 class Splitter {
  public:
-  ~Splitter();
+  static arrow::Result<std::shared_ptr<Splitter>> Make(
+      const std::string& short_name, std::shared_ptr<arrow::Schema> schema,
+      int num_partitions, const gandiva::ExpressionVector& expr_vector,
+      SplitOptions options = SplitOptions::Defaults());
 
   static arrow::Result<std::shared_ptr<Splitter>> Make(
       const std::string& short_name, std::shared_ptr<arrow::Schema> schema,
-      int num_partitions, const gandiva::ExpressionVector& expr_vector);
-
-  static arrow::Result<std::shared_ptr<Splitter>> Make(
-      const std::string& short_name, std::shared_ptr<arrow::Schema> schema,
-      int num_partitions);
+      int num_partitions, SplitOptions options = SplitOptions::Defaults());
 
   virtual const std::shared_ptr<arrow::Schema>& schema() const { return schema_; }
 
@@ -63,70 +71,68 @@ class Splitter {
 
   int64_t TotalComputePidTime() const { return total_compute_pid_time_; }
 
-  virtual const std::vector<std::pair<int32_t, std::string>>& GetPartitionFileInfo()
-      const {
-    return partition_file_info_;
-  }
+  const std::vector<int64_t>& PartitionLengths() const { return partition_lengths_; }
 
-  void set_compression_type(arrow::Compression::type compression_type) {
-    compression_type_ = compression_type;
-  }
-
-  void set_buffer_size(int32_t buffer_size) { buffer_size_ = buffer_size; };
-
-  void set_num_sub_dirs(int32_t num_sub_dirs) { num_sub_dirs_ = num_sub_dirs; }
+  // for testing
+  const std::string& DataFile() const { return options_.data_file; }
 
  protected:
-  Splitter() = default;
-  explicit Splitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema)
-      : num_partitions_(num_partitions), schema_(std::move(schema)) {}
+  Splitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
+           SplitOptions options)
+      : num_partitions_(num_partitions),
+        schema_(std::move(schema)),
+        options_(std::move(options)) {}
 
   virtual arrow::Status Init();
 
-  virtual arrow::Result<std::vector<int32_t>> GetNextBatchPartitionWriterIndex(
-      const arrow::RecordBatch& rb) = 0;
+  virtual arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
+  GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) = 0;
 
-  arrow::Status DoSplit(const arrow::RecordBatch& rb, std::vector<int32_t> writer_idx);
+  arrow::Status DoSplit(const arrow::RecordBatch& rb,
+                        std::vector<std::shared_ptr<PartitionWriter>> writer_idx);
 
-  arrow::Result<std::string> CreateDataFile();
-  const int32_t num_partitions_;
+  arrow::Result<std::shared_ptr<PartitionWriter>> GetPartitionWriter(
+      int32_t partition_id);
+
+  int32_t num_partitions_;
   std::shared_ptr<arrow::Schema> schema_;
+  SplitOptions options_;
 
-  arrow::Compression::type compression_type_ = arrow::Compression::UNCOMPRESSED;
-  int32_t buffer_size_ = kDefaultSplitterBufferSize;
-  int32_t num_sub_dirs_ = kDefaultNumSubDirs;
+  // Temporary file to hold all spilled data, which shares the same directory of
+  // options_.data_file
+  std::string spilled_file_;
 
   int64_t total_bytes_written_ = 0;
   int64_t total_write_time_ = 0;
   int64_t total_compute_pid_time_ = 0;
-
-  std::vector<std::pair<int32_t, std::string>> partition_file_info_;
-
-  std::shared_ptr<arrow::fs::LocalFileSystem> fs_;
+  std::vector<int64_t> partition_lengths_;
 
   // partition writer and parameters
   std::vector<std::shared_ptr<PartitionWriter>> partition_writer_;
   Type::typeId last_type_id_ = Type::SHUFFLE_NOT_IMPLEMENTED;
   std::vector<Type::typeId> column_type_id_;
 
-  // configured local dirs for temporary output file
-  int32_t dir_selection_ = 0;
-  std::vector<int32_t> sub_dir_selection_;
-  std::vector<std::string> configured_dirs_;
+  std::shared_ptr<arrow::io::OutputStream> spilled_file_os_;
+  std::shared_ptr<arrow::ipc::RecordBatchWriter> spilled_file_writer_;
+  std::shared_ptr<arrow::ipc::RecordBatchFileReader> spilled_file_reader_;
+  std::shared_ptr<arrow::io::OutputStream> data_file_os_;
+  int32_t spilled_batch_index = 0;
 };
 
 class RoundRobinSplitter : public Splitter {
  public:
   static arrow::Result<std::shared_ptr<RoundRobinSplitter>> Create(
-      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema);
+      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
+      SplitOptions options);
 
  protected:
-  arrow::Result<std::vector<int32_t>> GetNextBatchPartitionWriterIndex(
-      const arrow::RecordBatch& rb) override;
+  arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
+  GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) override;
 
  private:
-  RoundRobinSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema)
-      : Splitter(num_partitions, std::move(schema)) {}
+  RoundRobinSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
+                     SplitOptions options)
+      : Splitter(num_partitions, std::move(schema), std::move(options)) {}
 
   int32_t pid_selection_ = 0;
 };
@@ -135,16 +141,17 @@ class HashSplitter : public Splitter {
  public:
   static arrow::Result<std::shared_ptr<HashSplitter>> Create(
       int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
-      const gandiva::ExpressionVector& expr_vector);
+      const gandiva::ExpressionVector& expr_vector, SplitOptions options);
 
  private:
-  HashSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema)
-      : Splitter(num_partitions, std::move(schema)) {}
+  HashSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
+               SplitOptions options)
+      : Splitter(num_partitions, std::move(schema), std::move(options)) {}
 
   arrow::Status CreateProjector(const gandiva::ExpressionVector& expr_vector);
 
-  arrow::Result<std::vector<int32_t>> GetNextBatchPartitionWriterIndex(
-      const arrow::RecordBatch& rb) override;
+  arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
+  GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) override;
 
   std::shared_ptr<gandiva::Projector> projector_;
 };
@@ -152,20 +159,22 @@ class HashSplitter : public Splitter {
 class FallbackRangeSplitter : public Splitter {
  public:
   static arrow::Result<std::shared_ptr<FallbackRangeSplitter>> Create(
-      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema);
+      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
+      SplitOptions options);
 
   arrow::Status Split(const arrow::RecordBatch& rb) override;
 
   const std::shared_ptr<arrow::Schema>& schema() const override { return input_schema_; }
 
  private:
-  FallbackRangeSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema)
-      : Splitter(num_partitions, std::move(schema)) {}
+  FallbackRangeSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema,
+                        SplitOptions options)
+      : Splitter(num_partitions, std::move(schema), std::move(options)) {}
 
   arrow::Status Init() override;
 
-  arrow::Result<std::vector<int32_t>> GetNextBatchPartitionWriterIndex(
-      const arrow::RecordBatch& rb) override;
+  arrow::Result<std::vector<std::shared_ptr<PartitionWriter>>>
+  GetNextBatchPartitionWriter(const arrow::RecordBatch& rb) override;
 
   std::shared_ptr<arrow::Schema> input_schema_;
 };

--- a/oap-native-sql/cpp/src/shuffle/splitter.h
+++ b/oap-native-sql/cpp/src/shuffle/splitter.h
@@ -68,6 +68,8 @@ class Splitter {
 
   int64_t TotalBytesWritten() const { return total_bytes_written_; }
 
+  int64_t TotalBytesSpilled() const { return total_bytes_spilled_; }
+
   int64_t TotalWriteTime() const { return total_write_time_; }
 
   int64_t TotalSpillTime() const { return total_spill_time_; }
@@ -101,6 +103,7 @@ class Splitter {
   SplitOptions options_;
 
   int64_t total_bytes_written_ = 0;
+  int64_t total_bytes_spilled_= 0;
   int64_t total_write_time_ = 0;
   int64_t total_spill_time_ = 0;
   int64_t total_compute_pid_time_ = 0;

--- a/oap-native-sql/cpp/src/shuffle/type.h
+++ b/oap-native-sql/cpp/src/shuffle/type.h
@@ -28,6 +28,9 @@ namespace shuffle {
 static constexpr int32_t kDefaultSplitterBufferSize = 4096;
 static constexpr int32_t kDefaultNumSubDirs = 64;
 
+// This 0xFFFFFFFF value is the first 4 bytes of a valid IPC message
+static constexpr int32_t kIpcContinuationToken = -1;
+
 struct BufferInfo {
   std::shared_ptr<arrow::Buffer> validity_buffer;
   std::shared_ptr<arrow::Buffer> value_buffer;

--- a/oap-native-sql/cpp/src/shuffle/utils.h
+++ b/oap-native-sql/cpp/src/shuffle/utils.h
@@ -41,7 +41,6 @@ static arrow::Result<std::string> GetSpilledShuffleFileDir(
   std::stringstream ss;
   ss << std::setfill('0') << std::setw(2) << std::hex << sub_dir_id;
   auto dir = arrow::fs::internal::ConcatAbstractPath(configured_dir, ss.str());
-  RETURN_NOT_OK(fs->CreateDir(dir));
   return dir;
 }
 

--- a/oap-native-sql/cpp/src/tests/shuffle_split_test.cc
+++ b/oap-native-sql/cpp/src/tests/shuffle_split_test.cc
@@ -68,19 +68,15 @@ class SplitterTest : public ::testing::Test {
     }
   }
 
-  void CheckFileExsists(const std::string& file_name) {
+  static void CheckFileExsists(const std::string& file_name) {
     ASSERT_EQ(*arrow::internal::FileExists(
                   *arrow::internal::PlatformFilename::FromString(file_name)),
               true);
   }
 
-  arrow::Status MakeSplitter(const std::string& name, int32_t num_partitions,
-                             int32_t buffer_size) {
-    return arrow::Status::OK();
-  }
-
   arrow::Result<std::shared_ptr<arrow::RecordBatch>> TakeRows(
-      std::shared_ptr<arrow::RecordBatch> input_batch, std::string json_idx) {
+      const std::shared_ptr<arrow::RecordBatch>& input_batch,
+      const std::string& json_idx) {
     std::shared_ptr<arrow::Array> take_idx;
     ASSERT_NOT_OK(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::int32(), json_idx, &take_idx));
@@ -203,9 +199,6 @@ TEST_F(SplitterTest, TestRoundRobinSplitter) {
   output_batches.push_back(std::move(res_batch));
   ARROW_ASSIGN_OR_THROW(res_batch, TakeRows(input_batch_1_, "[1, 3]"))
   output_batches.push_back(std::move(res_batch));
-
-  // verify data file
-  CheckFileExsists(splitter_->DataFile());
 
   // read first block
   std::shared_ptr<arrow::ipc::RecordBatchReader> file_reader;

--- a/oap-native-sql/cpp/src/tests/shuffle_split_test.cc
+++ b/oap-native-sql/cpp/src/tests/shuffle_split_test.cc
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include <iostream>
+
 #include <arrow/compute/api.h>
 #include <arrow/io/api.h>
 #include <arrow/ipc/reader.h>
@@ -22,7 +24,7 @@
 #include <arrow/record_batch.h>
 #include <arrow/util/io_util.h>
 #include <gtest/gtest.h>
-#include <iostream>
+
 #include "shuffle/splitter.h"
 #include "tests/test_utils.h"
 
@@ -56,28 +58,20 @@ class SplitterTest : public ::testing::Test {
 
     MakeInputBatch(input_data_1, schema_, &input_batch_1_);
     MakeInputBatch(input_data_2, schema_, &input_batch_2_);
+
+    split_options_ = SplitOptions::Defaults();
   }
 
   void TearDown() override {
     if (file_ != nullptr && !file_->closed()) {
       file_->Close();
     }
-
-    auto& file_infos = splitter_->GetPartitionFileInfo();
-    std::vector<std::string> file_names;
-    for (const auto& file_info : file_infos) {
-      arrow::internal::DeleteFile(
-          *arrow::internal::PlatformFilename::FromString(file_info.second));
-    }
-    arrow::internal::DeleteDirTree(tmp_dir_1_->path());
-    arrow::internal::DeleteDirTree(tmp_dir_2_->path());
   }
 
   void CheckFileExsists(const std::string& file_name) {
     ASSERT_EQ(*arrow::internal::FileExists(
                   *arrow::internal::PlatformFilename::FromString(file_name)),
               true);
-    ASSERT_NE(file_name.find(tmp_dir_prefix), std::string::npos);
   }
 
   arrow::Status MakeSplitter(const std::string& name, int32_t num_partitions,
@@ -98,8 +92,8 @@ class SplitterTest : public ::testing::Test {
     return res;
   }
 
-  arrow::Result<std::shared_ptr<arrow::ipc::RecordBatchReader>> GetRecordBatchReader(
-      const std::string& file_name) {
+  arrow::Result<std::shared_ptr<arrow::ipc::RecordBatchReader>>
+  GetRecordBatchStreamReader(const std::string& file_name) {
     if (file_ != nullptr && !file_->closed()) {
       RETURN_NOT_OK(file_->Close());
     }
@@ -118,6 +112,7 @@ class SplitterTest : public ::testing::Test {
 
   std::shared_ptr<arrow::Schema> schema_;
   std::shared_ptr<Splitter> splitter_;
+  SplitOptions split_options_;
 
   std::shared_ptr<arrow::RecordBatch> input_batch_1_;
   std::shared_ptr<arrow::RecordBatch> input_batch_2_;
@@ -149,9 +144,8 @@ const std::vector<std::string> SplitterTest::input_data_2 = {
     R"([null, null, "3.01", "4.01"])"};
 
 TEST_F(SplitterTest, TestSingleSplitter) {
-  int32_t buffer_size = 2;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", schema_, 1))
-  splitter_->set_buffer_size(buffer_size);
+  split_options_.buffer_size = 2;
+  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", schema_, 1, split_options_))
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_2_));
@@ -159,15 +153,15 @@ TEST_F(SplitterTest, TestSingleSplitter) {
 
   ASSERT_NOT_OK(splitter_->Stop());
 
-  // verify output temporary files
-  const auto& file_info = splitter_->GetPartitionFileInfo();
-  ASSERT_EQ(file_info.size(), 1);
+  // verify data file
+  CheckFileExsists(splitter_->DataFile());
 
-  auto file_name = file_info[0].second;
-  CheckFileExsists(file_name);
+  // verify output temporary files
+  const auto& lengths = splitter_->PartitionLengths();
+  ASSERT_EQ(lengths.size(), 1);
 
   std::shared_ptr<arrow::ipc::RecordBatchReader> file_reader;
-  ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchReader(file_name));
+  ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchStreamReader(splitter_->DataFile()));
 
   // verify schema
   ASSERT_EQ(*file_reader->schema(), *schema_);
@@ -179,7 +173,7 @@ TEST_F(SplitterTest, TestSingleSplitter) {
   for (auto i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), schema_->num_fields());
-    ASSERT_EQ(rb->num_rows(), buffer_size);
+    ASSERT_EQ(rb->num_rows(), split_options_.buffer_size);
     for (auto j = 0; j < rb->num_columns(); ++j) {
       ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
     }
@@ -193,18 +187,15 @@ TEST_F(SplitterTest, TestSingleSplitter) {
 
 TEST_F(SplitterTest, TestRoundRobinSplitter) {
   int32_t num_partitions = 2;
-  int32_t buffer_size = 2;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", schema_, num_partitions));
-  splitter_->set_buffer_size(buffer_size);
+  split_options_.buffer_size = 2;
+  ARROW_ASSIGN_OR_THROW(splitter_,
+                        Splitter::Make("rr", schema_, num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_2_));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_));
 
   ASSERT_NOT_OK(splitter_->Stop());
-
-  auto file_info = splitter_->GetPartitionFileInfo();
-  ASSERT_EQ(file_info.size(), num_partitions);
 
   std::vector<std::shared_ptr<arrow::RecordBatch>> output_batches;
   std::shared_ptr<arrow::RecordBatch> res_batch;
@@ -213,38 +204,58 @@ TEST_F(SplitterTest, TestRoundRobinSplitter) {
   ARROW_ASSIGN_OR_THROW(res_batch, TakeRows(input_batch_1_, "[1, 3]"))
   output_batches.push_back(std::move(res_batch));
 
-  for (const auto& info : file_info) {
-    // verify output temporary files
-    auto pid = info.first;
-    const auto& file_name = info.second;
-    CheckFileExsists(file_name);
+  // verify data file
+  CheckFileExsists(splitter_->DataFile());
 
-    std::shared_ptr<arrow::ipc::RecordBatchReader> file_reader;
-    ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchReader(file_name));
+  // read first block
+  std::shared_ptr<arrow::ipc::RecordBatchReader> file_reader;
+  ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchStreamReader(splitter_->DataFile()));
 
-    // verify schema
-    ASSERT_EQ(*file_reader->schema(), *schema_);
+  // verify partition lengths
+  const auto& lengths = splitter_->PartitionLengths();
+  ASSERT_EQ(lengths.size(), 2);
+  ASSERT_EQ(*file_->GetSize(), lengths[0] + lengths[1]);
 
-    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-    ASSERT_NOT_OK(file_reader->ReadAll(&batches));
+  // verify schema
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+  ASSERT_EQ(*file_reader->schema(), *schema_);
+  ASSERT_NOT_OK(file_reader->ReadAll(&batches));
+  ASSERT_EQ(batches.size(), 3);
+  for (auto i = 0; i < batches.size(); ++i) {
+    const auto& rb = batches[i];
+    ASSERT_EQ(rb->num_columns(), schema_->num_fields());
+    ASSERT_EQ(rb->num_rows(), split_options_.buffer_size);
+    for (auto j = 0; j < rb->num_columns(); ++j) {
+      ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
+    }
+    if (i == batches.size() - 1) {
+      ASSERT_TRUE(rb->Equals(*output_batches[0]));
+    }
+  }
 
-    for (auto i = 0; i < batches.size(); ++i) {
-      const auto& rb = batches[i];
-      ASSERT_EQ(rb->num_columns(), schema_->num_fields());
-      ASSERT_EQ(rb->num_rows(), buffer_size);
-      for (auto j = 0; j < rb->num_columns(); ++j) {
-        ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
-      }
-      if (i == batches.size() - 1) {
-        ASSERT_TRUE(rb->Equals(*output_batches[pid]));
-      }
+  // read second block
+  batches.clear();
+  ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchStreamReader(splitter_->DataFile()));
+  ASSERT_EQ(*file_reader->schema(), *schema_);
+  ASSERT_NOT_OK(file_->Advance(lengths[0]));
+  ASSERT_NOT_OK(file_reader->ReadAll(&batches));
+  ASSERT_EQ(batches.size(), 3);
+  for (auto i = 0; i < batches.size(); ++i) {
+    const auto& rb = batches[i];
+    ASSERT_EQ(rb->num_columns(), schema_->num_fields());
+    ASSERT_EQ(rb->num_rows(), split_options_.buffer_size);
+    for (auto j = 0; j < rb->num_columns(); ++j) {
+      ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
+    }
+    if (i == batches.size() - 1) {
+      ASSERT_TRUE(rb->Equals(*output_batches[1]));
     }
   }
 }
 
 TEST_F(SplitterTest, TestHashSplitter) {
   int32_t num_partitions = 2;
-  int32_t buffer_size = 2;
+  split_options_.buffer_size = 2;
 
   auto f_0 = TreeExprBuilder::MakeField(schema_->field(1));
   auto f_1 = TreeExprBuilder::MakeField(schema_->field(2));
@@ -254,9 +265,8 @@ TEST_F(SplitterTest, TestHashSplitter) {
   auto expr_0 = TreeExprBuilder::MakeExpression(node_0, field("res0", int8()));
   auto expr_1 = TreeExprBuilder::MakeExpression(f_2, field("f_uint64", uint64()));
 
-  ARROW_ASSIGN_OR_THROW(splitter_,
-                        Splitter::Make("hash", schema_, num_partitions, {expr_0, expr_1}))
-  splitter_->set_buffer_size(buffer_size);
+  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("hash", schema_, num_partitions,
+                                                  {expr_0, expr_1}, split_options_))
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_2_));
@@ -264,37 +274,33 @@ TEST_F(SplitterTest, TestHashSplitter) {
 
   ASSERT_NOT_OK(splitter_->Stop());
 
-  auto file_info = splitter_->GetPartitionFileInfo();
-  ASSERT_EQ(file_info.size(), num_partitions);
+  const auto& lengths = splitter_->PartitionLengths();
+  ASSERT_EQ(lengths.size(), 2);
 
-  for (auto& info : file_info) {
-    // verify output temporary files
-    auto file_name = info.second;
-    CheckFileExsists(file_name);
+  // verify data file
+  CheckFileExsists(splitter_->DataFile());
 
-    std::shared_ptr<arrow::ipc::RecordBatchReader> file_reader;
-    ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchReader(file_name));
+  std::shared_ptr<arrow::ipc::RecordBatchReader> file_reader;
+  ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchStreamReader(splitter_->DataFile()));
 
-    // verify schema
-    ASSERT_EQ(*file_reader->schema(), *schema_);
+  // verify schema
+  ASSERT_EQ(*file_reader->schema(), *schema_);
 
-    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-    ASSERT_NOT_OK(file_reader->ReadAll(&batches));
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+  ASSERT_NOT_OK(file_reader->ReadAll(&batches));
 
-    for (auto i = 0; i < batches.size(); ++i) {
-      const auto& rb = batches[i];
-      ASSERT_EQ(rb->num_columns(), schema_->num_fields());
-      ASSERT_EQ(rb->num_rows(), buffer_size);
-      for (auto j = 0; j < rb->num_columns(); ++j) {
-        ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
-      }
+  for (const auto& rb : batches) {
+    ASSERT_EQ(rb->num_columns(), schema_->num_fields());
+    ASSERT_EQ(rb->num_rows(), split_options_.buffer_size);
+    for (auto i = 0; i < rb->num_columns(); ++i) {
+      ASSERT_EQ(rb->column(i)->length(), rb->num_rows());
     }
   }
 }
 
 TEST_F(SplitterTest, TestFallbackRangeSplitter) {
   int32_t num_partitions = 2;
-  int32_t buffer_size = 2;
+  split_options_.buffer_size = 2;
 
   std::shared_ptr<arrow::Array> pid_arr;
   ASSERT_NOT_OK(arrow::ipc::internal::json::ArrayFromJSON(arrow::int32(), "[0, 1, 0, 1]",
@@ -310,18 +316,14 @@ TEST_F(SplitterTest, TestFallbackRangeSplitter) {
   ARROW_ASSIGN_OR_THROW(input_batch_2_w_pid,
                         input_batch_2_->AddColumn(0, "pid", pid_arr));
 
-  ARROW_ASSIGN_OR_THROW(splitter_,
-                        Splitter::Make("range", std::move(schema_w_pid), num_partitions))
-  splitter_->set_buffer_size(buffer_size);
+  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("range", std::move(schema_w_pid),
+                                                  num_partitions, split_options_))
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_w_pid));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_2_w_pid));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_w_pid));
 
   ASSERT_NOT_OK(splitter_->Stop());
-
-  auto file_info = splitter_->GetPartitionFileInfo();
-  ASSERT_EQ(file_info.size(), num_partitions);
 
   std::vector<std::shared_ptr<arrow::RecordBatch>> output_batches;
   std::shared_ptr<arrow::RecordBatch> res_batch;
@@ -330,31 +332,51 @@ TEST_F(SplitterTest, TestFallbackRangeSplitter) {
   ARROW_ASSIGN_OR_THROW(res_batch, TakeRows(input_batch_1_, "[1, 3]"))
   output_batches.push_back(std::move(res_batch));
 
-  for (const auto& info : file_info) {
-    // verify output temporary files
-    auto pid = info.first;
-    const auto& file_name = info.second;
-    CheckFileExsists(file_name);
+  // verify data file
+  CheckFileExsists(splitter_->DataFile());
 
-    std::shared_ptr<arrow::ipc::RecordBatchReader> file_reader;
-    ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchReader(file_name));
+  // read first block
+  std::shared_ptr<arrow::ipc::RecordBatchReader> file_reader;
+  ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchStreamReader(splitter_->DataFile()));
 
-    // verify schema
-    ASSERT_EQ(*schema_, *file_reader->schema());
+  // verify partition lengths
+  const auto& lengths = splitter_->PartitionLengths();
+  ASSERT_EQ(lengths.size(), 2);
+  ASSERT_EQ(*file_->GetSize(), lengths[0] + lengths[1]);
 
-    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-    ASSERT_NOT_OK(file_reader->ReadAll(&batches));
+  // verify schema
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+  ASSERT_EQ(*file_reader->schema(), *schema_);
+  ASSERT_NOT_OK(file_reader->ReadAll(&batches));
+  ASSERT_EQ(batches.size(), 3);
+  for (auto i = 0; i < batches.size(); ++i) {
+    const auto& rb = batches[i];
+    ASSERT_EQ(rb->num_columns(), schema_->num_fields());
+    ASSERT_EQ(rb->num_rows(), split_options_.buffer_size);
+    for (auto j = 0; j < rb->num_columns(); ++j) {
+      ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
+    }
+    if (i == batches.size() - 1) {
+      ASSERT_TRUE(rb->Equals(*output_batches[0]));
+    }
+  }
 
-    for (auto i = 0; i < batches.size(); ++i) {
-      const auto& rb = batches[i];
-      ASSERT_EQ(rb->num_columns(), schema_->num_fields());
-      ASSERT_EQ(rb->num_rows(), buffer_size);
-      for (auto j = 0; j < rb->num_columns(); ++j) {
-        ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
-      }
-      if (i == batches.size() - 1) {
-        ASSERT_TRUE(rb->Equals(*output_batches[pid]));
-      }
+  // read second block
+  batches.clear();
+  ARROW_ASSIGN_OR_THROW(file_reader, GetRecordBatchStreamReader(splitter_->DataFile()));
+  ASSERT_EQ(*file_reader->schema(), *schema_);
+  ASSERT_NOT_OK(file_->Advance(lengths[0]));
+  ASSERT_NOT_OK(file_reader->ReadAll(&batches));
+  ASSERT_EQ(batches.size(), 3);
+  for (auto i = 0; i < batches.size(); ++i) {
+    const auto& rb = batches[i];
+    ASSERT_EQ(rb->num_columns(), schema_->num_fields());
+    ASSERT_EQ(rb->num_rows(), split_options_.buffer_size);
+    for (auto j = 0; j < rb->num_columns(); ++j) {
+      ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
+    }
+    if (i == batches.size() - 1) {
+      ASSERT_TRUE(rb->Equals(*output_batches[1]));
     }
   }
 }


### PR DESCRIPTION
The existing shuffle write will firstly produce number of reducer partition files, and then merge them into one data file. This results in twice inevitable file writes. 
This optimization handles two possibilities:
1. If one reducer partition buffer can hold all data, and when split finishes, the buffered data will be directly flushed to the final data file.
2. If the buffer cannot hold all data, which means data will spill to disk in the middle of split. When split finishes, it will firstly copy the spilled file to the final data file, and then flush the buffer.

issue: #1706 