### PR TITLE
[OAP-1818][SQL-Data-Source-Cache]Modify Spark webUI OAP Tab expressio…

### DIFF
--- a/oap-cache/oap/src/main/resources/oap/static/oap-template.html
+++ b/oap-cache/oap/src/main/resources/oap/static/oap-template.html
@@ -27,28 +27,28 @@ limitations under the License.
                     title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total size that PMem or DRAM has cached, including BackendCache and PendingCache size/the number of cache unit">TotalCache Size/Count</span>
+                    title="Total size that PMem or DRAM has cached, including Backend Cache and Pending Cache size/the number of cache unit">Total Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total size that Backend has cached, including DataCache and IndexCache
-                    size/the number of cache unit.">BackendCache Size/Count</span>
+                    title="Total size that Backend has cached, including Data Cache and Index Cache
+                    size/the number of cache unit.">Backend Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total cached Data Fiber size/the number of cache unit">DataCache Size/Count</span>
+                    title="Total cached Data Fiber size/the number of cache unit">Data Cache Size/Count</span>
           </th>
-          <th>DataCache Hit Rate(hit/miss)</th>
-          <th>DataCache Load/Eviction</th>
+          <th>Data Cache Hit Rate(hit/miss)</th>
+          <th>Data Cache Load/Eviction</th>
           <th><span data-toggle="tooltip"
                     title="average time of load data fiber">Data Load AvgTime(ms)</span></th>
           <th><span data-toggle="tooltip"
-                    title="Total cached Index Fiber size/the number of cache unit">IndexCache Size/Count</span>
+                    title="Total cached Index Fiber size/the number of cache unit">Index Cache Size/Count</span>
           </th>
-          <th>IndexCache Hit Rate(hit/miss)</th>
-          <th>IndexCache Load/Eviction</th>
+          <th>Index Cache Hit Rate(hit/miss)</th>
+          <th>Index Cache Load/Eviction</th>
           <th><span data-toggle="tooltip"
                     title="average time of load index fiber">Index Load AvgTime(ms)</span></th>
           <th><span data-toggle="tooltip"
-                    title="The size of caching in use/the number of cache unit">PendingCache Size/Count</span>
+                    title="The size of cache to be released/the number of cache unit">Pending Cache Size/Count</span>
           </th>
           </thead>
           <tbody>
@@ -67,25 +67,25 @@ limitations under the License.
             <th><span data-toggle="tooltip" data-placement="top" title="Status">Status</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
-              TotalCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="BackendCache Size/Count">
-                BackendCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="DataCache Size/Count">
-                DataCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="DataCache Hit Rate(hit/miss)">
-                DataCache Hit Rate(hit/miss)</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="DataCache Load/Eviction">
-                DataCache Load/Eviction</span></th>
+              Total Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Backend Cache Size/Count">
+                Backend Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Size/Count">
+                Data Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Hit Rate(hit/miss)">
+                Data Cache Hit Rate(hit/miss)</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Load/Eviction">
+                Data Cache Load/Eviction</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Data Load AvgTime">Data Load AvgTime(ms)</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="IndexCache Size/Count">
-                IndexCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="IndexCache Hit Rate(hit/miss)">
-                IndexCache Hit Rate(hit/miss)</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="IndexCache Load/Eviction">
-                IndexCache Load/Eviction</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Index Cache Size/Count">
+                Index Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Index Cache Hit Rate(hit/miss)">
+                Index Cache Hit Rate(hit/miss)</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Index Cache Load/Eviction">
+                Index Cache Load/Eviction</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Index Load AvgTime">Index Load AvgTime(ms)</span></th>
             <th><span data-toggle="tooltip" data-placement="top"
-                      title="PendingCache Size/Count">PendingCache Size/Count</span></th>
+                      title="Pending Cache Size/Count">Pending Cache Size/Count</span></th>
           </tr>
           </thead>
           <tbody>
@@ -105,20 +105,20 @@ limitations under the License.
                     title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total size that PMem or DRAM has cached, including BackendCache and PendingCache size/the number of cache unit">TotalCache Size/Count</span>
+                    title="Total size that PMem or DRAM has cached, including Backend Cache and Pending Cache size/the number of cache unit">Total Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total size that Backend has cached, including DataCache and IndexCache
-                    size/the number of cache unit.">BackendCache Size/Count</span>
+                    title="Total size that Backend has cached, including Data Cache and Index Cache
+                    size/the number of cache unit.">Backend Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total cached Data Fiber size/the number of cache unit">DataCache Size/Count</span>
+                    title="Total cached Data Fiber size/the number of cache unit">Data Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total cached Index Fiber size/the number of cache unit">IndexCache Size/Count</span>
+                    title="Total cached Index Fiber size/the number of cache unit">Index Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="The size of caching in use/the number of cache unit">PendingCache Size/Count</span>
+                    title="The size of cache to be released/the number of cache unit">Pending Cache Size/Count</span>
           </th>
           <th>Hit Rate(hit/miss)</th>
           <th>Load Count</th>
