### PR TITLE
[OAP-1833][oap-native-sql][Scala] fix CoalesceBatchs after HashAgg

### DIFF
--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -404,7 +404,9 @@ case class AdaptiveSparkPlanExec(
         if (columnarBHJEnabled && parent.isInstanceOf[BroadcastHashJoinExec]) {
           val columnarExchangeChild = b.child match {
             case WholeStageCodegenExec(child: ColumnarToRowExec) =>
-              CoalesceBatchesExec(child.child)
+              //CoalesceBatchesExec(child.child)
+              //TODO:() enable this when fixing hashagg hasNext
+              child.child
             case child: ColumnarToRowExec =>
               CoalesceBatchesExec(child.child)
             case child => {


### PR DESCRIPTION


(Please fill in changes proposed in this fix)

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

Remove Coalescebatches after Hashagg. This patch is a quick fix for hashAgg hasNext bug. 
 
related https://github.com/Intel-bigdata/OAP/issues/1833

## How was this patch tested?

locally tested
