### PR TITLE
[OAP-1733][oap-native-sql][Scala] fix mem leak

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -110,7 +110,8 @@ object ConverterUtils extends Logging {
   }
 
   def convertToNetty(iter: Array[ColumnarBatch]): Array[Byte] = {
-    val out = new ByteBufOutputStream(ByteBufAllocator.DEFAULT.buffer());
+    val innerBuf = ByteBufAllocator.DEFAULT.buffer()
+    val out = new ByteBufOutputStream(innerBuf)
     val channel = new WriteChannel(Channels.newChannel(out))
     var schema: Schema = null
     val option = new IpcOption
@@ -132,6 +133,7 @@ object ConverterUtils extends Logging {
     val buf = out.buffer
     val bytes = new Array[Byte](buf.readableBytes);
     buf.getBytes(buf.readerIndex, bytes);
+    innerBuf.release()
     out.close()
     bytes
   }


### PR DESCRIPTION

## What changes were proposed in this pull request?

this patch fixes the memory leakage when reading from netty buffer.

fixes #1733  
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

locally verfied with TPCH Q18