@@ -142,15 +142,15 @@ limitations under the License.
             <th><span data-toggle="tooltip" data-placement="top" title="Status">Status</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
-              TotalCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="BackendCache Size/Count">
-              BackendCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="DataCache Size/Count">
-              DataCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="IndexCache Size/Count">
-              IndexCache Size/Count</span></th>
+              Total Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Backend Cache Size/Count">
+              Backend Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Size/Count">
+              Data Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Index Cache Size/Count">
+              Index Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top"
-                      title="PendingCache Size/Count">PendingCache Size/Count</span></th>
+                      title="Pending Cache Size/Count">Pending Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Hit Rate (hit/miss)">Hit Rate
               (hit/miss)</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Load Count">Load Count</span></th>

--- a/oap-cache/oap/src/main/resources/oap/static/oap-template.html
+++ b/oap-cache/oap/src/main/resources/oap/static/oap-template.html
@@ -27,11 +27,11 @@ limitations under the License.
                     title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total size that PMem or DRAM has cached, including Backend Cache and Pending Cache size/the number of cache unit">Total Cache Size/Count</span>
+                    title="Total size that PMem or DRAM has cached, including Data&Index Cache and Unreleased Cache size/the number of cache unit">Total Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
                     title="Total size that Backend has cached, including Data Cache and Index Cache
-                    size/the number of cache unit.">Backend Cache Size/Count</span>
+                    size/the number of cache unit.">Data&Index Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
                     title="Total cached Data Fiber size/the number of cache unit">Data Cache Size/Count</span>
@@ -48,7 +48,7 @@ limitations under the License.
           <th><span data-toggle="tooltip"
                     title="average time of load index fiber">Index Load AvgTime(ms)</span></th>
           <th><span data-toggle="tooltip"
-                    title="The size of cache to be released/the number of cache unit">Pending Cache Size/Count</span>
+                    title="The size of cache to be released/the number of cache unit">Unreleased Cache Size/Count</span>
           </th>
           </thead>
           <tbody>
@@ -68,8 +68,8 @@ limitations under the License.
             <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
               Total Cache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="Backend Cache Size/Count">
-                Backend Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Data&Index Cache Size/Count">
+                Data&Index Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Size/Count">
                 Data Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Hit Rate(hit/miss)">
@@ -85,7 +85,7 @@ limitations under the License.
                 Index Cache Load/Eviction</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Index Load AvgTime">Index Load AvgTime(ms)</span></th>
             <th><span data-toggle="tooltip" data-placement="top"
-                      title="Pending Cache Size/Count">Pending Cache Size/Count</span></th>
+                      title="Unreleased Cache Size/Count">Unreleased Cache Size/Count</span></th>
           </tr>
           </thead>
           <tbody>
@@ -105,11 +105,11 @@ limitations under the License.
                     title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total size that PMem or DRAM has cached, including Backend Cache and Pending Cache size/the number of cache unit">Total Cache Size/Count</span>
+                    title="Total size that PMem or DRAM has cached, including Data&Index Cache and Unreleased Cache size/the number of cache unit">Total Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
                     title="Total size that Backend has cached, including Data Cache and Index Cache
-                    size/the number of cache unit.">Backend Cache Size/Count</span>
+                    size/the number of cache unit.">Data&Index Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
                     title="Total cached Data Fiber size/the number of cache unit">Data Cache Size/Count</span>
@@ -118,7 +118,7 @@ limitations under the License.
                     title="Total cached Index Fiber size/the number of cache unit">Index Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="The size of cache to be released/the number of cache unit">Pending Cache Size/Count</span>
+                    title="The size of cache to be released/the number of cache unit">Unreleased Cache Size/Count</span>
           </th>
           <th>Hit Rate(hit/miss)</th>
           <th>Load Count</th>
@@ -143,14 +143,14 @@ limitations under the License.
             <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
               Total Cache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="Backend Cache Size/Count">
-              Backend Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Data&Index Cache Size/Count">
+              Data&Index Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Size/Count">
               Data Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Index Cache Size/Count">
               Index Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top"
-                      title="Pending Cache Size/Count">Pending Cache Size/Count</span></th>
+                      title="Unreleased Cache Size/Count">Unreleased Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Hit Rate (hit/miss)">Hit Rate
               (hit/miss)</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Load Count">Load Count</span></th>

--- a/oap-cache/oap/src/main/resources/oap/static/oap-template.html
+++ b/oap-cache/oap/src/main/resources/oap/static/oap-template.html
@@ -26,20 +26,30 @@ limitations under the License.
           <th><span data-toggle="tooltip"
                     title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
           </th>
