### PR TITLE
[OAP-1727][POAE7-358] Spark integration: Memory Spill to PMem

### DIFF
--- a/oap-spark/src/main/java/org/apache/spark/memory/PMemManagerInitializer.java
+++ b/oap-spark/src/main/java/org/apache/spark/memory/PMemManagerInitializer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.memory;
+
+import com.intel.oap.common.storage.stream.PMemManager;
+
+import org.apache.spark.SparkEnv;
+import org.apache.spark.internal.config.ConfigEntry;
+import org.apache.spark.internal.config.package$;
+import org.apache.spark.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PMemManagerInitializer {
+    private static final Logger logger = LoggerFactory.getLogger(PMemManagerInitializer.class);
+    private static PMemManager pMemManager;
+    private static Properties properties;
+
+    public static Properties getProperties() {
+        if (properties == null) {
+            synchronized (Properties.class) {
+                if (properties == null) {
+                    ConfigEntry<String> pMemPropertiesFile =
+                            package$.MODULE$.PMEM_PROPERTY_FILE();
+                    String filePath = SparkEnv.get() == null ? pMemPropertiesFile.defaultValue().get() : SparkEnv.get().conf().get(pMemPropertiesFile);
+                    logger.debug("PMem Property file: " + filePath);
+                    Properties pps = new Properties();
+                    InputStream in = null;
+                    try {
+                        in = Utils.getSparkClassLoader().getResourceAsStream(filePath);
+                        if (in == null) {
+                            in = new BufferedInputStream(new FileInputStream(filePath));
+                        }
+                        pps.load(in);
+                        pps.setProperty("chunkSize", String.valueOf(
+                                Utils.byteStringAsBytes(pps.getProperty("chunkSize"))));
+                        pps.setProperty("totalSize", String.valueOf(
+                                Utils.byteStringAsBytes(pps.getProperty("totalSize"))));
+                        pps.setProperty("initialSize", String.valueOf(
+                                Utils.byteStringAsBytes(pps.getProperty("initialSize"))));
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    } finally {
+                        try {
+                            in.close();
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    properties = pps;
+                }
+            }
+        }
+        return properties;
+    }
+
+    public static PMemManager getPMemManager() {
+        if (pMemManager == null) {
+            synchronized (PMemManager.class) {
+                if (pMemManager == null) {
+                    pMemManager = new PMemManager(getProperties());
+                }
+            }
+        }
+        return pMemManager;
+    }
+}

--- a/oap-spark/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/oap-spark/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -833,7 +833,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
       dataPagesIterator.remove();
       freePage(dataPage);
     }
-    assert (dataPages.isEmpty());
+    assert(dataPages.isEmpty());
 
     deleteSpillFiles();
   }

--- a/oap-spark/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/oap-spark/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -25,6 +25,10 @@ import java.util.LinkedList;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Closeables;
+import com.intel.oap.common.storage.stream.ChunkInputStream;
+import com.intel.oap.common.storage.stream.DataStore;
+import org.apache.spark.internal.config.package$;
+import org.apache.spark.memory.PMemManagerInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -393,10 +397,23 @@ public final class BytesToBytesMap extends MemoryConsumer {
     }
 
     private void handleFailedDelete() {
-      // remove the spill file from disk
+      // remove the spill file from disk or pmem
+      boolean pMemSpillEnabled = SparkEnv.get() != null && (boolean) SparkEnv.get().conf().get(
+              package$.MODULE$.MEMORY_SPILL_PMEM_ENABLED());
       File file = spillWriters.removeFirst().getFile();
-      if (file != null && file.exists() && !file.delete()) {
-        logger.error("Was unable to delete spill file {}", file.getAbsolutePath());
+      if(pMemSpillEnabled == true) {
+        try {
+          ChunkInputStream cis = ChunkInputStream.getChunkInputStreamInstance(file.toString(),
+                  new DataStore(PMemManagerInitializer.getPMemManager(),
+                          PMemManagerInitializer.getProperties()));
+          cis.free();
+        } catch (IOException e) {
+          logger.debug(e.toString());
+        }
+      } else {
+        if (file != null && file.exists() && !file.delete()) {
+          logger.error("Was unable to delete spill file {}", file.getAbsolutePath());
+        }
       }
     }
   }
