### PR TITLE
[OAP-1751][oap-native-sql]fix sort on TPC-DS

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPlugin.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPlugin.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BuildLeft, BuildRight, ShuffledHashJoinExec, SortMergeJoinExec, _}
-import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.internal.SQLConf
 
@@ -114,9 +113,7 @@ case class ColumnarPreOverrides(conf: SparkConf) extends Rule[SparkPlan] {
       logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
       new ColumnarExpandExec(plan.projections, plan.output, children(0))
     case plan: SortExec =>
-      val sortList = {plan.sortOrder.filter(expr => expr.dataType == StringType)}
-      //TODO(Rui): fix sorting on string
-      if (columnarConf.enableColumnarSort && sortList.isEmpty) {
+      if (columnarConf.enableColumnarSort) {
         val child =
           if (nc == null) replaceWithColumnarPlan(plan.child) else nc(0)
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -194,31 +194,79 @@ object ColumnarSorter extends Logging {
     logInfo(s"ColumnarSorter sortOrder is ${sortOrder}, outputAttributes is ${outputAttributes}")
     ColumnarPluginConfig.getConf(sparkConf)
     /////////////// Prepare ColumnarSorter //////////////
-    val keyFieldList: List[Field] = sortOrder.toList.map(sort => {
-      val attr = ConverterUtils.getAttrFromExpr(sort.child)
-      if (attr.dataType.isInstanceOf[DecimalType])
-        throw new UnsupportedOperationException(s"Decimal type is not supported in ColumnarSorter.")
-      Field
-        .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
-    });
     val outputFieldList: List[Field] = outputAttributes.toList.map(expr => {
       val attr = ConverterUtils.getAttrFromExpr(expr)
       Field
         .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
     })
 
-    val sortFuncName = if (sortOrder.head.isAscending) {
-      "sortArraysToIndicesNullsFirstAsc"
-    } else {
-      "sortArraysToIndicesNullsFirstDesc"
+    val keyFieldList: List[Field] = sortOrder.toList.map(sort => {
+      val attr = ConverterUtils.getAttrFromExpr(sort.child)
+      if (attr.dataType.isInstanceOf[DecimalType])
+        throw new UnsupportedOperationException(s"Decimal type is not supported in ColumnarSorter.")
+      val field = Field
+        .nullable(s"${attr.name}#${attr.exprId.id}", CodeGeneration.getResultType(attr.dataType))
+      if (outputFieldList.indexOf(field) == -1) {
+        throw new UnsupportedOperationException(
+          s"ColumnarSorter not found ${attr.name}#${attr.exprId.id} in ${outputAttributes}")
+      }
+      field
+    });
+
+    /*
+    Get the sort directions and nulls order from SortOrder.
+    Directions: asc: true, desc: false
+    NullsOrder: NullsFirst: true, NullsLast: false
+    */
+    var directions = new ListBuffer[Boolean]()
+    var nullsOrder = new ListBuffer[Boolean]()
+    for (key <- sortOrder) {
+      val asc = key.isAscending
+      val nullOrdering = key.nullOrdering
+      directions += asc
+      nullsOrder += {
+        nullOrdering match {
+          case NullsFirst => true
+          case NullsLast => false
+        }
+      }
     }
+    val dirList = directions.toList
+    val nullList = nullsOrder.toList
+
+    val key_args_node = TreeBuilder.makeFunction("key_schema",
+      keyFieldList.map(field => {
+        TreeBuilder.makeField(field)
+      })
+        .asJava,
+      new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
+
+    val dir_node = TreeBuilder.makeFunction(
+      "sort_directions",
+      dirList.map(dir => {
+          TreeBuilder.makeLiteral(dir.asInstanceOf[java.lang.Boolean])
+        }).asJava,
+      new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
+
+    val nulls_order_node = TreeBuilder.makeFunction(
+      "sort_nulls_order",
+      nullList.map(nullsOrder => {
+        TreeBuilder.makeLiteral(nullsOrder.asInstanceOf[java.lang.Boolean])
+      }).asJava,
+      new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
+
+    val sortFuncName = "sortArraysToIndices"
+    val sort_func_node = TreeBuilder.makeFunction(
+      sortFuncName,
+      Lists.newArrayList(key_args_node, dir_node, nulls_order_node),
+      new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
 
     arrowSchema = new Schema(outputFieldList.asJava)
     ///////////////// prepare sort expression ////////////////
     val retType = Field.nullable("res", new ArrowType.Int(32, true))
     val sort_node = TreeBuilder.makeFunction(
-      sortFuncName,
-      keyFieldList.map(keyField => TreeBuilder.makeField(keyField)).asJava,
+      "standalone",
+      Lists.newArrayList(sort_func_node),
       new ArrowType.Int(32, true))
     sort_expr = TreeBuilder.makeExpression(sort_node, retType)
     /////////////////////////////////////////////////////

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -331,35 +331,8 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(
       RETURN_NOT_OK(
           HashRelationVisitorImpl::Make(field_list, func_node, ret_fields, p, &impl_));
     } else if (child_func_name.compare("sortArraysToIndices") == 0) {
-      // first child is key_schema
-      std::vector<std::shared_ptr<arrow::Field>> key_field_list;
-      auto sort_func_node =
-          std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[0]);
-      for (auto field : sort_func_node->children()) {
-        auto field_node = std::dynamic_pointer_cast<gandiva::FieldNode>(field);
-        key_field_list.push_back(field_node->field());
-      }
-      // second child is sort_directions
-      std::vector<bool> sort_directions;
-      auto sort_directions_node =
-          std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[1]);
-      for (auto direction : sort_directions_node->children()) {
-        auto dir_node = std::dynamic_pointer_cast<gandiva::LiteralNode>(direction);
-        bool dir_val = arrow::util::get<bool>(dir_node->holder());
-        sort_directions.push_back(dir_val);
-      }
-      // third child is nulls_order
-      std::vector<bool> nulls_order;
-      auto nulls_order_node =
-          std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[2]);
-      for (auto order : nulls_order_node->children()) {
-        auto order_node = std::dynamic_pointer_cast<gandiva::LiteralNode>(order);
-        bool order_val = arrow::util::get<bool>(order_node->holder());
-        nulls_order.push_back(order_val);
-      }
-      auto result_schema = arrow::schema(field_list);
-      RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(
-        p, &impl_, result_schema, key_field_list, sort_directions, nulls_order));
+      RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(field_list, func_node, 
+                                                         ret_fields, p, &impl_));
     }
     goto finish;
   }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -330,6 +330,36 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(
     } else if (child_func_name.compare("HashRelation") == 0) {
       RETURN_NOT_OK(
           HashRelationVisitorImpl::Make(field_list, func_node, ret_fields, p, &impl_));
+    } else if (child_func_name.compare("sortArraysToIndices") == 0) {
+      // first child is key_schema
+      std::vector<std::shared_ptr<arrow::Field>> key_field_list;
+      auto sort_func_node =
+          std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[0]);
+      for (auto field : sort_func_node->children()) {
+        auto field_node = std::dynamic_pointer_cast<gandiva::FieldNode>(field);
+        key_field_list.push_back(field_node->field());
+      }
+      // second child is sort_directions
+      std::vector<bool> sort_directions;
+      auto sort_directions_node =
+          std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[1]);
+      for (auto direction : sort_directions_node->children()) {
+        auto dir_node = std::dynamic_pointer_cast<gandiva::LiteralNode>(direction);
+        bool dir_val = arrow::util::get<bool>(dir_node->holder());
+        sort_directions.push_back(dir_val);
+      }
+      // third child is nulls_order
+      std::vector<bool> nulls_order;
+      auto nulls_order_node =
+          std::dynamic_pointer_cast<gandiva::FunctionNode>(func_node->children()[2]);
+      for (auto order : nulls_order_node->children()) {
+        auto order_node = std::dynamic_pointer_cast<gandiva::LiteralNode>(order);
+        bool order_val = arrow::util::get<bool>(order_node->holder());
+        nulls_order.push_back(order_val);
+      }
+      auto result_schema = arrow::schema(field_list);
+      RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(
+        p, &impl_, result_schema, key_field_list, sort_directions, nulls_order));
     }
     goto finish;
   }
