### PR TITLE
[OAP-1824][SQL data source cache] Decouple DataSourceScanExec.scala

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/OapFileSourceScanExec.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/OapFileSourceScanExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{And, Ascending, Attribute, AttributeReference, BoundReference, Expression, PlanExpression, Predicate, SortOrder, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.datasources._

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/OapFileSourceScanExec.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/OapFileSourceScanExec.scala
@@ -1,151 +1,27 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.apache.spark.sql.execution
 
-import java.util.concurrent.TimeUnit._
+import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.collection.mutable.HashMap
 
-import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.{And, Ascending, Attribute, AttributeReference, BoundReference, Expression, PlanExpression, Predicate, SortOrder, UnsafeProjection}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, UnknownPartitioning}
-import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.oap.{OapFileFormat, OapMetricsManager}
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat => ParquetSource}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.BitSet
 
-trait DataSourceScanExec extends LeafExecNode {
-  val relation: BaseRelation
-  val tableIdentifier: Option[TableIdentifier]
-
-  protected val nodeNamePrefix: String = ""
-
-  override val nodeName: String = {
-    s"Scan $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
-  }
-
-  // Metadata that describes more details of this scan.
-  protected def metadata: Map[String, String]
-
-  override def simpleString(maxFields: Int): String = {
-    val metadataEntries = metadata.toSeq.sorted.map {
-      case (key, value) =>
-        key + ": " + StringUtils.abbreviate(redact(value), 100)
-    }
-    val metadataStr = truncatedString(metadataEntries, " ", ", ", "", maxFields)
-    redact(
-      s"$nodeNamePrefix$nodeName${truncatedString(output, "[", ",", "]", maxFields)}$metadataStr")
-  }
-
-  override def verboseStringWithOperatorId(): String = {
-    val metadataStr = metadata.toSeq.sorted.filterNot {
-      case (_, value) if (value.isEmpty || value.equals("[]")) => true
-      case (key, _) if (key.equals("DataFilters") || key.equals("Format")) => true
-      case (_, _) => false
-    }.map {
-      case (key, value) => s"$key: ${redact(value)}"
-    }
-
-    s"""
-       |$formattedNodeName
-       |${ExplainUtils.generateFieldString("Output", output)}
-       |${metadataStr.mkString("\n")}
-       |""".stripMargin
-  }
-
-  /**
-   * Shorthand for calling redactString() without specifying redacting rules
-   */
-  protected def redact(text: String): String = {
-    Utils.redact(sqlContext.sessionState.conf.stringRedactionPattern, text)
-  }
-
-  /**
-   * The data being read in.  This is to provide input to the tests in a way compatible with
-   * [[InputRDDCodegen]] which all implementations used to extend.
-   */
-  def inputRDDs(): Seq[RDD[InternalRow]]
-}
-
-/** Physical plan node for scanning data from a relation. */
-case class RowDataSourceScanExec(
-    fullOutput: Seq[Attribute],
-    requiredColumnsIndex: Seq[Int],
-    filters: Set[Filter],
-    handledFilters: Set[Filter],
-    rdd: RDD[InternalRow],
-    @transient relation: BaseRelation,
-    override val tableIdentifier: Option[TableIdentifier])
-  extends DataSourceScanExec with InputRDDCodegen {
-
-  def output: Seq[Attribute] = requiredColumnsIndex.map(fullOutput)
-
-  override lazy val metrics =
-    Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
-
-  protected override def doExecute(): RDD[InternalRow] = {
-    val numOutputRows = longMetric("numOutputRows")
-
-    rdd.mapPartitionsWithIndexInternal { (index, iter) =>
-      val proj = UnsafeProjection.create(schema)
-      proj.initialize(index)
-      iter.map( r => {
-        numOutputRows += 1
-        proj(r)
-      })
-    }
-  }
-
-  // Input can be InternalRow, has to be turned into UnsafeRows.
-  override protected val createUnsafeProjection: Boolean = true
-
-  override def inputRDD: RDD[InternalRow] = rdd
-
-  override val metadata: Map[String, String] = {
-    val markedFilters = for (filter <- filters) yield {
-      if (handledFilters.contains(filter)) s"*$filter" else s"$filter"
-    }
-    Map(
-      "ReadSchema" -> output.toStructType.catalogString,
-      "PushedFilters" -> markedFilters.mkString("[", ", ", "]"))
-  }
-
-  // Don't care about `rdd` and `tableIdentifier` when canonicalizing.
-  override def doCanonicalize(): SparkPlan =
-    copy(
-      fullOutput.map(QueryPlan.normalizeExpressions(_, fullOutput)),
-      rdd = null,
-      tableIdentifier = None)
-}
 
 /**
  * Physical plan node for scanning data from HadoopFsRelations.
@@ -158,7 +34,7 @@ case class RowDataSourceScanExec(
  * @param dataFilters Filters on non-partition columns.
  * @param tableIdentifier identifier for the table in the metastore.
  */