-          <th>Cache Size/Count</th>
-          <th>BackendCache Size/Count</th>
-          <th>DataCache Size/Count</th>
+          <th><span data-toggle="tooltip"
+                    title="Total size that PMem or DRAM has cached, including BackendCache and PendingCache size/the number of cache unit">TotalCache Size/Count</span>
+          </th>
+          <th><span data-toggle="tooltip"
+                    title="Total size that Backend has cached, including DataCache and IndexCache
+                    size/the number of cache unit.">BackendCache Size/Count</span>
+          </th>
+          <th><span data-toggle="tooltip"
+                    title="Total cached Data Fiber size/the number of cache unit">DataCache Size/Count</span>
+          </th>
           <th>DataCache Hit Rate(hit/miss)</th>
           <th>DataCache Load/Eviction</th>
           <th><span data-toggle="tooltip"
                     title="average time of load data fiber">Data Load AvgTime(ms)</span></th>
-          <th>IndexCache Size/Count</th>
+          <th><span data-toggle="tooltip"
+                    title="Total cached Index Fiber size/the number of cache unit">IndexCache Size/Count</span>
+          </th>
           <th>IndexCache Hit Rate(hit/miss)</th>
           <th>IndexCache Load/Eviction</th>
           <th><span data-toggle="tooltip"
                     title="average time of load index fiber">Index Load AvgTime(ms)</span></th>
-          <th>PendingCache Size/Count</th>
-
+          <th><span data-toggle="tooltip"
+                    title="The size of caching in use/the number of cache unit">PendingCache Size/Count</span>
+          </th>
           </thead>
           <tbody>
           </tbody>
@@ -57,25 +67,25 @@ limitations under the License.
             <th><span data-toggle="tooltip" data-placement="top" title="Status">Status</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
-                Cache Size/Count</span></th>
+              TotalCache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="BackendCache Size/Count">
                 BackendCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="DataFiber Size/Count">
+            <th><span data-toggle="tooltip" data-placement="top" title="DataCache Size/Count">
                 DataCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="DataFiber Hit Rate(hit/miss)">
+            <th><span data-toggle="tooltip" data-placement="top" title="DataCache Hit Rate(hit/miss)">
                 DataCache Hit Rate(hit/miss)</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="DataFiber Load/Eviction">
+            <th><span data-toggle="tooltip" data-placement="top" title="DataCache Load/Eviction">
                 DataCache Load/Eviction</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Data Load AvgTime">Data Load AvgTime(ms)</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="IndexFiber Size/Count">
+            <th><span data-toggle="tooltip" data-placement="top" title="IndexCache Size/Count">
                 IndexCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="IndexFiber Hit Rate(hit/miss)">
+            <th><span data-toggle="tooltip" data-placement="top" title="IndexCache Hit Rate(hit/miss)">
                 IndexCache Hit Rate(hit/miss)</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="IndexFiber Load/Eviction">
+            <th><span data-toggle="tooltip" data-placement="top" title="IndexCache Load/Eviction">
                 IndexCache Load/Eviction</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Index Load AvgTime">Index Load AvgTime(ms)</span></th>
             <th><span data-toggle="tooltip" data-placement="top"
-                      title="PendingFiber Size/Count">PendingCache Size/Count</span></th>
+                      title="PendingCache Size/Count">PendingCache Size/Count</span></th>
           </tr>
           </thead>
           <tbody>
@@ -94,11 +104,22 @@ limitations under the License.
           <th><span data-toggle="tooltip"
                     title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
           </th>
-          <th>Cache Size/Count</th>
-          <th>BackendCache Size/Count</th>
-          <th>DataFiber Size/Count</th>
-          <th>IndexFiber Size/Count</th>
-          <th>PendingFiber Size/Count</th>
+          <th><span data-toggle="tooltip"
+                    title="Total size that PMem or DRAM has cached, including BackendCache and PendingCache size/the number of cache unit">TotalCache Size/Count</span>
+          </th>
+          <th><span data-toggle="tooltip"
+                    title="Total size that Backend has cached, including DataCache and IndexCache
+                    size/the number of cache unit.">BackendCache Size/Count</span>
+          </th>
+          <th><span data-toggle="tooltip"
+                    title="Total cached Data Fiber size/the number of cache unit">DataCache Size/Count</span>
+          </th>
+          <th><span data-toggle="tooltip"
+                    title="Total cached Index Fiber size/the number of cache unit">IndexCache Size/Count</span>
+          </th>
+          <th><span data-toggle="tooltip"
+                    title="The size of caching in use/the number of cache unit">PendingCache Size/Count</span>
+          </th>
           <th>Hit Rate(hit/miss)</th>
           <th>Load Count</th>
           <th><span data-toggle="tooltip"
