### PR TITLE
[OAP-1653][OAP-Cache]Keep consistency on 'enabled' of OapConf configu…

### DIFF
--- a/oap-cache/oap/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
+++ b/oap-cache/oap/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcColumnarBatchReader.java
@@ -138,7 +138,8 @@ public class OrcColumnarBatchReader implements RecordReader<ColumnarBatch> {
       OrcInputFormat.buildOptions(conf, fileReader, 0, length);
 
     boolean binaryCacheEnabled = conf
-      .getBoolean(OapConf$.MODULE$.OAP_ORC_BINARY_DATA_CACHE_ENABLED().key(), false);
+      .getBoolean(OapConf$.MODULE$.OAP_ORC_BINARY_DATA_CACHE_ENABLED().key(), false)||
+            conf.getBoolean(OapConf$.MODULE$.OAP_ORC_BINARY_DATA_CACHE_ENABLE().key(), false);
     if (binaryCacheEnabled) {
       Boolean zeroCopy = options.getUseZeroCopy();
       if (zeroCopy == null) {

--- a/oap-cache/oap/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcMapreduceRecordReader.java
+++ b/oap-cache/oap/src/main/java/org/apache/spark/sql/execution/datasources/oap/orc/OrcMapreduceRecordReader.java
@@ -64,7 +64,8 @@ public class OrcMapreduceRecordReader<V extends WritableComparable>
         fileReader, 0, length);
 
     boolean binaryCacheEnabled = conf
-      .getBoolean(OapConf$.MODULE$.OAP_ORC_BINARY_DATA_CACHE_ENABLED().key(), false);
+      .getBoolean(OapConf$.MODULE$.OAP_ORC_BINARY_DATA_CACHE_ENABLED().key(), false) ||
+            conf.getBoolean(OapConf$.MODULE$.OAP_ORC_BINARY_DATA_CACHE_ENABLE().key(), false);
     if (binaryCacheEnabled) {
       Boolean zeroCopy = options.getUseZeroCopy();
       if (zeroCopy == null) {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
@@ -59,7 +59,8 @@ object HadoopFsRelationOptimizer extends Logging {
       // 2. canUseIndex: OAP_PARQUET_ENABLED is true and hasAvailableIndex.
       // Other scenarios still use ParquetFileFormat.
       case _: ParquetFileFormat
-        if relation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) =>
+        if relation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) ||
+          relation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLE) =>
 
         val optimizedParquetFileFormat = new OptimizedParquetFileFormat
         optimizedParquetFileFormat
@@ -70,7 +71,8 @@ object HadoopFsRelationOptimizer extends Logging {
         def checkParquetDataCacheConfig(): Unit = {
           val runtimeConf = relation.sparkSession.conf
           val binaryCacheEnabled = runtimeConf.get(OapConf.OAP_PARQUET_BINARY_DATA_CACHE_ENABLED)
-          val vectorCacheEnabled = runtimeConf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED)
+          val vectorCacheEnabled = runtimeConf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED) ||
+            runtimeConf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLE)
           assert(!(binaryCacheEnabled && vectorCacheEnabled),
             "Current version cannot enabled both binary Cache and vector Cache")
         }
@@ -88,7 +90,8 @@ object HadoopFsRelationOptimizer extends Logging {
 
         def canUseVectorCache: Boolean = {
           val runtimeConf = relation.sparkSession.conf
-          val cacheEnabled = runtimeConf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED)
+          val cacheEnabled = runtimeConf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED) ||
+            runtimeConf.get(OapConf.OAP_PARQUET_DATA_CACHE_ENABLE)
           logDebug(s"config - ${OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key} is $cacheEnabled")
           val ret = cacheEnabled && runtimeConf.get(SQLConf.PARQUET_VECTORIZED_READER_ENABLED) &&
             runtimeConf.get(SQLConf.WHOLESTAGE_CODEGEN_ENABLED) &&
@@ -101,7 +104,8 @@ object HadoopFsRelationOptimizer extends Logging {
         }
 
         def canUseIndex: Boolean = {
-          val indexEnabled = relation.sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLED)
+          val indexEnabled = relation.sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLED) ||
+            relation.sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLE)
           logDebug(s"config - ${OapConf.OAP_PARQUET_INDEX_ENABLED.key} is $indexEnabled")
           val ret = indexEnabled && optimizedParquetFileFormat.hasAvailableIndex(dataFilters)
           if (ret) {
@@ -119,7 +123,8 @@ object HadoopFsRelationOptimizer extends Logging {
           (relation, false)
         }
 
-      case a if relation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) &&
+      case a if (relation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) ||
+        relation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLE)) &&
         (a.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
           a.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat]) =>
         val optimizedOrcFileFormat = new OptimizedOrcFileFormat
@@ -127,7 +132,6 @@ object HadoopFsRelationOptimizer extends Logging {
           .init(relation.sparkSession,
             relation.options,
             selectedPartitions.flatMap(p => p.files))
-
         def canUseCache: Boolean = {
           val runtimeConf = relation.sparkSession.conf
           var vectorCacheEnabled = runtimeConf.get(OapConf.OAP_ORC_DATA_CACHE_ENABLED)
@@ -137,7 +141,8 @@ object HadoopFsRelationOptimizer extends Logging {
             runtimeConf.get(SQLConf.WHOLESTAGE_CODEGEN_ENABLED) &&
             // runtimeConf.get(SQLConf.ORC_COPY_BATCH_TO_SPARK) &&
             outputSchema.forall(_.dataType.isInstanceOf[AtomicType])
-          val binaryCacheEnabled = runtimeConf.get(OapConf.OAP_ORC_BINARY_DATA_CACHE_ENABLED)
+          val binaryCacheEnabled = runtimeConf.get(OapConf.OAP_ORC_BINARY_DATA_CACHE_ENABLED) ||
+            runtimeConf.get(OapConf.OAP_ORC_BINARY_DATA_CACHE_ENABLE)
           logDebug(s"config - ${OapConf.OAP_ORC_BINARY_DATA_CACHE_ENABLED.key}" +
             s"is $binaryCacheEnabled")
           val ret = vectorCacheEnabled || binaryCacheEnabled

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationOptimizer.scala
@@ -59,7 +59,7 @@ object HadoopFsRelationOptimizer extends Logging {
       // 2. canUseIndex: OAP_PARQUET_ENABLED is true and hasAvailableIndex.
       // Other scenarios still use ParquetFileFormat.
       case _: ParquetFileFormat
-        if relation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) ||
+        if relation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) &&
           relation.sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLE) =>
 
         val optimizedParquetFileFormat = new OptimizedParquetFileFormat
@@ -104,7 +104,7 @@ object HadoopFsRelationOptimizer extends Logging {
         }
 
         def canUseIndex: Boolean = {
-          val indexEnabled = relation.sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLED) ||
+          val indexEnabled = relation.sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLED) &&
             relation.sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLE)
           logDebug(s"config - ${OapConf.OAP_PARQUET_INDEX_ENABLED.key} is $indexEnabled")
           val ret = indexEnabled && optimizedParquetFileFormat.hasAvailableIndex(dataFilters)
@@ -123,7 +123,7 @@ object HadoopFsRelationOptimizer extends Logging {
           (relation, false)
         }
 
-      case a if (relation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) ||
+      case a if (relation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) &&
         relation.sparkSession.conf.get(OapConf.OAP_ORC_ENABLE)) &&
         (a.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
           a.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat]) =>

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
@@ -40,10 +40,16 @@ object OapFileSourceStrategy extends Strategy with Logging {
      * Classified discussion the 4 scenarios and assemble a new [[SparkPlan]] if can optimized.
      */
     def tryOptimize(head: SparkPlan): SparkPlan = {
-      val tableEnbale = SparkSession.getActiveSession.get.conf
-        .get(OapConf.OAP_CACHE_TABLE_LISTS_ENABLE)
+      val tableEnbale =
+        SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_ENABLED) ||
+        SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_ENABLE)
       val cacheTablelists =
-        SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS).split(";")
+        if (SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS) !=
+          OapConf.OAP_CACHE_TABLE_LISTS.defaultValue.get) {
+          SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS).split(";")
+        } else {
+          SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_BK).split(";")
+        }
 
       head match {
         // ProjectExec -> FilterExec -> FileSourceScanExec

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
@@ -44,7 +44,7 @@ object OapFileSourceStrategy extends Strategy with Logging {
         SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_ENABLED) ||
         SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_ENABLE)
       val cacheTablelists =
-        if (!SparkSession.getActiveSession.get.conf.getOption(OapConf.OAP_CACHE_TABLE_LISTS.key).isEmpty) {
+        if (SparkSession.getActiveSession.get.conf.getOption(OapConf.OAP_CACHE_TABLE_LISTS.key).isDefined) {
           SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS).split(";")
         } else {
           SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_BK).split(";")

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
@@ -44,8 +44,7 @@ object OapFileSourceStrategy extends Strategy with Logging {
         SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_ENABLED) ||
         SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_ENABLE)
       val cacheTablelists =
-        if (SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS) !=
-          OapConf.OAP_CACHE_TABLE_LISTS.defaultValue.get) {
+        if (!SparkSession.getActiveSession.get.conf.getOption(OapConf.OAP_CACHE_TABLE_LISTS.key).isEmpty) {
           SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS).split(";")
         } else {
           SparkSession.getActiveSession.get.conf.get(OapConf.OAP_CACHE_TABLE_LISTS_BK).split(";")

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -69,7 +69,8 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
     // TODO we need to pass the extra data source meta information via the func parameter
     val (filterScanners, m) = meta match {
-      case Some(x) if sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLED) =>
+      case Some(x) if (sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLED)
+      || sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLE)) =>
         (indexScanners(x, filters), x)
       case _ =>
         // TODO Now we need use a meta with PARQUET_DATA_FILE_CLASSNAME & dataSchema to init

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/OptimizedParquetFileFormat.scala
@@ -70,7 +70,7 @@ private[sql] class OptimizedParquetFileFormat extends OapFileFormat {
     // TODO we need to pass the extra data source meta information via the func parameter
     val (filterScanners, m) = meta match {
       case Some(x) if (sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLED)
-      || sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLE)) =>
+      && sparkSession.conf.get(OapConf.OAP_PARQUET_INDEX_ENABLE)) =>
         (indexScanners(x, filters), x)
       case _ =>
         // TODO Now we need use a meta with PARQUET_DATA_FILE_CLASSNAME & dataSchema to init

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
@@ -34,7 +34,13 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
 
   private def checkSeparateMemory(): Boolean = {
     val memoryManagerOpt =
-      sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
+      if (sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER) !=
+        OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.defaultValue.get) {
+        sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
+      } else {
+        sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase
+      }
+    logInfo(s"${memoryManagerOpt}")
     val cacheName =
       sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_STRATEGY.key, "guava").toLowerCase
 
