### PR TITLE
[OAP-CACHE][OAP-1748][POAE7-453]Enable externalDB to store CacheMetaInfo branch 0.8

### DIFF
--- a/oap-cache/oap/pom.xml
+++ b/oap-cache/oap/pom.xml
@@ -112,21 +112,21 @@
   </pluginRepositories>
 
   <dependencies>
-      <dependency>
-          <groupId>redis.clients</groupId>
-          <artifactId>jedis</artifactId>
-          <version>3.1.0</version>
-      </dependency>
-      <dependency>
-          <groupId>io.etcd</groupId>
-          <artifactId>jetcd-core</artifactId>
-          <version>0.3.0</version>
-      </dependency>
-      <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-pool2</artifactId>
-          <version>2.6.2</version>
-      </dependency>
+    <dependency>
+        <groupId>redis.clients</groupId>
+        <artifactId>jedis</artifactId>
+        <version>3.1.0</version>
+    </dependency>
+    <dependency>
+        <groupId>io.etcd</groupId>
+        <artifactId>jetcd-core</artifactId>
+        <version>0.3.0</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-pool2</artifactId>
+        <version>2.6.2</version>
+    </dependency>
     <dependency>
       <groupId>com.intel.oap</groupId>
       <artifactId>oap-common</artifactId>

--- a/oap-cache/oap/pom.xml
+++ b/oap-cache/oap/pom.xml
@@ -118,11 +118,6 @@
           <version>3.1.0</version>
       </dependency>
       <dependency>
-          <groupId>org.json4s</groupId>
-          <artifactId>json4s-jackson_2.11</artifactId>
-          <version>3.5.3</version>
-      </dependency>
-      <dependency>
           <groupId>io.etcd</groupId>
           <artifactId>jetcd-core</artifactId>
           <version>0.3.0</version>

--- a/oap-cache/oap/pom.xml
+++ b/oap-cache/oap/pom.xml
@@ -112,6 +112,26 @@
   </pluginRepositories>
 
   <dependencies>
+      <dependency>
+          <groupId>redis.clients</groupId>
+          <artifactId>jedis</artifactId>
+          <version>3.1.0</version>
+      </dependency>
+      <dependency>
+          <groupId>org.json4s</groupId>
+          <artifactId>json4s-jackson_2.11</artifactId>
+          <version>3.5.3</version>
+      </dependency>
+      <dependency>
+          <groupId>io.etcd</groupId>
+          <artifactId>jetcd-core</artifactId>
+          <version>0.3.0</version>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-pool2</artifactId>
+          <version>2.6.2</version>
+      </dependency>
     <dependency>
       <groupId>com.intel.oap</groupId>
       <artifactId>oap-common</artifactId>
@@ -705,7 +725,7 @@
                     <source>src/test/oap-perf-suite</source>
                 </sources>
             </configuration>
