### PR TITLE
[OAP-CACHE][OAP-1690][POAE7-430] Cache backend fallback bugfix

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -75,18 +75,7 @@ private[sql] class FiberCacheManager(
     }
 
     val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
-    if (cacheName.equals(GUAVA_CACHE)) {
-      new GuavaOapCache(dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
-    } else if (cacheName.equals(SIMPLE_CACHE)) {
-      new SimpleOapCache()
-    } else if (cacheName.equals(NO_EVICT_CACHE)) {
-      new NoEvictPMCache(dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
-    } else if (cacheName.equals(VMEM_CACHE)) {
-      new VMemCache(FiberType.DATA)
-    } else if (cacheName.equals(EXTERNAL_CACHE)) {
-      val cache = new ExternalCache(FiberType.DATA)
-      cache
-    } else if (cacheName.equals(MIX_CACHE)) {
+    if (cacheName.equals(MIX_CACHE)) {
       val separateCache = sparkEnv.conf.getBoolean(
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
@@ -94,7 +83,8 @@ private[sql] class FiberCacheManager(
       new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
         indexCacheGuardianMemorySize, separateCache, sparkEnv)
     } else {
-      throw new OapException(s"Unsupported cache strategy $cacheName")
+      OapCache(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY,
+        dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
     }
   }
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -215,7 +215,6 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logg
 }
 
 private[filecache] object OapCache extends Logging {
-//  val PMemRelatedCacheBackend = Array("guava", "vmem", "noevict", "external")
   def plasmaServerDetect(): Boolean = {
     val command = "ps -ef" #| "grep plasma"
     val plasmaServerStatus = command.!!

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -24,6 +24,9 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import java.util.concurrent.locks.{Condition, ReentrantLock}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.language.postfixOps
+import scala.sys.process._
 import scala.util.Success
 
 import com.google.common.cache._
@@ -212,12 +215,20 @@ private[filecache] class CacheGuardian(maxMemory: Long) extends Thread with Logg
 }
 
 private[filecache] object OapCache extends Logging {
-  val PMemRelatedCacheBackend = Array("guava", "vmem", "noevict", "external")
+//  val PMemRelatedCacheBackend = Array("guava", "vmem", "noevict", "external")
+  def plasmaServerDetect(): Boolean = {
+    val command = "ps -ef" #| "grep plasma"
+    val plasmaServerStatus = command.!!
+    if (plasmaServerStatus.indexOf("plasma-store-server") == -1) {
+      logWarning("Plasma Store Server is not available, will fallback to simpleCache")
+      return false
+    }
+    true
+  }
   def cacheFallBackDetect(sparkEnv: SparkEnv,
                           fallBackEnabled: Boolean = true,
                           fallBackRes: Boolean = true): Boolean = {
-    if (fallBackEnabled == false && fallBackRes == true) return true
-    if (fallBackEnabled == false && fallBackRes == false) return false
+    if (fallBackEnabled == false) return fallBackRes
     val conf = sparkEnv.conf
     var numaId = conf.getInt("spark.executor.numa.id", -1)
     val executorIdStr = sparkEnv.executorId
@@ -228,7 +239,14 @@ private[filecache] object OapCache extends Logging {
         return false
     }
     val executorId = executorIdStr.toInt
-    val map = PersistentMemoryConfigUtils.parseConfig(conf)
+    var map: mutable.HashMap[Int, String] = mutable.HashMap.empty
+    try {
+      map = PersistentMemoryConfigUtils.parseConfig(conf)
+    } catch {
+      case e: OapException =>
+        logWarning("cacheFallBackDetect: execption when parse config" + e.getMessage)
+        return false
+    }
     if (numaId == -1) {
       logWarning(s"Executor ${executorId} is not bind with NUMA. It would be better to bind " +
         s"executor with NUMA when cache data to Intel Optane DC persistent memory.")
@@ -266,29 +284,38 @@ private[filecache] object OapCache extends Logging {
       "true").toLowerCase
     val fallBackRes = conf.get(OapConf.OAP_TEST_CACHE_BACKEND_FALLBACK_RES.key,
       "true").toLowerCase
-    if (PMemRelatedCacheBackend.contains(oapCacheOpt)) {
-      if (!cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean)) {
-        if (oapCacheOpt.equals("guava") && memoryManagerOpt.equals("offheap")) {
-          return new GuavaOapCache(cacheMemory, cacheGuardianMemory, fiberType)
+
+    oapCacheOpt match {
+      case "external" =>
+        if (plasmaServerDetect()) new ExternalCache(fiberType)
+        else new SimpleOapCache()
+      case "guava" =>
+        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean))
+          {
+            new GuavaOapCache(cacheMemory, cacheGuardianMemory, fiberType)
+          }
+        else {
+          if (oapCacheOpt.equals("guava") && memoryManagerOpt.equals("offheap"))
+            {
+              new GuavaOapCache(cacheMemory, cacheGuardianMemory, fiberType)
+            }
+          else new SimpleOapCache()
         }
-        logWarning(s"There is no Optane PMem DIMMs detected," +
-          s"has to fall back to simple cache implementation")
-        new SimpleOapCache()
-      }
-      else {
-        oapCacheOpt match {
-          case "guava" => new GuavaOapCache(cacheMemory, cacheGuardianMemory, fiberType)
-          case "vmem" => new VMemCache(fiberType)
-          case "noevict" => new NoEvictPMCache(cacheMemory, cacheGuardianMemory, fiberType)
-          case "external" => new ExternalCache(fiberType)
-          case _ => throw new UnsupportedOperationException(
-            s"The cache backend: ${oapCacheOpt} is not supported now")
-        }
-      }
-    }
-    else {
-      throw new UnsupportedOperationException(
-        s"The cache backend: ${oapCacheOpt} is not supported now")
+      case "noevict" =>
+        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean))
+          {
+            new NoEvictPMCache(cacheMemory, cacheGuardianMemory, fiberType)
+          }
+        else new SimpleOapCache()
+      case "vmem" =>
+        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean))
+          {
+            new VMemCache(fiberType)
+          }
+        else new SimpleOapCache()
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"The cache backend: ${oapCacheOpt} is not supported now")
     }
   }
 }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -289,28 +289,24 @@ private[filecache] object OapCache extends Logging {
         if (plasmaServerDetect()) new ExternalCache(fiberType)
         else new SimpleOapCache()
       case "guava" =>
-        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean))
-          {
+        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean)) {
+          new GuavaOapCache(cacheMemory, cacheGuardianMemory, fiberType)
+        }
+        else {
+          if (oapCacheOpt.equals("guava") && memoryManagerOpt.equals("offheap")) {
             new GuavaOapCache(cacheMemory, cacheGuardianMemory, fiberType)
           }
-        else {
-          if (oapCacheOpt.equals("guava") && memoryManagerOpt.equals("offheap"))
-            {
-              new GuavaOapCache(cacheMemory, cacheGuardianMemory, fiberType)
-            }
           else new SimpleOapCache()
         }
       case "noevict" =>
-        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean))
-          {
-            new NoEvictPMCache(cacheMemory, cacheGuardianMemory, fiberType)
-          }
+        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean)) {
+          new NoEvictPMCache(cacheMemory, cacheGuardianMemory, fiberType)
+        }
         else new SimpleOapCache()
       case "vmem" =>
-        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean))
-          {
-            new VMemCache(fiberType)
-          }
+        if (cacheFallBackDetect(sparkEnv, fallBackEnabled.toBoolean, fallBackRes.toBoolean)) {
+          new VMemCache(fiberType)
+        }
         else new SimpleOapCache()
       case _ =>
         throw new UnsupportedOperationException(

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -219,7 +219,8 @@ private[filecache] object OapCache extends Logging {
     val command = "ps -ef" #| "grep plasma"
     val plasmaServerStatus = command.!!
     if (plasmaServerStatus.indexOf("plasma-store-server") == -1) {
-      logWarning("Plasma Store Server is not available, will fallback to simpleCache")
+      logWarning("External cache strategy requires plasma-store-server launched, " +
+        "failed to detect plasma-store-server, will fallback to simpleCache.")
       return false
     }
     true


### PR DESCRIPTION
## What changes were proposed in this pull request?

call OapCache.apply method instead of directly call new specific CacheBackend like (new VMemCache、new ExternalCache)
Then can go cacheDetectFallBack codepath.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