@@ -54,9 +60,16 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
       ((memoryManager.memorySize * 0.9).toLong, (indexMemoryManager.memorySize * 0.9).toLong,
         (memoryManager.memorySize * 0.1).toLong, (indexMemoryManager.memorySize * 0.1).toLong)
     } else {
-      val cacheRatio = sparkEnv.conf.getDouble(
-        OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key,
-        OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.defaultValue.get)
+      val cacheRatio =
+        if (sparkEnv.conf.get(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO) !=
+          OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.defaultValue.get) {
+          sparkEnv.conf.getDouble(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key,
+            OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.defaultValue.get)
+        } else {
+          sparkEnv.conf.getDouble(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO_BK.key,
+            OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO_BK.defaultValue.get)
+        }
+
       require(cacheRatio >= 0 && cacheRatio <= 1,
         "Data and index cache ratio should be between 0 and 1")
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
@@ -34,7 +34,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
 
   private def checkSeparateMemory(): Boolean = {
     val memoryManagerOpt =
-      if (!sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isEmpty) {
+      if (sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isDefined) {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
       } else {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase
@@ -60,7 +60,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
         (memoryManager.memorySize * 0.1).toLong, (indexMemoryManager.memorySize * 0.1).toLong)
     } else {
       val cacheRatio =
-        if (! sparkEnv.conf.getOption(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key).isEmpty) {
+        if (sparkEnv.conf.getOption(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key).isDefined) {
           sparkEnv.conf.getDouble(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key,
             OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.defaultValue.get)
         } else {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/CacheMemoryAllocator.scala
@@ -34,8 +34,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
 
   private def checkSeparateMemory(): Boolean = {
     val memoryManagerOpt =
-      if (sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER) !=
-        OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.defaultValue.get) {
+      if (!sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isEmpty) {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
       } else {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase
@@ -61,8 +60,7 @@ private[filecache] class CacheMemoryAllocator(sparkEnv: SparkEnv)
         (memoryManager.memorySize * 0.1).toLong, (indexMemoryManager.memorySize * 0.1).toLong)
     } else {
       val cacheRatio =
-        if (sparkEnv.conf.get(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO) !=
-          OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.defaultValue.get) {
+        if (! sparkEnv.conf.getOption(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key).isEmpty) {
           sparkEnv.conf.getDouble(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key,
             OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.defaultValue.get)
         } else {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -46,7 +46,8 @@ class FiberCacheManager(
   private val DEFAULT_CACHE_STRATEGY = GUAVA_CACHE
 
   private var _dataCacheCompressEnable = sparkEnv.conf.get(
-    OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION)
+    OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION) ||
+    sparkEnv.conf.get(OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION_BK)
   private var _dataCacheCompressionCodec = sparkEnv.conf.get(
     OapConf.OAP_DATA_FIBER_CACHE_COMPRESSION_CODEC)
   private val _dataCacheCompressionSize = sparkEnv.conf.get(
@@ -89,6 +90,9 @@ class FiberCacheManager(
       val separateCache = sparkEnv.conf.getBoolean(
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
         OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get
+      ) || sparkEnv.conf.getBoolean(
+        OapConf.OAP_INDEX_DATA_SEPARATION_ENABLED.key,
+        OapConf.OAP_INDEX_DATA_SEPARATION_ENABLED.defaultValue.get
       )
       new MixCache(dataCacheMemorySize, indexCacheMemorySize, dataCacheGuardianMemorySize,
         indexCacheGuardianMemorySize, separateCache, sparkEnv)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -250,7 +250,7 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
 private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
   extends MemoryManager with Logging {
   val cacheGuardianMemorySizeStr =
-    if (!sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE.key).isEmpty) {
+    if (!sparkEnv.conf.getOption(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE.key).isEmpty) {
       sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE)
     } else {
       sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE_BK)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -144,8 +144,7 @@ private[sql] object MemoryManager extends Logging {
         configEntry.key,
         configEntry.defaultValue.get).toLowerCase
     val memoryManagerOpt =
-      if (sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER) !=
-        OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.defaultValue.get) {
+      if (!sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isEmpty) {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
       } else {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase
@@ -202,8 +201,7 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
 
   private lazy val oapMemory = {
     val offHeapSizeStr =
-      if (sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE).trim !=
-        OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE.defaultValue.get) {
+      if (!sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE.key).isEmpty) {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE).trim
       } else {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE_BK).trim
@@ -252,8 +250,7 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
 private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
   extends MemoryManager with Logging {
   val cacheGuardianMemorySizeStr =
-    if (sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE) !=
-      OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE.defaultValue.get) {
+    if (!sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE.key).isEmpty) {
       sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE)
     } else {
       sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE_BK)
@@ -339,20 +336,19 @@ private[filecache] class PersistentMemoryManager(sparkEnv: SparkEnv)
 
     val initialPath = map.get(numaId).get
     val initialSizeStr =
-      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
-        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
       } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
       }
     val initialSize = Utils.byteStringAsBytes(initialSizeStr)
     val reservedSizeStr =
-      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim !=
-        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.defaultValue.get.trim) {
-        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
+      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isEmpty) {
+      conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
       } else {
-        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim
+      conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim
       }
+
     val reservedSize = Utils.byteStringAsBytes(reservedSizeStr)
 
     val enableConservative = conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.key,
@@ -422,15 +418,13 @@ private[filecache] class DaxKmemMemoryManager(sparkEnv: SparkEnv)
 
 
     val kmemCacheMemoryStr =
-      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
-        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
         } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
         }
     val kmemCacheMemoryReserverdStr =
-      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim !=
-        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.defaultValue.get.trim) {
+      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isEmpty) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
         } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim
@@ -493,16 +487,14 @@ private[filecache] class HybridMemoryManager(sparkEnv: SparkEnv)
 
     val initialPath = map.get(numaId).get
     val initialSizeStr =
-      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
-        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
       } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
       }
     val initialPMSize = Utils.byteStringAsBytes(initialSizeStr)
     val reservedSizeStr =
-      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim !=
-        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.defaultValue.get.trim) {
+      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isEmpty) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
       } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -144,7 +144,7 @@ private[sql] object MemoryManager extends Logging {
         configEntry.key,
         configEntry.defaultValue.get).toLowerCase
     val memoryManagerOpt =
-      if (!sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isEmpty) {
+      if (sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isDefined) {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
       } else {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase
@@ -201,7 +201,7 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
 
   private lazy val oapMemory = {
     val offHeapSizeStr =
-      if (!sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE.key).isEmpty) {
+      if (sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE.key).isDefined) {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE).trim
       } else {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE_BK).trim
@@ -250,7 +250,7 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
 private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
   extends MemoryManager with Logging {
   val cacheGuardianMemorySizeStr =
-    if (!sparkEnv.conf.getOption(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE.key).isEmpty) {
+    if (sparkEnv.conf.getOption(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE.key).isDefined) {
       sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE)
     } else {
       sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE_BK)
@@ -336,14 +336,14 @@ private[filecache] class PersistentMemoryManager(sparkEnv: SparkEnv)
 
     val initialPath = map.get(numaId).get
     val initialSizeStr =
-      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
+      if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isDefined) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
       } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
       }
     val initialSize = Utils.byteStringAsBytes(initialSizeStr)
     val reservedSizeStr =
-      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isEmpty) {
+      if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isDefined) {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
       } else {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim
@@ -418,13 +418,13 @@ private[filecache] class DaxKmemMemoryManager(sparkEnv: SparkEnv)
 
 
     val kmemCacheMemoryStr =
-      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
+      if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isDefined) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
         } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
         }
     val kmemCacheMemoryReserverdStr =
-      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isEmpty) {
+      if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isDefined) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
         } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim
@@ -487,14 +487,14 @@ private[filecache] class HybridMemoryManager(sparkEnv: SparkEnv)
 
     val initialPath = map.get(numaId).get
     val initialSizeStr =
-      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
+      if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isDefined) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
       } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
       }
     val initialPMSize = Utils.byteStringAsBytes(initialSizeStr)
     val reservedSizeStr =
-      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isEmpty) {
+      if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.key).isDefined) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
       } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -352,7 +352,7 @@ private[filecache] class PersistentMemoryManager(sparkEnv: SparkEnv)
     val reservedSize = Utils.byteStringAsBytes(reservedSizeStr)
 
     val enableConservative = conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.key,
-      OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.defaultValue.get) ||
+      OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.defaultValue.get) &&
       conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE_BK.key,
         OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE_BK.defaultValue.get)
     val memkindPattern = if (enableConservative) 1 else 0
@@ -502,7 +502,7 @@ private[filecache] class HybridMemoryManager(sparkEnv: SparkEnv)
     val reservedPMSize = Utils.byteStringAsBytes(reservedSizeStr)
     val fullPath = Utils.createTempDir(initialPath + File.separator + executorId)
     val enableConservative = conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.key,
-      OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.defaultValue.get) ||
+      OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.defaultValue.get) &&
       conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE_BK.key,
         OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE_BK.defaultValue.get)
     val memkindPattern = if (enableConservative) 1 else 0

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/MemoryManager.scala
@@ -143,7 +143,12 @@ private[sql] object MemoryManager extends Logging {
         configEntry.key,
         configEntry.defaultValue.get).toLowerCase
     val memoryManagerOpt =
-      conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
+      if (sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER) !=
+        OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.defaultValue.get) {
+        sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
+      } else {
+        sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase
+      }
     checkConfCompatibility(cacheStrategyOpt, memoryManagerOpt)
     cacheStrategyOpt match {
       case "guava" => apply(sparkEnv, memoryManagerOpt)
@@ -190,7 +195,13 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
   private lazy val memoryManager = sparkEnv.memoryManager
 
   private lazy val oapMemory = {
-    val offHeapSizeStr = sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE).trim
+    val offHeapSizeStr =
+      if (sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE).trim !=
+        OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE.defaultValue.get) {
+        sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE).trim
+      } else {
+        sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE_BK).trim
+      }
     val offHeapSize = Utils.byteStringAsBytes(offHeapSizeStr)
     offHeapSize.toLong
   }
@@ -234,9 +245,13 @@ private[filecache] class OffHeapMemoryManager(sparkEnv: SparkEnv)
  */
 private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
   extends MemoryManager with Logging {
-
   val cacheGuardianMemorySizeStr =
-    sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE)
+    if (sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE) !=
+      OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE.defaultValue.get) {
+      sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE)
+    } else {
+      sparkEnv.conf.get(OapConf.OAP_CACHE_GUARDIAN_MEMORY_SIZE_BK)
+    }
   val cacheGuardianMemory = Utils.byteStringAsBytes(cacheGuardianMemorySizeStr)
   logInfo(s"cacheGuardian total use $cacheGuardianMemory bytes memory")
   val cacheGuardianRetrySleepTimeInMs = 10
