### PR TITLE
[OAP-1765][oap-native-sql] Fix for dropped CoalecseBatches before ColumnarBroadcastExchange

### DIFF
--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.adaptive
 
-import com.intel.oap.execution.RowToArrowColumnarExec
+import com.intel.oap.execution.{RowToArrowColumnarExec, CoalesceBatchesExec}
 
 import java.util
 import java.util.concurrent.LinkedBlockingQueue
@@ -404,9 +404,9 @@ case class AdaptiveSparkPlanExec(
         if (columnarBHJEnabled && parent.isInstanceOf[BroadcastHashJoinExec]) {
           val columnarExchangeChild = b.child match {
             case WholeStageCodegenExec(child: ColumnarToRowExec) =>
-              child.child
+              CoalesceBatchesExec(child.child)
             case child: ColumnarToRowExec =>
-              child.child
+              CoalesceBatchesExec(child.child)
             case child => {
               if (child.supportsColumnar) {
                 b.child


### PR DESCRIPTION
Since current columnarBHJ is applied after all additional Rules applied, previous optimization to remove CoalecseBatches when child is ColumnarToRow leads to CoalecseBatches removed in ColumnarBroadcastExchange, which shows huge performance degradation.

Fixed in this PR

Signed-off-by: Chendi Xue <chendi.xue@intel.com>