@@ -816,14 +833,44 @@ public final class BytesToBytesMap extends MemoryConsumer {
       dataPagesIterator.remove();
       freePage(dataPage);
     }
-    assert(dataPages.isEmpty());
+    assert (dataPages.isEmpty());
 
+    deleteSpillFiles();
+  }
+
+  /**
+   * Deletes any spill files created by this consumer.
+   */
+  private void deleteSpillFiles() {
+    boolean pMemSpillEnabled = SparkEnv.get() != null && (boolean) SparkEnv.get().conf().get(
+            package$.MODULE$.MEMORY_SPILL_PMEM_ENABLED());
+    if (pMemSpillEnabled == true)
+      deletePMemSpillFiles();
+    else
+      deleteDiskSpillFiles();
+  }
+
+  private void deleteDiskSpillFiles() {
     while (!spillWriters.isEmpty()) {
       File file = spillWriters.removeFirst().getFile();
       if (file != null && file.exists()) {
         if (!file.delete()) {
           logger.error("Was unable to delete spill file {}", file.getAbsolutePath());
         }
+      }
+    }
+  }
+
+  private void deletePMemSpillFiles() {
+    while (!spillWriters.isEmpty()) {
+      File file = spillWriters.removeFirst().getFile();
+      try {
+        ChunkInputStream cis = ChunkInputStream.getChunkInputStreamInstance(file.toString(),
+                new DataStore(PMemManagerInitializer.getPMemManager(),
+                        PMemManagerInitializer.getProperties()));
+        cis.free();
+      } catch (IOException e) {
+        logger.debug(e.toString());
       }
     }
   }