@@ -121,15 +142,15 @@ limitations under the License.
             <th><span data-toggle="tooltip" data-placement="top" title="Status">Status</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
-              Cache Size/Count</span></th>
+              TotalCache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="BackendCache Size/Count">
               BackendCache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="DataFiber Size/Count">
-              DataFiber Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="IndexFiber Size/Count">
-              IndexFiber Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="DataCache Size/Count">
+              DataCache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="IndexCache Size/Count">
+              IndexCache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top"
-                      title="PendingFiber Size/Count">PendingFiber Size/Count</span></th>
+                      title="PendingCache Size/Count">PendingCache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Hit Rate (hit/miss)">Hit Rate
               (hit/miss)</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Load Count">Load Count</span></th>

--- a/oap-cache/oap/src/main/resources/oap/static/oap-template.html
+++ b/oap-cache/oap/src/main/resources/oap/static/oap-template.html
@@ -27,11 +27,11 @@ limitations under the License.
                     title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total size that PMem or DRAM has cached, including Data&Index Cache and Unreleased Cache size/the number of cache unit">Total Cache Size/Count</span>
+                    title="Total size that PMem or DRAM has cached, including Data & Index Cache and Unreleased Cache size/the number of cache unit">Total Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
                     title="Total size that Backend has cached, including Data Cache and Index Cache
-                    size/the number of cache unit.">Data&Index Cache Size/Count</span>
+                    size/the number of cache unit.">Data & Index Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
                     title="Total cached Data Fiber size/the number of cache unit">Data Cache Size/Count</span>
@@ -68,8 +68,8 @@ limitations under the License.
             <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
               Total Cache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="Data&Index Cache Size/Count">
-                Data&Index Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Data & Index Cache Size/Count">
+                Data & Index Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Size/Count">
                 Data Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Hit Rate(hit/miss)">
@@ -105,11 +105,11 @@ limitations under the License.
                     title="Memory used / total available memory for storage of data like RDD partitions cached in memory. ">Storage Memory</span>
           </th>
           <th><span data-toggle="tooltip"
-                    title="Total size that PMem or DRAM has cached, including Data&Index Cache and Unreleased Cache size/the number of cache unit">Total Cache Size/Count</span>
+                    title="Total size that PMem or DRAM has cached, including Data & Index Cache and Unreleased Cache size/the number of cache unit">Total Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
                     title="Total size that Backend has cached, including Data Cache and Index Cache
-                    size/the number of cache unit.">Data&Index Cache Size/Count</span>
+                    size/the number of cache unit.">Data & Index Cache Size/Count</span>
           </th>
           <th><span data-toggle="tooltip"
                     title="Total cached Data Fiber size/the number of cache unit">Data Cache Size/Count</span>
@@ -143,8 +143,8 @@ limitations under the License.
             <th><span data-toggle="tooltip" data-placement="top" title="Storage Memory">Storage Memory</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="CacheSize/Count">
               Total Cache Size/Count</span></th>
-            <th><span data-toggle="tooltip" data-placement="top" title="Data&Index Cache Size/Count">
-              Data&Index Cache Size/Count</span></th>
+            <th><span data-toggle="tooltip" data-placement="top" title="Data & Index Cache Size/Count">
+              Data & Index Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Data Cache Size/Count">
               Data Cache Size/Count</span></th>
             <th><span data-toggle="tooltip" data-placement="top" title="Index Cache Size/Count">


### PR DESCRIPTION
…ns more user friendly

## What changes were proposed in this pull request?

Fix: #1818 

The Spark webUI OAP Tab is modified to be like picture below, and we have 2 targets to achieve:
1.	Make terms more user friendly
2.	Add explanations to these terms
Here, main modifications are listed below,
• Cache Size/Count --> Total Cache Size/Count: Total size that PMem or DRAM has cached, including Data & Index Cache and Unreleased Cache size/the number of cache unit
• BackendCache Size/Count --> Data & Index Cache Size/Count: Total size that Backend has cached, including Data Cache and Index Cache size/the number of cache unit
• DataFiber Size/Count --> Data Cache Size/Count: Total cached Data Fiber size/the number of cache unit
• IndexFiber Size/Count --> Index Cache Size/Count: Total cached Index Fiber size/the number of cache unit
• PendingFiber Size/Count --> Unreleased Cache Size/Count: The size of cache to be released/the number of cache unit


![image](https://user-images.githubusercontent.com/30172512/97386521-f83e4880-190e-11eb-8abf-129f1b7c86c4.png)

![image](https://user-images.githubusercontent.com/30172512/97384999-cb3c6680-190b-11eb-9bb1-da82871b9a2f.png)






## How was this patch tested?

Check TPC-DS Spark webUI