@@ -455,22 +485,6 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(const std::string& func_name,
   }
   if (func_name.compare("encodeArray") == 0) {
     RETURN_NOT_OK(EncodeVisitorImpl::Make(p, &impl_));
-    goto finish;
-  }
-  if (func_name.compare("sortArraysToIndicesNullsFirstAsc") == 0) {
-    RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(p, &impl_, true, true));
-    goto finish;
-  }
-  if (func_name.compare("sortArraysToIndicesNullsLastAsc") == 0) {
-    RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(p, &impl_, false, true));
-    goto finish;
-  }
-  if (func_name.compare("sortArraysToIndicesNullsFirstDesc") == 0) {
-    RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(p, &impl_, true, false));
-    goto finish;
-  }
-  if (func_name.compare("sortArraysToIndicesNullsLastDesc") == 0) {
-    RETURN_NOT_OK(SortArraysToIndicesVisitorImpl::Make(p, &impl_, false, false));
     goto finish;
   }
   goto unrecognizedFail;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -539,30 +539,61 @@ class EncodeVisitorImpl : public ExprVisitorImpl {
 ////////////////////////// SortArraysToIndicesVisitorImpl ///////////////////////
 class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
  public:
-  SortArraysToIndicesVisitorImpl(ExprVisitor* p,
-                                 std::shared_ptr<arrow::Schema> result_schema,
-                                 std::vector<std::shared_ptr<arrow::Field>> key_field_list, 
-                                 std::vector<bool> sort_directions, 
-                                 std::vector<bool> nulls_order)
-      : ExprVisitorImpl(p), result_schema_(result_schema), 
-        key_field_list_(key_field_list), sort_directions_(sort_directions), 
-        nulls_order_(nulls_order) {}
-  static arrow::Status Make(ExprVisitor* p, std::shared_ptr<ExprVisitorImpl>* out,
-                            std::shared_ptr<arrow::Schema> result_schema,
-                            std::vector<std::shared_ptr<arrow::Field>> key_field_list,
-                            std::vector<bool> sort_directions, 
-                            std::vector<bool> nulls_order) {
-    auto impl = std::make_shared<SortArraysToIndicesVisitorImpl>(
-      p, result_schema, key_field_list, sort_directions, nulls_order);
+  SortArraysToIndicesVisitorImpl(std::vector<std::shared_ptr<arrow::Field>> field_list,
+                                 std::shared_ptr<gandiva::FunctionNode> root_node,
+                                 std::vector<std::shared_ptr<arrow::Field>> ret_fields,
+                                 ExprVisitor* p)
+      : root_node_(root_node),
+        field_list_(field_list),
+        ret_fields_(ret_fields),
+        ExprVisitorImpl(p) {
+    auto children = root_node->children();
+    // first child is key_function
+    sort_key_node_ =
+        std::dynamic_pointer_cast<gandiva::FunctionNode>(children[0])->children();
+    // second child is key_field
+    auto key_field_node =
+        std::dynamic_pointer_cast<gandiva::FunctionNode>(children[1]);
+    for (auto field : key_field_node->children()) {
+      auto field_node = std::dynamic_pointer_cast<gandiva::FieldNode>(field);
+      key_field_list_.push_back(field_node->field());
+    }
+    // third child is sort_directions
+    auto sort_directions_node =
+        std::dynamic_pointer_cast<gandiva::FunctionNode>(children[2]);
+    for (auto direction : sort_directions_node->children()) {
+      auto dir_node = std::dynamic_pointer_cast<gandiva::LiteralNode>(direction);
+      bool dir_val = arrow::util::get<bool>(dir_node->holder());
+      sort_directions_.push_back(dir_val);
+    }
+    // fourth child is nulls_order
+    auto nulls_order_node =
+        std::dynamic_pointer_cast<gandiva::FunctionNode>(children[3]);
+    for (auto order : nulls_order_node->children()) {
+      auto order_node = std::dynamic_pointer_cast<gandiva::LiteralNode>(order);
+      bool order_val = arrow::util::get<bool>(order_node->holder());
+      nulls_order_.push_back(order_val);
+    }
+    result_schema_ = arrow::schema(ret_fields);
+  }
+
+  static arrow::Status Make(std::vector<std::shared_ptr<arrow::Field>> field_list,
+                            std::shared_ptr<gandiva::FunctionNode> root_node,
+                            std::vector<std::shared_ptr<arrow::Field>> ret_fields,
+                            ExprVisitor* p, std::shared_ptr<ExprVisitorImpl>* out) {
+
+    auto impl = std::make_shared<SortArraysToIndicesVisitorImpl>(field_list, root_node, 
+                                                                 ret_fields, p);
     *out = impl;
     return arrow::Status::OK();
   }
+
   arrow::Status Init() override {
     if (initialized_) {
       return arrow::Status::OK();
     }
-    RETURN_NOT_OK(extra::SortArraysToIndicesKernel::Make(
-        &p_->ctx_, result_schema_, key_field_list_, sort_directions_, nulls_order_, &kernel_));
+    RETURN_NOT_OK(extra::SortArraysToIndicesKernel::Make(&p_->ctx_, result_schema_, 
+        sort_key_node_, key_field_list_, sort_directions_, nulls_order_, &kernel_));
     p_->signature_ = kernel_->GetSignature();
     initialized_ = true;
     finish_return_type_ = ArrowComputeResultType::BatchIterator;
@@ -604,10 +635,14 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
   }
 
  private:
-  std::shared_ptr<arrow::Schema> result_schema_;
+  std::shared_ptr<gandiva::FunctionNode> root_node_;
+  gandiva::FieldVector field_list_;
+  gandiva::FieldVector ret_fields_;
+  gandiva::NodeVector sort_key_node_;
   std::vector<std::shared_ptr<arrow::Field>> key_field_list_;
   std::vector<bool> sort_directions_;
   std::vector<bool> nulls_order_;
+  std::shared_ptr<arrow::Schema> result_schema_;
 };
 
 ////////////////////////// ConditionedProbeArraysVisitorImpl ///////////////////////

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -306,12 +306,14 @@ class SortArraysToIndicesKernel : public KernalBase {
  public:
   static arrow::Status Make(arrow::compute::FunctionContext* ctx,
                             std::shared_ptr<arrow::Schema> result_schema,
+                            gandiva::NodeVector sort_key_node,
                             std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                             std::vector<bool> sort_directions, 
                             std::vector<bool> nulls_order, 
                             std::shared_ptr<KernalBase>* out);
   SortArraysToIndicesKernel(arrow::compute::FunctionContext* ctx,
                             std::shared_ptr<arrow::Schema> result_schema,
+                            gandiva::NodeVector sort_key_node,
                             std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                             std::vector<bool> sort_directions, 
                             std::vector<bool> nulls_order);

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -305,13 +305,16 @@ class StddevSampFinalArrayKernel : public KernalBase {
 class SortArraysToIndicesKernel : public KernalBase {
  public:
   static arrow::Status Make(arrow::compute::FunctionContext* ctx,
-                            std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                             std::shared_ptr<arrow::Schema> result_schema,
-                            std::shared_ptr<KernalBase>* out, bool nulls_first, bool asc);
+                            std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+                            std::vector<bool> sort_directions, 
+                            std::vector<bool> nulls_order, 
+                            std::shared_ptr<KernalBase>* out);
   SortArraysToIndicesKernel(arrow::compute::FunctionContext* ctx,
-                            std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                             std::shared_ptr<arrow::Schema> result_schema,
-                            bool nulls_first, bool asc);
+                            std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+                            std::vector<bool> sort_directions, 
+                            std::vector<bool> nulls_order);
   arrow::Status Evaluate(const ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -1017,12 +1017,12 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>>
       }
     }
     if (asc_) {
+      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
+        return cached_key_[x.array_id]->GetString(x.id) < cached_key_[y.array_id]->GetString(y.id);};
       if (nulls_first_) {
-        ska_sort(indices_begin + nulls_total_, indices_begin + items_total_, 
-            [this](auto& x) -> decltype(auto){ return cached_key_[x.array_id]->GetString(x.id); });
+        std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
       } else {
-        ska_sort(indices_begin, indices_begin + items_total_ - nulls_total_, 
-            [this](auto& x) -> decltype(auto){ return cached_key_[x.array_id]->GetString(x.id); });
+        std::sort(indices_begin, indices_begin + items_total_ - nulls_total_, comp);
       }
     } else {
       auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
@@ -39,14 +39,16 @@ TEST(TestArrowComputeSort, SortTestNullsFirstAsc) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
-  auto n_key = TreeExprBuilder::MakeFunction(
-      "key_schema", {TreeExprBuilder::MakeField(f0)}, uint32());
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
   auto n_dir = TreeExprBuilder::MakeFunction(
       "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -125,14 +127,16 @@ TEST(TestArrowComputeSort, SortTestNullsLastAsc) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
-  auto n_key = TreeExprBuilder::MakeFunction(
-      "key_schema", {TreeExprBuilder::MakeField(f0)}, uint32());
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
   auto n_dir = TreeExprBuilder::MakeFunction(
       "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -209,14 +213,16 @@ TEST(TestArrowComputeSort, SortTestNullsFirstDesc) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
-  auto n_key = TreeExprBuilder::MakeFunction(
-      "key_schema", {TreeExprBuilder::MakeField(f0)}, uint32());
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
   auto n_dir = TreeExprBuilder::MakeFunction(
       "sort_directions", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -293,14 +299,16 @@ TEST(TestArrowComputeSort, SortTestNullsLastDesc) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
-  auto n_key = TreeExprBuilder::MakeFunction(
-      "key_schema", {TreeExprBuilder::MakeField(f0)}, uint32());
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
   auto n_dir = TreeExprBuilder::MakeFunction(
       "sort_directions", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -382,14 +390,16 @@ TEST(TestArrowComputeSort, SortTestMultipleKeys) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
-  auto n_key = TreeExprBuilder::MakeFunction(
-      "key_schema", {arg_0, arg_1, arg_2}, uint32());
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0, arg_1, arg_2}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0, arg_1, arg_2}, uint32());
   auto n_dir = TreeExprBuilder::MakeFunction(
       "sort_directions", {true_literal, false_literal, true_literal}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -406,14 +416,14 @@ TEST(TestArrowComputeSort, SortTestMultipleKeys) {
   std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
 
   std::vector<std::string> input_data_string = {"[8, 8, 4, 50, 52, 32, 11]",
-                                                R"(["null", "b", "a", "b", "b","b", "b"])",
+                                                R"([null, "b", "a", "b", "b","b", "b"])",
                                                 "[11, 10, 5, 51, null, 33, 12]",
                                                 "[1, 3, 5, 10, null, 13, 2]"};
   MakeInputBatch(input_data_string, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   std::vector<std::string> input_data_string_2 = {"[1, 14, 8, 42, 6, null, 2]",
-                                                  R"(["a", "a", "null", "b", "b","b", "b"])",
+                                                  R"(["a", "a", null, "b", "b","b", "b"])",
                                                   "[2, null, 44, 43, 7, 34, 3]",
                                                   "[9, 7, 5, 1, 5, null, 17]"};
   MakeInputBatch(input_data_string_2, sch, &input_batch);
@@ -445,7 +455,7 @@ TEST(TestArrowComputeSort, SortTestMultipleKeys) {
   std::vector<std::string> expected_result_string = {
       "[1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
       "22, 23, 30, 32, 33, 35, 37, 41, 42, 50, 52, 59, 64, null, null]",
-      R"(["a","b","a","a","b","b", "null", "null","b","b","b","a","b","b","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a","b","a"])",
+      R"(["a","b","a","a","b","b", null, null,"b","b","b","a","b","b","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a","b","a"])",
       "[2, 3, 4, 5, 7, 8, 11, 44, null, 10, 20, 16, 10, 12, 14, null, 18, 19, 21, 22, 23, "
       "24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65, 34, 67]",
       "[9, 17, 8, 5, 5, 3, 1, 5, 9, 3, 12, 2, 10, 2, 15, 7, 16, 51, null, 19, 5, "
@@ -482,14 +492,16 @@ TEST(TestArrowComputeSort, SortTestInPlace) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
-  auto n_key = TreeExprBuilder::MakeFunction(
-      "key_schema", {arg_0}, uint32());
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
   auto n_dir = TreeExprBuilder::MakeFunction(
       "sort_directions", {true_literal}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -564,14 +576,16 @@ TEST(TestArrowComputeSort, SortTestOneKeyStr) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
-  auto n_key = TreeExprBuilder::MakeFunction(
-      "key_schema", {arg_0}, uint32());
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
   auto n_dir = TreeExprBuilder::MakeFunction(
       "sort_directions", {true_literal}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -625,6 +639,224 @@ TEST(TestArrowComputeSort, SortTestOneKeyStr) {
           sort_result_iterator_base);
   std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
   std::shared_ptr<arrow::RecordBatch> result_batch;
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestOneKeyWithProjection) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", utf8());
+  auto f1 = field("f1", utf8());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_projection = TreeExprBuilder::MakeFunction(
+      "upper", {arg_0}, utf8());
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {n_projection}, uint32());    
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  std::vector<std::string> input_data_string = {
+    R"(["B", "q", "s", "T", null, null, "a"])",
+    R"(["a", "c", "e", "f", "g", null, "h"])"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+  std::vector<std::string> input_data_string_2 = {
+    R"([null, "F", "Q", "d", "r", null, "g"])",
+    R"(["a", "c", "e", "f", null, "j", "h"])"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+  std::vector<std::string> input_data_string_3 = {
+    R"(["p", "q", "o", "E", null, null, "l"])",
+    R"(["a", "c", "e", "f", "g","j", null])"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+  std::vector<std::string> input_data_string_4 = {
+    R"(["q", "W", "Z", "x", "y", null, "u"])",
+    R"(["a", "c", "e", "f", "g","j", "h"])"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+  std::vector<std::string> input_data_string_5 = {
+    R"(["a", "C", "b", "D", null, null, null])",
+    R"(["a", null, "e", "f", "g","j", "h"])"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      R"(["a","a","b","B","C","D","d","E","F","g","l","o","p","q","q","Q","q","r","s","T","u","W","x","y","Z",null,null,null,null,null,null,null,null,null,null])",
+      R"(["h","a","e","a",null,"f","f","f","c","h",null,"e","a","c","a","e","c",null,"e","f","h","c","f","g","e","g",null,"a","j","g","j","j","g","j","h"])"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  auto sort_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          sort_result_iterator_base);
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestMultipleKeysWithProjection) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", utf8());
+  auto f2 = field("f2", uint32());
+  auto f3 = field("f3", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto arg_2 = TreeExprBuilder::MakeField(f2);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  auto f_res = field("res", uint32());
+  auto f_bool = field("res", arrow::boolean());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto uint32_node = TreeExprBuilder::MakeLiteral((uint32_t)0);
+  auto str_node = TreeExprBuilder::MakeStringLiteral("");
+
+  auto isnotnull_0 = TreeExprBuilder::MakeFunction(
+      "isnotnull", {TreeExprBuilder::MakeField(f0)}, arrow::boolean());
+  auto coalesce_0 = TreeExprBuilder::MakeIf(
+      isnotnull_0, TreeExprBuilder::MakeField(f0), uint32_node, uint32());
+  auto isnull_0 = TreeExprBuilder::MakeFunction(
+      "isnull", {arg_0}, arrow::boolean());
+
+  auto isnotnull_1 = TreeExprBuilder::MakeFunction(
+      "isnotnull", {TreeExprBuilder::MakeField(f1)}, arrow::boolean());
+  auto coalesce_1 = TreeExprBuilder::MakeIf(
+      isnotnull_1, TreeExprBuilder::MakeField(f1), str_node, utf8());
+  auto isnull_1 = TreeExprBuilder::MakeFunction(
+      "isnull", {arg_1}, arrow::boolean());
+  
+  auto isnotnull_2 = TreeExprBuilder::MakeFunction(
+      "isnotnull", {TreeExprBuilder::MakeField(f2)}, arrow::boolean());
+  auto coalesce_2 = TreeExprBuilder::MakeIf(
+      isnotnull_2, TreeExprBuilder::MakeField(f2), uint32_node, uint32());
+  auto isnull_2 = TreeExprBuilder::MakeFunction(
+      "isnull", {arg_2}, arrow::boolean());
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {coalesce_0, isnull_0, coalesce_1, isnull_1, coalesce_2, isnull_2}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0, arg_0, arg_1, arg_1, arg_2, arg_2}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal, true_literal, false_literal, false_literal, 
+                          true_literal, true_literal,}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal, false_literal, true_literal, true_literal, 
+                           true_literal, true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1, f2, f3});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2, f3};
+  auto ret_schema = arrow::schema(ret_types);
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[8, 8, 4, 50, 52, 32, 11]",
+                                                R"([null, "b", "a", "b", "b","b", "b"])",
+                                                "[11, 10, 5, 51, null, 33, 12]",
+                                                "[1, 3, 5, 10, null, 13, 2]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 8, 42, 6, null, 2]",
+                                                  R"(["a", "a", null, "b", "b","b", "b"])",
+                                                  "[2, null, 44, 43, 7, 34, 3]",
+                                                  "[9, 7, 5, 1, 5, null, 17]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, 33]",
+                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  "[4, 65, 16, 8, 10, 20, 34]",
+                                                  "[8, 6, 2, 3, 10, 12, 15]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  "[24, 18, 42, 19, 21, 36, 31]",
+                                                  "[15, 16, 2, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  "[38, 67, 23, 14, null, 60, 22]",
+                                                  "[16, 17, 5, 15, 9, null, 19]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null, null, 1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
+      "22, 23, 30, 32, 33, 35, 37, 41, 42, 50, 52, 59, 64]",
+      R"(["b","a","a","b","a","a","b","b","b","b","b","a", null, null,"b","b","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a"])",
+      "[34, 67, 2, 3, 4, 5, 7, 8, null, 10, 20, 16, 11, 44, 10, 12, 14, null, 18, 19, 21, 22, 23, "
+      "24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65]",
+      "[null, 17, 9, 17, 8, 5, 5, 3, 9, 3, 12, 2, 1, 5, 10, 2, 15, 7, 16, 51, null, 19, 5, "
+      "15, 12, 13, 15, 33, 16, 2, 1, 10, null, null, 6]"};
+
+  MakeInputBatch(expected_result_string, ret_schema, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
   if (sort_result_iterator->HasNext()) {
     ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
     ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
@@ -39,9 +39,17 @@ TEST(TestArrowComputeSort, SortTestNullsFirstAsc) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
+  auto n_key = TreeExprBuilder::MakeFunction(
+      "key_schema", {TreeExprBuilder::MakeField(f0)}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndicesNullsFirstAsc", {arg_0}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
 
   auto sch = arrow::schema({f0, f1});
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
@@ -117,9 +125,17 @@ TEST(TestArrowComputeSort, SortTestNullsLastAsc) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
-  auto n_sort_to_indices =
-      TreeExprBuilder::MakeFunction("sortArraysToIndicesNullsLastAsc", {arg_0}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+  auto n_key = TreeExprBuilder::MakeFunction(
+      "key_schema", {TreeExprBuilder::MakeField(f0)}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
 
   auto sch = arrow::schema({f0, f1});
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
@@ -193,9 +209,17 @@ TEST(TestArrowComputeSort, SortTestNullsFirstDesc) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
+  auto n_key = TreeExprBuilder::MakeFunction(
+      "key_schema", {TreeExprBuilder::MakeField(f0)}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(false)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndicesNullsFirstDesc", {arg_0}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
 
   auto sch = arrow::schema({f0, f1});
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
@@ -269,9 +293,17 @@ TEST(TestArrowComputeSort, SortTestNullsLastDesc) {
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
+  auto n_key = TreeExprBuilder::MakeFunction(
+      "key_schema", {TreeExprBuilder::MakeField(f0)}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(false)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndicesNullsLastDesc", {arg_0}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
 
   auto sch = arrow::schema({f0, f1});
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
@@ -335,69 +367,89 @@ TEST(TestArrowComputeSort, SortTestNullsLastDesc) {
   }
 }
 
-TEST(TestArrowComputeSort, SortTestNullsFirstAscMultipleKeys) {
+TEST(TestArrowComputeSort, SortTestMultipleKeys) {
   ////////////////////// prepare expr_vector ///////////////////////
   auto f0 = field("f0", uint32());
   auto f1 = field("f1", utf8());
   auto f2 = field("f2", uint32());
+  auto f3 = field("f3", uint32());
   auto arg_0 = TreeExprBuilder::MakeField(f0);
   auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto arg_2 = TreeExprBuilder::MakeField(f2);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
   auto f_res = field("res", uint32());
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
+  auto n_key = TreeExprBuilder::MakeFunction(
+      "key_schema", {arg_0, arg_1, arg_2}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal, false_literal, true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndicesNullsFirstAsc", {arg_0, arg_1}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
 
-  auto sch = arrow::schema({f0, f1, f2});
-  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2};
+  auto sch = arrow::schema({f0, f1, f2, f3});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2, f3};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
   std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
 
-  std::vector<std::string> input_data_string = {"[8, 12, 4, 50, 52, 32, 11]",
-                                                R"(["a", "a", "a", "b", "b","b", "b"])",
-                                                "[11, 13, 5, 51, null, 33, 12]"};
+  std::vector<std::string> input_data_string = {"[8, 8, 4, 50, 52, 32, 11]",
+                                                R"(["null", "b", "a", "b", "b","b", "b"])",
+                                                "[11, 10, 5, 51, null, 33, 12]",
+                                                "[1, 3, 5, 10, null, 13, 2]"};
   MakeInputBatch(input_data_string, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   std::vector<std::string> input_data_string_2 = {"[1, 14, 8, 42, 6, null, 2]",
-                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
-                                                  "[2, null, 44, 43, 7, 34, 3]"};
+                                                  R"(["a", "a", "null", "b", "b","b", "b"])",
+                                                  "[2, null, 44, 43, 7, 34, 3]",
+                                                  "[9, 7, 5, 1, 5, null, 17]"};
   MakeInputBatch(input_data_string_2, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, 33]",
                                                   R"(["a", "a", "a", "b", "b","b", "b"])",
-                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+                                                  "[4, 65, 16, 8, 10, 20, 34]",
+                                                  "[8, 6, 2, 3, 10, 12, 15]"};
   MakeInputBatch(input_data_string_3, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
                                                   R"(["a", "a", "a", "b", "b","b", "b"])",
-                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+                                                  "[24, 18, 42, 19, 21, 36, 31]",
+                                                  "[15, 16, 2, 51, null, 33, 12]"};
   MakeInputBatch(input_data_string_4, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
                                                   R"(["a", "a", "a", "b", "b","b", "b"])",
-                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+                                                  "[38, 67, 23, 14, null, 60, 22]",
+                                                  "[16, 17, 5, 15, 9, null, 19]"};
   MakeInputBatch(input_data_string_5, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   ////////////////////////////////// calculation ///////////////////////////////////
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string = {
-      "[null, null, 1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 8, 9, 11, 12, 13, 14, 17, 18, 20, 21, "
-      "22, 23, 30, 32, 33, 35, 37, 41, 42, 50, 52, 59, 64]",
-      R"(["b","a","a","b","a","a","b","b","a","a","a","b","b","b","b","a","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a"])",
-      "[34, 67, 2, 3, 4, 5, 7, 8, 11, 44, 16, 9, 20, 10, 12, 13, 14, null, 18, 19, 21, "
-      "22, 23, 24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65]"};
+      "[1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
+      "22, 23, 30, 32, 33, 35, 37, 41, 42, 50, 52, 59, 64, null, null]",
+      R"(["a","b","a","a","b","b", "null", "null","b","b","b","a","b","b","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a","b","a"])",
+      "[2, 3, 4, 5, 7, 8, 11, 44, null, 10, 20, 16, 10, 12, 14, null, 18, 19, 21, 22, 23, "
+      "24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65, 34, 67]",
+      "[9, 17, 8, 5, 5, 3, 1, 5, 9, 3, 12, 2, 10, 2, 15, 7, 16, 51, null, 19, 5, "
+      "15, 12, 13, 15, 33, 16, 2, 1, 10, null, null, 6, null, 17]"};
 
   MakeInputBatch(expected_result_string, sch, &expected_result);
 
@@ -423,14 +475,24 @@ TEST(TestArrowComputeSort, SortTestInPlace) {
   ////////////////////// prepare expr_vector ///////////////////////
   auto f0 = field("f0", uint32());
   auto arg_0 = TreeExprBuilder::MakeField(f0);
-
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  
   auto f_res = field("res", uint32());
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
+  auto n_key = TreeExprBuilder::MakeFunction(
+      "key_schema", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndicesNullsFirstAsc", {arg_0}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
 
   auto sch = arrow::schema({f0});
   std::vector<std::shared_ptr<Field>> ret_types = {f0};
@@ -489,72 +551,80 @@ TEST(TestArrowComputeSort, SortTestInPlace) {
   }
 }
 
-TEST(TestArrowComputeSort, SortTestInPlaceStr) {
+TEST(TestArrowComputeSort, SortTestOneKeyStr) {
   ////////////////////// prepare expr_vector ///////////////////////
-  auto f0 = field("f1", utf8());
+  auto f0 = field("f0", utf8());
+  auto f1 = field("f1", utf8());
   auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
 
   auto f_res = field("res", uint32());
   auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
   auto f_indices = field("indices", indices_type);
 
+  auto n_key = TreeExprBuilder::MakeFunction(
+      "key_schema", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndicesNullsFirstAsc", {arg_0}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort_to_indices, f_res);
+      "sortArraysToIndices", {n_key, n_dir, n_nulls_order}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
 
-  auto sch = arrow::schema({f0});
-  std::vector<std::shared_ptr<Field>> ret_types = {f0};
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
   ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
-
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
   std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
   std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
-
-  std::vector<std::string> input_data_string = {R"(["a", "c", "e", "f", "g","j", "h"])"};
+  std::vector<std::string> input_data_string = {
+    R"(["b", "q", "s", "t", null, null, "a"])",
+    R"(["a", "c", "e", "f", "g", null, "h"])"};
   MakeInputBatch(input_data_string, sch, &input_batch);
   input_batch_list.push_back(input_batch);
-
   std::vector<std::string> input_data_string_2 = {
-      R"(["a", "a", "a", "u", "f","d", "b"])"};
+    R"([null, "f", "q", "d", "r", null, "g"])",
+    R"(["a", "c", "e", "f", null, "j", "h"])"};
   MakeInputBatch(input_data_string_2, sch, &input_batch);
   input_batch_list.push_back(input_batch);
-
   std::vector<std::string> input_data_string_3 = {
-      R"(["a", "e", "t", "w", "j","p", "o"])"};
+    R"(["p", "q", "o", "e", null, null, "l"])",
+    R"(["a", "c", "e", "f", "g","j", null])"};
   MakeInputBatch(input_data_string_3, sch, &input_batch);
   input_batch_list.push_back(input_batch);
-
   std::vector<std::string> input_data_string_4 = {
-      R"(["g", "a", "a", "t", "b","y", "q"])"};
+    R"(["q", "w", "z", "x", "y", null, "u"])",
+    R"(["a", "c", "e", "f", "g","j", "h"])"};
   MakeInputBatch(input_data_string_4, sch, &input_batch);
   input_batch_list.push_back(input_batch);
-
   std::vector<std::string> input_data_string_5 = {
-      R"(["a", "a", "y", "o", "s","x", "z"])"};
+    R"(["a", "c", "b", "d", null, null, null])",
+    R"(["a", null, "e", "f", "g","j", "h"])"};
   MakeInputBatch(input_data_string_5, sch, &input_batch);
   input_batch_list.push_back(input_batch);
-
   ////////////////////////////////// calculation ///////////////////////////////////
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string = {
-      R"(["a","a","a","a","a","a","a","a","a","b","b","c","d","e","e","f","f","g","g","h","j","j","o","o","p","q","s","t","t","u","w","x","y","y","z"])"};
+      R"(["a","a","b","b","c","d","d","e","f","g","l","o","p","q","q","q","q","r","s","t","u","w","x","y","z",null,null,null,null,null,null,null,null,null,null])",
+      R"(["h","a","e","a",null,"f","f","f","c","h",null,"e","a","c","a","e","c",null,"e","f","h","c","f","g","e","g",null,"a","j","g","j","j","g","j","h"])"};
   MakeInputBatch(expected_result_string, sch, &expected_result);
-
   for (auto batch : input_batch_list) {
     ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
   }
   ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
-
   auto sort_result_iterator =
       std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
           sort_result_iterator_base);
-
   std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
   std::shared_ptr<arrow::RecordBatch> result_batch;
-
   if (sort_result_iterator->HasNext()) {
     ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
     ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
@@ -416,21 +416,21 @@ TEST(TestArrowComputeSort, SortTestMultipleKeys) {
   std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
 
   std::vector<std::string> input_data_string = {"[8, 8, 4, 50, 52, 32, 11]",
-                                                R"([null, "b", "a", "b", "b","b", "b"])",
+                                                R"([null, "a", "a", "b", "b","b", "b"])",
                                                 "[11, 10, 5, 51, null, 33, 12]",
                                                 "[1, 3, 5, 10, null, 13, 2]"};
   MakeInputBatch(input_data_string, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   std::vector<std::string> input_data_string_2 = {"[1, 14, 8, 42, 6, null, 2]",
-                                                  R"(["a", "a", null, "b", "b","b", "b"])",
+                                                  R"(["a", "a", null, "b", "b", "a", "b"])",
                                                   "[2, null, 44, 43, 7, 34, 3]",
                                                   "[9, 7, 5, 1, 5, null, 17]"};
   MakeInputBatch(input_data_string_2, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, 33]",
-                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  R"(["a", "a", "b", "b", "b","b", "b"])",
                                                   "[4, 65, 16, 8, 10, 20, 34]",
                                                   "[8, 6, 2, 3, 10, 12, 15]"};
   MakeInputBatch(input_data_string_3, sch, &input_batch);
@@ -444,7 +444,7 @@ TEST(TestArrowComputeSort, SortTestMultipleKeys) {
   input_batch_list.push_back(input_batch);
 
   std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
-                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  R"(["a", "b", "a", "b", "b","b", "b"])",
                                                   "[38, 67, 23, 14, null, 60, 22]",
                                                   "[16, 17, 5, 15, 9, null, 19]"};
   MakeInputBatch(input_data_string_5, sch, &input_batch);
@@ -456,10 +456,10 @@ TEST(TestArrowComputeSort, SortTestMultipleKeys) {
       "[1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
       "22, 23, 30, 32, 33, 35, 37, 41, 42, 50, 52, 59, 64, null, null]",
       R"(["a","b","a","a","b","b", null, null,"b","b","b","a","b","b","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a","b","a"])",
-      "[2, 3, 4, 5, 7, 8, 11, 44, null, 10, 20, 16, 10, 12, 14, null, 18, 19, 21, 22, 23, "
-      "24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65, 34, 67]",
-      "[9, 17, 8, 5, 5, 3, 1, 5, 9, 3, 12, 2, 10, 2, 15, 7, 16, 51, null, 19, 5, "
-      "15, 12, 13, 15, 33, 16, 2, 1, 10, null, null, 6, null, 17]"};
+      "[2, 3, 4, 5, 7, 8, 11, 44, null, 16, 20, 10, 10, 12, 14, null, 18, 19, 21, 22, 23, "
+      "24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65, 67, 34]",
+      "[9, 17, 8, 5, 5, 3, 1, 5, 9, 2, 12, 3, 10, 2, 15, 7, 16, 51, null, 19, 5, "
+      "15, 12, 13, 15, 33, 16, 2, 1, 10, null, null, 6, 17, null]"};
 
   MakeInputBatch(expected_result_string, sch, &expected_result);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. support multiple keys w/ different sort directions and nulls first/last
2. support sort with projection inside
3. use std sort for string

Fixes https://github.com/Intel-bigdata/OAP/issues/1751, https://github.com/Intel-bigdata/OAP/issues/1742

## How was this patch tested?

locally tested
