### PR TITLE
[OAP-CACHE] [OAP-1730] [POAE-428] Add OAP cache runtime enable

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
@@ -39,6 +39,14 @@ object OapFileSourceStrategy extends Strategy with Logging {
      * Classified discussion the 4 scenarios and assemble a new [[SparkPlan]] if can optimized.
      */
     def tryOptimize(head: SparkPlan): SparkPlan = {
+      val runtimeEnable = SparkSession.getActiveSession.get.conf
+        .get(OapConf.OAP_CACHE_RUNTIME_ENABLE)
+      if (!runtimeEnable) {
+        logInfo("OAP cache is disabled in runtime," +
+          " will fall back to default Parquet/ORC file format.")
+        return head
+      }
+
       val tableEnbale = SparkSession.getActiveSession.get.conf
         .get(OapConf.OAP_CACHE_TABLE_LISTS_ENABLE)
       val cacheTablelists =

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -144,6 +144,13 @@ object OapConf {
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_CACHE_RUNTIME_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.runtime.enable")
+      .internal()
+      .doc("This config is to enable/disable OAP datasource cache in runtime")
+      .booleanConf
+      .createWithDefault(true)
+
   val OAP_CACHE_TABLE_LISTS_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.table.list.enable")
       .internal()

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -145,7 +145,7 @@ object OapConf {
       .createWithDefault(false)
 
   val OAP_CACHE_RUNTIME_ENABLE =
-    SqlConfAdapter.buildConf("spark.sql.oap.cache.runtime.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.enable")
       .internal()
       .doc("This config is to enable/disable OAP datasource cache in runtime")
       .booleanConf

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapFileSourceStrategySuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapFileSourceStrategySuite.scala
@@ -182,6 +182,21 @@ class OapFileSourceStrategyForParquetSuite extends OapFileSourceStrategySuite {
       (plan1, plan2) => plan1.sameResult(plan2)
     )
   }
+
+  test("Disable Optimized") {
+    withSQLConf(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key -> "true",
+      OapConf.OAP_CACHE_RUNTIME_ENABLE.key -> "false") {
+      verifyProjectScan(
+        format => format.isInstanceOf[ParquetFileFormat],
+        (plan1, plan2) => plan1.sameResult(plan2)
+      )
+      verifyProjectFilterScan(
+        indexColumn = "b",
+        format => format.isInstanceOf[ParquetFileFormat],
+        (plan1, plan2) => plan1.sameResult(plan2)
+      )
+    }
+  }
 }
 
 class OapFileSourceStrategyForOrcSuite extends OapFileSourceStrategySuite {
@@ -210,6 +225,21 @@ class OapFileSourceStrategyForOrcSuite extends OapFileSourceStrategySuite {
       format => format.isInstanceOf[OrcFileFormat],
       (plan1, plan2) => plan1.sameResult(plan2)
     )
+  }
+
+  test("Disable Optimized") {
+    withSQLConf(OapConf.OAP_ORC_DATA_CACHE_ENABLED.key -> "true",
+      OapConf.OAP_CACHE_RUNTIME_ENABLE.key -> "false") {
+      verifyProjectScan(
+        format => format.isInstanceOf[OrcFileFormat],
+        (plan1, plan2) => plan1.sameResult(plan2)
+      )
+      verifyProjectFilterScan(
+        indexColumn = "b",
+        format => format.isInstanceOf[OrcFileFormat],
+        (plan1, plan2) => plan1.sameResult(plan2)
+      )
+    }
   }
 
   test("Scan : Not Optimized") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add OAP cache runtime enable, will fall back to default Parquet/ORC file format if disabled.

## How was this patch tested?

Add ut and did e2e test.