--- a/oap-spark/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/oap-spark/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -356,6 +356,18 @@ package object config {
     .doubleConf
     .createWithDefault(0.6)
 
+  val MEMORY_SPILL_PMEM_ENABLED =
+    ConfigBuilder("spark.memory.spill.pmem.enabled")
+      .doc("Set memory spill to PMem instead of disk.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val PMEM_PROPERTY_FILE =
+    ConfigBuilder("spark.memory.spill.pmem.config.file")
+      .doc("A config file used to config Intel PMem settings for memory extension.")
+      .stringConf
+      .createWithDefault("pmem.properties")
+
   private[spark] val STORAGE_SAFETY_FRACTION = ConfigBuilder("spark.storage.safetyFraction")
     .version("1.1.0")
     .doubleConf

--- a/oap-spark/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/oap-spark/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1285,6 +1285,22 @@ private[spark] class BlockManager(
   }
 
   /**
+    * A short circuited method to get a PMem writer that can write data directly to PMem.
+    * The Block will be appended to the PMem stream specified by filename. Callers should handle
+    * error cases.
+    */
+  def getPMemWriter(
+                     blockId: BlockId,
+                     file: File,
+                     serializerInstance: SerializerInstance,
+                     bufferSize: Int,
+                     writeMetrics: ShuffleWriteMetricsReporter): PMemBlockObjectWriter = {
+    val syncWrites = conf.getBoolean("spark.shuffle.sync", false)
+    new PMemBlockObjectWriter(file, serializerManager, serializerInstance, bufferSize,
+      syncWrites, writeMetrics, blockId)
+  }
+
+  /**
    * Put a new block of serialized bytes to the block manager.
    *
    * '''Important!''' Callers must not mutate or release the data buffer underlying `bytes`. Doing

--- a/oap-spark/src/main/scala/org/apache/spark/storage/PMemBlockObjectWriter.scala
+++ b/oap-spark/src/main/scala/org/apache/spark/storage/PMemBlockObjectWriter.scala
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.io.{BufferedOutputStream, File, OutputStream}
+
+import com.intel.oap.common.storage.stream.{ChunkOutputStream, DataStore}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.memory.PMemManagerInitializer
+import org.apache.spark.serializer.{SerializationStream, SerializerInstance, SerializerManager}
+import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
+import org.apache.spark.util.Utils
+
+/**
+ * A class for writing JVM objects directly to a file on disk. This class allows data to be appended
+ * to an existing block. For efficiency, it retains the underlying file channel across
+ * multiple commits. This channel is kept open until close() is called. In case of faults,
+ * callers should instead close with revertPartialWritesAndClose() to atomically revert the
+ * uncommitted partial writes.
+ *
+ * This class does not support concurrent writes. Also, once the writer has been opened it cannot be
+ * reopened again.
+ */
+private[spark] class PMemBlockObjectWriter(
+    file: File,
+    serializerManager: SerializerManager,
+    serializerInstance: SerializerInstance,
+    bufferSize: Int,
+    syncWrites: Boolean,
+    // These write metrics concurrently shared with other active DiskBlockObjectWriters who
+    // are themselves performing writes. All updates must be relative.
+    writeMetrics: ShuffleWriteMetricsReporter,
+    blockId: BlockId = null)
+  extends DiskBlockObjectWriter(file, serializerManager,
+    serializerInstance, bufferSize, syncWrites, writeMetrics, blockId)
+  with Logging {
+
+  /**
+   * Guards against close calls, e.g. from a wrapping stream.
+   * Call manualClose to close the stream that was extended by this trait.
+   * Commit uses this trait to close object streams without paying the
+   * cost of closing and opening the underlying file.
+   */
+  private trait ManualCloseOutputStream extends OutputStream {
+    abstract override def close(): Unit = {
+      flush()
+    }
+
+    def manualClose(): Unit = {
+      super.close()
+    }
+  }
+
+  // private var dataStore: DataStore = dataStore
+  /** The file channel, used for repositioning / truncating the file. */
+  // private var channel: FileChannel = null
+  private var mcs: ManualCloseOutputStream = null
+  private var bs: OutputStream = null
+  private var fos: ChunkOutputStream = null
+  private var ts: TimeTrackingOutputStream = null
+  private var objOut: SerializationStream = null
+  private var initialized = false
+  private var streamOpen = false
+  private var hasBeenClosed = false
+  private var dataStore: DataStore = null
+
+  def getFOS(): ChunkOutputStream = {
+   fos
+  }
+
+  // for tmp usage in UT
+  def getDataStore(): DataStore = {
+    dataStore
+  }
+
+  /**
+   * Cursors used to represent positions in the file.
+   *
+   * xxxxxxxxxx|----------|
+   *           ^          ^
+   *           |          |
+   *           |        reportedPosition
+   *         committedPosition
+   *
+   * reportedPosition: Position at the time of the last update to the write metrics.
+   * same as chunkoutputstream.position()
+   * committedPosition: Offset after last committed write.
+   * -----: Current writes to the underlying file.
+   * xxxxx: Committed contents of the file.
+   */
+  // private var committedPosition = file.length()
+  private var committedPosition = 0;
+  private var reportedPosition = committedPosition
+
+  /**
+   * Keep track of number of records written and also use this to periodically
+   * output bytes written since the latter is expensive to do for each record.
+   * And we reset it after every commitAndGet called.
+   */
+  private var numRecordsWritten = 0
+
+  private def initialize(): Unit = {
+    dataStore = new DataStore(PMemManagerInitializer.getPMemManager(),
+      PMemManagerInitializer.getProperties());
+    fos = ChunkOutputStream.getChunkOutputStreamInstance(file.toString, dataStore)
+    committedPosition = fos.position().toInt
+    reportedPosition = committedPosition
+    ts = new TimeTrackingOutputStream(writeMetrics, fos)
+    class ManualCloseBufferedOutputStream
+      extends BufferedOutputStream(ts, bufferSize) with ManualCloseOutputStream
+    mcs = new ManualCloseBufferedOutputStream
+  }
+
+  override def open(): PMemBlockObjectWriter = {
+    if (hasBeenClosed) {
+      throw new IllegalStateException("Writer already closed. Cannot be reopened.")
+    }
+    if (!initialized) {
+      initialize()
+      initialized = true
+    }
+
+    bs = serializerManager.wrapStream(blockId, mcs)
+    objOut = serializerInstance.serializeStream(bs)
+    streamOpen = true
+    this
+  }
+
+  /**
+   * Close and cleanup all resources.
+   * Should call after committing or reverting partial writes.
+   */
+  private def closeResources(): Unit = {
+    if (initialized) Utils.tryWithSafeFinally {
+      mcs.manualClose()
+    } {
+      mcs = null
+      bs = null
+      fos = null
+      ts = null
+      objOut = null
+      initialized = false
+      streamOpen = false
+      hasBeenClosed = true
+    }
+  }
+
+  /**
+   * Commits any remaining partial writes and closes resources.
+   */
+  override def close() {
+    if (initialized) {
+      Utils.tryWithSafeFinally {
+        commitAndGet()
+      } {
+        closeResources()
+      }
+    }
+  }
+
+  /**
+   * Flush the partial writes and commit them as a single atomic block.
+   * A commit may write additional bytes to frame the atomic block.
+   *
+   * @return file segment with previous offset and length committed on this call.
+   */
+  override def commitAndGet(): FileSegment = {
+    if (streamOpen) {
+      // NOTE: Because Kryo doesn't flush the underlying stream we explicitly flush both the
+      //       serializer stream and the lower level stream.
+      objOut.flush()
+      bs.flush()
+      objOut.close()
+      streamOpen = false
+
+      if (syncWrites) {
+        // Force outstanding writes to disk and track how long it takes
+        val start = System.nanoTime()
+        fos.getFD.sync()
+        writeMetrics.incWriteTime(System.nanoTime() - start)
+      }
+      val pos = fos.position().toInt
+      val previousCommitedPosition = committedPosition
+      val length = pos - committedPosition
+      committedPosition = pos
+      // In certain compression codecs, more bytes are written after streams are closed
+      writeMetrics.incBytesWritten(committedPosition - reportedPosition)
+      reportedPosition = committedPosition
+      numRecordsWritten = 0
+      new FileSegment(file, previousCommitedPosition, length)
+    } else {
+      new FileSegment(file, committedPosition, 0)
+    }
+  }
+
+
+  /**
+   * Reverts writes that haven't been committed yet. Callers should invoke this function
+   * when there are runtime exceptions. This method will not throw, though it may be
+   * unsuccessful in truncating written data.
+   *
+   * @return the file that this DiskBlockObjectWriter wrote to.
+   */
+  override def revertPartialWritesAndClose(): File = {
+    var cos: ChunkOutputStream = null
+    // Discard current writes. We do this by flushing the outstanding writes and then
+    // truncating the file to its initial position.
+    Utils.tryWithSafeFinally {
+      if (initialized) {
+        writeMetrics.decBytesWritten(reportedPosition - committedPosition)
+        writeMetrics.decRecordsWritten(numRecordsWritten)
+        streamOpen = false
+        closeResources()
+      }
+    } {
+      cos = ChunkOutputStream.getChunkOutputStreamInstance(file.toString, dataStore)
+      cos.truncate(committedPosition)
+    }
+    new File(file.toString)
+  }
+
+
+  /**
+    * Writes a key-value pair.
+    */
+  override def write(key: Any, value: Any): Unit = {
+    if (!streamOpen) {
+      open()
+    }
+
+    objOut.writeKey(key)
+    objOut.writeValue(value)
+    recordWritten()
+  }
+
+  override def write(b: Int): Unit = throw new UnsupportedOperationException()
+
+  override def write(kvBytes: Array[Byte], offs: Int, len: Int): Unit = {
+    if (!streamOpen) {
+      open()
+    }
+
+    bs.write(kvBytes, offs, len)
+  }
+
+  /**
+    * Notify the writer that a record worth of bytes has been written with OutputStream#write.
+    */
+  override def recordWritten(): Unit = {
+    numRecordsWritten += 1
+    writeMetrics.incRecordsWritten(1)
+
+    if (numRecordsWritten % 16384 == 0) {
+      updateBytesWritten()
+    }
+  }
+
+  // For testing
+  private[spark] override def flush(): Unit = {
+    objOut.flush()
+    bs.flush()
+  }
+
+  /**
+   * Report the number of bytes written in this writer's shuffle write metrics.
+   * Note that this is only valid before the underlying streams are closed.
+   */
+  private def updateBytesWritten() {
+    // val pos = channel.position()
+    // in high level, sometimes 16384 records written so this function called
+    // but the data is not actually wrote to PMem because writeBuffer isn't full
+    // and spill not finished
+    if (fos != null) {
+      val pos = fos.position().toInt
+      writeMetrics.incBytesWritten(pos - reportedPosition)
+      reportedPosition = pos
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable memory spill to Pmem in Spark

1) update spark files BytesToBytesMap, UnsafeExternalSorter, UnsafeSorterSpillReader, UnsafeSorterSpillWriter, BlockManager to allow memory spill to PMem
2) provide PMemBlockObjectWriter as a PMem writer
3) add config entry to enable/disable memory spill to PMem.


## How was this patch tested?

UT and end-to-end test applied