@@ -255,7 +270,7 @@ private[filecache] class TmpDramMemoryManager(sparkEnv: SparkEnv)
       if (retryTime > cacheGuardianRetryTime) {
         throw new OapException("cache guardian use too much memory over " +
           cacheGuardianRetryTime * cacheGuardianRetrySleepTimeInMs + "ms, please consider " +
-          "increase memory size by 'spark.sql.oap.cache.guardian.memory.size' configuration or " +
+          "increase memory size by 'spark.executor.sql.oap.cache.guardian.memory.size' configuration or " +
           "increase retry time by 'spark.sql.oap.cache.guardian.retry.time.in.ms' configuration")
       }
     }
@@ -317,13 +332,27 @@ private[filecache] class PersistentMemoryManager(sparkEnv: SparkEnv)
     }
 
     val initialPath = map.get(numaId).get
-    val initialSizeStr = conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+    val initialSizeStr =
+      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
+        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+      } else {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
+      }
     val initialSize = Utils.byteStringAsBytes(initialSizeStr)
-    val reservedSizeStr = conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
+    val reservedSizeStr =
+      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim !=
+        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.defaultValue.get.trim) {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
+      } else {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim
+      }
     val reservedSize = Utils.byteStringAsBytes(reservedSizeStr)
 
     val enableConservative = conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.key,
-      OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.defaultValue.get)
+      OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.defaultValue.get) ||
+      conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE_BK.key,
+        OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE_BK.defaultValue.get)
     val memkindPattern = if (enableConservative) 1 else 0
 
     logInfo(s"Current Memkind pattern: ${memkindPattern}")
@@ -385,12 +414,27 @@ private[filecache] class DaxKmemMemoryManager(sparkEnv: SparkEnv)
     val regularNodeNum = map.size
     val daxNodeId = numaId + regularNodeNum
 
+
+    val kmemCacheMemoryStr =
+      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
+        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+        } else {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
+        }
+    val kmemCacheMemoryReserverdStr =
+      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim !=
+        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.defaultValue.get.trim) {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
+        } else {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim
+        }
+
     val (kmemCacheMemory, kmemCacheMemoryReserverd) = {
-      (Utils.byteStringAsBytes(
-        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim),
-        Utils.byteStringAsBytes(
-          conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim))
+      (Utils.byteStringAsBytes(kmemCacheMemoryStr),
+        Utils.byteStringAsBytes(kmemCacheMemoryReserverdStr))
     }
+
     require(kmemCacheMemoryReserverd >= 0 && kmemCacheMemoryReserverd < kmemCacheMemory,
       s"Reserved size(${kmemCacheMemoryReserverd}) should greater than zero and less than " +
         s"initial size(${kmemCacheMemory})"
@@ -442,13 +486,27 @@ private[filecache] class HybridMemoryManager(sparkEnv: SparkEnv)
     }
 
     val initialPath = map.get(numaId).get
-    val initialSizeStr = conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+    val initialSizeStr =
+      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
+        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+      } else {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
+      }
     val initialPMSize = Utils.byteStringAsBytes(initialSizeStr)
-    val reservedSizeStr = conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
+    val reservedSizeStr =
+      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim !=
+        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE.defaultValue.get.trim) {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE).trim
+      } else {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK).trim
+      }
     val reservedPMSize = Utils.byteStringAsBytes(reservedSizeStr)
     val fullPath = Utils.createTempDir(initialPath + File.separator + executorId)
     val enableConservative = conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.key,
-      OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.defaultValue.get)
+      OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE.defaultValue.get) ||
+      conf.getBoolean(OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE_BK.key,
+        OapConf.OAP_ENABLE_MEMKIND_CONSERVATIVE_BK.defaultValue.get)
     val memkindPattern = if (enableConservative) 1 else 0
     PersistentMemoryPlatform.initialize(fullPath.getCanonicalPath, initialPMSize, memkindPattern)
     logInfo(s"Initialize Intel Optane DC persistent memory successfully, numaId: " +
@@ -458,8 +516,7 @@ private[filecache] class HybridMemoryManager(sparkEnv: SparkEnv)
       s"Reserved size(${reservedPMSize}) should be larger than zero and smaller than initial " +
         s"size(${initialPMSize})")
     val totalPMUsableSize = initialPMSize - reservedPMSize
-    val initialDRAMSizeSize = Utils.byteStringAsBytes(
-      conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim)
+    val initialDRAMSizeSize = initialPMSize
     ((totalPMUsableSize * 0.9).toLong,
       (totalPMUsableSize * 0.9).toLong,
       (initialDRAMSizeSize * 0.9).toLong,

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -254,8 +254,7 @@ private[filecache] object OapCache extends Logging {
     }
     val initialPath = map.get(numaId).get
     val initialSizeStr =
-      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
-        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
       } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
@@ -285,8 +284,7 @@ private[filecache] object OapCache extends Logging {
       configEntry.key,
       configEntry.defaultValue.get).toLowerCase
     val memoryManagerOpt =
-      if (sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER) !=
-        OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.defaultValue.get) {
+      if (!sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isEmpty) {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
       } else {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase
@@ -528,8 +526,7 @@ class VMemCache(fiberType: FiberType) extends OapCache with Logging {
   private val lock = new Object
   private val conf = SparkEnv.get.conf
   private val initialSizeStr =
-    if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
-      OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+    if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
     } else {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
@@ -984,8 +981,7 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
   val cacheReadOnlyEnbale = conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE) ||
     conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLED)
   val clientPoolSize =
-    if (conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE) !=
-      OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE.defaultValue.get) {
+    if (!conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE.key).isEmpty) {
       conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE)
     } else {
       conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE_BK)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -254,7 +254,7 @@ private[filecache] object OapCache extends Logging {
     }
     val initialPath = map.get(numaId).get
     val initialSizeStr =
-      if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
+      if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isDefined) {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
       } else {
         conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
@@ -526,7 +526,7 @@ class VMemCache(fiberType: FiberType) extends OapCache with Logging {
   private val lock = new Object
   private val conf = SparkEnv.get.conf
   private val initialSizeStr =
-    if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isEmpty) {
+    if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.key).isDefined) {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
     } else {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
@@ -981,7 +981,7 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
   val cacheReadOnlyEnbale = conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE) &&
     conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLED)
   val clientPoolSize =
-    if (!conf.getOption(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE.key).isEmpty) {
+    if (conf.getOption(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE.key).isDefined) {
       conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE)
     } else {
       conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE_BK)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -978,7 +978,7 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
     OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(fiberLength)
 
   var fiberSet = scala.collection.mutable.Set[FiberId]()
-  val cacheReadOnlyEnbale = conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE) ||
+  val cacheReadOnlyEnbale = conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE) &&
     conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLED)
   val clientPoolSize =
     if (!conf.getOption(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE.key).isEmpty) {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -981,7 +981,7 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
   val cacheReadOnlyEnbale = conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE) ||
     conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLED)
   val clientPoolSize =
-    if (!conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE.key).isEmpty) {
+    if (!conf.getOption(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE.key).isEmpty) {
       conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE)
     } else {
       conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE_BK)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -235,7 +235,13 @@ private[filecache] object OapCache extends Logging {
       numaId = executorId % PersistentMemoryConfigUtils.totalNumaNode(conf)
     }
     val initialPath = map.get(numaId).get
-    val initialSizeStr = conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+    val initialSizeStr =
+      if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
+        OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+      } else {
+        conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
+      }
     val initialSize = Utils.byteStringAsBytes(initialSizeStr)
 
     val file: File = new File(initialPath)
@@ -261,7 +267,13 @@ private[filecache] object OapCache extends Logging {
       configEntry.key,
       configEntry.defaultValue.get).toLowerCase
     val memoryManagerOpt =
-      conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
+      if (sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER) !=
+        OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.defaultValue.get) {
+        sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
+      } else {
+        sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase
+      }
+    logInfo(s"${memoryManagerOpt}")
     val fallBackEnabled = conf.get(OapConf.OAP_CACHE_BACKEND_FALLBACK_ENABLED.key,
       "true").toLowerCase
     val fallBackRes = conf.get(OapConf.OAP_TEST_CACHE_BACKEND_FALLBACK_RES.key,
@@ -491,10 +503,18 @@ class VMemCache(fiberType: FiberType) extends OapCache with Logging {
   @volatile private var initialized = false
   private val lock = new Object
   private val conf = SparkEnv.get.conf
-  private val initialSizeStr = conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+  private val initialSizeStr =
+    if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim !=
+      OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE.defaultValue.get.trim) {
+      conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE).trim
+    } else {
+      conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK).trim
+    }
   private val vmInitialSize = Utils.byteStringAsBytes(initialSizeStr)
-  require(!conf.getBoolean( OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION.key,
-    OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION.defaultValue.get),
+  require(!(conf.getBoolean(OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION.key,
+    OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION.defaultValue.get) ||
+    conf.getBoolean(OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION_BK.key,
+      OapConf.OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION_BK.defaultValue.get)),
     "Vmemcache strategy doesn't support fiber cache compression currently, " +
     "please try other strategy.")
   require(vmInitialSize > 0, "AEP initial size must be greater than zero")
@@ -931,8 +951,15 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
     OapRuntime.getOrCreate.fiberCacheManager.getEmptyDataFiberCache(fiberLength)
 
   var fiberSet = scala.collection.mutable.Set[FiberId]()
-  val cacheReadOnlyEnbale = conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE)
-  val clientPoolSize = conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE)
+  val cacheReadOnlyEnbale = conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE) ||
+    conf.get(OapConf.OAP_EXTERNAL_CACHE_READ_ONLY_ENABLED)
+  val clientPoolSize =
+    if (conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE) !=
+      OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE.defaultValue.get) {
+      conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE)
+    } else {
+      conf.get(OapConf.OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE_BK)
+    }
   val clientRoundRobin = new AtomicInteger(0)
   val plasmaClientPool = new Array[ plasma.PlasmaClient](clientPoolSize)
   for ( i <- 0 until clientPoolSize) {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -284,7 +284,7 @@ private[filecache] object OapCache extends Logging {
       configEntry.key,
       configEntry.defaultValue.get).toLowerCase
     val memoryManagerOpt =
-      if (!sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isEmpty) {
+      if (sparkEnv.conf.getOption(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key).isDefined) {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER.key, "offheap").toLowerCase
       } else {
         sparkEnv.conf.get(OapConf.OAP_FIBERCACHE_MEMORY_MANAGER_BK.key, "offheap").toLowerCase

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -953,7 +953,7 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
   private var cacheInit: Boolean = false
   private var externalDBClient: ExternalDBClient = null
 
-  if (SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ENABLE) == true) {
+  if (SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ENABLED) == true) {
     externalDBClient = ExternalDBClientFactory.getDBClientInstance(SparkEnv.get)
   }
 
@@ -1096,7 +1096,7 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
         case e: DuplicateObjectException => logWarning(e.getMessage)
       }
     }
