### PR TITLE
[OAP-CACHE][OAP-1690][POAE7-430] Cache backend fall back detect bug fix branch master

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -75,25 +75,15 @@ class FiberCacheManager(
     }
 
     val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
-    if (cacheName.equals(GUAVA_CACHE)) {
-      new GuavaOapCache(dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
-    } else if (cacheName.equals(SIMPLE_CACHE)) {
-      new SimpleOapCache()
-    } else if (cacheName.equals(NO_EVICT_CACHE)) {
-      new NoEvictPMCache(dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
-    } else if (cacheName.equals(VMEM_CACHE)) {
-      new VMemCache(FiberType.DATA)
-    } else if (cacheName.equals(EXTERNAL_CACHE)) {
-      new ExternalCache(FiberType.DATA)
-    } else if (cacheName.equals(MIX_CACHE)) {
+    if (cacheName.equals(MIX_CACHE)) {
       val separateCache = sparkEnv.conf.getBoolean(
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
-        OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
-      )
+        OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get)
       new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
         indexCacheGuardianMemorySize, separateCache, sparkEnv)
     } else {
-      throw new OapException(s"Unsupported cache strategy $cacheName")
+      OapCache(sparkEnv, OapConf.OAP_FIBERCACHE_STRATEGY,
+        dataCacheMemorySize, dataCacheGuardianMemorySize, FiberType.DATA)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

call OapCache.apply method instead of directly call new specific CacheBackend like (new VMemCache、new ExternalCache)
Then can go cacheDetectFallBack codepath.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


E2E
