### PR TITLE
[OAP-cache][OAP-1813][POAE7-481]package redis client related dependency

### DIFF
--- a/oap-cache/oap/pom.xml
+++ b/oap-cache/oap/pom.xml
@@ -430,6 +430,8 @@
           <shadedClassifierName>with-spark-${spark.internal.version}</shadedClassifierName>
           <artifactSet>
             <includes>
+              <include>redis.clients:*</include>
+              <include>org.apache.commons:commons-pool2</include>
               <include>org.spark-project.spark:unused</include>
               <include>com.google.guava:guava</include>
               <include>org.apache.parquet:*</include>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using redis as external DB service need redis related dependency, package these dependency into oap jar, then no need to copy releated jars to spark.jars folder

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