-case class FileSourceScanExec(
+case class OapFileSourceScanExec(
     @transient relation: HadoopFsRelation,
     output: Seq[Attribute],
     requiredSchema: StructType,
@@ -580,20 +456,7 @@ case class FileSourceScanExec(
       partition.files.flatMap { file =>
         // getPath() is very expensive so we only want to call it once in this block:
         val filePath = file.getPath
-        val isSplitable = relation.fileFormat.isSplitable(
-          relation.sparkSession, relation.options, filePath)
-        if (isSplitable) {
-          PartitionedFileUtil.splitFiles(
-            sparkSession = relation.sparkSession,
-            file = file,
-            filePath = filePath,
-            isSplitable = isSplitable,
-            maxSplitBytes = maxSplitBytes,
-            partitionValues = partition.values
-          )
-        } else {
-          CachedPartitionedFileUtil.splitFilesWithCacheLocality(file, filePath, partition.values)
-        }
+        CachedPartitionedFileUtil.splitFilesWithCacheLocality(file, filePath, partition.values)
       }
     }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
 
@@ -603,8 +466,8 @@ case class FileSourceScanExec(
     new FileScanRDD(fsRelation.sparkSession, readFile, partitions)
   }
 
-  override def doCanonicalize(): FileSourceScanExec = {
-    FileSourceScanExec(
+  override def doCanonicalize(): OapFileSourceScanExec = {
+    OapFileSourceScanExec(
       relation,
       output.map(QueryPlan.normalizeExpressions(_, output)),
       requiredSchema,

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/OapFileSourceScanExec.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/OapFileSourceScanExec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.execution
 
 import java.util.concurrent.TimeUnit.NANOSECONDS

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/OapFileSourceStrategy.scala
@@ -32,10 +32,10 @@ object OapFileSourceStrategy extends Strategy with Logging {
 
     /**
      * After call [[FileSourceStrategy]], the result [[SparkPlan]] should the follow 4 scenarios:
-     *  1. [[ProjectExec]] -> [[FilterExec]] -> [[OapFileSourceScanExec]]
-     *  2. [[ProjectExec]] -> [[OapFileSourceScanExec]]
-     *  3. [[FilterExec]] -> [[OapFileSourceScanExec]]
-     *  4. [[OapFileSourceScanExec]]
+     *  1. [[ProjectExec]] -> [[FilterExec]] -> [[FileSourceScanExec]]
+     *  2. [[ProjectExec]] -> [[FileSourceScanExec]]
+     *  3. [[FilterExec]] -> [[FileSourceScanExec]]
+     *  4. [[FileSourceScanExec]]
      * Classified discussion the 4 scenarios and assemble a new [[SparkPlan]] if can optimized.
      */
     def tryOptimize(head: SparkPlan): SparkPlan = {

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapFileSourceStrategySuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapFileSourceStrategySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.oap
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, ProjectExec, SparkPlan}
+import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, OapFileSourceScanExec, ProjectExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
@@ -78,10 +78,18 @@ abstract class OapFileSourceStrategySuite extends QueryTest with SharedOapContex
       assert(filter.children.length == 1)
 
       val scan = filter.children.head
-      assert(scan.isInstanceOf[FileSourceScanExec])
-      val relation = scan.asInstanceOf[FileSourceScanExec].relation
-      assert(relation.isInstanceOf[HadoopFsRelation])
-      assert(verifyFileFormat(relation.fileFormat))
+      var relation: HadoopFsRelation = null
+      try {
+        assert(scan.isInstanceOf[OapFileSourceScanExec])
+        relation = scan.asInstanceOf[OapFileSourceScanExec].relation
+      } catch {
+        case ex: Exception =>
+          assert(scan.isInstanceOf[FileSourceScanExec])
+          relation = scan.asInstanceOf[FileSourceScanExec].relation
+      } finally {
+        assert(relation.isInstanceOf[HadoopFsRelation])
+        assert(verifyFileFormat(relation.fileFormat))
+      }
 
       val sparkPlans = FileSourceStrategy(plan)
       assert(sparkPlans.size == 1)
@@ -107,10 +115,18 @@ abstract class OapFileSourceStrategySuite extends QueryTest with SharedOapContex
     assert(optimizedSparkPlan.children.length == 1)
 
     val scan = optimizedSparkPlan.children.head
-    assert(scan.isInstanceOf[FileSourceScanExec])
-    val relation = scan.asInstanceOf[FileSourceScanExec].relation
-    assert(relation.isInstanceOf[HadoopFsRelation])
-    assert(verifyFileFormat(relation.fileFormat))
+    var relation: HadoopFsRelation = null
+    try {
+      assert(scan.isInstanceOf[OapFileSourceScanExec])
+      relation = scan.asInstanceOf[OapFileSourceScanExec].relation
+    } catch {
+      case ex: Exception =>
+        assert(scan.isInstanceOf[FileSourceScanExec])
+        relation = scan.asInstanceOf[FileSourceScanExec].relation
+    } finally {
+      assert(relation.isInstanceOf[HadoopFsRelation])
+      assert(verifyFileFormat(relation.fileFormat))
+    }
 
     val sparkPlans = FileSourceStrategy(plan)
     assert(sparkPlans.size == 1)
@@ -129,8 +145,8 @@ abstract class OapFileSourceStrategySuite extends QueryTest with SharedOapContex
     val optimizedSparkPlans = OapFileSourceStrategy(plan)
     assert(optimizedSparkPlans.size == 1)
     val optimizedSparkPlan = optimizedSparkPlans.head
-    assert(optimizedSparkPlan.isInstanceOf[FileSourceScanExec])
-    val relation = optimizedSparkPlan.asInstanceOf[FileSourceScanExec].relation
+    assert(optimizedSparkPlan.isInstanceOf[OapFileSourceScanExec])
+    val relation = optimizedSparkPlan.asInstanceOf[OapFileSourceScanExec].relation
     assert(verifyFileFormat(relation.fileFormat))
 
     val sparkPlans = FileSourceStrategy(plan)

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapFileSourceStrategySuite.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/execution/datasources/oap/OapFileSourceStrategySuite.scala
@@ -51,6 +51,45 @@ abstract class OapFileSourceStrategySuite extends QueryTest with SharedOapContex
     sqlContext.dropTempTable(s"$testTableName")
   }
 
+  protected def verifyOapProjectFilterScan(
+      indexColumn: String,
+      verifyFileFormat: FileFormat => Boolean,
+      verifySparkPlan: (SparkPlan, SparkPlan) => Boolean): Unit = {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql(s"insert overwrite table $testTableName select * from t")
+
+    withIndex(TestIndex(s"$testTableName", "index1")) {
+      sql(s"create oindex index1 on $testTableName ($indexColumn)")
+      val plan =
+        sql(s"SELECT b FROM $testTableName WHERE b = 'this is test 1'")
+          .queryExecution.optimizedPlan
+      val optimizedSparkPlans = OapFileSourceStrategy(plan)
+      assert(optimizedSparkPlans.size == 1)
+
+      val optimizedSparkPlan = optimizedSparkPlans.head
+      assert(optimizedSparkPlan.isInstanceOf[ProjectExec])
+      assert(optimizedSparkPlan.children.nonEmpty)
+      assert(optimizedSparkPlan.children.length == 1)
+
+      val filter = optimizedSparkPlan.children.head
+      assert(filter.isInstanceOf[FilterExec])
+      assert(filter.children.nonEmpty)
+      assert(filter.children.length == 1)
+
+      val scan = filter.children.head
+      assert(scan.isInstanceOf[OapFileSourceScanExec])
+      val relation = scan.asInstanceOf[OapFileSourceScanExec].relation
+      assert(relation.isInstanceOf[HadoopFsRelation])
+      assert(verifyFileFormat(relation.fileFormat))
+
+      val sparkPlans = FileSourceStrategy(plan)
+      assert(sparkPlans.size == 1)
+      val sparkPlan = sparkPlans.head
+      assert(verifySparkPlan(sparkPlan, optimizedSparkPlan))
+    }
+  }
+
   protected def verifyProjectFilterScan(
       indexColumn: String,
       verifyFileFormat: FileFormat => Boolean,
@@ -78,24 +117,44 @@ abstract class OapFileSourceStrategySuite extends QueryTest with SharedOapContex
       assert(filter.children.length == 1)
 
       val scan = filter.children.head
-      var relation: HadoopFsRelation = null
-      try {
-        assert(scan.isInstanceOf[OapFileSourceScanExec])
-        relation = scan.asInstanceOf[OapFileSourceScanExec].relation
-      } catch {
-        case ex: Exception =>
-          assert(scan.isInstanceOf[FileSourceScanExec])
-          relation = scan.asInstanceOf[FileSourceScanExec].relation
-      } finally {
-        assert(relation.isInstanceOf[HadoopFsRelation])
-        assert(verifyFileFormat(relation.fileFormat))
-      }
+      assert(scan.isInstanceOf[FileSourceScanExec])
+      val relation = scan.asInstanceOf[FileSourceScanExec].relation
+      assert(relation.isInstanceOf[HadoopFsRelation])
+      assert(verifyFileFormat(relation.fileFormat))
 
       val sparkPlans = FileSourceStrategy(plan)
       assert(sparkPlans.size == 1)
       val sparkPlan = sparkPlans.head
       assert(verifySparkPlan(sparkPlan, optimizedSparkPlan))
     }
+  }
+
+  protected def verifyOapProjectScan(
+      verifyFileFormat: FileFormat => Boolean,
+      verifySparkPlan: (SparkPlan, SparkPlan) => Boolean): Unit = {
+    val data: Seq[(Int, String)] = (1 to 300).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    sql(s"insert overwrite table $testTableName select * from t")
+
+    val plan = sql(s"SELECT a FROM $testTableName").queryExecution.optimizedPlan
+    val optimizedSparkPlans = OapFileSourceStrategy(plan)
+    assert(optimizedSparkPlans.size == 1)
+
+    val optimizedSparkPlan = optimizedSparkPlans.head
+    assert(optimizedSparkPlan.isInstanceOf[ProjectExec])
+    assert(optimizedSparkPlan.children.nonEmpty)
+    assert(optimizedSparkPlan.children.length == 1)
+
+    val scan = optimizedSparkPlan.children.head
+    assert(scan.isInstanceOf[OapFileSourceScanExec])
+    val relation = scan.asInstanceOf[OapFileSourceScanExec].relation
+    assert(relation.isInstanceOf[HadoopFsRelation])
+    assert(verifyFileFormat(relation.fileFormat))
+
+    val sparkPlans = FileSourceStrategy(plan)
+    assert(sparkPlans.size == 1)
+    val sparkPlan = sparkPlans.head
+    assert(verifySparkPlan(sparkPlan, optimizedSparkPlan))
   }
 
   protected def verifyProjectScan(
@@ -115,18 +174,10 @@ abstract class OapFileSourceStrategySuite extends QueryTest with SharedOapContex
     assert(optimizedSparkPlan.children.length == 1)
 
     val scan = optimizedSparkPlan.children.head
-    var relation: HadoopFsRelation = null
-    try {
-      assert(scan.isInstanceOf[OapFileSourceScanExec])
-      relation = scan.asInstanceOf[OapFileSourceScanExec].relation
-    } catch {
-      case ex: Exception =>
-        assert(scan.isInstanceOf[FileSourceScanExec])
-        relation = scan.asInstanceOf[FileSourceScanExec].relation
-    } finally {
-      assert(relation.isInstanceOf[HadoopFsRelation])
-      assert(verifyFileFormat(relation.fileFormat))
-    }
+    assert(scan.isInstanceOf[FileSourceScanExec])
+    val relation = scan.asInstanceOf[FileSourceScanExec].relation
+    assert(relation.isInstanceOf[HadoopFsRelation])
+    assert(verifyFileFormat(relation.fileFormat))
 
     val sparkPlans = FileSourceStrategy(plan)
     assert(sparkPlans.size == 1)
@@ -163,7 +214,7 @@ class OapFileSourceStrategyForParquetSuite extends OapFileSourceStrategySuite {
   protected def fileFormat: String = "parquet"
 
   test("Project-> Filter -> Scan : Optimized") {
-    verifyProjectFilterScan(
+    verifyOapProjectFilterScan(
       indexColumn = "b",
       format => format.isInstanceOf[OptimizedParquetFileFormat],
       (plan1, plan2) => !plan1.sameResult(plan2)
@@ -180,7 +231,7 @@ class OapFileSourceStrategyForParquetSuite extends OapFileSourceStrategySuite {
 
   test("Project -> Scan : Optimized") {
     withSQLConf(OapConf.OAP_PARQUET_DATA_CACHE_ENABLED.key -> "true") {
-      verifyProjectScan(
+      verifyOapProjectScan(
         format => format.isInstanceOf[OptimizedParquetFileFormat],
         (plan1, plan2) => !plan1.sameResult(plan2)
       )
@@ -228,7 +279,7 @@ class OapFileSourceStrategyForOrcSuite extends OapFileSourceStrategySuite {
   protected def fileFormat: String = "orc"
 
   test("Project-> Filter -> Scan : Optimized") {
-    verifyProjectFilterScan(
+    verifyOapProjectFilterScan(
       indexColumn = "b",
       format => format.isInstanceOf[OptimizedOrcFileFormat],
       (plan1, plan2) => !plan1.sameResult(plan2)

--- a/oap-cache/oap/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
+++ b/oap-cache/oap/src/test/scala/org/apache/spark/sql/test/oap/SharedOapContext.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
 
 import org.apache.spark.sql.{OapExtensions, SparkSession}
-import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, SparkPlan}
+import org.apache.spark.sql.execution.{FilterExec, OapFileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.oap.{IndexType, OapFileFormat}
 import org.apache.spark.sql.internal.oap.OapConf
 import org.apache.spark.sql.oap.{OapDriverRuntime, OapRuntime}
@@ -78,7 +78,7 @@ trait SharedOapContextBase extends OapSharedSQLContext {
   protected def getOapFileFormat(sparkPlan: SparkPlan): Set[Option[OapFileFormat]] = {
     def getOapFileFormatFromSource(node: SparkPlan): Option[OapFileFormat] = {
       node match {
-        case f: FileSourceScanExec =>
+        case f: OapFileSourceScanExec =>
           f.relation.fileFormat match {
             case format: OapFileFormat =>
               Some(format)


### PR DESCRIPTION
Create OapFileSourceScanExec to replace FileSourceScanExec.