-          </execution>  
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/oap-cache/oap/src/main/java/org/apache/parquet/hadoop/ParquetFiberDataReader.java
+++ b/oap-cache/oap/src/main/java/org/apache/parquet/hadoop/ParquetFiberDataReader.java
@@ -103,15 +103,14 @@ public class ParquetFiberDataReader implements Closeable {
    */
   public PageReadStore readFiberData(
       BlockMetaData block,
-      ColumnDescriptor columnDescriptor) throws IOException {
+      ColumnDescriptor columnDescriptor,
+      ColumnChunkMetaData mc) throws IOException {
     Preconditions.checkNotNull(block, "block must not null");
     Preconditions.checkNotNull(columnDescriptor, "columnDescriptor must not null");
     if (block.getRowCount() == 0) {
       throw new IllegalArgumentException("Illegal row group of 0 rows");
     }
     ColumnChunkPageReadStore rowGroup = new ColumnChunkPageReadStore(block.getRowCount());
-    ColumnChunkMetaData mc = findColumnMeta(block, columnDescriptor);
-
     DataFiberDescriptor descriptor =
       new DataFiberDescriptor(
         columnDescriptor,
@@ -160,7 +159,7 @@ public class ParquetFiberDataReader implements Closeable {
 
 
   // TODO Use stream api if we use Java 8+.
-  private ColumnChunkMetaData findColumnMeta(
+  public ColumnChunkMetaData findColumnMeta(
       BlockMetaData block,
       ColumnDescriptor columnDescriptor) throws IOException {
     ColumnPath columnPath = ColumnPath.get(columnDescriptor.getPath());

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/CacheMetaInfo.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/CacheMetaInfo.scala
@@ -26,6 +26,10 @@ class CacheMetaInfoValue(host: String, offSet: Long, length: Long) {
   var _host: String = host
   var _offSet: Long = offSet
   var _length: Long = length
+
+  override def toString: String = {
+    "host: " + _host + ", offset: " + _offSet + ", length: " + _length + "."
+  }
 }
 
 class StoreCacheMetaInfo(key: String, value: CacheMetaInfoValue)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/CacheMetaInfo.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/CacheMetaInfo.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+abstract class CacheMetaInfo(key: String, value: CacheMetaInfoValue) {
+  val _key = key
+  val _value = value
+}
+
+class CacheMetaInfoValue(host: String, offSet: Long, length: Long) {
+  var _host: String = host
+  var _offSet: Long = offSet
+  var _length: Long = length
+}
+
+class StoreCacheMetaInfo(key: String, value: CacheMetaInfoValue)
+  extends CacheMetaInfo(key, value) {
+  override val _key: String = key
+  override val _value: CacheMetaInfoValue = value
+}
+
+class EvictCacheMetaInfo(key: String, value: CacheMetaInfoValue)
+  extends CacheMetaInfo(key, value) {
+  override val _key: String = key
+  override val _value: CacheMetaInfoValue = value
+}

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/CachedPartitionedFilePreferredLocs.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/CachedPartitionedFilePreferredLocs.scala
@@ -41,7 +41,7 @@ object CachedPartitionedFilePreferredLocs {
       if (cacheMetaInfoValueArr.size > 0) {
         // host<-> cachedBytes
         cacheMetaInfoValueArr.foreach(x => {
-          hostToCachedBytes.put(x._host, hostToCachedBytes.getOrElse(x._host, 0L) + x._length)
+          hostToCachedBytes.put(x.host, hostToCachedBytes.getOrElse(x.host, 0L) + x.length)
         })
       }
     }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/CachedPartitionedFilePreferredLocs.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/CachedPartitionedFilePreferredLocs.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{Partition, SparkEnv}
+
+object CachedPartitionedFilePreferredLocs {
+
+  private var externalDBClient: ExternalDBClient = null
+
+  def getPreferredLocsByCache(split: Partition): Seq[String] = {
+    if (null == externalDBClient) {
+      externalDBClient = ExternalDBClientFactory.getDBClientInstance(SparkEnv.get)
+    }
+
+    val files = split.asInstanceOf[FilePartition].files
+    var preferredLocs = new ArrayBuffer[String]
+
+    val hostToCachedBytes = mutable.HashMap.empty[String, Long]
+
+    files.foreach { file =>
+      val cacheMetaInfoValueArr = externalDBClient.get(file.filePath, file.start, file.length)
+      if (cacheMetaInfoValueArr.size > 0) {
+        // host<-> cachedBytes
+        cacheMetaInfoValueArr.foreach(x => {
+          hostToCachedBytes.put(x._host, hostToCachedBytes.getOrElse(x._host, 0L) + x._length)
+        })
+      }
+    }
+
+    // TODO if cachedBytes <<< hdfsPreferLocBytes
+    hostToCachedBytes.toSeq.sortWith(_._2 > _._2).take(3).foreach(x => preferredLocs.+=(x._1))
+    preferredLocs.take(3)
+  }
+
+}

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/EtcdClient.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/EtcdClient.scala
@@ -17,19 +17,80 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.nio.charset.Charset
+
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.SparkEnv
+import io.etcd.jetcd.{ByteSequence, Client, KV}
+import io.etcd.jetcd.options.GetOption
+import org.json4s.DefaultFormats
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
 
-class EtcdClient extends ExternalDBClient {
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.internal.oap.OapConf
+
+class EtcdClient extends ExternalDBClient with Logging {
+
+  private var kvCLient: KV = null
+
+  private implicit val formats = DefaultFormats
+
   override def init(sparkEnv: SparkEnv): Unit = {
 
+    kvCLient = Client
+      .builder().endpoints(sparkEnv.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ADDRESS))
+      .build()
+      .getKVClient
   }
 
-  override def get(fileName: String, offSet: Long, length: Long):
-      ArrayBuffer[CacheMetaInfoValue] = null
+  override def get(fileName: String, start: Long, length: Long): ArrayBuffer[CacheMetaInfoValue] = {
+    val cacheMetaInfoArrayBuffer: ArrayBuffer[CacheMetaInfoValue] =
+      new ArrayBuffer[CacheMetaInfoValue](0)
 
-  override def upsert(cacheMetaInfo: CacheMetaInfo): Boolean = false
+    val getOption: GetOption = GetOption.newBuilder()
+      .withPrefix(ByteSequence.from(fileName.getBytes()))
+      .withSortOrder(GetOption.SortOrder.ASCEND)
+      .build()
 
-  override def stop(): Unit = {}
+    val getResponse = kvCLient.get(ByteSequence.from(fileName.getBytes()), getOption).get
+    val kvs = getResponse.getKvs
+    // TODO search the startpoint more efficiently like binary search
+    for (i <- 0 to kvs.size()) {
+      val key = kvs.get(i).getKey.toString(Charset.defaultCharset())
+      val index = key.indexOf("offset") + 6
+      val offset = key.substring(index).asInstanceOf[Long]
+      if (offset > length) return cacheMetaInfoArrayBuffer
+      if (offset >= start && offset <= length) {
+        cacheMetaInfoArrayBuffer.+=(parse(kvs.get(i).getValue.toString(Charset.defaultCharset())).
+          extract[CacheMetaInfoValue])
+      }
+    }
+    cacheMetaInfoArrayBuffer
+  }
+
+  override def upsert(cacheMetaInfo: CacheMetaInfo): Boolean = {
+    cacheMetaInfo match {
+      case storeInfo: StoreCacheMetaInfo =>
+        val value = storeInfo._value
+        val cacheMetaInfoJson = ("offSet" -> value._offSet) ~
+          ("length" -> value._length) ~
+          ("host" -> value._host)
+        logDebug("upsert key: " + storeInfo._key +
+          "cacheMetaInfo is: " + value.toString)
+        kvCLient.put(ByteSequence.from((storeInfo._key + "offset" + value._offSet)
+          .getBytes()), ByteSequence.from(compact(render(cacheMetaInfoJson)).getBytes())).isDone
+      case evictInfo: EvictCacheMetaInfo =>
+        val value = evictInfo._value
+        logDebug("upsert key: " + evictInfo._key +
+          "cacheMetaInfo is: " + value.toString)
+        kvCLient.delete(ByteSequence.from((evictInfo._key + "offset" + value._offSet)
+          .getBytes())).isDone
+    }
+  }
+
+  override def stop(): Unit = {
+    kvCLient.close()
+  }
 }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/EtcdClient.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/EtcdClient.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.SparkEnv
+
+class EtcdClient extends ExternalDBClient {
+  override def init(sparkEnv: SparkEnv): Unit = {
+
+  }
+
+  override def get(fileName: String, offSet: Long, length: Long):
+      ArrayBuffer[CacheMetaInfoValue] = null
+
+  override def upsert(cacheMetaInfo: CacheMetaInfo): Boolean = false
+
+  override def stop(): Unit = {}
+}

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/EtcdClient.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/EtcdClient.scala
@@ -22,14 +22,14 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.SparkEnv
 
 class EtcdClient extends ExternalDBClient {
-  override def init(sparkEnv: SparkEnv): Unit = {
 
-  }
+  override def init(sparkEnv: SparkEnv): Unit = {}
 
   override def get(fileName: String, offSet: Long, length: Long):
   ArrayBuffer[CacheMetaInfoValue] = null
 
-  override def upsert(cacheMetaInfo: CacheMetaInfo): Boolean = false
+  override def upsert(cacheMetaInfo: CacheMetaInfo): Unit = {}
 
   override def stop(): Unit = {}
+
 }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/EtcdClient.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/EtcdClient.scala
@@ -17,80 +17,19 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.nio.charset.Charset
-
 import scala.collection.mutable.ArrayBuffer
 
-import io.etcd.jetcd.{ByteSequence, Client, KV}
-import io.etcd.jetcd.options.GetOption
-import org.json4s.DefaultFormats
-import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods._
-
 import org.apache.spark.SparkEnv
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql.internal.oap.OapConf
 
-class EtcdClient extends ExternalDBClient with Logging {
-
-  private var kvCLient: KV = null
-
-  private implicit val formats = DefaultFormats
-
+class EtcdClient extends ExternalDBClient {
   override def init(sparkEnv: SparkEnv): Unit = {
 
-    kvCLient = Client
-      .builder().endpoints(sparkEnv.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ADDRESS))
-      .build()
-      .getKVClient
   }
 
-  override def get(fileName: String, start: Long, length: Long): ArrayBuffer[CacheMetaInfoValue] = {
-    val cacheMetaInfoArrayBuffer: ArrayBuffer[CacheMetaInfoValue] =
-      new ArrayBuffer[CacheMetaInfoValue](0)
+  override def get(fileName: String, offSet: Long, length: Long):
+  ArrayBuffer[CacheMetaInfoValue] = null
 
-    val getOption: GetOption = GetOption.newBuilder()
-      .withPrefix(ByteSequence.from(fileName.getBytes()))
-      .withSortOrder(GetOption.SortOrder.ASCEND)
-      .build()
+  override def upsert(cacheMetaInfo: CacheMetaInfo): Boolean = false
 
-    val getResponse = kvCLient.get(ByteSequence.from(fileName.getBytes()), getOption).get
-    val kvs = getResponse.getKvs
-    // TODO search the startpoint more efficiently like binary search
-    for (i <- 0 to kvs.size()) {
-      val key = kvs.get(i).getKey.toString(Charset.defaultCharset())
-      val index = key.indexOf("offset") + 6
-      val offset = key.substring(index).asInstanceOf[Long]
-      if (offset > length) return cacheMetaInfoArrayBuffer
-      if (offset >= start && offset <= length) {
-        cacheMetaInfoArrayBuffer.+=(parse(kvs.get(i).getValue.toString(Charset.defaultCharset())).
-          extract[CacheMetaInfoValue])
-      }
-    }
-    cacheMetaInfoArrayBuffer
-  }
-
-  override def upsert(cacheMetaInfo: CacheMetaInfo): Boolean = {
-    cacheMetaInfo match {
-      case storeInfo: StoreCacheMetaInfo =>
-        val value = storeInfo._value
-        val cacheMetaInfoJson = ("offSet" -> value._offSet) ~
-          ("length" -> value._length) ~
-          ("host" -> value._host)
-        logDebug("upsert key: " + storeInfo._key +
-          "cacheMetaInfo is: " + value.toString)
-        kvCLient.put(ByteSequence.from((storeInfo._key + "offset" + value._offSet)
-          .getBytes()), ByteSequence.from(compact(render(cacheMetaInfoJson)).getBytes())).isDone
-      case evictInfo: EvictCacheMetaInfo =>
-        val value = evictInfo._value
-        logDebug("upsert key: " + evictInfo._key +
-          "cacheMetaInfo is: " + value.toString)
-        kvCLient.delete(ByteSequence.from((evictInfo._key + "offset" + value._offSet)
-          .getBytes())).isDone
-    }
-  }
-
-  override def stop(): Unit = {
-    kvCLient.close()
-  }
+  override def stop(): Unit = {}
 }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/ExternalDBClient.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/ExternalDBClient.scala
@@ -27,7 +27,7 @@ trait ExternalDBClient {
 
   def get(fileName: String, start: Long, length: Long): ArrayBuffer[CacheMetaInfoValue]
 
-  def upsert(cacheMetaInfo: CacheMetaInfo): Boolean
+  def upsert(cacheMetaInfo: CacheMetaInfo): Unit
 
   def stop(): Unit
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/ExternalDBClient.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/ExternalDBClient.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.SparkEnv
+
+trait ExternalDBClient {
+
+  def init(sparkEnv: SparkEnv): Unit
+
+  def get(fileName: String, start: Long, length: Long): ArrayBuffer[CacheMetaInfoValue]
+
+  def upsert(cacheMetaInfo: CacheMetaInfo): Boolean
+
+  def stop(): Unit
+
+}

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/ExternalDBClientFactory.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/ExternalDBClientFactory.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.internal.oap.OapConf
+import org.apache.spark.util.Utils
+
+object ExternalDBClientFactory {
+
+  private var instance: ExternalDBClient = null
+
+  def getDBClientInstance(sparkEnv: SparkEnv): ExternalDBClient = synchronized {
+    if (instance != null) return instance
+    instance = Utils
+      .classForName(SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_IMPL))
+      .getConstructor()
+      .newInstance()
+      .asInstanceOf[ExternalDBClient]
+
+    instance.init(sparkEnv)
+    instance
+  }
+
+  def destroyDBClientInstance(externalDBClientInstance: ExternalDBClient): Unit = {
+    externalDBClientInstance.stop()
+  }
+
+}

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/RedisClient.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/RedisClient.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.json4s.DefaultFormats
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import redis.clients.jedis.{Jedis, JedisPool, JedisPoolConfig}
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.internal.oap.OapConf
+
+
+class RedisClient extends ExternalDBClient with Logging {
+
+  private var redisClientPool: JedisPool = null
+
+  private implicit val formats = DefaultFormats
+
+  override def init(sparkEnv: SparkEnv): Unit = {
+    logInfo("Initing RedisClientPool, server address is : " +
+      sparkEnv.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ADDRESS))
+
+    val jedisPoolConfig = new JedisPoolConfig
+    jedisPoolConfig.setMaxTotal(10)
+    redisClientPool = new JedisPool(
+      jedisPoolConfig,
+      sparkEnv.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ADDRESS))
+  }
+
+  override def get(fileName: String, start: Long,
+                   length: Long): ArrayBuffer[CacheMetaInfoValue] = {
+    var jedisClientInstance: Jedis = null
+    val cacheMetaInfoArrayBuffer: ArrayBuffer[CacheMetaInfoValue] =
+      new ArrayBuffer[CacheMetaInfoValue](0)
+    try {
+      jedisClientInstance = redisClientPool.getResource
+      // start - 1 because zrange is (start, length]
+      val cacheMetaInfoValueSet = jedisClientInstance.zrange(fileName, start - 1, length)
+      for (x <- cacheMetaInfoValueSet.asInstanceOf[Set[String]]) {
+        cacheMetaInfoArrayBuffer.+=(parse(x.asInstanceOf[String]).extract[CacheMetaInfoValue])
+      }
+    } finally {
+      if (null != jedisClientInstance) {
+        jedisClientInstance.close()
+      }
+    }
+    cacheMetaInfoArrayBuffer
+  }
+
+  override def upsert(cacheMetaInfo: CacheMetaInfo): Boolean = {
+    var jedisClientInstance: Jedis = null
+    try {
+      jedisClientInstance = redisClientPool.getResource
+      cacheMetaInfo match {
+        case storeInfo: StoreCacheMetaInfo =>
+          val value = storeInfo._value
+          val cacheMetaInfoJson = ("offSet" -> value._offSet) ~
+            ("length" -> value._length) ~
+            ("host" -> value._host)
+          logInfo("upsert key: " + storeInfo._key +
+            "cacheMetaInfo is: " + compact(render(cacheMetaInfoJson)))
+          jedisClientInstance
+            .zadd(storeInfo._key, value._offSet, compact(render(cacheMetaInfoJson)))
+            .equals(1L)
+        case evictInfo: EvictCacheMetaInfo =>
+          val value = evictInfo._value
+          val cacheMetaInfoJson = ("offSet" -> value._offSet) ~
+            ("length" -> value._length) ~
+            ("host" -> value._host)
+          jedisClientInstance
+            .zrem(evictInfo._key.asInstanceOf[String], compact(render(cacheMetaInfoJson)))
+            .equals(1L)
+      }
+    } finally {
+      if (null != jedisClientInstance) {
+        jedisClientInstance.close()
+      }
+    }
+    false
+  }
+
+  override def stop(): Unit = {
+    if (null != redisClientPool) {
+      redisClientPool.destroy()
+      logWarning("Redis client pool closed.")
+    }
+  }
+}

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/RedisClient.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/RedisClient.scala
@@ -84,8 +84,8 @@ class RedisClient extends ExternalDBClient with Logging {
           val cacheMetaInfoJson = ("offSet" -> value._offSet) ~
             ("length" -> value._length) ~
             ("host" -> value._host)
-          logInfo("upsert key: " + storeInfo._key +
-            "cacheMetaInfo is: " + compact(render(cacheMetaInfoJson)))
+          logDebug("upsert key: " + storeInfo._key +
+            "cacheMetaInfo is: " + value.toString)
           jedisClientInstance
             .zadd(storeInfo._key, value._offSet, compact(render(cacheMetaInfoJson)))
             .equals(1L)
@@ -94,6 +94,8 @@ class RedisClient extends ExternalDBClient with Logging {
           val cacheMetaInfoJson = ("offSet" -> value._offSet) ~
             ("length" -> value._length) ~
             ("host" -> value._host)
+          logDebug("evict key: " + evictInfo._key +
+            "cacheMetaInfo is: " + value.toString)
           jedisClientInstance
             .zrem(evictInfo._key.asInstanceOf[String], compact(render(cacheMetaInfoJson)))
             .equals(1L)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberId.scala
@@ -20,13 +20,12 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 import org.apache.hadoop.fs.FSDataInputStream
 import org.apache.parquet.io.SeekableInputStream
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.{CacheMetaInfoValue, ExternalDBClient, StoreCacheMetaInfo}
 import org.apache.spark.sql.execution.datasources.oap.io.DataFile
 import org.apache.spark.sql.oap.OapRuntime
 import org.apache.spark.unsafe.Platform
 
-private[oap] abstract class FiberId extends Logging{
+private[oap] abstract class FiberId {
   def toFiberKey(): String = {
     throw new UnsupportedOperationException("Unsupported operation")
   }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -1046,6 +1046,10 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
         .doReport(SparkEnv.get.blockManager.blockManagerId.host, externalDBClient)
       case vectorData: VectorDataFiberId => vectorData
         .doReport(SparkEnv.get.blockManager.blockManagerId.host, externalDBClient)
+      case bitMapData: BitmapFiberId =>
+        logWarning("Index cache is not support to report cache to external DB.")
+      case bTreeData: BTreeFiberId =>
+        logWarning("Index cache is not support to report cache to external DB.")
     }
   }
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -1042,27 +1042,10 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
 
   def reportCacheMeta(fiberId: FiberId): Unit = {
     fiberId match {
-      case binary: BinaryDataFiberId =>
-        // TODO code refactor
-        val cacheMetaInfoValue: CacheMetaInfoValue = new CacheMetaInfoValue(
-          SparkEnv.get.blockManager.blockManagerId.host,
-          fiberId.asInstanceOf[BinaryDataFiberId].getOffset,
-          fiberId.asInstanceOf[BinaryDataFiberId].getLength)
-        val storeCacheMetaInfo = new StoreCacheMetaInfo(
-          fiberId.asInstanceOf[BinaryDataFiberId].getFilePath,
-          cacheMetaInfoValue)
-        // report cache locality info to redis/etcd
-        externalDBClient.upsert(storeCacheMetaInfo)
-      case vectorData: VectorDataFiberId =>
-        val cacheMetaInfoValue: CacheMetaInfoValue = new CacheMetaInfoValue(
-          SparkEnv.get.blockManager.blockManagerId.host,
-          fiberId.asInstanceOf[VectorDataFiberId].getOffset,
-          fiberId.asInstanceOf[VectorDataFiberId].getLength)
-        val storeCacheMetaInfo = new StoreCacheMetaInfo(
-          fiberId.asInstanceOf[VectorDataFiberId].getFilePath,
-          cacheMetaInfoValue)
-        // report cache locality info to redis/etcd
-        externalDBClient.upsert(storeCacheMetaInfo)
+      case binary: BinaryDataFiberId => binary
+        .doReport(SparkEnv.get.blockManager.blockManagerId.host, externalDBClient)
+      case vectorData: VectorDataFiberId => vectorData
+        .doReport(SparkEnv.get.blockManager.blockManagerId.host, externalDBClient)
     }
   }
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFiberReaderWriter.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFiberReaderWriter.scala
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.oap.io
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.OapException
+import org.apache.spark.sql.execution.datasources.oap.filecache.{FiberCache, FiberId}
+import org.apache.spark.sql.execution.datasources.oap.io.ParquetDataFiberWriter.{dumpDataAndDicToFiber, dumpDataToFiber, dumpNullsToFiber, emptyDataFiber, fiberLength, logDebug}
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
+import org.apache.spark.sql.oap.OapRuntime
+import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
+import org.apache.spark.unsafe.Platform
+
+object OrcDataFiberWriter extends Logging{
+  // orc dumpToCache
+  def orcDumpToCache(column: OnHeapColumnVector, total: Int,
+                     fiberId: FiberId = null): FiberCache = {
+    val header = ParquetDataFiberHeader(column, total)
+    logDebug(s"will dump column to data fiber dataType = ${column.dataType()}, " +
+      s"total = $total, header is $header")
+    header match {
+      case ParquetDataFiberHeader(true, false, 0) =>
+        val length = fiberLength(column, total, 0 )
+        logDebug(s"will apply $length bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(length, fiberId)
+        if (!fiber.isFailedMemoryBlock()) {
+          val nativeAddress = header.writeToCache(fiber.getBaseOffset)
+          dumpDataToFiber(nativeAddress, column, total)
+        } else {
+          fiber.setColumn(column)
+        }
+        fiber
+      case ParquetDataFiberHeader(true, false, dicLength) =>
+        val length = fiberLength(column, total, 0, dicLength)
+        logDebug(s"will apply $length bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(length, fiberId)
+        if (!fiber.isFailedMemoryBlock()) {
+          val nativeAddress = header.writeToCache(fiber.getBaseOffset)
+          dumpDataAndDicToFiber(nativeAddress, column, total, dicLength)
+        } else {
+          fiber.setColumn(column)
+        }
+        fiber
+      case ParquetDataFiberHeader(false, true, _) =>
+        logDebug(s"will apply ${ParquetDataFiberHeader.defaultSize} " +
+          s"bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(ParquetDataFiberHeader.defaultSize, fiberId)
+        if (!fiber.isFailedMemoryBlock()) {
+          header.writeToCache(fiber.getBaseOffset)
+        } else {
+          fiber.setColumn(column)
+        }
+        fiber
+      case ParquetDataFiberHeader(false, false, 0) =>
+        val length = fiberLength(column, total, 1)
+        logDebug(s"will apply $length bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(length, fiberId)
+        if (!fiber.isFailedMemoryBlock()) {
+          val nativeAddress =
+            dumpNullsToFiber(header.writeToCache(fiber.getBaseOffset), column, total)
+          dumpDataToFiber(nativeAddress, column, total)
+        } else {
+          fiber.setColumn(column)
+        }
+        fiber
+      case ParquetDataFiberHeader(false, false, dicLength) =>
+        val length = fiberLength(column, total, 1, dicLength)
+        logDebug(s"will apply $length bytes off heap memory for data fiber.")
+        val fiber = emptyDataFiber(length, fiberId)
+        if (!fiber.isFailedMemoryBlock()) {
+          val nativeAddress =
+            dumpNullsToFiber(header.writeToCache(fiber.getBaseOffset), column, total)
+          dumpDataAndDicToFiber(nativeAddress, column, total, dicLength)
+        } else {
+          fiber.setColumn(column)
+        }
+        fiber
+      case ParquetDataFiberHeader(true, true, _) =>
+        throw new OapException("impossible header status (true, true, _).")
+      case other => throw new OapException(s"impossible header status $other.")
+    }
+  }
+
+
+  /**
+   * TODO following functions are duplicate with those in ParquetDataFiberReaderWriter.scala
+   * TODO code refactor
+   */
+
+  /**
+   * Write nulls data to data fiber.
+   */
+  private def dumpNullsToFiber(
+      nativeAddress: Long, column: OnHeapColumnVector, total: Int): Long = {
+    Platform.copyMemory(column.getNulls,
+      Platform.BYTE_ARRAY_OFFSET, null, nativeAddress, total)
+    nativeAddress + total
+  }
+
+  /**
+   * noNulls is true, nulls are all 0, not dump nulls to cache,
+   * allNulls is false, need dump to cache,
+   * dicLength is 0, needn't calculate dictionary part.
+   */
+  private def dumpDataToFiber(nativeAddress: Long, column: OnHeapColumnVector, total: Int): Unit = {
+    column.dataType match {
+      case ByteType | BooleanType =>
+        Platform.copyMemory(column.getByteData,
+          Platform.BYTE_ARRAY_OFFSET, null, nativeAddress, total)
+      case ShortType =>
+        Platform.copyMemory(column.getShortData,
+          Platform.SHORT_ARRAY_OFFSET, null, nativeAddress, total * 2L)
+      case IntegerType | DateType =>
+        Platform.copyMemory(column.getIntData,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4L)
+      case FloatType =>
+        Platform.copyMemory(column.getFloatData,
+          Platform.FLOAT_ARRAY_OFFSET, null, nativeAddress, total * 4L)
+      case LongType | TimestampType =>
+        Platform.copyMemory(column.getLongData,
+          Platform.LONG_ARRAY_OFFSET, null, nativeAddress, total * 8L)
+      case DoubleType =>
+        Platform.copyMemory(column.getDoubleData,
+          Platform.DOUBLE_ARRAY_OFFSET, null, nativeAddress, total * 8L)
+      case StringType | BinaryType =>
+        Platform.copyMemory(column.getArrayLengths,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4L)
+        Platform.copyMemory(column.getArrayOffsets,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress + total * 4L, total * 4L)
+        val child = column.getChild(0).asInstanceOf[OnHeapColumnVector]
+        Platform.copyMemory(child.getByteData,
+          Platform.BYTE_ARRAY_OFFSET, null, nativeAddress + total * 8L,
+          child.getElementsAppended)
+      case other if DecimalType.is32BitDecimalType(other) =>
+        Platform.copyMemory(column.getIntData,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4L)
+      case other if DecimalType.is64BitDecimalType(other) =>
+        Platform.copyMemory(column.getLongData,
+          Platform.LONG_ARRAY_OFFSET, null, nativeAddress, total * 8L)
+      case other if DecimalType.isByteArrayDecimalType(other) =>
+        Platform.copyMemory(column.getArrayLengths,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4L)
+        Platform.copyMemory(column.getArrayOffsets,
+          Platform.INT_ARRAY_OFFSET, null, nativeAddress + total * 4L, total * 4L)
+        val child = column.getChild(0).asInstanceOf[OnHeapColumnVector]
+        Platform.copyMemory(child.getByteData,
+          Platform.BYTE_ARRAY_OFFSET, null, nativeAddress + total * 8L,
+          child.getElementsAppended)
+      case other => throw new OapException(s"$other data type is not support data cache.")
+    }
+  }
+
+  /**
+   * Write dictionaryIds(int array) and Dictionary data to data fiber.
+   */
+  private def dumpDataAndDicToFiber(
+      nativeAddress: Long, column: OnHeapColumnVector, total: Int, dicLength: Int): Unit = {
+    // dump dictionaryIds to data fiber, it's a int array.
+    val dictionaryIds = column.getDictionaryIds.asInstanceOf[OnHeapColumnVector]
+    Platform.copyMemory(dictionaryIds.getIntData,
+      Platform.INT_ARRAY_OFFSET, null, nativeAddress, total * 4L)
+    var dicNativeAddress = nativeAddress + total * 4L
+    val dictionary = column.getDictionary
+    // dump dictionary to data fiber case by dataType.
+    column.dataType() match {
+      case ByteType | ShortType | IntegerType | DateType =>
+        val intDictionaryContent = new Array[Int](dicLength)
+        (0 until dicLength).foreach(id => intDictionaryContent(id) = dictionary.decodeToInt(id))
+        Platform.copyMemory(intDictionaryContent, Platform.INT_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 4L)
+      case FloatType =>
+        val floatDictionaryContent = new Array[Float](dicLength)
+        (0 until dicLength).foreach(id => floatDictionaryContent(id) = dictionary.decodeToFloat(id))
+        Platform.copyMemory(floatDictionaryContent, Platform.FLOAT_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 4L)
+      case LongType | TimestampType =>
+        val longDictionaryContent = new Array[Long](dicLength)
+        (0 until dicLength).foreach(id => longDictionaryContent(id) = dictionary.decodeToLong(id))
+        Platform.copyMemory(longDictionaryContent, Platform.LONG_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 8L)
+      case DoubleType =>
+        val doubleDictionaryContent = new Array[Double](dicLength)
+        (0 until dicLength).foreach(id =>
+          doubleDictionaryContent(id) = dictionary.decodeToDouble(id))
+        Platform.copyMemory(doubleDictionaryContent, Platform.DOUBLE_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 8L);
+      case StringType | BinaryType =>
+        var bytesNativeAddress = dicNativeAddress + 4L * dicLength
+        (0 until dicLength).foreach( id => {
+          val binary = dictionary.decodeToBinary(id)
+          val length = binary.length
+          Platform.putInt(null, dicNativeAddress, length)
+          dicNativeAddress += 4
+          Platform.copyMemory(binary,
+            Platform.BYTE_ARRAY_OFFSET, null, bytesNativeAddress, length)
+          bytesNativeAddress += length
+        })
+      case other if DecimalType.is32BitDecimalType(other) =>
+        val intDictionaryContent = new Array[Int](dicLength)
+        (0 until dicLength).foreach(id => intDictionaryContent(id) = dictionary.decodeToInt(id))
+        Platform.copyMemory(intDictionaryContent, Platform.INT_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 4L)
+      case other if DecimalType.is64BitDecimalType(other) =>
+        val longDictionaryContent = new Array[Long](dicLength)
+        (0 until dicLength).foreach(id => longDictionaryContent(id) = dictionary.decodeToLong(id))
+        Platform.copyMemory(longDictionaryContent, Platform.LONG_ARRAY_OFFSET, null,
+          dicNativeAddress, dicLength * 8L)
+      case other if DecimalType.isByteArrayDecimalType(other) =>
+        var bytesNativeAddress = dicNativeAddress + 4L * dicLength
+        (0 until dicLength).foreach( id => {
+          val binary = dictionary.decodeToBinary(id)
+          val length = binary.length
+          Platform.putInt(null, dicNativeAddress, length)
+          dicNativeAddress += 4
+          Platform.copyMemory(binary,
+            Platform.BYTE_ARRAY_OFFSET, null, bytesNativeAddress, length)
+          bytesNativeAddress += length
+        })
+      case other => throw new OapException(s"$other data type is not support dictionary.")
+    }
+  }
+
+  /**
+   * noNulls is true, nulls are all 0, not dump nulls to cache, nullsLength is 0,
+   * allNulls is false, need dump to cache,
+   * dicLength is 0, needn't calculate dictionary part.
+   */
+  private def fiberLength(column: OnHeapColumnVector, total: Int, nullUnitLength: Int): Long =
+    if (isFixedLengthDataType(column.dataType())) {
+      logDebug(s"dataType ${column.dataType()} is fixed length. ")
+      // Fixed length data type fiber length.
+      ParquetDataFiberHeader.defaultSize +
+        nullUnitLength * total + column.dataType().defaultSize.toLong * total
+    } else {
+      logDebug(s"dataType ${column.dataType()} is not fixed length. ")
+      // lengthData and offsetData will be set and data will be put in child if type is Array.
+      // lengthData: 4 bytes, offsetData: 4 bytes, nulls: 1 byte,
+      // child.data: childColumns[0].elementsAppended bytes.
+      ParquetDataFiberHeader.defaultSize + nullUnitLength * total + total * 8L +
+        column.getChild(0).getElementsAppended
+    }
+
+  /**
+   * noNulls is true, nulls are all 0, not dump nulls to cache, nullsLength is 0,
+   * allNulls is false, need dump to cache,
+   * dicLength is not, need calculate dictionary part and dictionaryIds is a int array.
+   */
+  private def fiberLength(
+      column: OnHeapColumnVector, total: Int, nullUnitLength: Int, dicLength: Int): Long = {
+    val dicPartSize = column.dataType() match {
+      case ByteType | ShortType | IntegerType | DateType => dicLength * 4L
+      case FloatType => dicLength * 4L
+      case LongType | TimestampType => dicLength * 8L
+      case DoubleType => dicLength * 8L
+      case StringType | BinaryType =>
+        val dictionary = column.getDictionary
+        (0 until dicLength).map(id => dictionary.decodeToBinary(id).length + 4L).sum
+      // if DecimalType.is32BitDecimalType(other) as int data type
+      case other if DecimalType.is32BitDecimalType(other) => dicLength * 4L
+      // if DecimalType.is64BitDecimalType(other) as long data type
+      case other if DecimalType.is64BitDecimalType(other) => dicLength * 8L
+      // if DecimalType.isByteArrayDecimalType(other) as binary data type
+      case other if DecimalType.isByteArrayDecimalType(other) =>
+        val dictionary = column.getDictionary
+        (0 until dicLength).map(id => dictionary.decodeToBinary(id).length + 4L).sum
+      case other => throw new OapException(s"$other data type is not support dictionary.")
+    }
+    ParquetDataFiberHeader.defaultSize + nullUnitLength * total + 4L * total + dicPartSize
+  }
+
+  private def isFixedLengthDataType(dataType: DataType): Boolean = dataType match {
+    case StringType | BinaryType => false
+    case ByteType | BooleanType | ShortType |
+         IntegerType | DateType | FloatType |
+         LongType | DoubleType | TimestampType => true
+    // if DecimalType.is32BitDecimalType(other) as int data type,
+    // if DecimalType.is64BitDecimalType(other) as long data type,
+    // so they are fixed length
+    case other if DecimalType.is32BitDecimalType(other) ||
+      DecimalType.is64BitDecimalType(other) => true
+    // if DecimalType.isByteArrayDecimalType(other) as binary data type,
+    // so it's not fixed length
+    case other if DecimalType.isByteArrayDecimalType(other) => false
+    case other => throw new OapException(s"$other data type is not implemented for cache.")
+  }
+
+  private def emptyDataFiber(fiberLength: Long, fiberId: FiberId = null): FiberCache =
+    OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(fiberLength, fiberId)
+
+}

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
@@ -238,6 +238,6 @@ private[oap] case class OrcDataFile(
     else {
       OrcCacheReader.putValues(rowCount, field, fromColumn, toColumn)
     }
-    ParquetDataFiberWriter.dumpToCache(toColumn, rowCount, fiber)
+    OrcDataFiberWriter.orcDumpToCache(toColumn, rowCount, fiber)
   }
 }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberReaderWriter.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFiberReaderWriter.scala
@@ -48,14 +48,14 @@ object ParquetDataFiberWriter extends Logging {
     val header = ParquetDataFiberHeader(column, total)
     logDebug(s"will dump column to data fiber dataType = ${column.dataType()}, " +
       s"total = $total, header is $header")
+    if (fiberId != null) {
+      fiberId.asInstanceOf[VectorDataFiberId]
+        .setProperty(path, mc.getStartingPos, mc.getTotalSize)
+    }
     header match {
       case ParquetDataFiberHeader(true, false, 0) =>
         val length = fiberLength(column, total, 0 )
         logDebug(s"will apply $length bytes off heap memory for data fiber.")
-        if (fiberId != null) {
-          fiberId.asInstanceOf[VectorDataFiberId]
-            .setProperty(path, mc.getStartingPos, mc.getTotalSize)
-        }
         val fiber = emptyDataFiber(length, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           val nativeAddress = header.writeToCache(fiber.getBaseOffset)
@@ -67,10 +67,6 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(true, false, dicLength) =>
         val length = fiberLength(column, total, 0, dicLength)
         logDebug(s"will apply $length bytes off heap memory for data fiber.")
-        if (fiberId != null) {
-          fiberId.asInstanceOf[VectorDataFiberId]
-            .setProperty(path, mc.getStartingPos, mc.getTotalSize)
-        }
         val fiber = emptyDataFiber(length, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           val nativeAddress = header.writeToCache(fiber.getBaseOffset)
@@ -82,10 +78,6 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(false, true, _) =>
         logDebug(s"will apply ${ParquetDataFiberHeader.defaultSize} " +
           s"bytes off heap memory for data fiber.")
-        if (fiberId != null) {
-          fiberId.asInstanceOf[VectorDataFiberId]
-            .setProperty(path, mc.getStartingPos, mc.getTotalSize)
-        }
         val fiber = emptyDataFiber(ParquetDataFiberHeader.defaultSize, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           header.writeToCache(fiber.getBaseOffset)
@@ -96,10 +88,6 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(false, false, 0) =>
         val length = fiberLength(column, total, 1)
         logDebug(s"will apply $length bytes off heap memory for data fiber.")
-        if (fiberId != null) {
-          fiberId.asInstanceOf[VectorDataFiberId]
-            .setProperty(path, mc.getStartingPos, mc.getTotalSize)
-        }
         val fiber = emptyDataFiber(length, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           val nativeAddress =
@@ -112,10 +100,6 @@ object ParquetDataFiberWriter extends Logging {
       case ParquetDataFiberHeader(false, false, dicLength) =>
         val length = fiberLength(column, total, 1, dicLength)
         logDebug(s"will apply $length bytes off heap memory for data fiber.")
-        if (fiberId != null) {
-          fiberId.asInstanceOf[VectorDataFiberId]
-            .setProperty(path, mc.getStartingPos, mc.getTotalSize)
-        }
         val fiber = emptyDataFiber(length, fiberId)
         if (!fiber.isFailedMemoryBlock()) {
           val nativeAddress =

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -102,7 +102,7 @@ private[oap] case class ParquetDataFile(
     // setting required column to conf enables us to
     // Vectorized read & cache certain(not all) columns
     addRequestSchemaToConf(conf, Array(fiberId))
-    ParquetFiberDataLoader(conf, fiberDataReader, groupId).loadSingleColumn(fiber)
+    ParquetFiberDataLoader(conf, fiberDataReader, groupId).loadSingleColumn(fiber, path)
   }
 
   def iterator(

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -546,7 +546,7 @@ object OapConf {
   }
 
   val OAP_EXTERNAL_CACHE_METADB_IMPL =
-    SqlConfAdapter.buildConf("spark.sql.oap.extrenal.cache.metaDB.impl")
+    SqlConfAdapter.buildConf("spark.sql.oap.external.cache.metaDB.impl")
       .internal()
       .doc("ExternalDB used to store cache meta info, now support Redis/Etcd")
       .stringConf

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -528,4 +528,28 @@ object OapConf {
       .booleanConf
       .createWithDefault(false)
   }
+
+  val OAP_EXTERNAL_CACHE_METADB_ENABLE = {
+    SqlConfAdapter.buildConf("spark.sql.oap.external.cache.metaDB.enable")
+      .internal()
+      .doc("external cachemeta db enable")
+      .booleanConf
+      .createWithDefault(false)
+  }
+
+  val OAP_EXTERNAL_CACHE_METADB_ADDRESS = {
+    SqlConfAdapter.buildConf("spark.sql.oap.external.cache.metaDB.address")
+      .internal()
+      .doc("external cachemeta db address")
+      .stringConf
+      .createWithDefault("127.0.0.1")
+  }
+
+  val OAP_EXTERNAL_CACHE_METADB_IMPL =
+    SqlConfAdapter.buildConf("spark.sql.oap.extrenal.cache.metaDB.impl")
+      .internal()
+      .doc("ExternalDB used to store cache meta info, now support Redis/Etcd")
+      .stringConf
+      .createWithDefault("RedisClient")
+
 }

--- a/oap-cache/oap/src/main/spark2.4.4/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/oap-cache/oap/src/main/spark2.4.4/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.io.{FileNotFoundException, IOException}
+
+import scala.collection.mutable
+
+import org.apache.parquet.io.ParquetDecodingException
+
+import org.apache.spark.{Partition => RDDPartition, TaskContext, TaskKilledException}
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.rdd.{InputFileBlockHolder, RDD}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.QueryExecutionException
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.NextIterator
+
+/**
+ * A part (i.e. "block") of a single file that should be read, along with partition column values
+ * that need to be prepended to each row.
+ *
+ * @param partitionValues value of partition columns to be prepended to each row.
+ * @param filePath path of the file to read
+ * @param start the beginning offset (in bytes) of the block.
+ * @param length number of bytes to read.
+ * @param locations locality information (list of nodes that have the data).
+ */
+case class PartitionedFile(
+    partitionValues: InternalRow,
+    filePath: String,
+    start: Long,
+    length: Long,
+    @transient locations: Array[String] = Array.empty) {
+  override def toString: String = {
+    s"path: $filePath, range: $start-${start + length}, partition values: $partitionValues"
+  }
+}
+
+/**
+ * A collection of file blocks that should be read as a single task
+ * (possibly from multiple partitioned directories).
+ */
+case class FilePartition(index: Int, files: Array[PartitionedFile]) extends RDDPartition
+
+/**
+ * An RDD that scans a list of file partitions.
+ */
+class FileScanRDD(
+    @transient private val sparkSession: SparkSession,
+    readFunction: (PartitionedFile) => Iterator[InternalRow],
+    @transient val filePartitions: Seq[FilePartition])
+  extends RDD[InternalRow](sparkSession.sparkContext, Nil) {
+
+  private val ignoreCorruptFiles = sparkSession.sessionState.conf.ignoreCorruptFiles
+  private val ignoreMissingFiles = sparkSession.sessionState.conf.ignoreMissingFiles
+
+  override def compute(split: RDDPartition, context: TaskContext): Iterator[InternalRow] = {
+    val iterator = new Iterator[Object] with AutoCloseable {
+      private val inputMetrics = context.taskMetrics().inputMetrics
+      private val existingBytesRead = inputMetrics.bytesRead
+
+      // Find a function that will return the FileSystem bytes read by this thread. Do this before
+      // apply readFunction, because it might read some bytes.
+      private val getBytesReadCallback =
+      SparkHadoopUtil.get.getFSBytesReadOnThreadCallback()
+
+      // We get our input bytes from thread-local Hadoop FileSystem statistics.
+      // If we do a coalesce, however, we are likely to compute multiple partitions in the same
+      // task and in the same thread, in which case we need to avoid override values written by
+      // previous partitions (SPARK-13071).
+      private def incTaskInputMetricsBytesRead(): Unit = {
+        inputMetrics.setBytesRead(existingBytesRead + getBytesReadCallback())
+      }
+
+      private[this] val files = split.asInstanceOf[FilePartition].files.toIterator
+      private[this] var currentFile: PartitionedFile = null
+      private[this] var currentIterator: Iterator[Object] = null
+
+      def hasNext: Boolean = {
+        // Kill the task in case it has been marked as killed. This logic is from
+        // InterruptibleIterator, but we inline it here instead of wrapping the iterator in order
+        // to avoid performance overhead.
+        context.killTaskIfInterrupted()
+        (currentIterator != null && currentIterator.hasNext) || nextIterator()
+      }
+      def next(): Object = {
+        val nextElement = currentIterator.next()
+        // TODO: we should have a better separation of row based and batch based scan, so that we
+        // don't need to run this `if` for every record.
+        val preNumRecordsRead = inputMetrics.recordsRead
+        if (nextElement.isInstanceOf[ColumnarBatch]) {
+          incTaskInputMetricsBytesRead()
+          inputMetrics.incRecordsRead(nextElement.asInstanceOf[ColumnarBatch].numRows())
+        } else {
+          // too costly to update every record
+          if (inputMetrics.recordsRead %
+            SparkHadoopUtil.UPDATE_INPUT_METRICS_INTERVAL_RECORDS == 0) {
+            incTaskInputMetricsBytesRead()
+          }
+          inputMetrics.incRecordsRead(1)
+        }
+        nextElement
+      }
+
+      private def readCurrentFile(): Iterator[InternalRow] = {
+        try {
+          readFunction(currentFile)
+        } catch {
+          case e: FileNotFoundException =>
+            throw new FileNotFoundException(
+              e.getMessage + "\n" +
+                "It is possible the underlying files have been updated. " +
+                "You can explicitly invalidate the cache in Spark by " +
+                "running 'REFRESH TABLE tableName' command in SQL or " +
+                "by recreating the Dataset/DataFrame involved.")
+        }
+      }
+
+      /** Advances to the next file. Returns true if a new non-empty iterator is available. */
+      private def nextIterator(): Boolean = {
+        if (files.hasNext) {
+          currentFile = files.next()
+          logInfo(s"Reading File $currentFile")
+          // Sets InputFileBlockHolder for the file block's information
+          InputFileBlockHolder.set(currentFile.filePath, currentFile.start, currentFile.length)
+
+          if (ignoreMissingFiles || ignoreCorruptFiles) {
+            currentIterator = new NextIterator[Object] {
+              // The readFunction may read some bytes before consuming the iterator, e.g.,
+              // vectorized Parquet reader. Here we use lazy val to delay the creation of
+              // iterator so that we will throw exception in `getNext`.
+              private lazy val internalIter = readCurrentFile()
+
+              override def getNext(): AnyRef = {
+                try {
+                  if (internalIter.hasNext) {
+                    internalIter.next()
+                  } else {
+                    finished = true
+                    null
+                  }
+                } catch {
+                  case e: FileNotFoundException if ignoreMissingFiles =>
+                    logWarning(s"Skipped missing file: $currentFile", e)
+                    finished = true
+                    null
+                  // Throw FileNotFoundException even if `ignoreCorruptFiles` is true
+                  case e: FileNotFoundException if !ignoreMissingFiles => throw e
+                  case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
+                    logWarning(
+                      s"Skipped the rest of the content in the corrupted file: $currentFile", e)
+                    finished = true
+                    null
+                }
+              }
+
+              override def close(): Unit = {}
+            }
+          } else {
+            currentIterator = readCurrentFile()
+          }
+
+          try {
+            hasNext
+          } catch {
+            case e: SchemaColumnConvertNotSupportedException =>
+              val message = "Parquet column cannot be converted in " +
+                s"file ${currentFile.filePath}. Column: ${e.getColumn}, " +
+                s"Expected: ${e.getLogicalType}, Found: ${e.getPhysicalType}"
+              throw new QueryExecutionException(message, e)
+            case e: ParquetDecodingException =>
+              if (e.getMessage.contains("Can not read value at")) {
+                val message = "Encounter error while reading parquet files. " +
+                  "One possible cause: Parquet column cannot be converted in the " +
+                  "corresponding files. Details: "
+                throw new QueryExecutionException(message, e)
+              }
+              throw e
+          }
+        } else {
+          currentFile = null
+          InputFileBlockHolder.unset()
+          false
+        }
+      }
+
+      override def close(): Unit = {
+        incTaskInputMetricsBytesRead()
+        InputFileBlockHolder.unset()
+      }
+    }
+
+    // Register an on-task-completion callback to close the input stream.
+    context.addTaskCompletionListener[Unit](_ => iterator.close())
+
+    iterator.asInstanceOf[Iterator[InternalRow]] // This is an erasure hack.
+  }
+
+  override protected def getPartitions: Array[RDDPartition] = filePartitions.toArray
+
+  override protected def getPreferredLocations(split: RDDPartition): Seq[String] = {
+    val files = split.asInstanceOf[FilePartition].files
+
+    // Computes total number of bytes can be retrieved from each host.
+    val hostToNumBytes = mutable.HashMap.empty[String, Long]
+    files.foreach { file =>
+      file.locations.filter(_ != "localhost").foreach { host =>
+        hostToNumBytes(host) = hostToNumBytes.getOrElse(host, 0L) + file.length
+      }
+    }
+
+    // Takes the first 3 hosts with the most data to be retrieved
+    hostToNumBytes.toSeq.sortBy {
+      case (host, numBytes) => numBytes
+    }.reverse.take(3).map {
+      case (host, numBytes) => host
+    }
+  }
+}

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCacheSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCacheSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.execution.datasources.oap.filecache.FiberType.FiberT
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.test.oap.SharedOapContext
 
-class OapCacheSuite extends SharedOapContext with Logging{
+class OapCacheSuite extends SharedOapContext with Logging {
 
   override def beforeAll(): Unit = super.beforeAll()
 

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFileSuite.scala
@@ -632,7 +632,8 @@ class ParquetCacheDataWithDictionaryWithNullsCompressedSuite extends ParquetData
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(0)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(0).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -663,7 +664,8 @@ class ParquetCacheDataWithDictionaryWithNullsCompressedSuite extends ParquetData
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(1)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(1).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -695,7 +697,8 @@ class ParquetCacheDataWithDictionaryWithNullsCompressedSuite extends ParquetData
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(2)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(2).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -728,7 +731,8 @@ class ParquetCacheDataWithDictionaryWithNullsCompressedSuite extends ParquetData
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(3)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(3).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -761,7 +765,8 @@ class ParquetCacheDataWithDictionaryWithNullsCompressedSuite extends ParquetData
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(4)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(4).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -794,7 +799,8 @@ class ParquetCacheDataWithDictionaryWithNullsCompressedSuite extends ParquetData
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(5)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(5).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -864,7 +870,8 @@ class ParquetCacheDataWithDictionaryWithoutNullsCompressedSuite extends ParquetD
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(0)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(0).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -893,7 +900,8 @@ class ParquetCacheDataWithDictionaryWithoutNullsCompressedSuite extends ParquetD
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(1)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(1).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -923,7 +931,8 @@ class ParquetCacheDataWithDictionaryWithoutNullsCompressedSuite extends ParquetD
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(2)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(2).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -954,7 +963,8 @@ class ParquetCacheDataWithDictionaryWithoutNullsCompressedSuite extends ParquetD
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(3)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(3).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -985,7 +995,8 @@ class ParquetCacheDataWithDictionaryWithoutNullsCompressedSuite extends ParquetD
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(4)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(4).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -1016,7 +1027,8 @@ class ParquetCacheDataWithDictionaryWithoutNullsCompressedSuite extends ParquetD
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(5)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new VectorizedColumnReader(columnDescriptor, types.get(5).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -1535,7 +1547,8 @@ class ParquetFiberDataReaderSuite extends ParquetDataFileSuite {
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = parquetSchema.getColumns.get(0)
     val types: util.List[Type] = parquetSchema.asGroupType.getFields
-    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor)
+    val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+    val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     val columnReader =
       new SkippableVectorizedColumnReader(columnDescriptor, types.get(0).getOriginalType,
         fiberData.getPageReader(columnDescriptor), TimeZone.getDefault)
@@ -1555,7 +1568,8 @@ class ParquetFiberDataReaderSuite extends ParquetDataFileSuite {
     val blockMetaData = footer.getBlocks.get(0)
     val columnDescriptor = new ColumnDescriptor(Array(s"${fileName}_temp"), INT32, 0, 0)
     val exception = intercept[IOException] {
-      reader.readFiberData(blockMetaData, columnDescriptor)
+      val columnMeta = reader.findColumnMeta(blockMetaData, columnDescriptor)
+      val fiberData = reader.readFiberData(blockMetaData, columnDescriptor, columnMeta)
     }
     assert(exception.getMessage.contains("Can not find column meta of column"))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable external db to store cache locality info and schedule tasks accordingly.


## How was this patch tested?

E2E.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

