### PR TITLE
[OAP-1734][oap-native-sql]use non-codegen for sort with single key

### DIFF
--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_appender.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_appender.h
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <arrow/status.h>
+
+namespace sparkcolumnarplugin {
+namespace codegen {
+namespace arrowcompute {
+namespace extra {
+
+class AppenderBase {
+  public:
+  virtual ~AppenderBase() {}
+
+  virtual arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr)  {
+    return arrow::Status::NotImplemented("AppenderBase AddArray is abstract.");
+  }
+
+  virtual arrow::Status Append(uint16_t& array_id, uint16_t& item_id) {
+    return arrow::Status::NotImplemented("AppenderBase Append is abstract.");
+  }
+
+  virtual arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) {
+    return arrow::Status::NotImplemented("AppenderBase Finish is abstract.");
+  }
+
+  virtual arrow::Status Reset() {
+    return arrow::Status::NotImplemented("AppenderBase Reset is abstract.");
+  }
+};
+
+template <class DataType>
+class ArrayAppender : public AppenderBase {
+  public:
+  ArrayAppender(arrow::compute::FunctionContext* ctx) : ctx_(ctx) {
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    arrow::MakeBuilder(
+        ctx_->memory_pool(), arrow::TypeTraits<DataType>::type_singleton(), &array_builder);
+    builder_.reset(
+        arrow::internal::checked_cast<BuilderType_*>(array_builder.release()));
+  }
+  ~ArrayAppender() {}
+
+  arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr)  {
+    auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
+    cached_arr_.emplace_back(typed_arr_);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(uint16_t& array_id, uint16_t& item_id) {
+    if (!cached_arr_[array_id]->IsNull(item_id)) {
+      auto val = cached_arr_[array_id]->GetView(item_id);
+      builder_->Append(cached_arr_[array_id]->GetView(item_id));
+    } else {
+      builder_->AppendNull();
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) {
+    builder_->Finish(out_);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Reset() {
+    builder_->Reset();
+    return arrow::Status::OK();
+  }
+                                                           
+  private:
+  using BuilderType_ = typename arrow::TypeTraits<DataType>::BuilderType;
+  using ArrayType_ = typename arrow::TypeTraits<DataType>::ArrayType;
+  std::unique_ptr<BuilderType_> builder_;
+  std::vector<std::shared_ptr<ArrayType_>> cached_arr_;
+  arrow::compute::FunctionContext* ctx_;
+};
+
+}  // namespace extra
+}  // namespace arrowcompute
+}  // namespace codegen
+}  // namespace sparkcolumnarplugin

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -46,6 +46,12 @@ namespace extra {
 using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
 using namespace sparkcolumnarplugin::precompile;
 
+template <typename CTYPE>
+using enable_if_number = std::enable_if_t<std::is_arithmetic<CTYPE>::value>;
+
+template <typename CTYPE>
+using enable_if_string = std::enable_if_t<std::is_same<CTYPE, std::string>::value>;
+
 ///////////////  SortArraysToIndices  ////////////////
 class SortArraysToIndicesKernel::Impl {
  public:
@@ -53,7 +59,7 @@ class SortArraysToIndicesKernel::Impl {
   Impl(arrow::compute::FunctionContext* ctx,
        std::vector<std::shared_ptr<arrow::Field>> key_field_list,
        std::shared_ptr<arrow::Schema> result_schema, bool nulls_first, bool asc)
-      : ctx_(ctx), nulls_first_(nulls_first), asc_(asc) {
+      : ctx_(ctx), nulls_first_(nulls_first), asc_(asc), key_field_list_(key_field_list) {
     for (auto field : key_field_list) {
       auto indices = result_schema->GetAllFieldIndices(field->name());
       if (indices.size() != 1) {
@@ -127,6 +133,7 @@ class SortArraysToIndicesKernel::Impl {
   bool nulls_first_;
   bool asc_;
   std::vector<int> key_index_list_;
+  std::vector<std::shared_ptr<arrow::Field>> key_field_list_;
   class TypedSorterCodeGenImpl {
    public:
     TypedSorterCodeGenImpl(std::string indice, std::shared_ptr<arrow::DataType> data_type,
@@ -182,7 +189,7 @@ class SortArraysToIndicesKernel::Impl {
       indice++;
     }
     std::string cached_insert_str = GetCachedInsert(shuffle_typed_codegen_list.size());
-    std::string comp_func_str = GetCompFunction(key_index_list_);
+    std::string comp_func_str = GetCompFunction(key_index_list_, key_field_list_);
 
     std::string pre_sort_valid_str = GetPreSortValid();
 
@@ -363,32 +370,50 @@ extern "C" void MakeCodeGen(arrow::compute::FunctionContext* ctx,
     }
     return ss.str();
   }
-  std::string GetCompFunction(std::vector<int> sort_key_index_list) {
+  std::string GetCompFunction(std::vector<int> sort_key_index_list, 
+                              std::vector<std::shared_ptr<arrow::Field>> key_field_list) {
     std::stringstream ss;
     ss << "auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {"
-       << GetCompFunction_(0, sort_key_index_list) << "};";
+       << GetCompFunction_(0, sort_key_index_list, key_field_list) << "};";
     return ss.str();
   }
-  std::string GetCompFunction_(int cur_key_index, std::vector<int> sort_key_index_list) {
+  std::string GetCompFunction_(int cur_key_index, std::vector<int> sort_key_index_list, 
+                               std::vector<std::shared_ptr<arrow::Field>> key_field_list) {
     std::string comp_str;
     auto cur_key_id = sort_key_index_list[cur_key_index];
+    auto field = key_field_list[cur_key_index];
     if (asc_) {
       std::stringstream ss;
-      ss << "return cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) < cached_"
-         << cur_key_id << "_[y.array_id]->GetView(y.id);\n";
+      if (field->type()->id() == arrow::Type::STRING) {
+        ss << "return cached_" << cur_key_id << "_[x.array_id]->GetString(x.id) < cached_"
+           << cur_key_id << "_[y.array_id]->GetString(y.id);\n";
+      } else {
+        ss << "return cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) < cached_"
+           << cur_key_id << "_[y.array_id]->GetView(y.id);\n";
+      }
       comp_str = ss.str();
     } else {
       std::stringstream ss;
-      ss << "return cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) > cached_"
-         << cur_key_id << "_[y.array_id]->GetView(y.id);\n";
+      if (field->type()->id() == arrow::Type::STRING) {
+        ss << "return cached_" << cur_key_id << "_[x.array_id]->GetString(x.id) > cached_"
+           << cur_key_id << "_[y.array_id]->GetString(y.id);\n";
+      } else {
+        ss << "return cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) > cached_"
+           << cur_key_id << "_[y.array_id]->GetView(y.id);\n";
+      }
       comp_str = ss.str();
     }
     if ((cur_key_index + 1) < sort_key_index_list.size()) {
       std::stringstream ss;
-      ss << "if (cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) == cached_"
-         << cur_key_id << "_[y.array_id]->GetView(y.id)) {"
-         << GetCompFunction_(cur_key_index + 1, sort_key_index_list) << "} else { "
-         << comp_str << "}";
+      if (field->type()->id() == arrow::Type::STRING) {
+        ss << "if (cached_" << cur_key_id << "_[x.array_id]->GetString(x.id) == cached_"
+           << cur_key_id << "_[y.array_id]->GetString(y.id)) {";
+      } else {
+        ss << "if (cached_" << cur_key_id << "_[x.array_id]->GetView(x.id) == cached_"
+           << cur_key_id << "_[y.array_id]->GetView(y.id)) {";
+      }
+      ss << GetCompFunction_(cur_key_index + 1, sort_key_index_list, key_field_list) 
+         << "} else { " << comp_str << "}";
       return ss.str();
     } else {
       return comp_str;
@@ -690,9 +715,14 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
   };
 };
 
+template <typename DATATYPE, typename CTYPE, typename Enable = void>
+class SortOnekeyKernel {};
+
 ///////////////  SortArraysOneKey  ////////////////
+// This class is used when key type is arithmetic
 template <typename DATATYPE, typename CTYPE>
-class SortOnekeyKernel : public SortArraysToIndicesKernel::Impl {
+class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>> 
+  : public SortArraysToIndicesKernel::Impl {
  public:
   SortOnekeyKernel(arrow::compute::FunctionContext* ctx, 
       std::vector<std::shared_ptr<arrow::Field>> key_field_list,
@@ -914,6 +944,232 @@ class SortOnekeyKernel : public SortArraysToIndicesKernel::Impl {
 #undef PROCESS_SUPPORTED_TYPES
 };
 
+///////////////  SortArraysOneKey  ////////////////
+// This class is used when key type is string
+template <typename DATATYPE, typename CTYPE>
+class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>> 
+  : public SortArraysToIndicesKernel::Impl {
+ public:
+  SortOnekeyKernel(arrow::compute::FunctionContext* ctx, 
+      std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+       std::shared_ptr<arrow::Schema> result_schema,
+      bool nulls_first, bool asc)
+      : ctx_(ctx), nulls_first_(nulls_first), asc_(asc), result_schema_(result_schema) {
+      auto indices = result_schema->GetAllFieldIndices(key_field_list[0]->name());
+      key_id_ = indices[0];
+      col_num_ = result_schema->num_fields();
+  }
+
+  arrow::Status Evaluate(const ArrayList& in) override {
+    num_batches_++;
+    cached_key_.push_back(std::dynamic_pointer_cast<ArrayType_key>(in[key_id_]));
+    items_total_ += in[key_id_]->length();
+    nulls_total_ += in[key_id_]->null_count();
+    length_list_.push_back(in[key_id_]->length());
+    if (cached_.size() <= col_num_) {
+      cached_.resize(col_num_ + 1);
+    }
+    for (int i = 0; i < col_num_; i++) {
+      cached_[i].push_back(in[i]);
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status FinishInternal(std::shared_ptr<FixedSizeBinaryArray>* out) {    
+    // initiate buffer for all arrays
+    std::shared_ptr<arrow::Buffer> indices_buf;
+    int64_t buf_size = items_total_ * sizeof(ArrayItemIndex);
+    RETURN_NOT_OK(arrow::AllocateBuffer(ctx_->memory_pool(), buf_size, &indices_buf));
+    // start to partition not_null with null
+    ArrayItemIndex* indices_begin = 
+      reinterpret_cast<ArrayItemIndex*>(indices_buf->mutable_data());
+    ArrayItemIndex* indices_end = indices_begin + items_total_;
+    int64_t indices_i = 0;
+    int64_t indices_null = 0;
+    // we should support nulls first and nulls last here
+    // we should also support desc and asc here
+    for (int array_id = 0; array_id < num_batches_; array_id++) {
+      for (int64_t i = 0; i < length_list_[array_id]; i++) {
+        if (nulls_first_) {
+          if (!cached_key_[array_id]->IsNull(i)) {
+            (indices_begin + nulls_total_ + indices_i)->array_id = array_id;
+            (indices_begin + nulls_total_ + indices_i)->id = i;
+            indices_i++;
+          } else {
+            (indices_begin + indices_null)->array_id = array_id;
+            (indices_begin + indices_null)->id = i;
+            indices_null++;
+          }
+        } else {
+          if (!cached_key_[array_id]->IsNull(i)) {
+            (indices_begin + indices_i)->array_id = array_id;
+            (indices_begin + indices_i)->id = i;
+            indices_i++;
+          } else {
+            (indices_end - nulls_total_ + indices_null)->array_id = array_id;
+            (indices_end - nulls_total_ + indices_null)->id = i;
+            indices_null++;
+          }
+        }
+      }
+    }
+    if (asc_) {
+      if (nulls_first_) {
+        ska_sort(indices_begin + nulls_total_, indices_begin + items_total_, 
+            [this](auto& x) -> decltype(auto){ return cached_key_[x.array_id]->GetString(x.id); });
+      } else {
+        ska_sort(indices_begin, indices_begin + items_total_ - nulls_total_, 
+            [this](auto& x) -> decltype(auto){ return cached_key_[x.array_id]->GetString(x.id); });
+      }
+    } else {
+      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
+        return cached_key_[x.array_id]->GetString(x.id) > cached_key_[y.array_id]->GetString(y.id);};
+      if (nulls_first_) {
+        std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
+      } else {
+        std::sort(indices_begin, indices_begin + items_total_ - nulls_total_, comp);
+      }
+    }
+    std::shared_ptr<arrow::FixedSizeBinaryType> out_type;
+    RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndex) / sizeof(int32_t), &out_type));
+    RETURN_NOT_OK(MakeFixedSizeBinaryArray(out_type, items_total_, indices_buf, out));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status MakeResultIterator(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override {
+    std::shared_ptr<FixedSizeBinaryArray> indices_out;
+    RETURN_NOT_OK(FinishInternal(&indices_out));
+    *out = std::make_shared<SorterResultIterator>(ctx_, schema, indices_out, cached_);
+    return arrow::Status::OK();
+  }
+
+ private:
+  using ArrayType_key = typename arrow::TypeTraits<DATATYPE>::ArrayType;
+  std::vector<std::shared_ptr<ArrayType_key>> cached_key_;
+  std::vector<arrow::ArrayVector> cached_;
+  arrow::compute::FunctionContext* ctx_;
+  std::shared_ptr<arrow::Schema> result_schema_;
+  bool nulls_first_;
+  bool asc_;
+  std::vector<int64_t> length_list_;
+  uint64_t num_batches_ = 0;
+  uint64_t items_total_ = 0;
+  uint64_t nulls_total_ = 0;
+  uint64_t col_num_;
+  int key_id_;
+     
+#define PROCESS_SUPPORTED_TYPES(PROCESS) \
+  PROCESS(arrow::UInt8Type)              \
+  PROCESS(arrow::Int8Type)               \
+  PROCESS(arrow::UInt16Type)             \
+  PROCESS(arrow::Int16Type)              \
+  PROCESS(arrow::UInt32Type)             \
+  PROCESS(arrow::Int32Type)              \
+  PROCESS(arrow::UInt64Type)             \
+  PROCESS(arrow::Int64Type)              \
+  PROCESS(arrow::FloatType)              \
+  PROCESS(arrow::DoubleType)             \
+  PROCESS(arrow::Date32Type)             \
+  PROCESS(arrow::Date64Type)             
+  class SorterResultIterator : public ResultIterator<arrow::RecordBatch> {
+   public:
+    SorterResultIterator(arrow::compute::FunctionContext* ctx,
+                         std::shared_ptr<arrow::Schema> schema,
+                         std::shared_ptr<FixedSizeBinaryArray> indices_in,
+                         std::vector<arrow::ArrayVector>& cached)
+        : ctx_(ctx),
+          schema_(schema),
+          indices_in_cache_(indices_in),
+          total_length_(indices_in->length()),
+          cached_in_(cached) {
+      col_num_ = schema->num_fields();
+      indices_begin_ = (ArrayItemIndex*)indices_in->value_data();
+      for (uint64_t i = 0; i < col_num_; i++) {
+        auto field = schema->field(i);
+        if (field->type()->id() == arrow::Type::STRING) {
+          auto app_ptr = std::make_shared<ArrayAppender<arrow::StringType>>(ctx);
+          auto appender = std::dynamic_pointer_cast<AppenderBase>(app_ptr);
+          appender_list_.push_back(appender);
+        } else {
+          switch (field->type()->id()) {
+#define PROCESS(InType)                                                       \
+  case InType::type_id: {                                                     \
+    auto app_ptr = std::make_shared<ArrayAppender<InType>>(ctx);              \
+    auto appender = std::dynamic_pointer_cast<AppenderBase>(app_ptr);         \
+    appender_list_.push_back(appender);                                       \
+  } break;
+      PROCESS_SUPPORTED_TYPES(PROCESS)
+#undef PROCESS
+  default: {
+          std::cout << "SortOnekeyKernel type not supported, type is "
+                    << field->type() << std::endl;
+            } break;
+          }
+        }
+      }
+    for (int i = 0; i < col_num_; i++) {
+      arrow::ArrayVector array_vector = cached_in_[i];
+      int array_num = array_vector.size();
+      for (int array_id = 0; array_id < array_num; array_id++) {
+        auto arr = array_vector[array_id];
+        appender_list_[i]->AddArray(arr);
+      }
+    }
+      batch_size_ = GetBatchSize();
+    }
+
+    std::string ToString() override { return "SortArraysToIndicesResultIterator"; }
+
+    bool HasNext() override {
+      if (offset_ >= total_length_) {
+        return false;
+      }
+      return true;
+    }
+
+    arrow::Status Next(std::shared_ptr<arrow::RecordBatch>* out) {
+      auto length = (total_length_ - offset_) > batch_size_ ? batch_size_
+                                                            : (total_length_ - offset_);
+      uint64_t count = 0;
+      for (int i = 0; i < col_num_; i++) {
+        while (count < length) {
+          auto item = indices_begin_ + offset_ + count++;
+          RETURN_NOT_OK(appender_list_[i]->Append(item->array_id, item->id));
+        }
+        count = 0;
+      }
+      offset_ += length;
+      ArrayList arrays;
+      for (int i = 0; i < col_num_; i++) {
+        std::shared_ptr<arrow::Array> out_array;
+        RETURN_NOT_OK(appender_list_[i]->Finish(&out_array));
+        arrays.push_back(out_array);
+        appender_list_[i]->Reset();
+      }
+
+      *out = arrow::RecordBatch::Make(schema_, length, arrays);
+      return arrow::Status::OK();
+    }
+
+   private:
+    uint64_t offset_ = 0;
+    const uint64_t total_length_;
+    std::shared_ptr<arrow::Schema> schema_;
+    arrow::compute::FunctionContext* ctx_;
+    uint64_t batch_size_;
+    uint64_t col_num_;
+    ArrayItemIndex* indices_begin_;
+    std::vector<arrow::ArrayVector> cached_in_;
+    std::vector<std::shared_ptr<arrow::DataType>> type_list_;
+    std::vector<std::shared_ptr<AppenderBase>> appender_list_;
+    std::vector<std::shared_ptr<arrow::Array>> array_list_;
+    std::shared_ptr<FixedSizeBinaryArray> indices_in_cache_;
+  };
+#undef PROCESS_SUPPORTED_TYPES
+};
+
 arrow::Status SortArraysToIndicesKernel::Make(
     arrow::compute::FunctionContext* ctx,
     std::vector<std::shared_ptr<arrow::Field>> key_field_list,
@@ -964,15 +1220,14 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
     std::cout << "UseSortOneKey" << std::endl;
 #endif
     if (key_field_list[0]->type()->id() == arrow::Type::STRING) {
-      impl_.reset(
-        new SortOnekeyKernel<arrow::StringType, std::string>(ctx, key_field_list, 
-        result_schema, nulls_first, asc));
+      impl_.reset(new SortOnekeyKernel<arrow::StringType, std::string>(ctx, 
+        key_field_list, result_schema, nulls_first, asc));
     } else {
       switch (key_field_list[0]->type()->id()) {
 #define PROCESS(InType)                                                       \
   case InType::type_id: {                                                     \
     using CType = typename arrow::TypeTraits<InType>::CType;                  \
-    impl_.reset(new SortOnekeyKernel<InType, CType>(ctx, key_field_list, result_schema, nulls_first, asc));  \
+    impl_.reset(new SortOnekeyKernel<InType, CType>(ctx, key_field_list, result_schema, nulls_first, asc)); \
   } break;
         PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -630,18 +630,20 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
     arrow::Status Next(std::shared_ptr<arrow::RecordBatch>* out) {
       auto length = (total_length_ - offset_) > batch_size_ ? batch_size_
                                                             : (total_length_ - offset_);
-      uint64_t count = 0;
+      uint64_t valid_count = 0;
+      uint64_t total_count = 0;
       if (offset_ >= nulls_total_) {
-        while (count < length) {
-          RETURN_NOT_OK(builder_0_->Append(result_arr_->GetView(offset_ + count++)));
+        while (total_count < length) {
+          RETURN_NOT_OK(builder_0_->Append(result_arr_->GetView(offset_ + total_count++)));
         }
       } else {
-        while (count < length) {
-          if ((offset_ + count) < nulls_total_) {
+        while (total_count < length) {
+          if ((offset_ + total_count) < nulls_total_) {
             RETURN_NOT_OK(builder_0_->AppendNull());
           } else {
-            RETURN_NOT_OK(builder_0_->Append(result_arr_->GetView(offset_ + count++)));
+            RETURN_NOT_OK(builder_0_->Append(result_arr_->GetView(offset_ + valid_count++)));
           }
+          total_count++;
         }
       }
       offset_ += length;

--- a/oap-native-sql/cpp/src/precompile/array.cc
+++ b/oap-native-sql/cpp/src/precompile/array.cc
@@ -31,8 +31,12 @@ BooleanArray::BooleanArray(const std::shared_ptr<arrow::Array>& in) : cache_(in)
     raw_value_ = typed_in->raw_values();                                     \
   }
 
+TYPED_NUMERIC_ARRAY_IMPL(Int8Array, int8_t)
+TYPED_NUMERIC_ARRAY_IMPL(Int16Array, int16_t)
 TYPED_NUMERIC_ARRAY_IMPL(Int32Array, int32_t)
 TYPED_NUMERIC_ARRAY_IMPL(Int64Array, int64_t)
+TYPED_NUMERIC_ARRAY_IMPL(UInt8Array, uint8_t)
+TYPED_NUMERIC_ARRAY_IMPL(UInt16Array, uint16_t)
 TYPED_NUMERIC_ARRAY_IMPL(UInt32Array, uint32_t)
 TYPED_NUMERIC_ARRAY_IMPL(UInt64Array, uint64_t)
 TYPED_NUMERIC_ARRAY_IMPL(FloatArray, float)

--- a/oap-native-sql/cpp/src/precompile/array.h
+++ b/oap-native-sql/cpp/src/precompile/array.h
@@ -76,8 +76,12 @@ class BooleanArray {
     uint64_t null_count_;                                      \
   };
 
+TYPED_ARRAY_DEFINE(Int8Array, int8_t)
+TYPED_ARRAY_DEFINE(Int16Array, int16_t)
 TYPED_ARRAY_DEFINE(Int32Array, int32_t)
 TYPED_ARRAY_DEFINE(Int64Array, int64_t)
+TYPED_ARRAY_DEFINE(UInt8Array, uint8_t)
+TYPED_ARRAY_DEFINE(UInt16Array, uint16_t)
 TYPED_ARRAY_DEFINE(UInt32Array, uint32_t)
 TYPED_ARRAY_DEFINE(UInt64Array, uint64_t)
 TYPED_ARRAY_DEFINE(FloatArray, float)

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
@@ -48,7 +48,7 @@ TEST(TestArrowComputeSort, SortTestNullsFirstAsc) {
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
   ASSERT_NOT_OK(
-      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -124,7 +124,7 @@ TEST(TestArrowComputeSort, SortTestNullsLastAsc) {
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
   ASSERT_NOT_OK(
-      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -198,7 +198,7 @@ TEST(TestArrowComputeSort, SortTestNullsFirstDesc) {
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
   ASSERT_NOT_OK(
-      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -272,7 +272,7 @@ TEST(TestArrowComputeSort, SortTestNullsLastDesc) {
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
   ASSERT_NOT_OK(
-      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -347,7 +347,7 @@ TEST(TestArrowComputeSort, SortTestNullsFirstAscMultipleKeys) {
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
   ASSERT_NOT_OK(
-      CreateCodeGenerator(sch, {sortArrays_expr}, {f_indices}, &sort_expr, true));
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
@@ -476,5 +476,70 @@ TEST(TestArrowComputeSort, SortTestInPlace) {
   }
 }
 
+TEST(TestArrowComputeSort, SortTestInPlaceStr) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f1", utf8());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndicesNullsFirstAsc", {arg_0}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+
+  auto sch = arrow::schema({f0});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+
+  std::vector<std::string> input_data_string = {R"(["a", "c", "e", "f", "g","j", "h"])"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {R"(["a", "a", "a", "u", "f","d", "b"])"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {R"(["a", "e", "t", "w", "j","p", "o"])"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {R"(["g", "a", "a", "t", "b","y", "q"])"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {R"(["a", "a", "y", "o", "s","x", "z"])"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      R"(["a","a","a","a","a","a","a","a","a","b","b","c","d","e","e","f","f","g","g","h","j","j","o","o","p","q","s","t","t","u","w","x","y","y","z"])"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator));
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
 }  // namespace codegen
 }  // namespace sparkcolumnarplugin


### PR DESCRIPTION
1. changes sort with one key inside several cols into non-codegen version. 
2. fixes data type issue and null value issue for InplaceSort.

Fixes: https://github.com/Intel-bigdata/OAP/issues/1734