-    if (SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ENABLE) == true) {
+    if (SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ENABLED) == true) {
       reportCacheMeta(fiberId)
     }
     fiber

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -388,7 +388,8 @@ private[oap] object IndexUtils extends  Logging {
       case LogicalRelation(
           _fsRelation @ HadoopFsRelation(f, _, s, _, _: ParquetFileFormat, _),
           attributes, id, _) =>
-        if (!sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED)) {
+        if (!(sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) ||
+          sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLE))) {
           throw new OapException(s"turn on ${
             OapConf.OAP_PARQUET_ENABLED.key
           } to allow index operation on parquet files")
@@ -404,7 +405,9 @@ private[oap] object IndexUtils extends  Logging {
           _fsRelation @ HadoopFsRelation(f, _, s, _, format, _), attributes, id, _)
         if format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
           format.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat] =>
-        if (!sparkSession.conf.get(OapConf.OAP_ORC_ENABLED)) {
+        if (!(sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) ||
+          sparkSession.conf.get(OapConf.OAP_ORC_ENABLE)))
+        {
           throw new OapException(s"turn on ${
             OapConf.OAP_ORC_ENABLED.key
           } to allow index building on orc files")

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/index/IndexUtils.scala
@@ -388,7 +388,7 @@ private[oap] object IndexUtils extends  Logging {
       case LogicalRelation(
           _fsRelation @ HadoopFsRelation(f, _, s, _, _: ParquetFileFormat, _),
           attributes, id, _) =>
-        if (!(sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) ||
+        if (!(sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLED) &&
           sparkSession.conf.get(OapConf.OAP_PARQUET_ENABLE))) {
           throw new OapException(s"turn on ${
             OapConf.OAP_PARQUET_ENABLED.key
@@ -405,7 +405,7 @@ private[oap] object IndexUtils extends  Logging {
           _fsRelation @ HadoopFsRelation(f, _, s, _, format, _), attributes, id, _)
         if format.isInstanceOf[org.apache.spark.sql.hive.orc.OrcFileFormat] ||
           format.isInstanceOf[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat] =>
-        if (!(sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) ||
+        if (!(sparkSession.conf.get(OapConf.OAP_ORC_ENABLED) &&
           sparkSession.conf.get(OapConf.OAP_ORC_ENABLE)))
         {
           throw new OapException(s"turn on ${

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFile.scala
@@ -70,7 +70,9 @@ private[oap] case class OrcDataFile(
   private lazy val filePath: Path = new Path(path)
   private lazy val orcDataCacheEnable =
     configuration.getBoolean(OapConf.OAP_ORC_DATA_CACHE_ENABLED.key,
-      OapConf.OAP_ORC_DATA_CACHE_ENABLED.defaultValue.get)
+      OapConf.OAP_ORC_DATA_CACHE_ENABLED.defaultValue.get) ||
+      configuration.getBoolean(OapConf.OAP_ORC_DATA_CACHE_ENABLE.key,
+        OapConf.OAP_ORC_DATA_CACHE_ENABLE.defaultValue.get)
   lazy val meta =
     OapRuntime.getOrCreate.dataFileMetaCacheManager.get(this).asInstanceOf[OrcDataFileMeta]
 //  meta.getOrcFileReader()

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/io/ParquetDataFile.scala
@@ -72,7 +72,9 @@ private[oap] case class ParquetDataFile(
   private val file = new Path(StringUtils.unEscapeString(path))
   private val parquetDataCacheEnable =
     configuration.getBoolean(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key,
-      OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.defaultValue.get)
+      OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.defaultValue.get) ||
+      configuration.getBoolean(OapConf.OAP_PARQUET_DATA_CACHE_ENABLE.key,
+        OapConf.OAP_PARQUET_DATA_CACHE_ENABLE.defaultValue.get)
 
   private var fiberDataReader: ParquetFiberDataReader = _
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -56,9 +56,11 @@ class StatisticsWriteManager {
   // When a task initialize statisticsWriteManager, we read all config from `conf`,
   // which is created from `SparkUtils`, hence containing all spark config values.
   def initialize(indexType: OapIndexType, s: StructType, conf: Configuration): Unit = {
-    _isExternalSorterEnable = conf.getBoolean(OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.key,
-      OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.defaultValue.get
-    ) && indexType.toString.equals(BTreeIndexType.toString)
+    _isExternalSorterEnable = conf.getBoolean(OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLED.key,
+      OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLED.defaultValue.get) ||
+      conf.getBoolean(OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.key,
+      OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.defaultValue.get) &&
+        indexType.toString.equals(BTreeIndexType.toString)
 
     val statsTypes = StatisticsManager.statisticsTypeMap(indexType).filter { statType =>
       val typeFromConfig = conf.get(OapConf.OAP_STATISTICS_TYPES.key,

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/statistics/StatisticsManager.scala
@@ -57,7 +57,7 @@ class StatisticsWriteManager {
   // which is created from `SparkUtils`, hence containing all spark config values.
   def initialize(indexType: OapIndexType, s: StructType, conf: Configuration): Unit = {
     _isExternalSorterEnable = conf.getBoolean(OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLED.key,
-      OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLED.defaultValue.get) ||
+      OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLED.defaultValue.get) &&
       conf.getBoolean(OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.key,
       OapConf.OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE.defaultValue.get) &&
         indexType.toString.equals(BTreeIndexType.toString)

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/PersistentMemoryConfigUtils.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/PersistentMemoryConfigUtils.scala
@@ -40,8 +40,13 @@ object PersistentMemoryConfigUtils extends Logging {
   private val numaToPMProperty = new mutable.HashMap[Int, String]()
 
   def parseConfig(conf: SparkConf): mutable.HashMap[Int, String] = {
-    val configFile = conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key,
-      DEFAULT_PERSISTENT_MEMORY_CONFIG_FILE)
+    val configFile = if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key,
+      DEFAULT_PERSISTENT_MEMORY_CONFIG_FILE) !=
+      OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.defaultValue.get) {
+      conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key,
+        DEFAULT_PERSISTENT_MEMORY_CONFIG_FILE) } else {
+      conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE_BK.key,
+        DEFAULT_PERSISTENT_MEMORY_CONFIG_FILE) }
     // If already parsed, just return it
     if (numaToPMProperty.size == 0) {
       val is = Utils.getSparkClassLoader.getResourceAsStream(configFile)
@@ -58,7 +63,7 @@ object PersistentMemoryConfigUtils extends Logging {
         val initialPath = (numaNode \ INITIAL_PATH_PROPERTY).text.trim
         numaToPMProperty += ((numaNodeId, initialPath))
       }
-    }
+  }
 
     require(numaToPMProperty.nonEmpty, "The Intel Optane DC persistent memory configuration" +
       "file must not be empty.")

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/PersistentMemoryConfigUtils.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/PersistentMemoryConfigUtils.scala
@@ -40,7 +40,7 @@ object PersistentMemoryConfigUtils extends Logging {
   private val numaToPMProperty = new mutable.HashMap[Int, String]()
 
   def parseConfig(conf: SparkConf): mutable.HashMap[Int, String] = {
-    val configFile = if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key).isEmpty) {
+    val configFile = if (conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key).isDefined) {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key,
         DEFAULT_PERSISTENT_MEMORY_CONFIG_FILE) } else {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE_BK.key,

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/PersistentMemoryConfigUtils.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/utils/PersistentMemoryConfigUtils.scala
@@ -40,9 +40,7 @@ object PersistentMemoryConfigUtils extends Logging {
   private val numaToPMProperty = new mutable.HashMap[Int, String]()
 
   def parseConfig(conf: SparkConf): mutable.HashMap[Int, String] = {
-    val configFile = if (conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key,
-      DEFAULT_PERSISTENT_MEMORY_CONFIG_FILE) !=
-      OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.defaultValue.get) {
+    val configFile = if (!conf.getOption(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key).isEmpty) {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE.key,
         DEFAULT_PERSISTENT_MEMORY_CONFIG_FILE) } else {
       conf.get(OapConf.OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE_BK.key,

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -28,16 +28,32 @@ import org.apache.spark.sql.oap.adapter.SqlConfAdapter
 object OapConf {
 
   val OAP_ORC_ENABLED =
-    SqlConfAdapter.buildConf("spark.sql.oap.orc.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.orc.enabled")
       .internal()
       .doc("Whether enable oap file format when encountering orc files")
       .booleanConf
       .createWithDefault(true)
 
+  val OAP_ORC_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.orc.enable")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.orc.enabled', compatible to OAP versions before 1.0" +
+        "Whether enable oap file format when encountering orc files")
+      .booleanConf
+      .createWithDefault(true)
+
   val OAP_PARQUET_ENABLED =
-    SqlConfAdapter.buildConf("spark.sql.oap.parquet.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.enabled")
       .internal()
       .doc("Whether enable oap file format when encountering parquet files")
+      .booleanConf
+      .createWithDefault(true)
+
+  val OAP_PARQUET_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.enable")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.parquet.enabled', compatible with OAP verisions before 1.0." +
+        " Whether enable oap file format when encountering parquet files")
       .booleanConf
       .createWithDefault(true)
 
@@ -105,29 +121,23 @@ object OapConf {
       .intConf
       .createWithDefault(3)
 
-  val OAP_FIBERCACHE_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.size")
-      .internal()
-      .doc("Define the size of fiber cache in KB, default 300 * 1024 KB")
-      .longConf
-      .createWithDefault(307200)
-
-  val OAP_FIBERCACHE_STATS =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.stats")
-      .internal()
-      .doc("Whether enable cach stats record, default false")
-      .booleanConf
-      .createWithDefault(false)
-
   val OAP_FIBERCACHE_USE_OFFHEAP_RATIO =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.use.offheap.ratio")
+    SqlConfAdapter.buildConf("spark.sql.oap.offheap.cache.ratio")
       .internal()
       .doc("Define the ratio of fiber cache use 'spark.memory.offHeap.size' ratio.")
       .doubleConf
       .createWithDefault(0.7)
 
+  val OAP_FIBERCACHE_USE_OFFHEAP_RATIO_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.use.offheap.ratio")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0. Equal to 'spark.sql.oap.offheap.cache.ratio'" +
+        "Define the ratio of fiber cache use 'spark.memory.offHeap.size' ratio.")
+      .doubleConf
+      .createWithDefault(0.7)
+
   val OAP_DATAFIBER_USE_FIBERCACHE_RATIO =
-    SqlConfAdapter.buildConf("spark.sql.oap.dataCache.use.fiberCache.ratio")
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.dataCache.ratio")
       .internal()
       .doc("Define the ratio of data cache use fiber cache ratio " +
         "when enable cache separation for single physical storage. " +
@@ -136,34 +146,82 @@ object OapConf {
       .doubleConf
       .createWithDefault(0.8)
 
-  val OAP_INDEX_DATA_SEPARATION_ENABLE =
-    SqlConfAdapter.buildConf("spark.sql.oap.index.data.cache.separation.enable")
+  val OAP_DATAFIBER_USE_FIBERCACHE_RATIO_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.dataCache.use.fiberCache.ratio")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0. Equal to 'spark.sql.oap.cache.dataCache.ratio'" +
+        "Define the ratio of data cache use fiber cache ratio " +
+        "when enable cache separation for single physical storage. " +
+        "This is not available under mix mode because the index and data " +
+        "will be stored in different physical storage")
+      .doubleConf
+      .createWithDefault(0.8)
+
+  val OAP_INDEX_DATA_SEPARATION_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.data.cache.separation.enabled")
       .internal()
       .doc("This is to enable index data cache separation feature including mix memory manager" +
         "and mix cache backend")
       .booleanConf
       .createWithDefault(false)
 
-  val OAP_CACHE_TABLE_LISTS_ENABLE =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.table.list.enable")
+  val OAP_INDEX_DATA_SEPARATION_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.data.cache.separation.enable")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.index.data.cache.separation.enabled', compatible to OAP version" +
+        "before 1.0. This is to enable index data cache separation feature including mix memory manager" +
+        "and mix cache backend")
+      .booleanConf
+      .createWithDefault(false)
+
+  val OAP_CACHE_TABLE_LISTS_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.table.list.enabled")
       .internal()
       .doc("This is to enable table lists fiberCache")
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_CACHE_TABLE_LISTS_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.table.list.enable")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0. Equal to " +
+        "'spark.sql.oap.fiberCache.table.list.enable'. This is to enable table lists fiberCache")
+      .booleanConf
+      .createWithDefault(false)
+
   val OAP_CACHE_TABLE_LISTS =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.table.list")
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.table.list")
       .internal()
       .doc("Table lists using fiberCache actively, format: {database}.{table}" +
         "Separator is semicolon. For example: default.table1;default.table2 ." +
-        "This conf item only takes effect when spark.sql.oap.fiberCache.table.list.enable=true")
+        "This conf item only takes effect when spark.sql.oap.cache.table.list.enabled = true")
+      .stringConf
+      .createWithDefault("default.xx;default.xx")
+  val OAP_CACHE_TABLE_LISTS_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.table.list")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0. Equal to 'spark.sql.oap.cache.table.list'" +
+        "Table lists using fiberCache actively, format: {database}.{table}" +
+        "Separator is semicolon. For example: default.table1;default.table2 ." +
+        "This conf item only takes effect when spark.sql.oap.cache.table.list.enabled=true")
       .stringConf
       .createWithDefault("default.xx;default.xx")
 
   val OAP_FIBERCACHE_MEMORY_MANAGER =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.memory.manager")
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.memory.manager")
       .internal()
       .doc("Sets the implement of memory manager, it currently supports offheap(DRAM OFF_HEAP), " +
+        "pm(Intel Optane DC persistent memory) and mix(A combination of offheap and pm)." +
+        "To enable mix mode, you need to set " +
+        "spark.sql.oap.index.data.cache.separation.enable to true")
+      .stringConf
+      .createWithDefault("offheap")
+
+  val OAP_FIBERCACHE_MEMORY_MANAGER_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.memory.manager")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0. Equal to 'spark.sql.oap.cache.memory.manager'" +
+        "Sets the implement of memory manager, it currently supports offheap(DRAM OFF_HEAP), " +
         "pm(Intel Optane DC persistent memory) and mix(A combination of offheap and pm)." +
         "To enable mix mode, you need to set " +
         "spark.sql.oap.index.data.cache.separation.enable to true")
@@ -191,9 +249,17 @@ object OapConf {
       .createWithDefault("offheap")
 
   val OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.offheap.memory.size")
+    SqlConfAdapter.buildConf("spark.executor.sql.oap.cache.offheap.memory.size")
       .internal()
       .doc("Used to set available memory size for fiberCache for each executor.")
+      .stringConf
+      .createWithDefault("100m")
+
+  val OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.offheap.memory.size")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0. Used to set available memory size " +
+        "for fiberCache for each executor.")
       .stringConf
       .createWithDefault("100m")
 
@@ -222,25 +288,56 @@ object OapConf {
       .createWithDefault("guava")
 
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.config.file")
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.persistent.memory.config.file")
       .internal()
       .doc("A config file used to config the Intel Optane DC persistent memory initial path," +
         " and mapping with NUMA node.")
       .stringConf
       .createWithDefault("persistent-memory.xml")
 
+  val OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.config.file")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.cache.persistent.memory.config.file', compatible with " +
+        "OAP versions before 1.0. A config file used to config the Intel Optane DC persistent memory" +
+        "initial path, and mapping with NUMA node.")
+      .stringConf
+      .createWithDefault("persistent-memory.xml")
+
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.initial.size")
+    SqlConfAdapter.buildConf("spark.executor.sql.oap.cache.persistent.memory.initial.size")
       .internal()
       .doc("Used to set the initial size of Intel Optane DC persistent memory. The size is " +
         "used to control the maximum available persistent memory size used for each executor.")
       .stringConf
       .createWithDefault("0b")
 
+  val OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.initial.size")
+      .internal()
+      .doc("Equal to 'spark.executor.sql.oap.cache.persistent.memory.initial.size', " +
+        "compatible with OAP versions before 1.0. Used to set the initial size of" +
+        "Intel Optane DC persistent memory. The size is " +
+        "used to control the maximum available persistent memory size used for each executor.")
+      .stringConf
+      .createWithDefault("0b")
+
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.reserved.size")
+    SqlConfAdapter.buildConf("spark.executor.sql.oap.cache.persistent.memory.reserved.size")
       .internal()
       .doc("Used to set the reserved size of Intel Optane DC persistent memory. Because the " +
+        "heap management of Intel Optane DC persistent memory are based on jemalloc, so we " +
+        "can't full use the total initial size memory. The reserved size should smaller than" +
+        " initial size. Too small reserved size could result in OOM, too big size could reduce" +
+        " the memory utilization rate.")
+      .stringConf
+      .createWithDefault("0b")
+
+  val OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.reserved.size")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0. Used to set the reserved size of " +
+        "Intel Optane DC persistent memory. Because the " +
         "heap management of Intel Optane DC persistent memory are based on jemalloc, so we " +
         "can't full use the total initial size memory. The reserved size should smaller than" +
         " initial size. Too small reserved size could result in OOM, too big size could reduce" +
@@ -391,13 +488,28 @@ object OapConf {
       .createWithDefault("v1")
 
   val OAP_PARQUET_DATA_CACHE_ENABLED =
-    SqlConfAdapter.buildConf("spark.sql.oap.parquet.data.cache.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.data.cache.enabled")
       .internal()
       .doc("To indicate if enable parquet data cache, default false")
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_PARQUET_DATA_CACHE_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.data.cache.enable")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0, to indicate if enable parquet data cache," +
+        " default false. same as 'spark.sql.oap.parquet.data.cache.enabled'")
+      .booleanConf
+      .createWithDefault(false)
+
   val OAP_ORC_DATA_CACHE_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.orc.data.cache.enabled")
+      .internal()
+      .doc("To indicate if enable orc data cache, default false")
+      .booleanConf
+      .createWithDefault(false)
+
+  val OAP_ORC_DATA_CACHE_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.orc.data.cache.enable")
       .internal()
       .doc("To indicate if enable orc data cache, default false")
@@ -405,16 +517,33 @@ object OapConf {
       .createWithDefault(false)
 
   val OAP_ORC_BINARY_DATA_CACHE_ENABLED =
-    SqlConfAdapter.buildConf("spark.sql.oap.orc.binary.cache.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.orc.binary.cache.enabled")
       .internal()
       .doc("To indicate if enable orc binary data cache, default false")
       .booleanConf
       .createWithDefault(false)
 
+  val OAP_ORC_BINARY_DATA_CACHE_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.orc.binary.cache.enable")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.orc.binary.cache.enabled', compatible to " +
+        "OAP version before 1.0." +
+        "To indicate if enable orc binary data cache, default false")
+      .booleanConf
+      .createWithDefault(false)
+
   val OAP_PARQUET_INDEX_ENABLED =
-    SqlConfAdapter.buildConf("spark.sql.oap.parquet.index.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.index.enabled")
       .internal()
       .doc("To indicate if enable parquet index, default true")
+      .booleanConf
+      .createWithDefault(true)
+
+  val OAP_PARQUET_INDEX_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.parquet.index.enable")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.parquet.index.enabled', compatible to OAP versions" +
+        "before 1.0. To indicate if enable parquet index, default true")
       .booleanConf
       .createWithDefault(true)
 
@@ -427,16 +556,30 @@ object OapConf {
       .createWithDefault("")
 
   val OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE =
-    SqlConfAdapter.buildConf("spark.sql.oap.cache.external.client.pool.size")
+    SqlConfAdapter.buildConf("spark.executor.sql.oap.cache.external.client.pool.size")
       .internal()
       .doc("client pool for external cache")
       .intConf
       .createWithDefault(1)
+  val OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.external.client.pool.size")
+      .internal()
+      .doc("Compatible with OAP versions before 1.0, client pool for external cache")
+      .intConf
+      .createWithDefault(1)
+
+  val OAP_EXTERNAL_CACHE_READ_ONLY_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.cache.external.read.only.enabled")
+      .internal()
+      .doc("whether we need cache data")
+      .booleanConf
+      .createWithDefault(true)
 
   val OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.cache.external.read.only.enable")
     .internal()
-    .doc("whether we need cache data")
+    .doc("Equal to 'spark.sql.oap.cache.external.read.only.enabled', compatible to" +
+      "OAP versions before 1.0, whether we need cache data")
     .booleanConf
     .createWithDefault(true)
 
@@ -448,9 +591,17 @@ object OapConf {
       .createWithDefault(2)
 
   val OAP_CACHE_GUARDIAN_MEMORY_SIZE =
+    SqlConfAdapter.buildConf("spark.executor.sql.oap.cache.guardian.memory.size")
+      .internal()
+      .doc("total cache guardian memory size per executor")
+      .stringConf
+      .createWithDefault("10g")
+
+  val OAP_CACHE_GUARDIAN_MEMORY_SIZE_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.cache.guardian.memory.size")
       .internal()
-      .doc("total cache guardian memory size")
+      .doc("Compatible with OAP versions before 1.0, total cache guardian memory size per executor, " +
+        "same as 'spark.executor.sql.oap.cache.guardian.memory.size'")
       .stringConf
       .createWithDefault("10g")
 
@@ -461,17 +612,34 @@ object OapConf {
     .intConf
     .createWithDefault(5000)
 
-  val OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE =
-    SqlConfAdapter.buildConf("spark.sql.oap.index.statistic.externalsorter.enable")
+  val OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLED =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistic.externalsorter.enabled")
       .internal()
       .doc("To indicate if to enable externalsorter for statistic calculation")
       .booleanConf
       .createWithDefault(true)
 
+  val OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE =
+    SqlConfAdapter.buildConf("spark.sql.oap.index.statistic.externalsorter.enable")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.index.statistic.externalsorter.enabled', compatible to" +
+        "OAP versions before 1.0." +
+        "To indicate if to enable externalsorter for statistic calculation")
+      .booleanConf
+      .createWithDefault(true)
+
   val OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION =
-    SqlConfAdapter.buildConf("spark.sql.oap.data.fiber.cache.compress.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.data.fiber.cache.compress.enabled")
       .internal()
       .doc("To indicate if enable/disable data fiber cache compression")
+      .booleanConf
+      .createWithDefault(false)
+
+  val OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.data.fiber.cache.compress.enable")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.data.fiber.cache.compress.enabled', compatible to OAP verisons" +
+        "before 1.0. To indicate if enable/disable data fiber cache compression")
       .booleanConf
       .createWithDefault(false)
 
@@ -500,9 +668,17 @@ object OapConf {
       .createWithDefault(524288000L)
 
   val OAP_ENABLE_MEMKIND_CONSERVATIVE =
-    SqlConfAdapter.buildConf("spark.sql.oap.memkind.conservative.enable")
+    SqlConfAdapter.buildConf("spark.sql.oap.memkind.conservative.enabled")
       .internal()
       .doc("To enable memkind conservative pattern")
+      .booleanConf
+      .createWithDefault(true)
+
+  val OAP_ENABLE_MEMKIND_CONSERVATIVE_BK =
+    SqlConfAdapter.buildConf("spark.sql.oap.memkind.conservative.enable")
+      .internal()
+      .doc("Equal to 'spark.sql.oap.memkind.conservative.enabled', compatible to " +
+        "OAP versions before 1.0. To enable memkind conservative pattern")
       .booleanConf
       .createWithDefault(true)
 

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -203,6 +203,7 @@ object OapConf {
         "This conf item only takes effect when spark.sql.oap.cache.table.list.enabled = true")
       .stringConf
       .createWithDefault("default.xx;default.xx")
+
   val OAP_CACHE_TABLE_LISTS_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.table.list")
       .internal()
@@ -213,7 +214,7 @@ object OapConf {
         "This conf item only takes effect when spark.sql.oap.cache.table.list.enabled=true")
       .stringConf
       .createWithDefault("default.xx;default.xx")
-,
+
   val OAP_FIBERCACHE_MEMORY_MANAGER =
     SqlConfAdapter.buildConf("spark.sql.oap.cache.memory.manager")
       .internal()

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -685,7 +685,7 @@ object OapConf {
   val OAP_PARQUET_BINARY_DATA_CACHE_ENABLED =
     SqlConfAdapter.buildConf("spark.sql.oap.parquet.binary.cache.enabled")
       .internal()
-      .doc("To indicate if enable parquet binary data cache, defalt false")
+      .doc("To indicate if enable parquet binary data cache, default false")
       .booleanConf
       .createWithDefault(false)
 
@@ -712,10 +712,10 @@ object OapConf {
       .intConf
       .createWithDefault(2)
 
-  val OAP_EXTERNAL_CACHE_METADB_ENABLE = {
-    SqlConfAdapter.buildConf("spark.sql.oap.external.cache.metaDB.enable")
+  val OAP_EXTERNAL_CACHE_METADB_ENABLED = {
+    SqlConfAdapter.buildConf("spark.sql.oap.external.cache.metaDB.enabled")
       .internal()
-      .doc("external cachemeta db enable")
+      .doc("Whether to enable external cachemeta db")
       .booleanConf
       .createWithDefault(false)
   }

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -37,7 +37,8 @@ object OapConf {
   val OAP_ORC_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.orc.enable")
       .internal()
-      .doc("Equal to 'spark.sql.oap.orc.enabled', compatible to OAP versions before 1.0" +
+      .doc("Equivalent to OAP_ORC_ENABLED, it is reserved for compatibility with versions before OAP 1.0" +
+        "this older key name is still accepted, but take lower precedence." +
         "Whether enable oap file format when encountering orc files")
       .booleanConf
       .createWithDefault(true)
@@ -52,8 +53,9 @@ object OapConf {
   val OAP_PARQUET_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.parquet.enable")
       .internal()
-      .doc("Equal to 'spark.sql.oap.parquet.enabled', compatible with OAP verisions before 1.0." +
-        " Whether enable oap file format when encountering parquet files")
+      .doc("Equivalent to OAP_PARQUET_ENABLED, it is reserved for compatibility with versions before" +
+        "OAP 1.0, this older key name is still accepted, but take lower precedence." +
+        "Whether enable oap file format when encountering parquet files")
       .booleanConf
       .createWithDefault(true)
 
@@ -131,7 +133,8 @@ object OapConf {
   val OAP_FIBERCACHE_USE_OFFHEAP_RATIO_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.use.offheap.ratio")
       .internal()
-      .doc("Compatible with OAP versions before 1.0. Equal to 'spark.sql.oap.offheap.cache.ratio'" +
+      .doc("Equivalent to OAP_FIBERCACHE_USE_OFFHEAP_RATIO, it is reserved for compatibility with" +
+        "versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
         "Define the ratio of fiber cache use 'spark.memory.offHeap.size' ratio.")
       .doubleConf
       .createWithDefault(0.7)
@@ -149,7 +152,8 @@ object OapConf {
   val OAP_DATAFIBER_USE_FIBERCACHE_RATIO_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.dataCache.use.fiberCache.ratio")
       .internal()
-      .doc("Compatible with OAP versions before 1.0. Equal to 'spark.sql.oap.cache.dataCache.ratio'" +
+      .doc("Equivalent to OAP_DATAFIBER_USE_FIBERCACHE_RATIO, it is reserved for compatibility with" +
+        "versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
         "Define the ratio of data cache use fiber cache ratio " +
         "when enable cache separation for single physical storage. " +
         "This is not available under mix mode because the index and data " +
@@ -160,7 +164,7 @@ object OapConf {
   val OAP_INDEX_DATA_SEPARATION_ENABLED =
     SqlConfAdapter.buildConf("spark.sql.oap.index.data.cache.separation.enabled")
       .internal()
-      .doc("This is to enable index data cache separation feature including mix memory manager" +
+      .doc("Whether enable index and data cache separation feature including mix memory manager" +
         "and mix cache backend")
       .booleanConf
       .createWithDefault(false)
@@ -168,8 +172,9 @@ object OapConf {
   val OAP_INDEX_DATA_SEPARATION_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.index.data.cache.separation.enable")
       .internal()
-      .doc("Equal to 'spark.sql.oap.index.data.cache.separation.enabled', compatible to OAP version" +
-        "before 1.0. This is to enable index data cache separation feature including mix memory manager" +
+      .doc("Equivalent to OAP_INDEX_DATA_SEPARATION_ENABLED, it is reserved for compatibility with" +
+        "versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
+        "Whether enable index and data cache separation feature including mix memory manager" +
         "and mix cache backend")
       .booleanConf
       .createWithDefault(false)
@@ -177,15 +182,16 @@ object OapConf {
   val OAP_CACHE_TABLE_LISTS_ENABLED =
     SqlConfAdapter.buildConf("spark.sql.oap.cache.table.list.enabled")
       .internal()
-      .doc("This is to enable table lists fiberCache")
+      .doc("Whether enable table lists fiberCache")
       .booleanConf
       .createWithDefault(false)
 
   val OAP_CACHE_TABLE_LISTS_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.table.list.enable")
       .internal()
-      .doc("Compatible with OAP versions before 1.0. Equal to " +
-        "'spark.sql.oap.fiberCache.table.list.enable'. This is to enable table lists fiberCache")
+      .doc("Equivalent to OAP_CACHE_TABLE_LISTS_ENABLED, it is reserved for compatibility with" +
+        "versions before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "Whether enable table lists fiberCache")
       .booleanConf
       .createWithDefault(false)
 
@@ -200,31 +206,33 @@ object OapConf {
   val OAP_CACHE_TABLE_LISTS_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.table.list")
       .internal()
-      .doc("Compatible with OAP versions before 1.0. Equal to 'spark.sql.oap.cache.table.list'" +
+      .doc("Equivalent to OAP_CACHE_TABLE_LISTS, it is reserved for compatibility with versions" +
+        "before OAP 1.0; this older key name is still accepted, but take lower precedence." +
         "Table lists using fiberCache actively, format: {database}.{table}" +
         "Separator is semicolon. For example: default.table1;default.table2 ." +
         "This conf item only takes effect when spark.sql.oap.cache.table.list.enabled=true")
       .stringConf
       .createWithDefault("default.xx;default.xx")
-
+,
   val OAP_FIBERCACHE_MEMORY_MANAGER =
     SqlConfAdapter.buildConf("spark.sql.oap.cache.memory.manager")
       .internal()
       .doc("Sets the implement of memory manager, it currently supports offheap(DRAM OFF_HEAP), " +
         "pm(Intel Optane DC persistent memory) and mix(A combination of offheap and pm)." +
         "To enable mix mode, you need to set " +
-        "spark.sql.oap.index.data.cache.separation.enable to true")
+        "spark.sql.oap.index.data.cache.separation.enabled to true")
       .stringConf
       .createWithDefault("offheap")
 
   val OAP_FIBERCACHE_MEMORY_MANAGER_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.memory.manager")
       .internal()
-      .doc("Compatible with OAP versions before 1.0. Equal to 'spark.sql.oap.cache.memory.manager'" +
-        "Sets the implement of memory manager, it currently supports offheap(DRAM OFF_HEAP), " +
+      .doc("Equivalent to OAP_FIBERCACHE_MEMORY_MANAGER, it is reserved for compatibility with" +
+        "versions before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "Set the implementation of memory manager, it currently supports offheap(DRAM OFF_HEAP), " +
         "pm(Intel Optane DC persistent memory) and mix(A combination of offheap and pm)." +
         "To enable mix mode, you need to set " +
-        "spark.sql.oap.index.data.cache.separation.enable to true")
+        "spark.sql.oap.index.data.cache.separation.enabled to true")
       .stringConf
       .createWithDefault("offheap")
 
@@ -234,7 +242,7 @@ object OapConf {
       .doc("Sets the implement of cache strategy, it currently supports guava(Guava Cache), " +
         "vmem(VMemCache), simple, noevict." +
         "To enable mix mode, you need to set " +
-        "spark.sql.oap.index.data.cache.separation.enable to true")
+        "spark.sql.oap.index.data.cache.separation.enabled to true")
       .stringConf
       .createWithDefault("guava")
 
@@ -258,8 +266,9 @@ object OapConf {
   val OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.offheap.memory.size")
       .internal()
-      .doc("Compatible with OAP versions before 1.0. Used to set available memory size " +
-        "for fiberCache for each executor.")
+      .doc("Equivalent to OAP_FIBERCACHE_OFFHEAP_MEMORY_SIZE, it is reserved for compatibility with" +
+        "versions before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "Used to set available memory size for fiberCache for each executor.")
       .stringConf
       .createWithDefault("100m")
 
@@ -298,8 +307,9 @@ object OapConf {
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.config.file")
       .internal()
-      .doc("Equal to 'spark.sql.oap.cache.persistent.memory.config.file', compatible with " +
-        "OAP versions before 1.0. A config file used to config the Intel Optane DC persistent memory" +
+      .doc("Equivalent to OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE, it is reserved for compatibility" +
+        "with versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
+        "A config file used to config the Intel Optane DC persistent memory" +
         "initial path, and mapping with NUMA node.")
       .stringConf
       .createWithDefault("persistent-memory.xml")
@@ -315,9 +325,9 @@ object OapConf {
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.initial.size")
       .internal()
-      .doc("Equal to 'spark.executor.sql.oap.cache.persistent.memory.initial.size', " +
-        "compatible with OAP versions before 1.0. Used to set the initial size of" +
-        "Intel Optane DC persistent memory. The size is " +
+      .doc("Equivalent to OAP_FIBERCACHE_PERSISTENT_MEMORY_INITIAL_SIZE, it is reserved for compatibility" +
+        "with versions before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "Used to set the initial size of Intel Optane DC persistent memory. The size is " +
         "used to control the maximum available persistent memory size used for each executor.")
       .stringConf
       .createWithDefault("0b")
@@ -336,8 +346,9 @@ object OapConf {
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.reserved.size")
       .internal()
-      .doc("Compatible with OAP versions before 1.0. Used to set the reserved size of " +
-        "Intel Optane DC persistent memory. Because the " +
+      .doc("Equivalent to OAP_FIBERCACHE_PERSISTENT_MEMORY_RESERVED_SIZE, it is reserved for compatibility" +
+        "with versions before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "Used to set the reserved size of Intel Optane DC persistent memory. Because the " +
         "heap management of Intel Optane DC persistent memory are based on jemalloc, so we " +
         "can't full use the total initial size memory. The reserved size should smaller than" +
         " initial size. Too small reserved size could result in OOM, too big size could reduce" +
@@ -497,8 +508,9 @@ object OapConf {
   val OAP_PARQUET_DATA_CACHE_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.parquet.data.cache.enable")
       .internal()
-      .doc("Compatible with OAP versions before 1.0, to indicate if enable parquet data cache," +
-        " default false. same as 'spark.sql.oap.parquet.data.cache.enabled'")
+      .doc("Equivalent to OAP_PARQUET_DATA_CACHE_ENABLED, it is reserved for compatibility with" +
+        "versions before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "To indicate if enable parquet data cache, default false.")
       .booleanConf
       .createWithDefault(false)
 
@@ -512,7 +524,9 @@ object OapConf {
   val OAP_ORC_DATA_CACHE_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.orc.data.cache.enable")
       .internal()
-      .doc("To indicate if enable orc data cache, default false")
+      .doc("Equivalent to OAP_ORC_DATA_CACHE_ENABLED, it is reserved for compatibility with" +
+        "versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
+        "To indicate if enable orc data cache, default false")
       .booleanConf
       .createWithDefault(false)
 
@@ -526,8 +540,8 @@ object OapConf {
   val OAP_ORC_BINARY_DATA_CACHE_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.orc.binary.cache.enable")
       .internal()
-      .doc("Equal to 'spark.sql.oap.orc.binary.cache.enabled', compatible to " +
-        "OAP version before 1.0." +
+      .doc("Equivalent to OAP_ORC_BINARY_DATA_CACHE_ENABLED, it is reserved for compatibility with" +
+        "versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
         "To indicate if enable orc binary data cache, default false")
       .booleanConf
       .createWithDefault(false)
@@ -542,8 +556,9 @@ object OapConf {
   val OAP_PARQUET_INDEX_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.parquet.index.enable")
       .internal()
-      .doc("Equal to 'spark.sql.oap.parquet.index.enabled', compatible to OAP versions" +
-        "before 1.0. To indicate if enable parquet index, default true")
+      .doc("Equivalent to OAP_PARQUET_INDEX_ENABLED, it is reserved for compatibility with versions" +
+        "before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "To indicate if enable parquet index, default true")
       .booleanConf
       .createWithDefault(true)
 
@@ -564,7 +579,9 @@ object OapConf {
   val OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.cache.external.client.pool.size")
       .internal()
-      .doc("Compatible with OAP versions before 1.0, client pool for external cache")
+      .doc("Equivalent to OAP_EXTERNAL_CACHE_CLIENT_POOL_SIZE, it is reserved for compatibility with" +
+        "versions before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "client pool for external cache")
       .intConf
       .createWithDefault(1)
 
@@ -578,8 +595,9 @@ object OapConf {
   val OAP_EXTERNAL_CACHE_READ_ONLY_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.cache.external.read.only.enable")
     .internal()
-    .doc("Equal to 'spark.sql.oap.cache.external.read.only.enabled', compatible to" +
-      "OAP versions before 1.0, whether we need cache data")
+    .doc("Equivalent to OAP_EXTERNAL_CACHE_READ_ONLY_ENABLED, it is reserved for compatibility with" +
+      "versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
+      "Whether we need cache data")
     .booleanConf
     .createWithDefault(true)
 
@@ -600,8 +618,9 @@ object OapConf {
   val OAP_CACHE_GUARDIAN_MEMORY_SIZE_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.cache.guardian.memory.size")
       .internal()
-      .doc("Compatible with OAP versions before 1.0, total cache guardian memory size per executor, " +
-        "same as 'spark.executor.sql.oap.cache.guardian.memory.size'")
+      .doc("Equivalent to OAP_CACHE_GUARDIAN_MEMORY_SIZE, it is reserved for compatibility with versions " +
+        "before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "total cache guardian memory size per executor")
       .stringConf
       .createWithDefault("10g")
 
@@ -622,8 +641,8 @@ object OapConf {
   val OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLE =
     SqlConfAdapter.buildConf("spark.sql.oap.index.statistic.externalsorter.enable")
       .internal()
-      .doc("Equal to 'spark.sql.oap.index.statistic.externalsorter.enabled', compatible to" +
-        "OAP versions before 1.0." +
+      .doc("Equivalent to OAP_INDEX_STATISTIC_EXTERNALSORTER_ENABLED, it is reserved for compatibility with" +
+        "versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
         "To indicate if to enable externalsorter for statistic calculation")
       .booleanConf
       .createWithDefault(true)
@@ -638,8 +657,9 @@ object OapConf {
   val OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.data.fiber.cache.compress.enable")
       .internal()
-      .doc("Equal to 'spark.sql.oap.data.fiber.cache.compress.enabled', compatible to OAP verisons" +
-        "before 1.0. To indicate if enable/disable data fiber cache compression")
+      .doc("Equivalent to OAP_ENABLE_DATA_FIBER_CACHE_COMPRESSION, it is reserved for compatibility with" +
+        "versions before OAP 1.0; this older key name is still accepted, but take lower precedence." +
+        "To indicate if enable/disable data fiber cache compression")
       .booleanConf
       .createWithDefault(false)
 
@@ -677,8 +697,9 @@ object OapConf {
   val OAP_ENABLE_MEMKIND_CONSERVATIVE_BK =
     SqlConfAdapter.buildConf("spark.sql.oap.memkind.conservative.enable")
       .internal()
-      .doc("Equal to 'spark.sql.oap.memkind.conservative.enabled', compatible to " +
-        "OAP versions before 1.0. To enable memkind conservative pattern")
+      .doc("Equivalent to OAP_ENABLE_MEMKIND_CONSERVATIVE, it is reserved for compatibility" +
+        "with versions before OAP 1.0, this older key name is still accepted, but take lower precedence." +
+        "To enable memkind conservative pattern")
       .booleanConf
       .createWithDefault(true)
 

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -47,7 +47,7 @@ case class FilePartition(index: Int, files: Array[PartitionedFile])
       case (host, numBytes) => host
     }.toArray
 
-    if (SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ENABLE) == true) {
+    if (SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ENABLED) == true) {
       CachedPartitionedFilePreferredLocs.getPreferredLocsByCache(files)
         .++(hdfsPreLocs)
         .take(3)

--- a/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
+++ b/oap-cache/oap/src/main/spark3.0.0/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
@@ -91,7 +91,10 @@ private[v1] class AbstractApplicationResource extends BaseAppResource {
           getOrDefault(executorSummary.id, CacheStats())
         val indexDataCacheSeparationEnable = SparkEnv.get.conf.getBoolean(
           OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.key,
-          OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get)
+          OapConf.OAP_INDEX_DATA_SEPARATION_ENABLE.defaultValue.get) ||
+          SparkEnv.get.conf.getBoolean(
+            OapConf.OAP_INDEX_DATA_SEPARATION_ENABLED.key,
+            OapConf.OAP_INDEX_DATA_SEPARATION_ENABLED.defaultValue.get)
 
         new FiberCacheManagerSummary(
           executorSummary.id,

--- a/oap-cache/oap/src/test/oap-perf-suite/scala/org/apache/spark/sql/BenchmarkConfig.scala
+++ b/oap-cache/oap/src/test/oap-perf-suite/scala/org/apache/spark/sql/BenchmarkConfig.scala
@@ -184,13 +184,13 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("Orc w/ index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true"),
+          .setSparkConf("spark.sql.oap.orc.binary.cache.enabled", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("orc w/ index binary data cache separation same medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.orc.binary.cache.enabled", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
           .setBenchmarkConfName("Orc w/o index")
@@ -200,7 +200,7 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("Orc w/o index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false")
-          .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true"),
+          .setSparkConf("spark.sql.oap.orc.binary.cache.enabled", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/ index")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
@@ -209,7 +209,7 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("parquet w/ index oap cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.parquet.data.cache.enable", "true"),
+          .setSparkConf("spark.sql.oap.parquet.data.cache.enabled", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/ index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
@@ -223,7 +223,7 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("parquet w/o index oap cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false")
-          .setSparkConf("spark.sql.oap.parquet.data.cache.enable", "true"),
+          .setSparkConf("spark.sql.oap.parquet.data.cache.enabled", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/o index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
@@ -233,15 +233,15 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("parquet w/ index data cache separation same medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.parquet.data.cache.enable", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.parquet.data.cache.enabled", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/ index binary data cache separation same medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
           .setSparkConf("spark.sql.oap.parquet.binary.cache.enabled", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.oap.cache.strategy", "mix")
       )
     }else{
@@ -254,20 +254,20 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("Orc w/ index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true"),
+          .setSparkConf("spark.sql.oap.orc.binary.cache.enabled", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("orc w/ index binary data cache separation same medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.orc.binary.cache.enabled", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
           .setBenchmarkConfName("Orc w/ index data binary cache separation different medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.orc.binary.cache.enabled", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.sql.oap.fiberCache.memory.manager", "mix")
           .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
@@ -278,7 +278,7 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("Orc w/o index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false")
-          .setSparkConf("spark.sql.oap.orc.binary.cache.enable", "true"),
+          .setSparkConf("spark.sql.oap.orc.binary.cache.enabled", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/ index")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
@@ -287,7 +287,7 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("parquet w/ index oap cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.parquet.data.cache.enable", "true"),
+          .setSparkConf("spark.sql.oap.parquet.data.cache.enabled", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/ index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
@@ -301,7 +301,7 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("parquet w/o index oap cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false")
-          .setSparkConf("spark.sql.oap.parquet.data.cache.enable", "true"),
+          .setSparkConf("spark.sql.oap.parquet.data.cache.enabled", "true"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/o index oap binary cache enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
@@ -311,22 +311,22 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConfName("parquet w/ index data cache separation same medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.parquet.data.cache.enable", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.parquet.data.cache.enabled", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/ index binary data cache separation same medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
           .setSparkConf("spark.sql.oap.parquet.binary.cache.enabled", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
           .setBenchmarkConfName("parquet w/ index data cache separation different medium enabled")
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
-          .setSparkConf("spark.sql.oap.parquet.data.cache.enable", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.parquet.data.cache.enabled", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.sql.oap.fiberCache.memory.manager", "mix")
           .setSparkConf("spark.oap.cache.strategy", "mix"),
         new BenchmarkConfig()
@@ -334,7 +334,7 @@ trait ParquetVsOrcConfigSet extends BenchmarkConfigSelector{
           .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "parquet")
           .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true")
           .setSparkConf("spark.sql.oap.parquet.binary.cache.enabled", "true")
-          .setSparkConf("spark.sql.oap.index.data.cache.separation.enable", "true")
+          .setSparkConf("spark.sql.oap.index.data.cache.separation.enabled", "true")
           .setSparkConf("spark.sql.oap.fiberCache.memory.manager", "mix")
           .setSparkConf("spark.oap.cache.strategy", "mix")
       )

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/CacheHotTablesSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/CacheHotTablesSuite.scala
@@ -151,7 +151,7 @@ class CacheHotTablesForParquetSuite extends CacheHotTablesSuite {
 
   test("Project-> Filter -> Scan : Not Optimized, only cache hot Tables") {
     withSQLConf(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key -> "true",
-      OapConf.OAP_CACHE_TABLE_LISTS_ENABLE.key -> "true") {
+      OapConf.OAP_CACHE_TABLE_LISTS_ENABLED.key -> "true") {
       verifyProjectFilterScan(
         format => format.isInstanceOf[ParquetFileFormat],
         (plan1, plan2) => plan1.sameResult(plan2)
@@ -161,7 +161,7 @@ class CacheHotTablesForParquetSuite extends CacheHotTablesSuite {
 
   test("Project-> Filter -> Scan : Optimized, only cache hot Tables") {
     withSQLConf(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key -> "true",
-      OapConf.OAP_CACHE_TABLE_LISTS_ENABLE.key -> "true",
+      OapConf.OAP_CACHE_TABLE_LISTS_ENABLED.key -> "true",
       OapConf.OAP_CACHE_TABLE_LISTS.key -> "default.parquet_test;xxx") {
       verifyProjectFilterScan(
         format => format.isInstanceOf[OptimizedParquetFileFormat],
@@ -181,7 +181,7 @@ class CacheHotTablesForParquetSuite extends CacheHotTablesSuite {
 
   test("Project -> Scan :  Not Optimized, only cache hot Tables") {
     withSQLConf(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key -> "true",
-      OapConf.OAP_CACHE_TABLE_LISTS_ENABLE.key -> "true") {
+      OapConf.OAP_CACHE_TABLE_LISTS_ENABLED.key -> "true") {
       verifyProjectScan(
         format => format.isInstanceOf[ParquetFileFormat],
         (plan1, plan2) => plan1.sameResult(plan2)
@@ -191,7 +191,7 @@ class CacheHotTablesForParquetSuite extends CacheHotTablesSuite {
 
   test("Project -> Scan :  Optimized, only cache hot Tables") {
     withSQLConf(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key -> "true",
-      OapConf.OAP_CACHE_TABLE_LISTS_ENABLE.key -> "true",
+      OapConf.OAP_CACHE_TABLE_LISTS_ENABLED.key -> "true",
       OapConf.OAP_CACHE_TABLE_LISTS.key -> "default.parquet_test;xxx") {
       verifyProjectScan(
         format => format.isInstanceOf[OptimizedParquetFileFormat],

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/FilterSuite.scala
@@ -1362,7 +1362,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
   }
 
   test("filtering parquet in FiberCache") {
-    withSQLConf("spark.sql.oap.parquet.data.cache.enable" -> "true") {
+    withSQLConf("spark.sql.oap.parquet.data.cache.enabled" -> "true") {
       val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
       data.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table parquet_test select * from t")
@@ -1393,7 +1393,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 //  }
 
   test("filtering parquet in FiberCache with partition") {
-    withSQLConf("spark.sql.oap.parquet.data.cache.enable" -> "true") {
+    withSQLConf("spark.sql.oap.parquet.data.cache.enabled" -> "true") {
       val data: Seq[(Int, Int)] = (1 to 100).map { i => (i, i) }
       data.toDF("key", "value").createOrReplaceTempView("t")
       sql(
@@ -1412,7 +1412,7 @@ class FilterSuite extends QueryTest with SharedOapContext with BeforeAndAfterEac
 
   test("filtering parquet without both code gen and off-heap cache") {
     spark.sqlContext.setConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "false")
-    withSQLConf("spark.sql.oap.parquet.data.cache.enable" -> "false") {
+    withSQLConf("spark.sql.oap.parquet.data.cache.enabled" -> "false") {
       val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
       data.toDF("key", "value").createOrReplaceTempView("t")
       sql("insert overwrite table parquet_test select * from t")

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/IndexDataCacheSeparationSuite.scala
@@ -42,7 +42,7 @@ class IndexDataCacheSeparationSuite extends SharedOapContext with BeforeAndAfter
     fiberGroupId
   }
 
-  oapSparkConf.set("spark.sql.oap.index.data.cache.separation.enable", "true")
+  oapSparkConf.set("spark.sql.oap.index.data.cache.separation.enabled", "true")
   oapSparkConf.set("spark.oap.cache.strategy", "mix")
   oapSparkConf.set("spark.sql.oap.mix.data.memory.manager", "offheap")
 
@@ -59,7 +59,7 @@ class IndexDataCacheSeparationSuite extends SharedOapContext with BeforeAndAfter
     // restore oapSparkConf to default
     oapSparkConf.set("spark.oap.cache.strategy", "guava")
     oapSparkConf.set("spark.sql.oap.fiberCache.memory.manager", "offheap")
-    oapSparkConf.set("spark.sql.oap.index.data.cache.separation.enable", "false")
+    oapSparkConf.set("spark.sql.oap.index.data.cache.separation.enabled", "false")
     oapSparkConf.set("spark.sql.oap.mix.data.memory.manager", "pm")
   }
 

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFileSuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/io/OrcDataFileSuite.scala
@@ -67,6 +67,7 @@ class OrcDataFileSuite extends QueryTest with SharedOapContext with BeforeAndAft
 
   override def afterEach(): Unit = {
     configuration.unset(OapConf.OAP_ORC_DATA_CACHE_ENABLED.key)
+    configuration.unset(OapConf.OAP_ORC_DATA_CACHE_ENABLE.key)
   }
 
   private val partitionSchema: StructType = new StructType()

--- a/oap-spark/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/oap-spark/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -181,7 +181,7 @@ private[spark] class BlockManager(
   private[spark] val externalShuffleServiceEnabled: Boolean = externalBlockStoreClient.isDefined
 
   val isDriver = executorId == SparkContext.DRIVER_IDENTIFIER
-  var memExtensionEnabled = conf.getBoolean("spark.memory.pmem.extension.enable", false)
+  var memExtensionEnabled = conf.getBoolean("spark.memory.pmem.extension.enabled", false)
 
   var numaNodeId = conf.getInt("spark.executor.numa.id", -1)
   val pmemInitialPaths = conf.get("spark.memory.pmem.initial.path", "").split(",")


### PR DESCRIPTION
…rations and be compatible with 'enable'

## What changes were proposed in this pull request?

Fix : #1653 

Refine OapConf and achieve compatibilty with the old configs if users ignore the new configs

1. Add   .executor to to notify users corresponding size setting is for per executor
2. Modify .fiberCache to .cache
3. Change .enable to .enabled

OLD | NEW
-- | --
  | Add   .executor
spark.sql.oap.fiberCache.offheap.memory.size | spark.executor.sql.oap.cache.offheap.memory.size
spark.sql.oap.fiberCache.persistent.memory.initial.size | spark.executor.sql.oap.cache.persistent.memory.initial.size
spark.sql.oap.fiberCache.persistent.memory.reserved.size | spark.executor.sql.oap.cache.persistent.memory.reserved.size
spark.sql.oap.cache.guardian.memory.size | spark.executor.sql.oap.cache.guardian.memory.size
spark.sql.oap.cache.external.client.pool.size | spark.executor.sql.oap.cache.external.client.pool.size
  | Modify .fibercache to .cache
spark.sql.oap.fiberCache.use.offheap.ratio | spark.sql.oap.offheap.cache.ratio
spark.sql.oap.dataCache.use.fiberCache.ratio | spark.sql.oap.cache.dataCache.ratio
spark.sql.oap.fiberCache.table.list.enable | spark.sql.oap.cache.table.list.enabled
spark.sql.oap.fiberCache.table.list | spark.sql.oap.cache.table.list
spark.sql.oap.fiberCache.memory.manager | spark.sql.oap.cache.memory.manager
spark.sql.oap.fiberCache.persistent.memory.config.file | spark.sql.oap.cache.persistent.memory.config.file
spark.sql.oap.fiberCache.size | ----no longer used and   deleted----
spark.sql.oap.fiberCache.stats | ----no longer used and   deleted----
  | Change .enable to .enabled (48/50 of Spark SQLConf use .enabled)
spark.sql.oap.orc.enable | spark.sql.oap.orc.enabled
spark.sql.oap.parquet.enable | spark.sql.oap.parquet.enabled
spark.sql.oap.index.data.cache.separation.enable | spark.sql.oap.index.data.cache.separation.enabled
spark.sql.oap.fiberCache.table.list.enable | spark.sql.oap.cache.table.list.enabled
spark.sql.oap.parquet.data.cache.enable | spark.sql.oap.parquet.data.cache.enabled
spark.sql.oap.orc.data.cache.enable | spark.sql.oap.orc.data.cache.enabled
spark.sql.oap.orc.binary.cache.enable | spark.sql.oap.orc.binary.cache.enabled
spark.sql.oap.parquet.index.enable | spark.sql.oap.parquet.index.enabled
spark.sql.oap.cache.external.read.only.enable | spark.sql.oap.cache.external.read.only.enabled
spark.sql.oap.index.statistic.externalsorter.enable | spark.sql.oap.index.statistic.externalsorter.enabled
spark.sql.oap.data.fiber.cache.compress.enable | spark.sql.oap.data.fiber.cache.compress.enabled
spark.sql.oap.memkind.conservative.enable | spark.sql.oap.memkind.conservative.enabled



## How was this patch tested?



