### PR TITLE
[OAP-1828][oap-shuffle]Update PmofShuffleManager.scala log

### DIFF
--- a/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmofShuffleManager.scala
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmofShuffleManager.scala
@@ -9,7 +9,7 @@ import org.apache.spark.util.configuration.pmof.PmofConf
 import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv, TaskContext}
 
 private[spark] class PmofShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
-  logInfo("Initialize RdmaShuffleManager")
+  logInfo("Initialize PmofShuffleManager")
 
   if (!conf.getBoolean("spark.shuffle.spill", defaultValue = true)) {
     logWarning("spark.shuffle.spill was set to false")


### PR DESCRIPTION
The log content is inconsistent with the actual Class Name，it should be PmofShuffleManager.

## What changes were proposed in this pull request?
Fixed printing the wrong class name.
