### PR TITLE
[OAP-1835][oap-native-sql] Support ColumnarBHJ to build and broadcast hashrelation

### DIFF
--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/BatchIterator.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/BatchIterator.java
@@ -32,21 +32,26 @@ import org.apache.arrow.vector.ipc.message.MessageSerializer;
 public class BatchIterator {
   private native boolean nativeHasNext(long nativeHandler);
   private native ArrowRecordBatchBuilder nativeNext(long nativeHandler);
-  private native ArrowRecordBatchBuilder nativeProcess(long nativeHandler, byte[] schemaBuf, int numRows, long[] bufAddrs, long[] bufSizes);
-  private native void nativeProcessAndCacheOne(long nativeHandler, byte[] schemaBuf, int numRows, long[] bufAddrs, long[] bufSizes);
-  private native ArrowRecordBatchBuilder nativeProcessWithSelection(long nativeHandler, byte[] schemaBuf, int numRows, long[] bufAddrs, long[] bufSizes,
+  private native ArrowRecordBatchBuilder nativeProcess(long nativeHandler,
+      byte[] schemaBuf, int numRows, long[] bufAddrs, long[] bufSizes);
+  private native void nativeProcessAndCacheOne(long nativeHandler, byte[] schemaBuf,
+      int numRows, long[] bufAddrs, long[] bufSizes);
+  private native ArrowRecordBatchBuilder nativeProcessWithSelection(long nativeHandler,
+      byte[] schemaBuf, int numRows, long[] bufAddrs, long[] bufSizes,
       int selectionVectorRecordCount, long selectionVectorAddr, long selectionVectorSize);
-  private native void nativeProcessAndCacheOneWithSelection(long nativeHandler, byte[] schemaBuf, int numRows, long[] bufAddrs, long[] bufSizes,
+  private native void nativeProcessAndCacheOneWithSelection(long nativeHandler,
+      byte[] schemaBuf, int numRows, long[] bufAddrs, long[] bufSizes,
       int selectionVectorRecordCount, long selectionVectorAddr, long selectionVectorSize);
   private native void nativeSetDependencies(long nativeHandler, long[] dependencies);
-
+  private native NativeSerializableObject nativeNextHashRelation(long nativeHandler);
+  private native void nativeSetHashRelation(
+      long nativeHandler, long[] memoryAddrs, int[] sizes);
   private native void nativeClose(long nativeHandler);
 
   private long nativeHandler = 0;
   private boolean closed = false;
 
-  public BatchIterator() throws IOException {
-  }
+  public BatchIterator() throws IOException {}
 
   public BatchIterator(long instance_id) throws IOException {
     JniUtils.getInstance();
@@ -70,7 +75,25 @@ public class BatchIterator {
     return resRecordBatchBuilderImpl.build();
   }
 
-  public ArrowRecordBatch process(Schema schema, ArrowRecordBatch recordBatch) throws IOException {
+  public SerializableObject nextHashRelationObject() throws IOException {
+    if (nativeHandler == 0) {
+      return null;
+    }
+    NativeSerializableObject obj = nativeNextHashRelation(nativeHandler);
+    SerializableObject objImpl = new SerializableObject(obj);
+    return objImpl;
+  }
+
+  public void setHashRelationObject(SerializableObject obj) throws IOException {
+    if (nativeHandler == 0) {
+      return;
+    }
+    // pass directbuffer memory to below function
+    nativeSetHashRelation(nativeHandler, obj.getDirectMemoryAddrs(), obj.size);
+  }
+
+  public ArrowRecordBatch process(Schema schema, ArrowRecordBatch recordBatch)
+      throws IOException {
     return process(schema, recordBatch, null);
   }
 
@@ -101,11 +124,12 @@ public class BatchIterator {
       int selectionVectorRecordCount = selectionVector.getRecordCount();
       long selectionVectorAddr = selectionVector.getBuffer().memoryAddress();
       long selectionVectorSize = selectionVector.getBuffer().capacity();
-      resRecordBatchBuilder = nativeProcessWithSelection(
-        nativeHandler, getSchemaBytesBuf(schema), num_rows, bufAddrs, bufSizes, 
-        selectionVectorRecordCount, selectionVectorAddr, selectionVectorSize);
+      resRecordBatchBuilder = nativeProcessWithSelection(nativeHandler,
+          getSchemaBytesBuf(schema), num_rows, bufAddrs, bufSizes,
+          selectionVectorRecordCount, selectionVectorAddr, selectionVectorSize);
     } else {
-      resRecordBatchBuilder = nativeProcess(nativeHandler, getSchemaBytesBuf(schema), num_rows, bufAddrs, bufSizes);
+      resRecordBatchBuilder = nativeProcess(
+          nativeHandler, getSchemaBytesBuf(schema), num_rows, bufAddrs, bufSizes);
     }
     if (resRecordBatchBuilder == null) {
       return null;
@@ -115,11 +139,12 @@ public class BatchIterator {
     return resRecordBatchBuilderImpl.build();
   }
 
-  public void processAndCacheOne(Schema schema, ArrowRecordBatch recordBatch) throws IOException {
+  public void processAndCacheOne(Schema schema, ArrowRecordBatch recordBatch)
+      throws IOException {
     processAndCacheOne(schema, recordBatch, null);
   }
 
-  public void processAndCacheOne(Schema schema, ArrowRecordBatch recordBatch, 
+  public void processAndCacheOne(Schema schema, ArrowRecordBatch recordBatch,
       SelectionVectorInt16 selectionVector) throws IOException {
     int num_rows = recordBatch.getLength();
     List<ArrowBuf> buffers = recordBatch.getBuffers();
@@ -145,22 +170,22 @@ public class BatchIterator {
       int selectionVectorRecordCount = selectionVector.getRecordCount();
       long selectionVectorAddr = selectionVector.getBuffer().memoryAddress();
       long selectionVectorSize = selectionVector.getBuffer().capacity();
-      nativeProcessAndCacheOneWithSelection(
-          nativeHandler, getSchemaBytesBuf(schema), num_rows, bufAddrs, bufSizes,
-          selectionVectorRecordCount, selectionVectorAddr, selectionVectorSize);
+      nativeProcessAndCacheOneWithSelection(nativeHandler, getSchemaBytesBuf(schema),
+          num_rows, bufAddrs, bufSizes, selectionVectorRecordCount, selectionVectorAddr,
+          selectionVectorSize);
     } else {
-      nativeProcessAndCacheOne(nativeHandler, getSchemaBytesBuf(schema), num_rows, bufAddrs, bufSizes);
+      nativeProcessAndCacheOne(
+          nativeHandler, getSchemaBytesBuf(schema), num_rows, bufAddrs, bufSizes);
     }
   }
 
-  public void setDependencies(BatchIterator[] dependencies){
+  public void setDependencies(BatchIterator[] dependencies) {
     long[] instanceIdList = new long[dependencies.length];
     for (int i = 0; i < dependencies.length; i++) {
       instanceIdList[i] = dependencies[i].getInstanceId();
     }
     nativeSetDependencies(nativeHandler, instanceIdList);
   }
-
 
   public void close() {
     if (!closed) {
@@ -178,5 +203,4 @@ public class BatchIterator {
   long getInstanceId() {
     return nativeHandler;
   }
-
 }

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/BatchIterator.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/BatchIterator.java
@@ -75,7 +75,8 @@ public class BatchIterator {
     return resRecordBatchBuilderImpl.build();
   }
 
-  public SerializableObject nextHashRelationObject() throws IOException {
+  public SerializableObject nextHashRelationObject()
+      throws IOException, ClassNotFoundException {
     if (nativeHandler == 0) {
       return null;
     }

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/NativeSerializableObject.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/NativeSerializableObject.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.vectorized;
+
+/** ArrowBufBuilder. */
+public class NativeSerializableObject {
+  public int[] size;
+  public long[] memoryAddress;
+
+  /**
+   * Create an instance for NativeSerializableObject.
+   *
+   * @param memoryAddress native ArrowBuf data addr.
+   * @param size ArrowBuf size.
+   */
+  public NativeSerializableObject(long[] memoryAddress, int[] size) {
+    this.memoryAddress = memoryAddress;
+    this.size = size;
+  }
+}

--- a/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SerializableObject.java
+++ b/oap-native-sql/core/src/main/java/com/intel/oap/vectorized/SerializableObject.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.vectorized;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+/** ArrowBufBuilder. */
+public class SerializableObject implements Serializable {
+  public int total_size;
+  public int[] size;
+  public byte[] data;
+  private transient ByteBuf[] directAddrs;
+  private transient ByteBufAllocator allocator;
+
+  /**
+   * Create an instance for NativeSerializableObject.
+   *
+   * @param memoryAddress native ArrowBuf data addr.
+   * @param size ArrowBuf size.
+   */
+  public SerializableObject(long[] memoryAddress, int[] size) throws IOException {
+    this.total_size = 0;
+    this.size = size;
+    ByteBuf[] bufList = new ByteBuf[size.length];
+    for (int i = 0; i < size.length; i++) {
+      this.total_size += size[i];
+      bufList[i] = Unpooled.wrappedBuffer(memoryAddress[i], size[i], false);
+    }
+
+    this.data = new byte[this.total_size];
+    int off = 0;
+    for (int i = 0; i < size.length; i++) {
+      ByteBufInputStream in = new ByteBufInputStream(bufList[i]);
+      in.read(data, off, size[i]);
+      off += size[i];
+    }
+  }
+
+  /**
+   * Create an instance for NativeSerializableObject.
+   *
+   * @param memoryAddress native ArrowBuf data addr.
+   * @param size ArrowBuf size.
+   */
+  public SerializableObject(NativeSerializableObject obj) throws IOException {
+    this(obj.memoryAddress, obj.size);
+  }
+
+  public long[] getDirectMemoryAddrs() throws IOException {
+    if (directAddrs == null) {
+      allocator = UnpooledByteBufAllocator.DEFAULT;
+      directAddrs = new ByteBuf[size.length];
+      int pos = 0;
+      for (int i = 0; i < size.length; i++) {
+        directAddrs[i] = allocator.directBuffer(size[i], size[i]);
+        OutputStream out = new ByteBufOutputStream(directAddrs[i]);
+        out.write(data, pos, size[i]);
+        pos += size[i];
+        out.close();
+      }
+    }
+    long[] addrs = new long[size.length];
+    for (int i = 0; i < size.length; i++) {
+      addrs[i] = directAddrs[i].memoryAddress();
+    }
+    return addrs;
+  }
+
+  public void releaseDirectMemory() {
+    if (directAddrs != null) {
+      for (int i = 0; i < directAddrs.length; i++) {
+        directAddrs[i].release();
+      }
+    }
+  }
+
+  public int getRefCnt() {
+    if (directAddrs != null) {
+      return directAddrs[0].refCnt();
+    }
+    return 0;
+  }
+}

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -45,6 +45,8 @@ class ColumnarPluginConfig(conf: SparkConf) {
     conf.getInt("spark.sql.execution.arrow.maxRecordsPerBatch", defaultValue = 10000)
   val tmpFile: String =
     conf.getOption("spark.sql.columnar.tmp_dir").getOrElse(null)
+  val broadcastCacheTimeout: Int =
+    conf.getInt("spark.sql.columnar.sort.broadcast.cache.timeout", defaultValue = -1)
 }
 
 object ColumnarPluginConfig {

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/BroadcastColumnarRDD.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/BroadcastColumnarRDD.scala
@@ -23,6 +23,7 @@ import com.intel.oap.vectorized.CloseableColumnBatchIterator
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.vectorized.ColumnarBatch

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBasicPhysicalOperators.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBasicPhysicalOperators.scala
@@ -173,8 +173,7 @@ case class ColumnarConditionProjectExec(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "numOutputBatches" -> SQLMetrics.createMetric(sparkContext, "output_batches"),
     "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "input_batches"),
-    "processTime" -> SQLMetrics.createTimingMetric(sparkContext, "totaltime_condproject"),
-    "buildTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to build hash map"))
+    "processTime" -> SQLMetrics.createTimingMetric(sparkContext, "totaltime_condproject"))
 
   ColumnarConditionProjector.prebuild(condition, projectList, child.output)
 

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBroadcastHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarBroadcastHashJoinExec.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
-import org.apache.spark.sql.execution.{BinaryExecNode, CodegenSupport, SparkPlan}
+import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.SQLMetrics
 
 import scala.collection.JavaConverters._

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashedRelation.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarHashedRelation.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.execution
+
+import java.io._
+import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.intel.oap.expression.ConverterUtils
+import com.intel.oap.vectorized.{ArrowWritableColumnVector, SerializableObject}
+import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
+
+class ColumnarHashedRelation(
+    var hashRelationObj: SerializableObject,
+    var arrowColumnarBatch: Array[ColumnarBatch],
+    var arrowColumnarBatchSize: Int)
+    extends Externalizable
+    with KryoSerializable
+    with AutoCloseable {
+
+  def this() = {
+    this(null, null, 0)
+  }
+
+  def asReadOnlyCopy(): ColumnarHashedRelation = {
+    new ColumnarHashedRelation(hashRelationObj, arrowColumnarBatch, arrowColumnarBatchSize)
+  }
+
+  override def close(): Unit = {
+    hashRelationObj.close
+    arrowColumnarBatch.foreach(_.close)
+    System.out.println("ColumnarHashedRelation closed")
+  }
+
+  override def writeExternal(out: ObjectOutput): Unit = {
+    out.writeObject(hashRelationObj)
+    val rawArrowData = ConverterUtils.convertToNetty(arrowColumnarBatch)
+    out.writeObject(rawArrowData)
+  }
+
+  override def write(kryo: Kryo, out: Output): Unit = {
+    kryo.writeObject(out, hashRelationObj)
+    val rawArrowData = ConverterUtils.convertToNetty(arrowColumnarBatch)
+    kryo.writeObject(out, rawArrowData)
+  }
+
+  override def readExternal(in: ObjectInput): Unit = {
+    hashRelationObj = in.readObject().asInstanceOf[SerializableObject]
+    val rawArrowData = in.readObject().asInstanceOf[Array[Byte]]
+    arrowColumnarBatchSize = rawArrowData.length
+    arrowColumnarBatch =
+      ConverterUtils.convertFromNetty(null, new ByteArrayInputStream(rawArrowData)).toArray
+    // retain all cols
+    arrowColumnarBatch.foreach(cb => {
+      (0 until cb.numCols).toList.foreach(i =>
+        cb.column(i).asInstanceOf[ArrowWritableColumnVector].retain())
+    })
+  }
+
+  override def read(kryo: Kryo, in: Input): Unit = {
+    hashRelationObj =
+      kryo.readObject(in, classOf[SerializableObject]).asInstanceOf[SerializableObject]
+    val rawArrowData = kryo.readObject(in, classOf[Array[Byte]]).asInstanceOf[Array[Byte]]
+    arrowColumnarBatchSize = rawArrowData.length
+    arrowColumnarBatch =
+      ConverterUtils.convertFromNetty(null, new ByteArrayInputStream(rawArrowData)).toArray
+    // retain all cols
+    arrowColumnarBatch.foreach(cb => {
+      (0 until cb.numCols).toList.foreach(i =>
+        cb.column(i).asInstanceOf[ArrowWritableColumnVector].retain())
+    })
+  }
+
+  def size(): Int = {
+    hashRelationObj.total_size + arrowColumnarBatchSize
+  }
+
+  def getColumnarBatchAsIter: Iterator[ColumnarBatch] = {
+    new Iterator[ColumnarBatch] {
+      var idx = 0
+      val total_len = arrowColumnarBatch.length
+      override def hasNext: Boolean = idx < total_len
+      override def next(): ColumnarBatch = {
+        val tmp_idx = idx
+        idx += 1
+        val cb = arrowColumnarBatch(tmp_idx)
+        // retain all cols
+        (0 until cb.numCols).toList.foreach(i =>
+          cb.column(i).asInstanceOf[ArrowWritableColumnVector].retain())
+        cb
+      }
+    }
+  }
+
+}

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -121,7 +121,7 @@ case class ColumnarShuffledHashJoinExec(
 
   override def supportColumnarCodegen: Boolean = true
 
-  def getKernelFunction: TreeNode = {
+  def getKernelFunction(_type: Int = 0): TreeNode = {
 
     val buildInputAttributes = buildPlan.output.toList
     val streamInputAttributes = streamedPlan.output.toList
@@ -140,7 +140,8 @@ case class ColumnarShuffledHashJoinExec(
       output_skip_alias,
       joinType,
       buildSide,
-      condition)
+      condition,
+      _type)
   }
 
   override def doCodeGen: ColumnarCodegenContext = {
@@ -155,7 +156,7 @@ case class ColumnarShuffledHashJoinExec(
       (
         TreeBuilder.makeFunction(
           s"child",
-          Lists.newArrayList(getKernelFunction, childCtx.root),
+          Lists.newArrayList(getKernelFunction(1), childCtx.root),
           new ArrowType.Int(32, true)),
         childCtx.inputSchema)
     } else {
@@ -163,7 +164,7 @@ case class ColumnarShuffledHashJoinExec(
         TreeBuilder
           .makeFunction(
             s"child",
-            Lists.newArrayList(getKernelFunction),
+            Lists.newArrayList(getKernelFunction(1)),
             new ArrowType.Int(32, true)),
         ConverterUtils.toArrowSchema(streamedPlan.output))
     }
@@ -213,7 +214,7 @@ case class ColumnarShuffledHashJoinExec(
 
       val native_function = TreeBuilder.makeFunction(
         s"standalone",
-        Lists.newArrayList(getKernelFunction),
+        Lists.newArrayList(getKernelFunction(0)),
         new ArrowType.Int(32, true))
       val probe_expr =
         TreeBuilder

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/DataToArrowColumnarExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/DataToArrowColumnarExec.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.expressions.{
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
-import org.apache.spark.sql.execution.{UnaryExecNode, BinaryExecNode, CodegenSupport, SparkPlan}
+import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
 import scala.collection.JavaConverters._

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -161,6 +161,9 @@ object ConverterUtils extends Logging {
         }
       override def next(): ColumnarBatch = {
         if (input.available == 0) {
+          if (attributes == null) {
+            return null
+          }
           val resultStructType = StructType(
             attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
           val resultColumnVectors =

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -58,6 +58,7 @@ import scala.collection.mutable.ListBuffer
 import io.netty.buffer.{ByteBuf, ByteBufAllocator, ByteBufOutputStream}
 import java.nio.channels.{Channels, WritableByteChannel}
 import com.google.common.collect.Lists
+import java.io.{InputStream, OutputStream}
 
 object ConverterUtils extends Logging {
   def createArrowRecordBatch(columnarBatch: ColumnarBatch): ArrowRecordBatch = {
@@ -109,9 +110,7 @@ object ConverterUtils extends Logging {
     vector.getChildrenFromFields.asScala.foreach(child => appendNodes(child, nodes, buffers))
   }
 
-  def convertToNetty(iter: Array[ColumnarBatch]): Array[Byte] = {
-    val innerBuf = ByteBufAllocator.DEFAULT.buffer()
-    val out = new ByteBufOutputStream(innerBuf)
+  def convertToNetty(iter: Array[ColumnarBatch], out: OutputStream): Unit = {
     val channel = new WriteChannel(Channels.newChannel(out))
     var schema: Schema = null
     val option = new IpcOption
@@ -130,12 +129,80 @@ object ConverterUtils extends Logging {
           .createArrowRecordBatch(columnarBatch.numRows, vectors.map(_.getValueVector)),
         option)
     }
-    val buf = out.buffer
-    val bytes = new Array[Byte](buf.readableBytes);
-    buf.getBytes(buf.readerIndex, bytes);
+  }
+
+  def convertToNetty(iter: Array[ColumnarBatch]): Array[Byte] = {
+    val innerBuf = ByteBufAllocator.DEFAULT.buffer()
+    val outStream = new ByteBufOutputStream(innerBuf)
+    convertToNetty(iter, outStream)
+    val bytes = new Array[Byte](innerBuf.readableBytes);
+    innerBuf.getBytes(innerBuf.readerIndex, bytes);
     innerBuf.release()
-    out.close()
+    outStream.close()
     bytes
+  }
+
+  def convertFromNetty(
+      attributes: Seq[Attribute],
+      input: InputStream): Iterator[ColumnarBatch] = {
+    new Iterator[ColumnarBatch] {
+      val allocator = ArrowWritableColumnVector.getNewAllocator
+      var messageReader =
+        new MessageChannelReader(new ReadChannel(Channels.newChannel(input)), allocator)
+      var schema: Schema = null
+      var result: MessageResult = null
+
+      override def hasNext: Boolean =
+        if (input.available > 0) {
+          return true
+        } else {
+          messageReader.close
+          return false
+        }
+      override def next(): ColumnarBatch = {
+        if (input.available == 0) {
+          val resultStructType = StructType(
+            attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
+          val resultColumnVectors =
+            ArrowWritableColumnVector.allocateColumns(0, resultStructType).toArray
+          return new ColumnarBatch(resultColumnVectors.map(_.asInstanceOf[ColumnVector]), 0)
+        }
+        try {
+          if (schema == null) {
+            result = messageReader.readNext();
+            if (result == null) {
+              throw new IOException("Unexpected end of input. Missing schema.");
+            }
+            if (result.getMessage().headerType() != MessageHeader.Schema) {
+              throw new IOException(
+                "Expected schema but header was " + result.getMessage().headerType());
+            }
+            schema = MessageSerializer.deserializeSchema(result.getMessage());
+          }
+          result = messageReader.readNext();
+          if (result.getMessage().headerType() != MessageHeader.RecordBatch) {
+            throw new IOException(
+              "Expected recordbatch but header was " + result.getMessage().headerType());
+          }
+          var bodyBuffer = result.getBodyBuffer();
+
+          // For zero-length batches, need an empty buffer to deserialize the batch
+          if (bodyBuffer == null) {
+            bodyBuffer = allocator.getEmpty();
+          }
+
+          val batch = MessageSerializer.deserializeRecordBatch(result.getMessage(), bodyBuffer);
+          val vectors = fromArrowRecordBatch(schema, batch, allocator)
+          val length = batch.getLength
+          batch.close
+          new ColumnarBatch(vectors.map(_.asInstanceOf[ColumnVector]), length)
+        } catch {
+          case e: Throwable =>
+            messageReader.close
+            throw e
+        }
+      }
+    }
   }
 
   def convertFromNetty(
@@ -315,15 +382,23 @@ object ConverterUtils extends Logging {
     }
   }
 
-  def getColumnarFuncNode(expr: Expression): (TreeNode, ArrowType) = {
+  def getColumnarFuncNode(
+      expr: Expression,
+      attributes: Seq[Attribute] = null): (TreeNode, ArrowType) = {
     if (expr.isInstanceOf[AttributeReference] && expr
           .asInstanceOf[AttributeReference]
           .name == "none") {
       throw new UnsupportedOperationException(
         s"Unsupport to generate native expression from replaceable expression.")
     }
-    var columnarExpr: Expression =
+    var columnarExpr: Expression = if (attributes != null) {
+      ColumnarExpressionConverter.replaceWithColumnarExpression(
+        expr,
+        attributeSeq = attributes,
+        convertBoundRefToAttrRef = true)
+    } else {
       ColumnarExpressionConverter.replaceWithColumnarExpression(expr)
+    }
     var inputList: java.util.List[Field] = Lists.newArrayList()
     columnarExpr.asInstanceOf[ColumnarExpression].doColumnarCodeGen(inputList)
   }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -146,7 +146,7 @@ object ConverterUtils extends Logging {
       attributes: Seq[Attribute],
       input: InputStream): Iterator[ColumnarBatch] = {
     new Iterator[ColumnarBatch] {
-      val allocator = ArrowWritableColumnVector.getAllocator
+      val allocator = ArrowWritableColumnVector.getOffRecordAllocator
       var messageReader =
         new MessageChannelReader(new ReadChannel(Channels.newChannel(input)), allocator)
       var schema: Schema = null
@@ -213,7 +213,7 @@ object ConverterUtils extends Logging {
       data: Array[Array[Byte]]): Iterator[ColumnarBatch] = {
     new Iterator[ColumnarBatch] {
       var array_id = 0
-      val allocator = ArrowWritableColumnVector.getAllocator
+      val allocator = ArrowWritableColumnVector.getOffRecordAllocator
       var input = new ByteArrayInputStream(data(array_id))
       var messageReader =
         new MessageChannelReader(new ReadChannel(Channels.newChannel(input)), allocator)

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -146,7 +146,7 @@ object ConverterUtils extends Logging {
       attributes: Seq[Attribute],
       input: InputStream): Iterator[ColumnarBatch] = {
     new Iterator[ColumnarBatch] {
-      val allocator = ArrowWritableColumnVector.getNewAllocator
+      val allocator = ArrowWritableColumnVector.getAllocator
       var messageReader =
         new MessageChannelReader(new ReadChannel(Channels.newChannel(input)), allocator)
       var schema: Schema = null

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -1,7 +1,6 @@
 package org.apache.spark.sql.execution
 
 import com.google.common.collect.Lists;
-import com.intel.oap.execution.ColumnarHashedRelation
 import com.intel.oap.expression._
 import com.intel.oap.vectorized.{ArrowWritableColumnVector, ExpressionEvaluator, BatchIterator}
 import io.netty.buffer.{ByteBuf, ByteBufAllocator, ByteBufOutputStream}
@@ -17,7 +16,7 @@ import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.expressions.BoundReference
-import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.{SparkPlan, SQLExecution, ColumnarHashedRelation}
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
-import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 import org.apache.spark.TaskContext
 import org.apache.spark.util.{SparkFatalException, ThreadUtils}
 
@@ -83,31 +83,66 @@ class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
           .mapPartitions { iter =>
             var _numRows: Long = 0
             val _input = new ArrayBuffer[ColumnarBatch]()
+            val _input_before_concat = new ArrayBuffer[ColumnarBatch]()
+
+            val concatArrayKernel = new ExpressionEvaluator()
+            val concat_kernel = TreeBuilder.makeFunction(
+              "ConcatArrayList",
+              Lists.newArrayList(),
+              new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
+            val concat_kernel_standalone = TreeBuilder.makeFunction(
+              "standalone",
+              Lists.newArrayList(concat_kernel),
+              new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
+            val concat_expr = TreeBuilder
+              .makeExpression(
+                concat_kernel_standalone,
+                Field.nullable("result", new ArrowType.Int(32, true)))
+            concatArrayKernel.build(
+              ConverterUtils.toArrowSchema(output),
+              Lists.newArrayList(concat_expr),
+              ConverterUtils.toArrowSchema(output),
+              true)
 
             while (iter.hasNext) {
               val batch = iter.next
               (0 until batch.numCols).foreach(i =>
                 batch.column(i).asInstanceOf[ArrowWritableColumnVector].retain())
-              _numRows += batch.numRows
-              _input += batch
+              _input_before_concat += batch
 
+              val input_batch = ConverterUtils.createArrowRecordBatch(batch)
+              concatArrayKernel.evaluate(input_batch)
+              ConverterUtils.releaseArrowRecordBatch(input_batch)
+            }
+            val concat_res_iterator = concatArrayKernel.finishByIterator
+            while (concat_res_iterator.hasNext()) {
+              val output_rb = concat_res_iterator.next()
+              if (output_rb != null && output_rb.getLength > 0) {
+                val output_batch = ConverterUtils.fromArrowRecordBatch(
+                  ConverterUtils.toArrowSchema(output),
+                  output_rb)
+                val batch = new ColumnarBatch(
+                  output_batch.map(v => v.asInstanceOf[ColumnVector]).toArray,
+                  output_rb.getLength())
+                ConverterUtils.releaseArrowRecordBatch(output_rb)
+                _numRows += batch.numRows
+                _input += batch
+              }
             }
             val bytes = ConverterUtils.convertToNetty(_input.toArray)
+            _input_before_concat.foreach(_.close)
+            _input.foreach(_.close)
 
-            _input.toArray.foreach(batch => {
-              (0 until batch.numCols).foreach(i =>
-                batch.column(i).asInstanceOf[ArrowWritableColumnVector].close())
-            })
             Iterator((_numRows, bytes))
           }
           .collect
         ///////////////////////////////////////////////////////////////////////////
         val input = countsAndBytes.map(_._2)
         val size_raw = input.map(_.length).sum
+        val hash_relation_schema = ConverterUtils.toArrowSchema(output)
 
         ///////////// After collect data to driver side, build hashmap here /////////////
         val beforeBuild = System.nanoTime()
-        val hash_relation_schema = ConverterUtils.toArrowSchema(output)
         val hash_relation_function =
           ColumnarConditionedProbeJoin.prepareHashBuildFunction(buildKeyExprs, output, 1, true)
         val hash_relation_expr =

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.intel.oap.execution
+package org.apache.spark.sql.execution
 
 import java.io._
 import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean}
@@ -23,6 +23,7 @@ import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.intel.oap.expression.ConverterUtils
 import com.intel.oap.vectorized.{ArrowWritableColumnVector, SerializableObject}
+import org.apache.spark.util.{KnownSizeEstimation, Utils}
 import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -34,7 +35,8 @@ class ColumnarHashedRelation(
     var arrowColumnarBatch: Array[ColumnarBatch],
     var arrowColumnarBatchSize: Int)
     extends Externalizable
-    with KryoSerializable {
+    with KryoSerializable
+    with KnownSizeEstimation {
   val refCnt: AtomicInteger = new AtomicInteger()
   val closed: AtomicBoolean = new AtomicBoolean()
 
@@ -47,6 +49,8 @@ class ColumnarHashedRelation(
     refCnt.incrementAndGet()
     this
   }
+
+  override def estimatedSize: Long = 0
 
   def close(waitTime: Int): Future[Int] = Future {
     Thread.sleep(waitTime * 1000)

--- a/oap-native-sql/cpp/src/benchmarks/arrow_compute_benchmark_join.cc
+++ b/oap-native-sql/cpp/src/benchmarks/arrow_compute_benchmark_join.cc
@@ -148,10 +148,12 @@ TEST_F(BenchmarkArrowComputeJoin, JoinBenchmark) {
     result_node_list.push_back(TreeExprBuilder::MakeField(field));
   }
   auto n_result = TreeExprBuilder::MakeFunction("result", result_node_list, uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
 
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysInner", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysInner",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
 

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -325,11 +325,12 @@ class WindowVisitorImpl : public ExprVisitorImpl {
     this->partition_fields_ = partition_fields;
   }
 
-  static arrow::Status Make(ExprVisitor* p, std::vector<std::string> window_function_names,
-                            std::vector<std::shared_ptr<arrow::DataType>> return_types,
-                            std::vector<std::vector<gandiva::FieldPtr>> function_param_fields,
-                            std::vector<gandiva::FieldPtr> partition_fields,
-                            std::shared_ptr<ExprVisitorImpl>* out) {
+  static arrow::Status Make(
+      ExprVisitor* p, std::vector<std::string> window_function_names,
+      std::vector<std::shared_ptr<arrow::DataType>> return_types,
+      std::vector<std::vector<gandiva::FieldPtr>> function_param_fields,
+      std::vector<gandiva::FieldPtr> partition_fields,
+      std::shared_ptr<ExprVisitorImpl>* out) {
     auto impl = std::make_shared<WindowVisitorImpl>(
         p, window_function_names, return_types, function_param_fields, partition_fields);
     *out = impl;
@@ -359,7 +360,8 @@ class WindowVisitorImpl : public ExprVisitorImpl {
     for (int func_id = 0; func_id < window_function_names_.size(); func_id++) {
       std::string window_function_name = window_function_names_.at(func_id);
       std::shared_ptr<arrow::DataType> return_type = return_types_.at(func_id);
-      std::vector<gandiva::FieldPtr> function_param_fields_of_each = function_param_fields_.at(func_id);
+      std::vector<gandiva::FieldPtr> function_param_fields_of_each =
+          function_param_fields_.at(func_id);
       std::shared_ptr<extra::KernalBase> function_kernel;
       std::vector<int> function_param_field_ids_of_each;
       std::vector<std::shared_ptr<arrow::DataType>> function_param_type_list;
@@ -387,7 +389,7 @@ class WindowVisitorImpl : public ExprVisitorImpl {
                                                     &function_kernel, true));
       } else {
         return arrow::Status::Invalid("window function not supported: " +
-            window_function_name);
+                                      window_function_name);
       }
       function_kernels_.push_back(function_kernel);
     }
@@ -454,13 +456,15 @@ class WindowVisitorImpl : public ExprVisitorImpl {
       if (num_batches == -1) {
         num_batches = out0.size();
       } else if (num_batches != out0.size()) {
-        return arrow::Status::Invalid("WindowVisitorImpl: Return batch counts are not the same for "
-                                      "different window functions");
+        return arrow::Status::Invalid(
+            "WindowVisitorImpl: Return batch counts are not the same for "
+            "different window functions");
       }
       outs.push_back(out0);
     }
     if (num_batches == -1) {
-      return arrow::Status::Invalid("WindowVisitorImpl: No batches returned for window functions");
+      return arrow::Status::Invalid(
+          "WindowVisitorImpl: No batches returned for window functions");
     }
     std::vector<ArrayList> out;
     std::vector<int> out_sizes;
@@ -472,13 +476,16 @@ class WindowVisitorImpl : public ExprVisitorImpl {
         if (length == -1L) {
           length = arr->length();
         } else if (length != arr->length()) {
-          return arrow::Status::Invalid("WindowVisitorImpl: Return array length in the same batch are not the same for "
-                                        "different window functions");
+          return arrow::Status::Invalid(
+              "WindowVisitorImpl: Return array length in the same batch are not the same "
+              "for "
+              "different window functions");
         }
         temp.push_back(arr);
       }
       if (length == -1) {
-        return arrow::Status::Invalid("WindowVisitorImpl: No valid batch length returned for window functions");
+        return arrow::Status::Invalid(
+            "WindowVisitorImpl: No valid batch length returned for window functions");
       }
       out.push_back(temp);
       out_sizes.push_back(length);
@@ -586,8 +593,7 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
     sort_key_node_ =
         std::dynamic_pointer_cast<gandiva::FunctionNode>(children[0])->children();
     // second child is key_field
-    auto key_field_node =
-        std::dynamic_pointer_cast<gandiva::FunctionNode>(children[1]);
+    auto key_field_node = std::dynamic_pointer_cast<gandiva::FunctionNode>(children[1]);
     for (auto field : key_field_node->children()) {
       auto field_node = std::dynamic_pointer_cast<gandiva::FieldNode>(field);
       key_field_list_.push_back(field_node->field());
@@ -601,8 +607,7 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
       sort_directions_.push_back(dir_val);
     }
     // fourth child is nulls_order
-    auto nulls_order_node =
-        std::dynamic_pointer_cast<gandiva::FunctionNode>(children[3]);
+    auto nulls_order_node = std::dynamic_pointer_cast<gandiva::FunctionNode>(children[3]);
     for (auto order : nulls_order_node->children()) {
       auto order_node = std::dynamic_pointer_cast<gandiva::LiteralNode>(order);
       bool order_val = arrow::util::get<bool>(order_node->holder());
@@ -615,8 +620,7 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
                             std::shared_ptr<gandiva::FunctionNode> root_node,
                             std::vector<std::shared_ptr<arrow::Field>> ret_fields,
                             ExprVisitor* p, std::shared_ptr<ExprVisitorImpl>* out) {
-
-    auto impl = std::make_shared<SortArraysToIndicesVisitorImpl>(field_list, root_node, 
+    auto impl = std::make_shared<SortArraysToIndicesVisitorImpl>(field_list, root_node,
                                                                  ret_fields, p);
     *out = impl;
     return arrow::Status::OK();
@@ -626,8 +630,9 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
     if (initialized_) {
       return arrow::Status::OK();
     }
-    RETURN_NOT_OK(extra::SortArraysToIndicesKernel::Make(&p_->ctx_, result_schema_, 
-        sort_key_node_, key_field_list_, sort_directions_, nulls_order_, &kernel_));
+    RETURN_NOT_OK(extra::SortArraysToIndicesKernel::Make(
+        &p_->ctx_, result_schema_, sort_key_node_, key_field_list_, sort_directions_,
+        nulls_order_, &kernel_));
     p_->signature_ = kernel_->GetSignature();
     initialized_ = true;
     finish_return_type_ = ArrowComputeResultType::BatchIterator;
@@ -1079,7 +1084,82 @@ class HashRelationVisitorImpl : public ExprVisitorImpl {
       } break;
       default:
         return arrow::Status::Invalid(
-            "WholeStageCodeGenVisitorImpl MakeResultIterator does not support "
+            "HashRelationVisitorImpl MakeResultIterator does not support "
+            "dependency type other than Batch.");
+    }
+    return arrow::Status::OK();
+  }
+
+ private:
+  std::shared_ptr<gandiva::Node> root_node_;
+  std::vector<std::shared_ptr<arrow::Field>> field_list_;
+  std::vector<std::shared_ptr<arrow::Field>> ret_fields_;
+};
+
+////////////////////////// ConcatArrayListVisitorImpl ///////////////////////
+class ConcatArrayListVisitorImpl : public ExprVisitorImpl {
+ public:
+  ConcatArrayListVisitorImpl(std::vector<std::shared_ptr<arrow::Field>> field_list,
+                             std::shared_ptr<gandiva::Node> root_node,
+                             std::vector<std::shared_ptr<arrow::Field>> ret_fields,
+                             ExprVisitor* p)
+      : root_node_(root_node),
+        field_list_(field_list),
+        ret_fields_(ret_fields),
+        ExprVisitorImpl(p) {
+    finish_return_type_ = ArrowComputeResultType::BatchIterator;
+  }
+  static arrow::Status Make(std::vector<std::shared_ptr<arrow::Field>> field_list,
+                            std::shared_ptr<gandiva::Node> root_node,
+                            std::vector<std::shared_ptr<arrow::Field>> ret_fields,
+                            ExprVisitor* p, std::shared_ptr<ExprVisitorImpl>* out) {
+    auto impl = std::make_shared<ConcatArrayListVisitorImpl>(field_list, root_node,
+                                                             ret_fields, p);
+    *out = impl;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Init() override {
+    if (initialized_) {
+      return arrow::Status::OK();
+    }
+    RETURN_NOT_OK(extra::ConcatArrayListKernel::Make(&p_->ctx_, field_list_, root_node_,
+                                                     ret_fields_, &kernel_));
+    p_->signature_ = kernel_->GetSignature();
+    initialized_ = true;
+    finish_return_type_ = ArrowComputeResultType::BatchIterator;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Eval() override {
+    switch (p_->dependency_result_type_) {
+      case ArrowComputeResultType::None: {
+        ArrayList in;
+        for (int i = 0; i < p_->in_record_batch_->num_columns(); i++) {
+          in.push_back(p_->in_record_batch_->column(i));
+        }
+        TIME_MICRO_OR_RAISE(p_->elapse_time_, kernel_->Evaluate(in));
+      } break;
+      default:
+        return arrow::Status::NotImplemented(
+            "ConcatArrayListVisitorImpl: Does not support this type of "
+            "input.");
+    }
+    return arrow::Status::OK();
+  }
+  arrow::Status MakeResultIterator(std::shared_ptr<arrow::Schema> schema,
+                                   std::shared_ptr<ResultIteratorBase>* out) override {
+    switch (finish_return_type_) {
+      case ArrowComputeResultType::BatchIterator: {
+        std::shared_ptr<ResultIterator<arrow::RecordBatch>> iter_out;
+        TIME_MICRO_OR_RAISE(p_->elapse_time_,
+                            kernel_->MakeResultIterator(schema, &iter_out));
+        *out = std::dynamic_pointer_cast<ResultIteratorBase>(iter_out);
+        p_->return_type_ = ArrowComputeResultType::Batch;
+      } break;
+      default:
+        return arrow::Status::Invalid(
+            "ConcatArrayListVisitorImpl MakeResultIterator does not support "
             "dependency type other than Batch.");
     }
     return arrow::Status::OK();

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -562,11 +562,7 @@ class EncodeVisitorImpl : public ExprVisitorImpl {
     return arrow::Status::OK();
   }
 
-  arrow::Status Finish() override {
-    std::cout << "Concat keys took " << TIME_TO_STRING(concat_elapse_time) << std::endl;
-
-    return arrow::Status::OK();
-  }
+  arrow::Status Finish() override { return arrow::Status::OK(); }
 
  private:
   std::vector<int> col_id_list_;
@@ -717,9 +713,11 @@ class ConditionedProbeArraysVisitorImpl : public ExprVisitorImpl {
         std::dynamic_pointer_cast<gandiva::FunctionNode>(children[3])->children();
     result_field_list_ =
         std::dynamic_pointer_cast<gandiva::FunctionNode>(children[4])->children();
-    if (children.size() > 5) {
+    hash_configuration_list_ =
+        std::dynamic_pointer_cast<gandiva::FunctionNode>(children[5])->children();
+    if (children.size() > 6) {
       condition_ =
-          std::dynamic_pointer_cast<gandiva::FunctionNode>(children[5])->children()[0];
+          std::dynamic_pointer_cast<gandiva::FunctionNode>(children[6])->children()[0];
     }
   }
   static arrow::Status Make(std::vector<std::shared_ptr<arrow::Field>> field_list,
@@ -738,7 +736,8 @@ class ConditionedProbeArraysVisitorImpl : public ExprVisitorImpl {
     }
     RETURN_NOT_OK(extra::ConditionedProbeKernel::Make(
         &p_->ctx_, left_key_list_, right_key_list_, left_field_list_, right_field_list_,
-        condition_, join_type_, result_field_list_, 0, &kernel_));
+        condition_, join_type_, result_field_list_, hash_configuration_list_, 0,
+        &kernel_));
     p_->signature_ = kernel_->GetSignature();
     initialized_ = true;
     finish_return_type_ = ArrowComputeResultType::BatchIterator;
@@ -791,6 +790,7 @@ class ConditionedProbeArraysVisitorImpl : public ExprVisitorImpl {
   gandiva::NodeVector left_field_list_;
   gandiva::NodeVector right_field_list_;
   gandiva::NodeVector result_field_list_;
+  gandiva::NodeVector hash_configuration_list_;
 };
 
 ////////////////////////// ConditionedJoinArraysVisitorImpl ///////////////////////

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
@@ -40,6 +40,7 @@
 #include "codegen/arrow_compute/ext/typed_node_visitor.h"
 #include "codegen/common/hash_relation_number.h"
 #include "codegen/common/hash_relation_string.h"
+#include "precompile/unsafe_array.h"
 #include "utils/macros.h"
 
 namespace sparkcolumnarplugin {
@@ -58,7 +59,8 @@ class ConditionedProbeKernel::Impl {
        const gandiva::NodeVector& left_schema_node_list,
        const gandiva::NodeVector& right_schema_node_list,
        const gandiva::NodePtr& condition, int join_type,
-       const gandiva::NodeVector& result_node_list, int hash_relation_idx)
+       const gandiva::NodeVector& result_node_list,
+       const gandiva::NodeVector& hash_configuration_list, int hash_relation_idx)
       : ctx_(ctx),
         join_type_(join_type),
         condition_(condition),
@@ -75,10 +77,19 @@ class ConditionedProbeKernel::Impl {
       result_schema_.push_back(
           std::dynamic_pointer_cast<gandiva::FieldNode>(node)->field());
     }
+
+    auto hash_map_type_str = gandiva::ToString(
+        std::dynamic_pointer_cast<gandiva::LiteralNode>(hash_configuration_list[0])
+            ->holder());
+    hash_map_type_ = std::stoi(hash_map_type_str);
     /////////// right_key_list may need to do precodegen /////////////
     gandiva::FieldVector right_key_list;
+    /** two scenarios:
+     *  1. hash_map_type 0 => SHJ probe with no condition and single join
+     *  2. hash_map_type 1 => BHJ probe with no condition and single join
+     **/
     pre_processed_key_ = true;
-    if (right_key_node_list.size() == 1) {
+    if (hash_map_type_ == 0 && right_key_node_list.size() == 1) {
       auto key_node = right_key_node_list[0];
       std::shared_ptr<TypedNodeVisitor> node_visitor;
       THROW_NOT_OK(MakeTypedNodeVisitor(key_node, &node_visitor));
@@ -91,14 +102,22 @@ class ConditionedProbeKernel::Impl {
             GetIndexList(right_key_list, right_field_list_, &right_key_index_list_));
       }
     }
-    if (pre_processed_key_) {
+    /* *
+     * Since we support two scenario here
+     * 1. hash_map_type == 0 will use right_key_project_
+     * 2. hash_map_type == 1 will use right_key_project_codegen_ and
+     * right_key_hash_codegen_
+     * */
+    if (pre_processed_key_ && hash_map_type_ == 0) {
       right_key_project_expr_ = GetConcatedKernel(right_key_node_list);
       right_key_project_ = right_key_project_expr_->root();
     }
-    right_key_project_codegen_ = GetGandivaKernel(right_key_node_list);
-    right_key_hash_codegen_ = GetHash32Kernel(right_key_node_list);
-    for (auto expr : right_key_project_codegen_) {
-      key_hash_field_list_.push_back(expr->result());
+    if (hash_map_type_ == 1) {
+      right_key_project_codegen_ = GetGandivaKernel(right_key_node_list);
+      right_key_hash_codegen_ = GetHash32Kernel(right_key_node_list);
+      for (auto expr : right_key_project_codegen_) {
+        key_hash_field_list_.push_back(expr->result());
+      }
     }
 
     /////////// map result_schema to input schema /////////////
@@ -122,19 +141,22 @@ class ConditionedProbeKernel::Impl {
       return arrow::Status::NotImplemented(
           "ConditionedProbeKernel(Non-Codegen) doesn't support condition.");
     }
-    std::shared_ptr<gandiva::Projector> right_key_projector;
+    std::vector<gandiva::ExpressionVector> right_key_projector_list;
     std::shared_ptr<arrow::DataType> key_type;
     if (right_key_project_) {
-      auto schema = arrow::schema(right_field_list_);
-      auto configuration = gandiva::ConfigurationBuilder().DefaultConfiguration();
-      THROW_NOT_OK(gandiva::Projector::Make(schema, {right_key_project_expr_},
-                                            configuration, &right_key_projector));
+      // hash_map_type == 0
       key_type = right_key_project_->return_type();
+      right_key_projector_list.push_back({right_key_project_expr_});
+    } else if (right_key_hash_codegen_) {
+      // hash_map_type == 1
+      key_type = right_key_hash_codegen_->result()->type();
+      right_key_projector_list.push_back({right_key_hash_codegen_});
+      right_key_projector_list.push_back(right_key_project_codegen_);
     } else {
       key_type = right_field_list_[right_key_index_list_[0]]->type();
     }
     *out = std::make_shared<ConditionedProbeResultIterator>(
-        ctx_, right_key_index_list_, key_type, join_type_, right_key_projector,
+        ctx_, right_key_index_list_, key_type, join_type_, right_key_projector_list,
         result_schema_, result_schema_index_list_, exist_index_, left_field_list_,
         right_field_list_);
     return arrow::Status::OK();
@@ -283,12 +305,17 @@ class ConditionedProbeKernel::Impl {
   arrow::MemoryPool* pool_;
   std::string signature_;
   int join_type_;
+
+  gandiva::NodePtr condition_;
+  int hash_map_type_;
+
+  // only be used when hash_map_type_ == 0
   gandiva::ExpressionPtr right_key_project_expr_;
   gandiva::NodePtr right_key_project_;
+  // only be used when hash_map_type_ == 1
   gandiva::ExpressionPtr right_key_hash_codegen_;
   gandiva::ExpressionVector right_key_project_codegen_;
   gandiva::FieldVector key_hash_field_list_;
-  gandiva::NodePtr condition_;
 
   bool pre_processed_key_ = false;
   gandiva::FieldVector left_field_list_;
@@ -307,7 +334,7 @@ class ConditionedProbeKernel::Impl {
     ConditionedProbeResultIterator(
         arrow::compute::FunctionContext* ctx, std::vector<int> right_key_index_list,
         std::shared_ptr<arrow::DataType> key_type, int join_type,
-        std::shared_ptr<gandiva::Projector> right_key_project,
+        std::vector<gandiva::ExpressionVector> right_key_project_list,
         gandiva::FieldVector result_schema,
         std::vector<std::pair<int, int>> result_schema_index_list, int exist_index,
         gandiva::FieldVector left_field_list, gandiva::FieldVector right_field_list)
@@ -315,12 +342,31 @@ class ConditionedProbeKernel::Impl {
           right_key_index_list_(right_key_index_list),
           key_type_(key_type),
           join_type_(join_type),
-          right_key_project_(right_key_project),
           result_schema_index_list_(result_schema_index_list),
           exist_index_(exist_index),
           left_field_list_(left_field_list),
           right_field_list_(right_field_list) {
       result_schema_ = arrow::schema(result_schema);
+      hash_map_type_ = right_key_project_list.size() == 2 ? 1 : 0;
+      if (hash_map_type_ == 0) {
+        if (right_key_project_list.size() == 1) {
+          auto configuration = gandiva::ConfigurationBuilder().DefaultConfiguration();
+          THROW_NOT_OK(gandiva::Projector::Make(arrow::schema(right_field_list_),
+                                                right_key_project_list[0], configuration,
+                                                &right_hash_key_project_));
+        }
+      } else if (hash_map_type_ == 1) {
+        auto configuration = gandiva::ConfigurationBuilder().DefaultConfiguration();
+        for (auto expr : right_key_project_list[1]) {
+          right_projected_field_list_.push_back(expr->result());
+        }
+        THROW_NOT_OK(gandiva::Projector::Make(arrow::schema(right_projected_field_list_),
+                                              right_key_project_list[0], configuration,
+                                              &right_hash_key_project_));
+        THROW_NOT_OK(gandiva::Projector::Make(arrow::schema(right_field_list_),
+                                              right_key_project_list[1], configuration,
+                                              &right_keys_project_));
+      }
     }
 
 #define PROCESS_SUPPORTED_TYPES(PROCESS) \
@@ -383,7 +429,42 @@ class ConditionedProbeKernel::Impl {
       }
 
       // prepare probe function
-      switch (key_type_->id()) {
+      if (hash_map_type_ == 1) {
+        // if hash_map_type == 1, we will simply use HashRelation
+        switch (join_type_) {
+          case 0: { /*Inner Join*/
+            auto func = std::make_shared<UnsafeInnerProbeFunction>(hash_relation_,
+                                                                   appender_list_);
+            probe_func_ = std::dynamic_pointer_cast<ProbeFunctionBase>(func);
+          } break;
+          case 1: { /*Outer Join*/
+            auto func = std::make_shared<UnsafeOuterProbeFunction>(hash_relation_,
+                                                                   appender_list_);
+            probe_func_ = std::dynamic_pointer_cast<ProbeFunctionBase>(func);
+          } break;
+          case 2: { /*Anti Join*/
+            auto func =
+                std::make_shared<UnsafeAntiProbeFunction>(hash_relation_, appender_list_);
+            probe_func_ = std::dynamic_pointer_cast<ProbeFunctionBase>(func);
+          } break;
+          case 3: { /*Semi Join*/
+            auto func =
+                std::make_shared<UnsafeSemiProbeFunction>(hash_relation_, appender_list_);
+            probe_func_ = std::dynamic_pointer_cast<ProbeFunctionBase>(func);
+          } break;
+          case 4: { /*Existence Join*/
+            auto func = std::make_shared<UnsafeExistenceProbeFunction>(hash_relation_,
+                                                                       appender_list_);
+            probe_func_ = std::dynamic_pointer_cast<ProbeFunctionBase>(func);
+          } break;
+          default:
+            return arrow::Status::NotImplemented(
+                "ConditionedProbeArraysTypedImpl only support join type: InnerJoin, "
+                "RightJoin");
+        }
+      } else {
+        // if hash_map_type == 0, we use TypedHashRelation
+        switch (key_type_->id()) {
 #define PROCESS(InType)                                                                  \
   case InType::type_id: {                                                                \
     switch (join_type_) {                                                                \
@@ -418,12 +499,13 @@ class ConditionedProbeKernel::Impl {
             "RightJoin");                                                                \
     }                                                                                    \
   } break;
-        PROCESS_SUPPORTED_TYPES(PROCESS)
+          PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
-        default: {
-          std::cout << "ConditionedProbeArraysTypedImpl does not support key type as "
-                    << key_type_ << std::endl;
-        } break;
+          default: {
+            std::cout << "ConditionedProbeArraysTypedImpl does not support key type as "
+                      << key_type_ << std::endl;
+          } break;
+        }
       }
       return arrow::Status::OK();
     }
@@ -435,16 +517,32 @@ class ConditionedProbeKernel::Impl {
         const std::shared_ptr<arrow::Array>& selection = nullptr) override {
       // Get key array, which should be typed
       std::shared_ptr<arrow::Array> key_array;
-      if (right_key_project_) {
-        arrow::ArrayVector outputs;
-        auto length = in.size() > 0 ? in[0]->length() : 0;
-        auto in_batch =
-            arrow::RecordBatch::Make(arrow::schema(right_field_list_), length, in);
+      arrow::ArrayVector projected_keys_outputs;
+      /**
+       * if hash_map_type_ == 0, we only need to build a single-column hashArray for key
+       * if hash_map_type_ == 1, we need to both get a single-column hashArray and
+       *projected result of original keys for hashmap
+       **/
+      arrow::ArrayVector outputs;
+      auto length = in.size() > 0 ? in[0]->length() : 0;
+      std::shared_ptr<arrow::RecordBatch> in_batch =
+          arrow::RecordBatch::Make(arrow::schema(right_field_list_), length, in);
+      if (hash_map_type_ == 1) {
+        RETURN_NOT_OK(right_keys_project_->Evaluate(*in_batch, ctx_->memory_pool(),
+                                                    &projected_keys_outputs));
+        in_batch = arrow::RecordBatch::Make(arrow::schema(right_projected_field_list_),
+                                            in_batch->num_rows(), projected_keys_outputs);
         RETURN_NOT_OK(
-            right_key_project_->Evaluate(*in_batch, ctx_->memory_pool(), &outputs));
+            right_hash_key_project_->Evaluate(*in_batch, ctx_->memory_pool(), &outputs));
         key_array = outputs[0];
       } else {
-        key_array = in[right_key_index_list_[0]];
+        if (right_hash_key_project_) {
+          RETURN_NOT_OK(right_hash_key_project_->Evaluate(*in_batch, ctx_->memory_pool(),
+                                                          &outputs));
+          key_array = outputs[0];
+        } else {
+          key_array = in[right_key_index_list_[0]];
+        }
       }
       // put in to ArrayAppender then doing evaluate
       for (int tmp_idx = 0; tmp_idx < appender_list_.size(); tmp_idx++) {
@@ -456,7 +554,12 @@ class ConditionedProbeKernel::Impl {
           RETURN_NOT_OK(appender->AddArray(in[right_in_idx]));
         }
       }
-      auto out_length = probe_func_->Evaluate(key_array);
+      uint64_t out_length = 0;
+      if (hash_map_type_ == 0) {
+        out_length = probe_func_->Evaluate(key_array);
+      } else if (hash_map_type_ == 1) {
+        out_length = probe_func_->Evaluate(key_array, projected_keys_outputs);
+      }
       arrow::ArrayVector out_arr_list;
       for (auto appender : appender_list_) {
         std::shared_ptr<arrow::Array> out_arr;
@@ -475,6 +578,240 @@ class ConditionedProbeKernel::Impl {
     class ProbeFunctionBase {
      public:
       virtual uint64_t Evaluate(std::shared_ptr<arrow::Array>) { return 0; }
+      virtual uint64_t Evaluate(std::shared_ptr<arrow::Array>,
+                                const arrow::ArrayVector&) {
+        return 0;
+      }
+    };
+
+    class UnsafeInnerProbeFunction : public ProbeFunctionBase {
+     public:
+      UnsafeInnerProbeFunction(std::shared_ptr<HashRelation> hash_relation,
+                               std::vector<std::shared_ptr<AppenderBase>> appender_list)
+          : hash_relation_(hash_relation), appender_list_(appender_list) {}
+      uint64_t Evaluate(std::shared_ptr<arrow::Array> key_array,
+                        const arrow::ArrayVector& key_payloads) override {
+        auto typed_key_array = std::dynamic_pointer_cast<ArrayType>(key_array);
+        std::vector<std::shared_ptr<UnsafeArray>> payloads;
+        int i = 0;
+        for (auto arr : key_payloads) {
+          std::shared_ptr<UnsafeArray> payload;
+          MakeUnsafeArray(arr->type(), i++, arr, &payload);
+          payloads.push_back(payload);
+        }
+        uint64_t out_length = 0;
+        for (int i = 0; i < key_array->length(); i++) {
+          auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+          for (auto payload_arr : payloads) {
+            payload_arr->Append(i, &unsafe_key_row);
+          }
+          int index = hash_relation_->Get(typed_key_array->GetView(i), unsafe_key_row);
+          if (index == -1) {
+            continue;
+          }
+          for (auto tmp : hash_relation_->GetItemListByIndex(index)) {
+            for (auto appender : appender_list_) {
+              if (appender->GetType() == AppenderBase::left) {
+                THROW_NOT_OK(appender->Append(tmp.array_id, tmp.id));
+              } else {
+                THROW_NOT_OK(appender->Append(0, i));
+              }
+            }
+            out_length += 1;
+          }
+        }
+        return out_length;
+      }
+
+     private:
+      using ArrayType = arrow::Int32Array;
+      std::shared_ptr<HashRelation> hash_relation_;
+      std::vector<std::shared_ptr<AppenderBase>> appender_list_;
+    };
+
+    class UnsafeOuterProbeFunction : public ProbeFunctionBase {
+     public:
+      UnsafeOuterProbeFunction(std::shared_ptr<HashRelation> hash_relation,
+                               std::vector<std::shared_ptr<AppenderBase>> appender_list)
+          : hash_relation_(hash_relation), appender_list_(appender_list) {}
+      uint64_t Evaluate(std::shared_ptr<arrow::Array> key_array,
+                        const arrow::ArrayVector& key_payloads) override {
+        auto typed_key_array = std::dynamic_pointer_cast<ArrayType>(key_array);
+        std::vector<std::shared_ptr<UnsafeArray>> payloads;
+        int i = 0;
+        for (auto arr : key_payloads) {
+          std::shared_ptr<UnsafeArray> payload;
+          MakeUnsafeArray(arr->type(), i++, arr, &payload);
+          payloads.push_back(payload);
+        }
+        uint64_t out_length = 0;
+        for (int i = 0; i < key_array->length(); i++) {
+          auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+          for (auto payload_arr : payloads) {
+            payload_arr->Append(i, &unsafe_key_row);
+          }
+          int index = hash_relation_->Get(typed_key_array->GetView(i), unsafe_key_row);
+          if (index == -1) {
+            for (auto appender : appender_list_) {
+              if (appender->GetType() == AppenderBase::left) {
+                THROW_NOT_OK(appender->AppendNull());
+              } else {
+                THROW_NOT_OK(appender->Append(0, i));
+              }
+            }
+            out_length += 1;
+            continue;
+          }
+          for (auto tmp : hash_relation_->GetItemListByIndex(index)) {
+            for (auto appender : appender_list_) {
+              if (appender->GetType() == AppenderBase::left) {
+                THROW_NOT_OK(appender->Append(tmp.array_id, tmp.id));
+              } else {
+                THROW_NOT_OK(appender->Append(0, i));
+              }
+            }
+            out_length += 1;
+          }
+        }
+        return out_length;
+      }
+
+     private:
+      using ArrayType = arrow::Int32Array;
+      std::shared_ptr<HashRelation> hash_relation_;
+      std::vector<std::shared_ptr<AppenderBase>> appender_list_;
+    };
+
+    class UnsafeAntiProbeFunction : public ProbeFunctionBase {
+     public:
+      UnsafeAntiProbeFunction(std::shared_ptr<HashRelation> hash_relation,
+                              std::vector<std::shared_ptr<AppenderBase>> appender_list)
+          : hash_relation_(hash_relation), appender_list_(appender_list) {}
+      uint64_t Evaluate(std::shared_ptr<arrow::Array> key_array,
+                        const arrow::ArrayVector& key_payloads) override {
+        auto typed_key_array = std::dynamic_pointer_cast<ArrayType>(key_array);
+        std::vector<std::shared_ptr<UnsafeArray>> payloads;
+        int i = 0;
+        for (auto arr : key_payloads) {
+          std::shared_ptr<UnsafeArray> payload;
+          MakeUnsafeArray(arr->type(), i++, arr, &payload);
+          payloads.push_back(payload);
+        }
+        uint64_t out_length = 0;
+        for (int i = 0; i < key_array->length(); i++) {
+          auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+          for (auto payload_arr : payloads) {
+            payload_arr->Append(i, &unsafe_key_row);
+          }
+          int index = hash_relation_->Get(typed_key_array->GetView(i), unsafe_key_row);
+          if (index == -1) {
+            for (auto appender : appender_list_) {
+              if (appender->GetType() == AppenderBase::left) {
+                THROW_NOT_OK(appender->AppendNull());
+              } else {
+                THROW_NOT_OK(appender->Append(0, i));
+              }
+            }
+            out_length += 1;
+          }
+        }
+        return out_length;
+      }
+
+     private:
+      using ArrayType = arrow::Int32Array;
+      std::shared_ptr<HashRelation> hash_relation_;
+      std::vector<std::shared_ptr<AppenderBase>> appender_list_;
+    };
+
+    class UnsafeSemiProbeFunction : public ProbeFunctionBase {
+     public:
+      UnsafeSemiProbeFunction(std::shared_ptr<HashRelation> hash_relation,
+                              std::vector<std::shared_ptr<AppenderBase>> appender_list)
+          : hash_relation_(hash_relation), appender_list_(appender_list) {}
+      uint64_t Evaluate(std::shared_ptr<arrow::Array> key_array,
+                        const arrow::ArrayVector& key_payloads) override {
+        auto typed_key_array = std::dynamic_pointer_cast<ArrayType>(key_array);
+        std::vector<std::shared_ptr<UnsafeArray>> payloads;
+        int i = 0;
+        for (auto arr : key_payloads) {
+          std::shared_ptr<UnsafeArray> payload;
+          MakeUnsafeArray(arr->type(), i++, arr, &payload);
+          payloads.push_back(payload);
+        }
+        uint64_t out_length = 0;
+        for (int i = 0; i < key_array->length(); i++) {
+          auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+          for (auto payload_arr : payloads) {
+            payload_arr->Append(i, &unsafe_key_row);
+          }
+          int index = hash_relation_->Get(typed_key_array->GetView(i), unsafe_key_row);
+          if (index == -1) {
+            continue;
+          }
+          for (auto appender : appender_list_) {
+            if (appender->GetType() == AppenderBase::left) {
+              THROW_NOT_OK(appender->AppendNull());
+            } else {
+              THROW_NOT_OK(appender->Append(0, i));
+            }
+          }
+          out_length += 1;
+        }
+        return out_length;
+      }
+
+     private:
+      using ArrayType = arrow::Int32Array;
+      std::shared_ptr<HashRelation> hash_relation_;
+      std::vector<std::shared_ptr<AppenderBase>> appender_list_;
+    };
+
+    class UnsafeExistenceProbeFunction : public ProbeFunctionBase {
+     public:
+      UnsafeExistenceProbeFunction(
+          std::shared_ptr<HashRelation> hash_relation,
+          std::vector<std::shared_ptr<AppenderBase>> appender_list)
+          : hash_relation_(hash_relation), appender_list_(appender_list) {}
+      uint64_t Evaluate(std::shared_ptr<arrow::Array> key_array,
+                        const arrow::ArrayVector& key_payloads) override {
+        auto typed_key_array = std::dynamic_pointer_cast<ArrayType>(key_array);
+        std::vector<std::shared_ptr<UnsafeArray>> payloads;
+        int i = 0;
+        for (auto arr : key_payloads) {
+          std::shared_ptr<UnsafeArray> payload;
+          MakeUnsafeArray(arr->type(), i++, arr, &payload);
+          payloads.push_back(payload);
+        }
+        uint64_t out_length = 0;
+        for (int i = 0; i < key_array->length(); i++) {
+          auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+          for (auto payload_arr : payloads) {
+            payload_arr->Append(i, &unsafe_key_row);
+          }
+          int index = hash_relation_->Get(typed_key_array->GetView(i), unsafe_key_row);
+          bool exists = true;
+          if (index == -1) {
+            exists = false;
+          }
+          for (auto appender : appender_list_) {
+            if (appender->GetType() == AppenderBase::exist) {
+              THROW_NOT_OK(appender->AppendExistence(exists));
+            } else if (appender->GetType() == AppenderBase::right) {
+              THROW_NOT_OK(appender->Append(0, i));
+            } else {
+              THROW_NOT_OK(appender->AppendNull());
+            }
+          }
+          out_length += 1;
+        }
+        return out_length;
+      }
+
+     private:
+      using ArrayType = arrow::Int32Array;
+      std::shared_ptr<HashRelation> hash_relation_;
+      std::vector<std::shared_ptr<AppenderBase>> appender_list_;
     };
 
     template <typename DataType>
@@ -695,7 +1032,11 @@ class ConditionedProbeKernel::Impl {
     arrow::compute::FunctionContext* ctx_;
     int join_type_;
     std::vector<int> right_key_index_list_;
-    std::shared_ptr<gandiva::Projector> right_key_project_;
+    // used for hash key to hashMap probe
+    int hash_map_type_ = 0;
+    std::shared_ptr<gandiva::Projector> right_hash_key_project_;
+    std::shared_ptr<gandiva::Projector> right_keys_project_;
+
     std::shared_ptr<arrow::DataType> key_type_;
     std::shared_ptr<HashRelation> hash_relation_;
 
@@ -706,6 +1047,7 @@ class ConditionedProbeKernel::Impl {
 
     gandiva::FieldVector left_field_list_;
     gandiva::FieldVector right_field_list_;
+    gandiva::FieldVector right_projected_field_list_;
     std::shared_ptr<ProbeFunctionBase> probe_func_;
   };
 
@@ -979,18 +1321,19 @@ class ConditionedProbeKernel::Impl {
     }
     return arrow::Status::OK();
   }
-};
+};  // namespace extra
 
 arrow::Status ConditionedProbeKernel::Make(
     arrow::compute::FunctionContext* ctx, const gandiva::NodeVector& left_key_list,
     const gandiva::NodeVector& right_key_list,
     const gandiva::NodeVector& left_schema_list,
     const gandiva::NodeVector& right_schema_list, const gandiva::NodePtr& condition,
-    int join_type, const gandiva::NodeVector& result_schema, int hash_relation_idx,
+    int join_type, const gandiva::NodeVector& result_schema,
+    const gandiva::NodeVector& hash_configuration_list, int hash_relation_idx,
     std::shared_ptr<KernalBase>* out) {
   *out = std::make_shared<ConditionedProbeKernel>(
       ctx, left_key_list, right_key_list, left_schema_list, right_schema_list, condition,
-      join_type, result_schema, hash_relation_idx);
+      join_type, result_schema, hash_configuration_list, hash_relation_idx);
   return arrow::Status::OK();
 }
 
@@ -999,10 +1342,11 @@ ConditionedProbeKernel::ConditionedProbeKernel(
     const gandiva::NodeVector& right_key_list,
     const gandiva::NodeVector& left_schema_list,
     const gandiva::NodeVector& right_schema_list, const gandiva::NodePtr& condition,
-    int join_type, const gandiva::NodeVector& result_schema, int hash_relation_idx) {
+    int join_type, const gandiva::NodeVector& result_schema,
+    const gandiva::NodeVector& hash_configuration_list, int hash_relation_idx) {
   impl_.reset(new Impl(ctx, left_key_list, right_key_list, left_schema_list,
                        right_schema_list, condition, join_type, result_schema,
-                       hash_relation_idx));
+                       hash_configuration_list, hash_relation_idx));
   kernel_name_ = "ConditionedProbeKernel";
 }
 

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
@@ -202,9 +202,8 @@ class ConditionedProbeKernel::Impl {
     idx = 0;
     auto unsafe_row_name = "unsafe_row_" + std::to_string(hash_relation_id_);
     prepare_ss << "std::shared_ptr<UnsafeRow> " << unsafe_row_name
-               << " = std::make_shared<UnsafeRow>();" << std::endl;
-    prepare_ss << "initTempUnsafeRow(" << unsafe_row_name << ".get(), "
-               << right_key_project_codegen_.size() << ");" << std::endl;
+               << " = std::make_shared<UnsafeRow>(" << right_key_project_codegen_.size()
+               << ");" << std::endl;
     for (auto expr : right_key_project_codegen_) {
       std::shared_ptr<ExpressionCodegenVisitor> project_node_visitor;
       RETURN_NOT_OK(MakeExpressionCodegenVisitor(expr->root(), input, {right_field_list_},
@@ -721,8 +720,6 @@ class ConditionedProbeKernel::Impl {
     codes_ss << index_name << " = " << hash_relation_name << "->Get(key_"
              << hash_relation_id_ << ", unsafe_row_" << hash_relation_id_ << ");"
              << std::endl;
-    codes_ss << "releaseTempUnsafeRow(unsafe_row_" << hash_relation_id_ << ".get());"
-             << std::endl;
     codes_ss << "if (" << index_name << " == -1) { continue; }" << std::endl;
     codes_ss << "for (auto tmp : " << hash_relation_name << "->GetItemListByIndex("
              << index_name << ")) {" << std::endl;
@@ -752,8 +749,6 @@ class ConditionedProbeKernel::Impl {
     codes_ss << "int32_t " << index_name << ";" << std::endl;
     codes_ss << index_name << " = " << hash_relation_name << "->Get(key_"
              << hash_relation_id_ << ", unsafe_row_" << hash_relation_id_ << ");"
-             << std::endl;
-    codes_ss << "releaseTempUnsafeRow(unsafe_row_" << hash_relation_id_ << ".get());"
              << std::endl;
     codes_ss << "std::vector<ArrayItemIndex> " << matched_index_list_name << ";"
              << std::endl;
@@ -789,8 +784,6 @@ class ConditionedProbeKernel::Impl {
     codes_ss << "int32_t " << index_name << ";" << std::endl;
     codes_ss << index_name << " = " << hash_relation_name << "->Get(key_"
              << hash_relation_id_ << ", unsafe_row_" << hash_relation_id_ << ");"
-             << std::endl;
-    codes_ss << "releaseTempUnsafeRow(unsafe_row_" << hash_relation_id_ << ".get());"
              << std::endl;
     codes_ss << "std::vector<ArrayItemIndex> " << matched_index_list_name << ";"
              << std::endl;
@@ -832,8 +825,6 @@ class ConditionedProbeKernel::Impl {
     codes_ss << "int32_t " << index_name << ";" << std::endl;
     codes_ss << index_name << " = " << hash_relation_name << "->Get(key_"
              << hash_relation_id_ << ", unsafe_row_" << hash_relation_id_ << ");"
-             << std::endl;
-    codes_ss << "releaseTempUnsafeRow(unsafe_row_" << hash_relation_id_ << ".get());"
              << std::endl;
     codes_ss << "std::vector<ArrayItemIndex> " << matched_index_list_name << ";"
              << std::endl;
@@ -881,8 +872,6 @@ class ConditionedProbeKernel::Impl {
     codes_ss << "int32_t " << index_name << ";" << std::endl;
     codes_ss << index_name << " = " << hash_relation_name << "->Get(key_"
              << hash_relation_id_ << ", unsafe_row_" << hash_relation_id_ << ");"
-             << std::endl;
-    codes_ss << "releaseTempUnsafeRow(unsafe_row_" << hash_relation_id_ << ".get());"
              << std::endl;
     codes_ss << "bool " << exist_name << " = false;" << std::endl;
     codes_ss << "bool " << exist_validity << " = true;" << std::endl;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
@@ -223,8 +223,7 @@ class ConditionedProbeKernel::Impl {
     std::vector<std::string> project_output_list;
     auto unsafe_row_name = "unsafe_row_" + std::to_string(hash_relation_id_);
     bool do_unsafe_row = true;
-    if (right_key_project_codegen_.size() == 1 &&
-        right_key_project_codegen_[0]->result()->type()->id() != arrow::Type::STRING) {
+    if (right_key_project_codegen_.size() == 1) {
       // when right_key is single and not string, we don't need to use unsafeRow
       // chendi: But we still use name unsafe_row_${id} to pass key data
       prepare_ss << GetCTypeString(right_key_project_codegen_[0]->result()->type()) << " "
@@ -626,8 +625,7 @@ class ConditionedProbeKernel::Impl {
         bool do_unsafe_row = true;
         std::function<int(int i)> fast_probe;
         /* for single key case, we don't need to create unsafeRow */
-        if (key_payloads.size() == 1 &&
-            key_payloads[0]->type_id() != arrow::Type::STRING) {
+        if (key_payloads.size() == 1) {
           do_unsafe_row = false;
           switch (key_payloads[0]->type_id()) {
 #define PROCESS(InType)                                                      \
@@ -641,6 +639,13 @@ class ConditionedProbeKernel::Impl {
   } break;
             PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
+            case TypeTraits<arrow::StringType>::type_id: {
+              auto typed_first_key_arr = std::make_shared<StringArray>(key_payloads[0]);
+              fast_probe = [this, typed_key_array, typed_first_key_arr](int i) {
+                return hash_relation_->Get(typed_key_array->GetView(i),
+                                           typed_first_key_arr->GetString(i));
+              };
+            } break;
             default: {
               throw std::runtime_error(
                   "UnsafeInnerProbeFunction Evaluate doesn't support single key type ");
@@ -715,8 +720,7 @@ class ConditionedProbeKernel::Impl {
         bool do_unsafe_row = true;
         std::function<int(int i)> fast_probe;
         /* for single key case, we don't need to create unsafeRow */
-        if (key_payloads.size() == 1 &&
-            key_payloads[0]->type_id() != arrow::Type::STRING) {
+        if (key_payloads.size() == 1) {
           do_unsafe_row = false;
           switch (key_payloads[0]->type_id()) {
 #define PROCESS(InType)                                                      \
@@ -730,6 +734,13 @@ class ConditionedProbeKernel::Impl {
   } break;
             PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
+            case TypeTraits<arrow::StringType>::type_id: {
+              auto typed_first_key_arr = std::make_shared<StringArray>(key_payloads[0]);
+              fast_probe = [this, typed_key_array, typed_first_key_arr](int i) {
+                return hash_relation_->Get(typed_key_array->GetView(i),
+                                           typed_first_key_arr->GetString(i));
+              };
+            } break;
             default: {
               throw std::runtime_error(
                   "UnsafeOuterProbeFunction Evaluate doesn't support single key type ");
@@ -812,8 +823,7 @@ class ConditionedProbeKernel::Impl {
         bool do_unsafe_row = true;
         std::function<int(int i)> fast_probe;
         /* for single key case, we don't need to create unsafeRow */
-        if (key_payloads.size() == 1 &&
-            key_payloads[0]->type_id() != arrow::Type::STRING) {
+        if (key_payloads.size() == 1) {
           do_unsafe_row = false;
           switch (key_payloads[0]->type_id()) {
 #define PROCESS(InType)                                                      \
@@ -827,6 +837,13 @@ class ConditionedProbeKernel::Impl {
   } break;
             PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
+            case TypeTraits<arrow::StringType>::type_id: {
+              auto typed_first_key_arr = std::make_shared<StringArray>(key_payloads[0]);
+              fast_probe = [this, typed_key_array, typed_first_key_arr](int i) {
+                return hash_relation_->IfExists(typed_key_array->GetView(i),
+                                                typed_first_key_arr->GetString(i));
+              };
+            } break;
             default: {
               throw std::runtime_error(
                   "UnsafeAntiProbeFunction Evaluate doesn't support single key type ");
@@ -899,8 +916,7 @@ class ConditionedProbeKernel::Impl {
         bool do_unsafe_row = true;
         std::function<int(int i)> fast_probe;
         /* for single key case, we don't need to create unsafeRow */
-        if (key_payloads.size() == 1 &&
-            key_payloads[0]->type_id() != arrow::Type::STRING) {
+        if (key_payloads.size() == 1) {
           do_unsafe_row = false;
           switch (key_payloads[0]->type_id()) {
 #define PROCESS(InType)                                                      \
@@ -914,6 +930,13 @@ class ConditionedProbeKernel::Impl {
   } break;
             PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
+            case TypeTraits<arrow::StringType>::type_id: {
+              auto typed_first_key_arr = std::make_shared<StringArray>(key_payloads[0]);
+              fast_probe = [this, typed_key_array, typed_first_key_arr](int i) {
+                return hash_relation_->IfExists(typed_key_array->GetView(i),
+                                                typed_first_key_arr->GetString(i));
+              };
+            } break;
             default: {
               throw std::runtime_error(
                   "UnsafeSemiProbeFunction Evaluate doesn't support single key type ");
@@ -989,8 +1012,7 @@ class ConditionedProbeKernel::Impl {
         bool do_unsafe_row = true;
         std::function<int(int i)> fast_probe;
         /* for single key case, we don't need to create unsafeRow */
-        if (key_payloads.size() == 1 &&
-            key_payloads[0]->type_id() != arrow::Type::STRING) {
+        if (key_payloads.size() == 1) {
           do_unsafe_row = false;
           switch (key_payloads[0]->type_id()) {
 #define PROCESS(InType)                                                      \
@@ -1004,6 +1026,13 @@ class ConditionedProbeKernel::Impl {
   } break;
             PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
+            case TypeTraits<arrow::StringType>::type_id: {
+              auto typed_first_key_arr = std::make_shared<StringArray>(key_payloads[0]);
+              fast_probe = [this, typed_key_array, typed_first_key_arr](int i) {
+                return hash_relation_->IfExists(typed_key_array->GetView(i),
+                                                typed_first_key_arr->GetString(i));
+              };
+            } break;
             default: {
               throw std::runtime_error(
                   "UnsafeSemiProbeFunction Evaluate doesn't support single key type ");

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/expression_codegen_visitor.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/expression_codegen_visitor.cc
@@ -449,6 +449,86 @@ arrow::Status ExpressionCodegenVisitor::Visit(const gandiva::FunctionNode& node)
     }
     prepare_str_ += prepare_ss.str();
     check_str_ = validity;
+  } else if (func_name.compare("shift_left") == 0) {
+    codes_str_ = "shift_left_" + std::to_string(cur_func_id);
+    auto validity = codes_str_ + "_validity";
+    std::stringstream prepare_ss;
+    prepare_ss << GetCTypeString(node.return_type()) << " " << codes_str_ << ";"
+               << std::endl;
+    prepare_ss << "bool " << validity << " = ("
+               << CombineValidity({child_visitor_list[0]->GetPreCheck(),
+                                   child_visitor_list[1]->GetPreCheck()})
+               << ");" << std::endl;
+    prepare_ss << "if (" << validity << ") {" << std::endl;
+    prepare_ss << codes_str_ << " = " << child_visitor_list[0]->GetResult() << " << "
+               << child_visitor_list[1]->GetResult() << ";" << std::endl;
+    prepare_ss << "}" << std::endl;
+
+    for (int i = 0; i < 2; i++) {
+      prepare_str_ += child_visitor_list[i]->GetPrepare();
+    }
+    prepare_str_ += prepare_ss.str();
+    check_str_ = validity;
+  } else if (func_name.compare("shift_right") == 0) {
+    codes_str_ = "shift_right_" + std::to_string(cur_func_id);
+    auto validity = codes_str_ + "_validity";
+    std::stringstream prepare_ss;
+    prepare_ss << GetCTypeString(node.return_type()) << " " << codes_str_ << ";"
+               << std::endl;
+    prepare_ss << "bool " << validity << " = ("
+               << CombineValidity({child_visitor_list[0]->GetPreCheck(),
+                                   child_visitor_list[1]->GetPreCheck()})
+               << ");" << std::endl;
+    prepare_ss << "if (" << validity << ") {" << std::endl;
+    prepare_ss << codes_str_ << " = " << child_visitor_list[0]->GetResult() << " >> "
+               << child_visitor_list[1]->GetResult() << ";" << std::endl;
+    prepare_ss << "}" << std::endl;
+
+    for (int i = 0; i < 2; i++) {
+      prepare_str_ += child_visitor_list[i]->GetPrepare();
+    }
+    prepare_str_ += prepare_ss.str();
+    check_str_ = validity;
+  } else if (func_name.compare("bitwise_and") == 0) {
+    codes_str_ = "bitwise_and_" + std::to_string(cur_func_id);
+    auto validity = codes_str_ + "_validity";
+    std::stringstream prepare_ss;
+    prepare_ss << GetCTypeString(node.return_type()) << " " << codes_str_ << ";"
+               << std::endl;
+    prepare_ss << "bool " << validity << " = ("
+               << CombineValidity({child_visitor_list[0]->GetPreCheck(),
+                                   child_visitor_list[1]->GetPreCheck()})
+               << ");" << std::endl;
+    prepare_ss << "if (" << validity << ") {" << std::endl;
+    prepare_ss << codes_str_ << " = " << child_visitor_list[0]->GetResult() << " & "
+               << child_visitor_list[1]->GetResult() << ";" << std::endl;
+    prepare_ss << "}" << std::endl;
+
+    for (int i = 0; i < 2; i++) {
+      prepare_str_ += child_visitor_list[i]->GetPrepare();
+    }
+    prepare_str_ += prepare_ss.str();
+    check_str_ = validity;
+  } else if (func_name.compare("bitwise_or") == 0) {
+    codes_str_ = "bitwise_or_" + std::to_string(cur_func_id);
+    auto validity = codes_str_ + "_validity";
+    std::stringstream prepare_ss;
+    prepare_ss << GetCTypeString(node.return_type()) << " " << codes_str_ << ";"
+               << std::endl;
+    prepare_ss << "bool " << validity << " = ("
+               << CombineValidity({child_visitor_list[0]->GetPreCheck(),
+                                   child_visitor_list[1]->GetPreCheck()})
+               << ");" << std::endl;
+    prepare_ss << "if (" << validity << ") {" << std::endl;
+    prepare_ss << codes_str_ << " = " << child_visitor_list[0]->GetResult() << " | "
+               << child_visitor_list[1]->GetResult() << ";" << std::endl;
+    prepare_ss << "}" << std::endl;
+
+    for (int i = 0; i < 2; i++) {
+      prepare_str_ += child_visitor_list[i]->GetPrepare();
+    }
+    prepare_str_ += prepare_ss.str();
+    check_str_ = validity;
   } else {
     return arrow::Status::NotImplemented(func_name, " is currently not supported.");
   }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/expression_codegen_visitor.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/expression_codegen_visitor.cc
@@ -166,7 +166,13 @@ arrow::Status ExpressionCodegenVisitor::Visit(const gandiva::FunctionNode& node)
     for (int i = 0; i < 3; i++) {
       prepare_str_ += child_visitor_list[i]->GetPrepare();
     }
-    codes_str_ = ss.str();
+    // codes_str_ = ss.str();
+    codes_str_ = "substr_" + std::to_string(cur_func_id);
+    check_str_ = GetValidityName(codes_str_);
+    std::stringstream prepare_ss;
+    prepare_ss << "auto " << codes_str_ << " = " << ss.str() << ";" << std::endl;
+    prepare_ss << "bool " << check_str_ << " = true;" << std::endl;
+    prepare_str_ += prepare_ss.str();
   } else if (func_name.compare("upper") == 0) {
     std::stringstream prepare_ss;
     auto child_name = child_visitor_list[0]->GetResult();

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
@@ -171,7 +171,8 @@ class HashRelationKernel::Impl {
   PROCESS(arrow::FloatType)              \
   PROCESS(arrow::DoubleType)             \
   PROCESS(arrow::Date32Type)             \
-  PROCESS(arrow::Date64Type)
+  PROCESS(arrow::Date64Type)             \
+  PROCESS(arrow::StringType)
       if (project_outputs.size() == 1 &&
           project_outputs[0]->type_id() != arrow::Type::STRING) {
         switch (project_outputs[0]->type_id()) {

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -24,10 +24,10 @@
 #include <gandiva/node.h>
 #include <gandiva/tree_expr_builder.h>
 
+#include "codegen/arrow_compute/ext/array_item_index.h"
 #include "codegen/arrow_compute/ext/codegen_context.h"
 #include "codegen/common/hash_relation.h"
 #include "codegen/common/result_iterator.h"
-#include "codegen/arrow_compute/ext/array_item_index.h"
 
 using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
 
@@ -132,23 +132,23 @@ class EncodeArrayKernel : public KernalBase {
   arrow::compute::FunctionContext* ctx_;
 };
 
-
 class WindowAggregateFunctionKernel : public KernalBase {
  public:
   class ActionFactory;
-  WindowAggregateFunctionKernel(arrow::compute::FunctionContext* ctx,
-                                std::vector<std::shared_ptr<arrow::DataType>> type_list,
-                                std::shared_ptr<arrow::DataType> result_type,
-                                std::vector<std::shared_ptr<arrow::Int32Array>> accumulated_group_ids,
-                                std::shared_ptr<ActionFactory> action);
+  WindowAggregateFunctionKernel(
+      arrow::compute::FunctionContext* ctx,
+      std::vector<std::shared_ptr<arrow::DataType>> type_list,
+      std::shared_ptr<arrow::DataType> result_type,
+      std::vector<std::shared_ptr<arrow::Int32Array>> accumulated_group_ids,
+      std::shared_ptr<ActionFactory> action);
   static arrow::Status Make(arrow::compute::FunctionContext* ctx,
                             std::string function_name,
                             std::vector<std::shared_ptr<arrow::DataType>> type_list,
                             std::shared_ptr<arrow::DataType> result_type,
                             std::shared_ptr<KernalBase>* out);
-  arrow::Status Evaluate(const ArrayList &in) override;
+  arrow::Status Evaluate(const ArrayList& in) override;
   arrow::Status Finish(ArrayList* out) override;
-  template<typename ArrowType>
+  template <typename ArrowType>
   arrow::Status Finish0(ArrayList* out);
 
  private:
@@ -309,14 +309,14 @@ class SortArraysToIndicesKernel : public KernalBase {
                             std::shared_ptr<arrow::Schema> result_schema,
                             gandiva::NodeVector sort_key_node,
                             std::vector<std::shared_ptr<arrow::Field>> key_field_list,
-                            std::vector<bool> sort_directions, 
-                            std::vector<bool> nulls_order, 
+                            std::vector<bool> sort_directions,
+                            std::vector<bool> nulls_order,
                             std::shared_ptr<KernalBase>* out);
   SortArraysToIndicesKernel(arrow::compute::FunctionContext* ctx,
                             std::shared_ptr<arrow::Schema> result_schema,
                             gandiva::NodeVector sort_key_node,
                             std::vector<std::shared_ptr<arrow::Field>> key_field_list,
-                            std::vector<bool> sort_directions, 
+                            std::vector<bool> sort_directions,
                             std::vector<bool> nulls_order);
   arrow::Status Evaluate(const ArrayList& in) override;
   arrow::Status MakeResultIterator(
@@ -338,9 +338,9 @@ class WindowSortKernel : public KernalBase {
                             std::shared_ptr<arrow::Schema> result_schema,
                             std::shared_ptr<KernalBase>* out, bool nulls_first, bool asc);
   WindowSortKernel(arrow::compute::FunctionContext* ctx,
-                            std::vector<std::shared_ptr<arrow::Field>> key_field_list,
-                            std::shared_ptr<arrow::Schema> result_schema,
-                            bool nulls_first, bool asc);
+                   std::vector<std::shared_ptr<arrow::Field>> key_field_list,
+                   std::shared_ptr<arrow::Schema> result_schema, bool nulls_first,
+                   bool asc);
   arrow::Status Evaluate(const ArrayList& in) override;
   std::string GetSignature() override;
 
@@ -379,22 +379,23 @@ class WindowRankKernel : public KernalBase {
  public:
   WindowRankKernel(arrow::compute::FunctionContext* ctx,
                    std::vector<std::shared_ptr<arrow::DataType>> type_list,
-                   std::shared_ptr<WindowSortKernel::Impl> sorter,
-                   bool desc);
+                   std::shared_ptr<WindowSortKernel::Impl> sorter, bool desc);
   static arrow::Status Make(arrow::compute::FunctionContext* ctx,
                             std::string function_name,
                             std::vector<std::shared_ptr<arrow::DataType>> type_list,
-                            std::shared_ptr<KernalBase>* out,
-                            bool desc);
-  arrow::Status Evaluate(const ArrayList &in) override;
+                            std::shared_ptr<KernalBase>* out, bool desc);
+  arrow::Status Evaluate(const ArrayList& in) override;
   arrow::Status Finish(ArrayList* out) override;
 
   arrow::Status SortToIndicesPrepare(std::vector<ArrayList> values);
-  arrow::Status SortToIndicesFinish(std::vector<std::shared_ptr<ArrayItemIndex>> elements_to_sort,
-                                    std::vector<std::shared_ptr<ArrayItemIndex>>* offsets);
+  arrow::Status SortToIndicesFinish(
+      std::vector<std::shared_ptr<ArrayItemIndex>> elements_to_sort,
+      std::vector<std::shared_ptr<ArrayItemIndex>>* offsets);
 
-  template<typename ArrayType>
-  arrow::Status AreTheSameValue(std::vector<ArrayList> values, int column, std::shared_ptr<ArrayItemIndex> i, std::shared_ptr<ArrayItemIndex> j, bool* out);
+  template <typename ArrayType>
+  arrow::Status AreTheSameValue(std::vector<ArrayList> values, int column,
+                                std::shared_ptr<ArrayItemIndex> i,
+                                std::shared_ptr<ArrayItemIndex> j, bool* out);
 
  private:
   std::shared_ptr<WindowSortKernel::Impl> sorter_;
@@ -535,6 +536,7 @@ class ConditionedProbeKernel : public KernalBase {
                             const gandiva::NodeVector& right_schema_list,
                             const gandiva::NodePtr& condition, int join_type,
                             const gandiva::NodeVector& result_schema,
+                            const gandiva::NodeVector& hash_configuration_list,
                             int hash_relation_idx, std::shared_ptr<KernalBase>* out);
   ConditionedProbeKernel(arrow::compute::FunctionContext* ctx,
                          const gandiva::NodeVector& left_key_list,
@@ -542,7 +544,9 @@ class ConditionedProbeKernel : public KernalBase {
                          const gandiva::NodeVector& left_schema_list,
                          const gandiva::NodeVector& right_schema_list,
                          const gandiva::NodePtr& condition, int join_type,
-                         const gandiva::NodeVector& result_schema, int hash_relation_idx);
+                         const gandiva::NodeVector& result_schema,
+                         const gandiva::NodeVector& hash_configuration_list,
+                         int hash_relation_idx);
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -527,6 +527,30 @@ class HashRelationKernel : public KernalBase {
   std::unique_ptr<Impl> impl_;
   arrow::compute::FunctionContext* ctx_;
 };
+class ConcatArrayListKernel : public KernalBase {
+ public:
+  static arrow::Status Make(
+      arrow::compute::FunctionContext* ctx,
+      const std::vector<std::shared_ptr<arrow::Field>>& input_field_list,
+      std::shared_ptr<gandiva::Node> root_node,
+      const std::vector<std::shared_ptr<arrow::Field>>& output_field_list,
+      std::shared_ptr<KernalBase>* out);
+  ConcatArrayListKernel(
+      arrow::compute::FunctionContext* ctx,
+      const std::vector<std::shared_ptr<arrow::Field>>& input_field_list,
+      std::shared_ptr<gandiva::Node> root_node,
+      const std::vector<std::shared_ptr<arrow::Field>>& output_field_list);
+  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status MakeResultIterator(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override;
+
+  class Impl;
+
+ private:
+  std::unique_ptr<Impl> impl_;
+  arrow::compute::FunctionContext* ctx_;
+};
 class ConditionedProbeKernel : public KernalBase {
  public:
   static arrow::Status Make(arrow::compute::FunctionContext* ctx,

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/whole_stage_codegen_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/whole_stage_codegen_kernel.cc
@@ -99,9 +99,11 @@ class WholeStageCodeGenKernel::Impl {
       RETURN_NOT_OK(GetArguments(function_node, 3, &right_key_list));
       gandiva::NodeVector result_list;
       RETURN_NOT_OK(GetArguments(function_node, 4, &result_list));
+      gandiva::NodeVector configuration_list;
+      RETURN_NOT_OK(GetArguments(function_node, 5, &configuration_list));
       gandiva::NodePtr condition;
-      if (function_node->children().size() > 5) {
-        condition = function_node->children()[5];
+      if (function_node->children().size() > 6) {
+        condition = function_node->children()[6];
       }
 
       if (func_name.compare("conditionedProbeArraysInner") == 0) {
@@ -119,7 +121,8 @@ class WholeStageCodeGenKernel::Impl {
       *hash_relation_idx += 1;
       RETURN_NOT_OK(ConditionedProbeKernel::Make(
           ctx_, left_key_list, right_key_list, left_schema_list, right_schema_list,
-          condition, join_type, result_list, cur_hash_relation_idx, out));
+          condition, join_type, result_list, configuration_list, cur_hash_relation_idx,
+          out));
 
     } else if (func_name.compare("project") == 0) {
       auto project_expression_list =

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation.h
@@ -167,7 +167,11 @@ class HashRelation {
     if (hash_table_ == nullptr) {
       throw std::runtime_error("HashRelation Get failed, hash_table is null.");
     }
-    return safeLookup(hash_table_, payload, v);
+    int step;
+    auto res = safeLookup(hash_table_, payload, v, &step);
+    total_get_++;
+    total_steps_ += step;
+    return res;
   }
 
   int GetNull() { return null_index_set_ ? 0 : HASH_NEW_KEY; }
@@ -221,6 +225,8 @@ class HashRelation {
   }
 
   virtual std::vector<ArrayItemIndex> GetItemListByIndex(int i) { return arrayid_list_; }
+  uint64_t total_steps_ = 0;
+  uint64_t total_get_ = 0;
 
  protected:
   bool unsafe_set = false;

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation.h
@@ -145,6 +145,7 @@ class HashRelation {
     }
 
     num_arrays_++;
+    // DumpHashMap();
     return arrow::Status::OK();
   }
 
@@ -160,6 +161,13 @@ class HashRelation {
       arrayid_list_.push_back(*((ArrayItemIndex*)index));
     }
     return 0;
+  }
+
+  int IfExists(int32_t v, std::shared_ptr<UnsafeRow> payload) {
+    if (hash_table_ == nullptr) {
+      throw std::runtime_error("HashRelation Get failed, hash_table is null.");
+    }
+    return safeLookup(hash_table_, payload, v);
   }
 
   int GetNull() { return null_index_set_ ? 0 : HASH_NEW_KEY; }
@@ -202,7 +210,7 @@ class HashRelation {
     hash_table_->cursor = sizes[2];
     hash_table_->keyArray = (int*)addrs[1];
     hash_table_->bytesMap = (char*)addrs[2];
-    unsafe_set == true;
+    unsafe_set = true;
     // dump(hash_table_);
     return arrow::Status::OK();
   }

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation.h
@@ -198,22 +198,14 @@ class HashRelation {
     if (hash_table_ == nullptr) {
       throw std::runtime_error("HashRelation Get failed, hash_table is null.");
     }
-    int step;
-    auto res = safeLookup(hash_table_, payload, v, &step);
-    total_get_++;
-    total_steps_ += step;
-    return res;
+    return safeLookup(hash_table_, payload, v);
   }
 
   int IfExists(int32_t v, std::shared_ptr<UnsafeRow> payload) {
     if (hash_table_ == nullptr) {
       throw std::runtime_error("HashRelation Get failed, hash_table is null.");
     }
-    int step;
-    auto res = safeLookup(hash_table_, payload, v, &step);
-    total_get_++;
-    total_steps_ += step;
-    return res;
+    return safeLookup(hash_table_, payload, v);
   }
 
   int GetNull() { return null_index_set_ ? 0 : HASH_NEW_KEY; }
@@ -237,8 +229,6 @@ class HashRelation {
       return arrow::Status::Invalid("UnsafeGetHashTableObject hash_table is null");
     }
     // dump(hash_table_);
-    std::cout << "HashRelation UnsafeGetHashTableObject contains numKeys of "
-              << hash_table_->numKeys << std::endl;
     addrs[0] = (int64_t)hash_table_;
     sizes[0] = (int)sizeof(unsafeHashMap);
 
@@ -267,8 +257,6 @@ class HashRelation {
   }
 
   virtual std::vector<ArrayItemIndex> GetItemListByIndex(int i) { return arrayid_list_; }
-  uint64_t total_steps_ = 0;
-  uint64_t total_get_ = 0;
 
  protected:
   bool unsafe_set = false;

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation_number.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation_number.h
@@ -59,6 +59,10 @@ class TypedHashRelation<DataType, enable_if_number<DataType>> : public HashRelat
 
   int GetNull() { return hash_table_->GetNull(); }
 
+  std::vector<ArrayItemIndex> GetItemListByIndex(int i) override {
+    return memo_index_to_arrayid_[i];
+  }
+
  private:
   arrow::Status Insert(T v, uint32_t array_id, uint32_t id) {
     int i;
@@ -84,6 +88,8 @@ class TypedHashRelation<DataType, enable_if_number<DataType>> : public HashRelat
     return arrow::Status::OK();
   }
 
+  int num_items_ = 0;
   std::shared_ptr<SparseHashMap<T>> hash_table_;
   using ArrayType = typename TypeTraits<DataType>::ArrayType;
+  std::vector<std::vector<ArrayItemIndex>> memo_index_to_arrayid_;
 };

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation_string.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation_string.h
@@ -65,6 +65,10 @@ class TypedHashRelation<DataType, enable_if_string_like<DataType>> : public Hash
 
   int GetNull() { return hash_table_->GetNull(); }
 
+  std::vector<ArrayItemIndex> GetItemListByIndex(int i) override {
+    return memo_index_to_arrayid_[i];
+  }
+
  private:
   arrow::Status Insert(arrow::util::string_view v, uint32_t array_id, uint32_t id) {
     int i;
@@ -90,6 +94,8 @@ class TypedHashRelation<DataType, enable_if_string_like<DataType>> : public Hash
     return arrow::Status::OK();
   }
 
+  int num_items_ = 0;
   std::shared_ptr<StringHashMap> hash_table_;
   using ArrayType = sparkcolumnarplugin::precompile::StringArray;
+  std::vector<std::vector<ArrayItemIndex>> memo_index_to_arrayid_;
 };

--- a/oap-native-sql/cpp/src/codegen/common/result_iterator.h
+++ b/oap-native-sql/cpp/src/codegen/common/result_iterator.h
@@ -24,6 +24,11 @@ class ResultIteratorBase {
  public:
   virtual bool HasNext() { return false; }
   virtual std::string ToString() { return ""; }
+  virtual arrow::Status ProcessAndCacheOne(
+      const std::vector<std::shared_ptr<arrow::Array>>& in,
+      const std::shared_ptr<arrow::Array>& selection = nullptr) {
+    return arrow::Status::NotImplemented("ResultIterator abstract ProcessAndCacheOne()");
+  }
 };
 
 template <typename T>
@@ -43,11 +48,6 @@ class ResultIterator : public ResultIteratorBase {
       const std::vector<std::shared_ptr<arrow::Array>>& projected_in,
       std::shared_ptr<T>* out, const std::shared_ptr<arrow::Array>& selection = nullptr) {
     return arrow::Status::NotImplemented("ResultIterator abstract Process()");
-  }
-  virtual arrow::Status ProcessAndCacheOne(
-      const std::vector<std::shared_ptr<arrow::Array>>& in,
-      const std::shared_ptr<arrow::Array>& selection = nullptr) {
-    return arrow::Status::NotImplemented("ResultIterator abstract ProcessAndCacheOne()");
   }
   virtual arrow::Status SetDependencies(
       const std::vector<std::shared_ptr<ResultIteratorBase>>&) {

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_join_wocg.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_join_wocg.cc
@@ -73,9 +73,12 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestProjectKeyInnerJoin) {
       uint64());
   auto n_condition = TreeExprBuilder::MakeFunction(
       "greater_than", {n_add, TreeExprBuilder::MakeField(table0_f2)}, boolean());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysInner",
-      {n_left, n_right, n_left_key, n_right_key, n_result, n_condition}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config, n_condition},
+      uint32());
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
 
@@ -123,9 +126,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestStringInnerJoin) {
        TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f0),
        TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysInner", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysInner",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
 
@@ -255,9 +260,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestTwoStringInnerJoin) {
        TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f0),
        TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysInner", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysInner",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
   auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
@@ -378,9 +385,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestOuterJoin) {
       {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
        TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysOuter", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysOuter",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
 
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
@@ -502,9 +511,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestAntiJoin) {
       "result",
       {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysAnti", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysAnti",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
 
@@ -621,9 +632,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestSemiJoin) {
       "result",
       {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysSemi", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysSemi",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
   auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
@@ -742,9 +755,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestExistenceJoin) {
       {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(f_exist),
        TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysExistence",
-      {n_left, n_right, n_left_key, n_right_key, n_result}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
   auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
@@ -866,9 +881,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestExistenceJoin2) {
       {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1),
        TreeExprBuilder::MakeField(f_exist)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)0)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysExistence",
-      {n_left, n_right, n_left_key, n_right_key, n_result}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_standalone =
       TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
   auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
@@ -928,6 +945,631 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestExistenceJoin2) {
 
   expected_result_string = {"[7, 8, 9, 10, 11, 12]", "[7, 8, 9, 10, 11, 12]",
                             "[false, true, false, true, false, true]"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  ////////////////////// evaluate //////////////////////
+  for (auto batch : table_0) {
+    ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIteratorBase> build_result_iterator;
+  std::shared_ptr<ResultIteratorBase> probe_result_iterator_base;
+  ASSERT_NOT_OK(expr_build->finish(&build_result_iterator));
+  ASSERT_NOT_OK(expr_probe->finish(&probe_result_iterator_base));
+
+  auto probe_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          probe_result_iterator_base);
+  probe_result_iterator->SetDependencies({build_result_iterator});
+
+  for (int i = 0; i < 2; i++) {
+    auto right_batch = table_1[i];
+
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+    std::vector<std::shared_ptr<arrow::Array>> input;
+    for (int i = 0; i < right_batch->num_columns(); i++) {
+      input.push_back(right_batch->column(i));
+    }
+
+    ASSERT_NOT_OK(probe_result_iterator->Process(input, &result_batch));
+    ASSERT_NOT_OK(Equals(*(expected_table[i]).get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeWSCG, JoinWOCGTestTwoStringInnerJoinType2) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto table0_f0 = field("table0_f0", utf8());
+  auto table0_f1 = field("table0_f1", utf8());
+  auto table0_f2 = field("table0_f2", uint32());
+  auto table1_f0 = field("table1_f0", utf8());
+  auto table1_f1 = field("table1_f1", utf8());
+
+  ///////////////////////////////////////////
+  auto n_left = TreeExprBuilder::MakeFunction(
+      "codegen_left_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2)},
+      uint32());
+  auto n_right = TreeExprBuilder::MakeFunction(
+      "codegen_right_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto f_res = field("res", uint32());
+
+  auto n_left_key = TreeExprBuilder::MakeFunction(
+      "codegen_left_key_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1)},
+      uint32());
+  auto n_right_key = TreeExprBuilder::MakeFunction(
+      "codegen_right_key_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_result = TreeExprBuilder::MakeFunction(
+      "result",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f0),
+       TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
+  auto n_probeArrays = TreeExprBuilder::MakeFunction(
+      "conditionedProbeArraysInner",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
+  auto n_standalone =
+      TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
+  auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
+
+  auto schema_table_0 = arrow::schema({table0_f0, table0_f1, table0_f2});
+  auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
+  auto schema_table =
+      arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
+
+  auto n_hash_kernel = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config}, uint32());
+  auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
+  auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
+  std::shared_ptr<CodeGenerator> expr_build;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  std::shared_ptr<CodeGenerator> expr_probe;
+  ASSERT_NOT_OK(CreateCodeGenerator(
+      schema_table_1, {probeArrays_expr},
+      {table0_f0, table0_f1, table0_f2, table1_f0, table1_f1}, &expr_probe, true));
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_0;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_1;
+
+  std::vector<std::string> input_data_string = {
+      R"(["l", "c", "a", "b"])", R"(["L", "C", "A", "B"])", "[10, 3, 1, 2]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  input_data_string = {R"(["f", "n", "e", "j"])", R"(["F", "N", "E", "J"])",
+                       "[6, 12, 5, 8]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  std::vector<std::string> input_data_2_string = {R"(["a", "b", "c", "d", "e", "f"])",
+                                                  R"(["A", "B", "C", "D", "F", "F"])"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  input_data_2_string = {R"(["i", "j", "k", "l", "m", "n"])",
+                         R"(["I", "J", "K", "L", "M", "N"])"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  //////////////////////// data prepared /////////////////////////
+
+  std::vector<std::shared_ptr<RecordBatch>> expected_table;
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      R"(["a", "b", "c", "f"])", R"(["A", "B", "C", "F"])", "[1, 2, 3, 6]",
+      R"(["a", "b", "c", "f"])", R"(["A", "B", "C", "F"])"};
+  MakeInputBatch(expected_result_string, schema_table, &expected_result);
+  expected_table.push_back(expected_result);
+
+  expected_result_string = {R"(["j", "l", "n"])", R"(["J", "L", "N"])", "[8, 10, 12]",
+                            R"(["j", "l", "n"])", R"(["J", "L", "N"])"};
+  MakeInputBatch(expected_result_string, schema_table, &expected_result);
+  expected_table.push_back(expected_result);
+
+  ////////////////////// evaluate //////////////////////
+  for (auto batch : table_0) {
+    ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIteratorBase> build_result_iterator;
+  std::shared_ptr<ResultIteratorBase> probe_result_iterator_base;
+  ASSERT_NOT_OK(expr_build->finish(&build_result_iterator));
+  ASSERT_NOT_OK(expr_probe->finish(&probe_result_iterator_base));
+
+  auto probe_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          probe_result_iterator_base);
+  probe_result_iterator->SetDependencies({build_result_iterator});
+
+  for (int i = 0; i < 2; i++) {
+    auto right_batch = table_1[i];
+
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+    std::vector<std::shared_ptr<arrow::Array>> input;
+    for (int i = 0; i < right_batch->num_columns(); i++) {
+      input.push_back(right_batch->column(i));
+    }
+
+    ASSERT_NOT_OK(probe_result_iterator->Process(input, &result_batch));
+    ASSERT_NOT_OK(Equals(*(expected_table[i]).get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeWSCG, JoinWOCGTestOuterJoinType2) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto table0_f0 = field("table0_f0", uint32());
+  auto table0_f1 = field("table0_f1", uint32());
+  auto table0_f2 = field("table0_f2", uint32());
+  auto table1_f0 = field("table1_f0", uint32());
+  auto table1_f1 = field("table1_f1", uint32());
+
+  ///////////////////////////////////////////
+  auto n_left = TreeExprBuilder::MakeFunction(
+      "codegen_left_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2)},
+      uint32());
+  auto n_right = TreeExprBuilder::MakeFunction(
+      "codegen_right_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto f_res = field("res", uint32());
+
+  auto n_left_key = TreeExprBuilder::MakeFunction(
+      "codegen_left_key_schema", {TreeExprBuilder::MakeField(table0_f0)}, uint32());
+  auto n_right_key = TreeExprBuilder::MakeFunction(
+      "codegen_right_key_schema", {TreeExprBuilder::MakeField(table1_f0)}, uint32());
+  auto n_result = TreeExprBuilder::MakeFunction(
+      "result",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
+  auto n_probeArrays = TreeExprBuilder::MakeFunction(
+      "conditionedProbeArraysOuter",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
+
+  auto n_standalone =
+      TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
+  auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
+
+  auto schema_table_0 = arrow::schema({table0_f0, table0_f1, table0_f2});
+  auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
+  auto schema_table =
+      arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
+
+  auto n_hash_kernel = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config}, uint32());
+  auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
+  auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
+  std::shared_ptr<CodeGenerator> expr_build;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  std::shared_ptr<CodeGenerator> expr_probe;
+  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+                                    {table0_f0, table0_f1, table0_f2, table1_f1},
+                                    &expr_probe, true));
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_0;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_1;
+
+  std::vector<std::string> input_data_string = {
+      "[10, 3, 1, 2, 3, 1]", "[10, 3, 1, 2, 13, 11]", "[10, 3, 1, 2, 13, 11]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  input_data_string = {"[6, 12, 5, 8, 6, 10]", "[6, 12, 5, 8, 16, 110]",
+                       "[6, 12, 5, 8, 16, 110]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  std::vector<std::string> input_data_2_string = {"[1, 2, 3, 4, 5, 6]",
+                                                  "[1, 2, 3, 4, 5, 6]"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  input_data_2_string = {"[7, 8, 9, 10, 11, 12]", "[7, 8, 9, 10, 11, 12]"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  //////////////////////// data prepared /////////////////////////
+
+  auto res_sch = arrow::schema({table0_f0, table0_f1, table0_f2, table1_f1});
+  std::vector<std::shared_ptr<RecordBatch>> expected_table;
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 1, 2, 3, 3, null, 5, 6, 6]", "[1, 11, 2, 3, 13, null, 5, 6, 16]",
+      "[1, 11, 2, 3, 13, null, 5, 6, 16]", "[1, 1, 2, 3, 3, 4, 5, 6, 6]"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  expected_result_string = {
+      "[null, 8, null, 10, 10, null, 12]", "[null, 8, null, 10, 110, null, 12]",
+      "[null, 8, null, 10, 110, null, 12]", "[7, 8, 9, 10, 10, 11, 12]"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  ////////////////////// evaluate //////////////////////
+  for (auto batch : table_0) {
+    ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIteratorBase> build_result_iterator;
+  std::shared_ptr<ResultIteratorBase> probe_result_iterator_base;
+  ASSERT_NOT_OK(expr_build->finish(&build_result_iterator));
+  ASSERT_NOT_OK(expr_probe->finish(&probe_result_iterator_base));
+
+  auto probe_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          probe_result_iterator_base);
+  probe_result_iterator->SetDependencies({build_result_iterator});
+
+  for (int i = 0; i < 2; i++) {
+    auto right_batch = table_1[i];
+
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+    std::vector<std::shared_ptr<arrow::Array>> input;
+    for (int i = 0; i < right_batch->num_columns(); i++) {
+      input.push_back(right_batch->column(i));
+    }
+
+    ASSERT_NOT_OK(probe_result_iterator->Process(input, &result_batch));
+    ASSERT_NOT_OK(Equals(*(expected_table[i]).get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeWSCG, JoinWOCGTestAntiJoinType2) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto table0_f0 = field("table0_f0", uint32());
+  auto table0_f1 = field("table0_f1", uint32());
+  auto table0_f2 = field("table0_f2", uint32());
+  auto table1_f0 = field("table1_f0", uint32());
+  auto table1_f1 = field("table1_f1", uint32());
+
+  ///////////////////////////////////////////
+  auto n_left = TreeExprBuilder::MakeFunction(
+      "codegen_left_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2)},
+      uint32());
+  auto n_right = TreeExprBuilder::MakeFunction(
+      "codegen_right_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto f_res = field("res", uint32());
+
+  auto n_left_key = TreeExprBuilder::MakeFunction(
+      "codegen_left_key_schema", {TreeExprBuilder::MakeField(table0_f0)}, uint32());
+  auto n_right_key = TreeExprBuilder::MakeFunction(
+      "codegen_right_key_schema", {TreeExprBuilder::MakeField(table1_f0)}, uint32());
+  auto n_result = TreeExprBuilder::MakeFunction(
+      "result",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
+  auto n_probeArrays = TreeExprBuilder::MakeFunction(
+      "conditionedProbeArraysAnti",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
+  auto n_standalone =
+      TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
+
+  auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
+
+  auto schema_table_0 = arrow::schema({table0_f0, table0_f1, table0_f2});
+  auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
+  auto schema_table =
+      arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
+
+  auto n_hash_kernel = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config}, uint32());
+  auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
+  auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
+  std::shared_ptr<CodeGenerator> expr_build;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  std::shared_ptr<CodeGenerator> expr_probe;
+  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+                                    {table1_f0, table1_f1}, &expr_probe, true));
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_0;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_1;
+
+  std::vector<std::string> input_data_string = {
+      "[10, 3, 1, 2, 3, 1]", "[10, 3, 1, 2, 13, 11]", "[10, 3, 1, 2, 13, 11]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  input_data_string = {"[6, 12, 5, 8, 6, 10]", "[6, 12, 5, 8, 16, 110]",
+                       "[6, 12, 5, 8, 16, 110]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  std::vector<std::string> input_data_2_string = {"[1, 2, 3, 4, 5, 6]",
+                                                  "[1, 2, 3, 4, 5, 6]"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  input_data_2_string = {"[7, 8, 9, 10, 11, 12]", "[7, 8, 9, 10, 11, 12]"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  //////////////////////// data prepared /////////////////////////
+
+  auto res_sch = arrow::schema({table1_f0, table1_f1});
+  std::vector<std::shared_ptr<RecordBatch>> expected_table;
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {"[4]", "[4]"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  expected_result_string = {"[7, 9, 11]", "[7, 9, 11]"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  ////////////////////// evaluate //////////////////////
+  for (auto batch : table_0) {
+    ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIteratorBase> build_result_iterator;
+  std::shared_ptr<ResultIteratorBase> probe_result_iterator_base;
+  ASSERT_NOT_OK(expr_build->finish(&build_result_iterator));
+  ASSERT_NOT_OK(expr_probe->finish(&probe_result_iterator_base));
+
+  auto probe_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          probe_result_iterator_base);
+  probe_result_iterator->SetDependencies({build_result_iterator});
+
+  for (int i = 0; i < 2; i++) {
+    auto right_batch = table_1[i];
+
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+    std::vector<std::shared_ptr<arrow::Array>> input;
+    for (int i = 0; i < right_batch->num_columns(); i++) {
+      input.push_back(right_batch->column(i));
+    }
+
+    ASSERT_NOT_OK(probe_result_iterator->Process(input, &result_batch));
+    ASSERT_NOT_OK(Equals(*(expected_table[i]).get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeWSCG, JoinWOCGTestSemiJoinType2) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto table0_f0 = field("table0_f0", uint32());
+  auto table0_f1 = field("table0_f1", uint32());
+  auto table0_f2 = field("table0_f2", uint32());
+  auto table1_f0 = field("table1_f0", uint32());
+  auto table1_f1 = field("table1_f1", utf8());
+
+  ///////////////////////////////////////////
+  auto n_left = TreeExprBuilder::MakeFunction(
+      "codegen_left_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2)},
+      uint32());
+  auto n_right = TreeExprBuilder::MakeFunction(
+      "codegen_right_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto f_res = field("res", uint32());
+
+  auto n_left_key = TreeExprBuilder::MakeFunction(
+      "codegen_left_key_schema", {TreeExprBuilder::MakeField(table0_f0)}, uint32());
+  auto n_right_key = TreeExprBuilder::MakeFunction(
+      "codegen_right_key_schema", {TreeExprBuilder::MakeField(table1_f0)}, uint32());
+  auto n_result = TreeExprBuilder::MakeFunction(
+      "result",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
+  auto n_probeArrays = TreeExprBuilder::MakeFunction(
+      "conditionedProbeArraysSemi",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
+  auto n_standalone =
+      TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
+  auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
+
+  auto schema_table_0 = arrow::schema({table0_f0, table0_f1, table0_f2});
+  auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
+  auto schema_table = arrow::schema({table1_f0, table1_f1});
+
+  auto n_hash_kernel = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config}, uint32());
+  auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
+  auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
+  std::shared_ptr<CodeGenerator> expr_build;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  std::shared_ptr<CodeGenerator> expr_probe;
+  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+                                    {table1_f0, table1_f1}, &expr_probe, true));
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_0;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_1;
+
+  std::vector<std::string> input_data_string = {
+      "[10, 3, 1, 2, 3, 1]", "[10, 3, 1, 2, 13, 11]", "[10, 3, 1, 2, 13, 11]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  input_data_string = {"[6, 12, 5, 8, 6, 10]", "[6, 12, 5, 8, 16, 110]",
+                       "[6, 12, 5, 8, 16, 110]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  std::vector<std::string> input_data_2_string = {"[1, 3, 4, 5, 6]",
+                                                  R"(["BJ", "TY", "NY", "SH", "HZ"])"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  input_data_2_string = {"[7, 8, 9, 10, 11, 12]",
+                         R"(["SH", "NY", "BJ", "IT", "BR", "TL"])"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  //////////////////////// data prepared /////////////////////////
+
+  auto res_sch = arrow::schema({table1_f0, table1_f1});
+  std::vector<std::shared_ptr<RecordBatch>> expected_table;
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {"[1, 3, 5, 6]",
+                                                     R"(["BJ", "TY", "SH", "HZ"])"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  expected_result_string = {"[8, 10, 12]", R"(["NY", "IT", "TL"])"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  ////////////////////// evaluate //////////////////////
+  for (auto batch : table_0) {
+    ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIteratorBase> build_result_iterator;
+  std::shared_ptr<ResultIteratorBase> probe_result_iterator_base;
+  ASSERT_NOT_OK(expr_build->finish(&build_result_iterator));
+  ASSERT_NOT_OK(expr_probe->finish(&probe_result_iterator_base));
+
+  auto probe_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          probe_result_iterator_base);
+  probe_result_iterator->SetDependencies({build_result_iterator});
+
+  for (int i = 0; i < 2; i++) {
+    auto right_batch = table_1[i];
+
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+    std::vector<std::shared_ptr<arrow::Array>> input;
+    for (int i = 0; i < right_batch->num_columns(); i++) {
+      input.push_back(right_batch->column(i));
+    }
+
+    ASSERT_NOT_OK(probe_result_iterator->Process(input, &result_batch));
+    ASSERT_NOT_OK(Equals(*(expected_table[i]).get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeWSCG, JoinWOCGTestExistenceJoinType2) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto table0_f0 = field("table0_f0", uint32());
+  auto table0_f1 = field("table0_f1", uint32());
+  auto table0_f2 = field("table0_f2", uint32());
+  auto table1_f0 = field("table1_f0", uint32());
+  auto table1_f1 = field("table1_f1", uint32());
+
+  ///////////////////////////////////////////
+  auto f_res = field("res", uint32());
+  auto f_exist = field("res", arrow::boolean());
+  auto n_left = TreeExprBuilder::MakeFunction(
+      "codegen_left_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2)},
+      uint32());
+  auto n_right = TreeExprBuilder::MakeFunction(
+      "codegen_right_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+
+  auto n_left_key = TreeExprBuilder::MakeFunction(
+      "codegen_left_key_schema", {TreeExprBuilder::MakeField(table0_f0)}, uint32());
+  auto n_right_key = TreeExprBuilder::MakeFunction(
+      "codegen_right_key_schema", {TreeExprBuilder::MakeField(table1_f0)}, uint32());
+  auto n_result = TreeExprBuilder::MakeFunction(
+      "result",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(f_exist),
+       TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
+  auto n_probeArrays = TreeExprBuilder::MakeFunction(
+      "conditionedProbeArraysExistence",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
+  auto n_standalone =
+      TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
+  auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
+
+  auto schema_table_0 = arrow::schema({table0_f0, table0_f1, table0_f2});
+  auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
+  auto schema_table =
+      arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
+
+  auto n_hash_kernel = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config}, uint32());
+  auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
+  auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
+  std::shared_ptr<CodeGenerator> expr_build;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  std::shared_ptr<CodeGenerator> expr_probe;
+  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+                                    {table1_f0, f_exist, table1_f1}, &expr_probe, true));
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_0;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_1;
+
+  std::vector<std::string> input_data_string = {
+      "[10, 3, 1, 2, 3, 1]", "[10, 3, 1, 2, 13, 11]", "[10, 3, 1, 2, 13, 11]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  input_data_string = {"[6, 12, 5, 8, 6, 10]", "[6, 12, 5, 8, 16, 110]",
+                       "[6, 12, 5, 8, 16, 110]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  std::vector<std::string> input_data_2_string = {"[1, 2, 3, 4, 5, 6]",
+                                                  "[1, 2, 3, 4, 5, 6]"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  input_data_2_string = {"[7, 8, 9, 10, 11, 12]", "[7, 8, 9, 10, 11, 12]"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  //////////////////////// data prepared /////////////////////////
+
+  auto res_sch = arrow::schema({table1_f0, f_exist, table1_f1});
+  std::vector<std::shared_ptr<RecordBatch>> expected_table;
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 5, 6]", "[true, true, true, false, true, true]",
+      "[1, 2, 3, 4, 5, 6]"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  expected_result_string = {"[7, 8, 9, 10, 11, 12]",
+                            "[false, true, false, true, false, true]",
+                            "[7, 8, 9, 10, 11, 12]"};
   MakeInputBatch(expected_result_string, res_sch, &expected_result);
   expected_table.push_back(expected_result);
 

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_join_wocg.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_join_wocg.cc
@@ -25,6 +25,7 @@
 
 #include "codegen/code_generator.h"
 #include "codegen/code_generator_factory.h"
+#include "codegen/common/hash_relation.h"
 #include "tests/test_utils.h"
 
 using arrow::boolean;
@@ -1586,6 +1587,415 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestExistenceJoinType2) {
       std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
           probe_result_iterator_base);
   probe_result_iterator->SetDependencies({build_result_iterator});
+
+  for (int i = 0; i < 2; i++) {
+    auto right_batch = table_1[i];
+
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+    std::vector<std::shared_ptr<arrow::Array>> input;
+    for (int i = 0; i < right_batch->num_columns(); i++) {
+      input.push_back(right_batch->column(i));
+    }
+
+    ASSERT_NOT_OK(probe_result_iterator->Process(input, &result_batch));
+    ASSERT_NOT_OK(Equals(*(expected_table[i]).get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeWSCG, JoinWOCGTestSemiJoinType2WithUInt64) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto table0_f0 = field("table0_f0", uint64());
+  auto table0_f1 = field("table0_f1", uint32());
+  auto table0_f2 = field("table0_f2", uint32());
+  auto table1_f0 = field("table1_f0", uint64());
+  auto table1_f1 = field("table1_f1", utf8());
+
+  ///////////////////////////////////////////
+  auto n_left = TreeExprBuilder::MakeFunction(
+      "codegen_left_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2)},
+      uint32());
+  auto n_right = TreeExprBuilder::MakeFunction(
+      "codegen_right_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto f_res = field("res", uint32());
+
+  auto n_left_key = TreeExprBuilder::MakeFunction(
+      "codegen_left_key_schema", {TreeExprBuilder::MakeField(table0_f0)}, uint32());
+  auto n_right_key = TreeExprBuilder::MakeFunction(
+      "codegen_right_key_schema", {TreeExprBuilder::MakeField(table1_f0)}, uint32());
+  auto n_result = TreeExprBuilder::MakeFunction(
+      "result",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
+  auto n_probeArrays = TreeExprBuilder::MakeFunction(
+      "conditionedProbeArraysSemi",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
+  auto n_standalone =
+      TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
+  auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
+
+  auto schema_table_0 = arrow::schema({table0_f0, table0_f1, table0_f2});
+  auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
+  auto schema_table = arrow::schema({table1_f0, table1_f1});
+
+  auto n_hash_kernel = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config}, uint32());
+  auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
+  auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
+  std::shared_ptr<CodeGenerator> expr_build;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  std::shared_ptr<CodeGenerator> expr_probe;
+  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+                                    {table1_f0, table1_f1}, &expr_probe, true));
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_0;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_1;
+
+  std::vector<std::string> input_data_string = {
+      "[10, 3, 1, 2, 3, 1]", "[10, 3, 1, 2, 13, 11]", "[10, 3, 1, 2, 13, 11]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  input_data_string = {"[6, 12, 5, 8, 6, 10]", "[6, 12, 5, 8, 16, 110]",
+                       "[6, 12, 5, 8, 16, 110]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  std::vector<std::string> input_data_2_string = {"[1, 3, 4, 5, 6]",
+                                                  R"(["BJ", "TY", "NY", "SH", "HZ"])"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  input_data_2_string = {"[7, 8, 9, 10, 11, 12]",
+                         R"(["SH", "NY", "BJ", "IT", "BR", "TL"])"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  //////////////////////// data prepared /////////////////////////
+
+  auto res_sch = arrow::schema({table1_f0, table1_f1});
+  std::vector<std::shared_ptr<RecordBatch>> expected_table;
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {"[1, 3, 5, 6]",
+                                                     R"(["BJ", "TY", "SH", "HZ"])"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  expected_result_string = {"[8, 10, 12]", R"(["NY", "IT", "TL"])"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  ////////////////////// evaluate //////////////////////
+  for (auto batch : table_0) {
+    ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIteratorBase> build_result_iterator;
+  std::shared_ptr<ResultIteratorBase> probe_result_iterator_base;
+  ASSERT_NOT_OK(expr_build->finish(&build_result_iterator));
+  ASSERT_NOT_OK(expr_probe->finish(&probe_result_iterator_base));
+
+  auto probe_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          probe_result_iterator_base);
+  probe_result_iterator->SetDependencies({build_result_iterator});
+
+  for (int i = 0; i < 2; i++) {
+    auto right_batch = table_1[i];
+
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+    std::vector<std::shared_ptr<arrow::Array>> input;
+    for (int i = 0; i < right_batch->num_columns(); i++) {
+      input.push_back(right_batch->column(i));
+    }
+
+    ASSERT_NOT_OK(probe_result_iterator->Process(input, &result_batch));
+    ASSERT_NOT_OK(Equals(*(expected_table[i]).get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeWSCG, JoinWOCGTestInnerJoinType2WithUInt16) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto table0_f0 = field("table0_f0", uint16());
+  auto table0_f1 = field("table0_f1", uint32());
+  auto table0_f2 = field("table0_f2", uint32());
+  auto table1_f0 = field("table1_f0", uint16());
+  auto table1_f1 = field("table1_f1", utf8());
+
+  ///////////////////////////////////////////
+  auto n_left = TreeExprBuilder::MakeFunction(
+      "codegen_left_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2)},
+      uint32());
+  auto n_right = TreeExprBuilder::MakeFunction(
+      "codegen_right_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto f_res = field("res", uint32());
+
+  auto n_left_key = TreeExprBuilder::MakeFunction(
+      "codegen_left_key_schema", {TreeExprBuilder::MakeField(table0_f0)}, uint32());
+  auto n_right_key = TreeExprBuilder::MakeFunction(
+      "codegen_right_key_schema", {TreeExprBuilder::MakeField(table1_f0)}, uint32());
+  auto n_result = TreeExprBuilder::MakeFunction(
+      "result",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
+  auto n_probeArrays = TreeExprBuilder::MakeFunction(
+      "conditionedProbeArraysInner",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
+  auto n_standalone =
+      TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
+  auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
+
+  auto schema_table_0 = arrow::schema({table0_f0, table0_f1, table0_f2});
+  auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
+  auto schema_table = arrow::schema({table1_f0, table1_f1});
+
+  auto n_hash_kernel = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config}, uint32());
+  auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
+  auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
+  std::shared_ptr<CodeGenerator> expr_build;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  std::shared_ptr<CodeGenerator> expr_probe;
+  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+                                    {table1_f0, table1_f1}, &expr_probe, true));
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_0;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_1;
+
+  std::vector<std::string> input_data_string = {
+      "[10, 3, 1, 2, 3, 1]", "[10, 3, 1, 2, 13, 11]", "[10, 3, 1, 2, 13, 11]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  input_data_string = {"[6, 12, 5, 8, 6, 10]", "[6, 12, 5, 8, 16, 110]",
+                       "[6, 12, 5, 8, 16, 110]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  std::vector<std::string> input_data_2_string = {"[1, 3, 4, 5, 6]",
+                                                  R"(["BJ", "TY", "NY", "SH", "HZ"])"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  input_data_2_string = {"[7, 8, 9, 10, 11, 12]",
+                         R"(["SH", "NY", "BJ", "IT", "BR", "TL"])"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  //////////////////////// data prepared /////////////////////////
+
+  auto res_sch = arrow::schema({table1_f0, table1_f1});
+  std::vector<std::shared_ptr<RecordBatch>> expected_table;
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 1, 3, 3, 5, 6, 6]", R"(["BJ", "BJ", "TY", "TY","SH", "HZ", "HZ"])"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  expected_result_string = {"[8, 10, 10, 12]", R"(["NY", "IT", "IT","TL"])"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  ////////////////////// evaluate //////////////////////
+  for (auto batch : table_0) {
+    ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIteratorBase> build_result_iterator_base;
+  ASSERT_NOT_OK(expr_build->finish(&build_result_iterator_base));
+  std::shared_ptr<ResultIteratorBase> probe_result_iterator_base;
+  ASSERT_NOT_OK(expr_probe->finish(&probe_result_iterator_base));
+
+  auto build_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<HashRelation>>(build_result_iterator_base);
+  std::shared_ptr<HashRelation> hash_relation;
+  ASSERT_NOT_OK(build_result_iterator->Next(&hash_relation));
+  hash_relation->TESTGrowAndRehashKeyArray();
+
+  auto probe_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          probe_result_iterator_base);
+  probe_result_iterator->SetDependencies({build_result_iterator});
+
+  for (int i = 0; i < 2; i++) {
+    auto right_batch = table_1[i];
+
+    std::shared_ptr<arrow::RecordBatch> result_batch;
+    std::vector<std::shared_ptr<arrow::Array>> input;
+    for (int i = 0; i < right_batch->num_columns(); i++) {
+      input.push_back(right_batch->column(i));
+    }
+
+    ASSERT_NOT_OK(probe_result_iterator->Process(input, &result_batch));
+    ASSERT_NOT_OK(Equals(*(expected_table[i]).get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeWSCG, JoinWOCGTestStringInnerJoinType2LoadHashRelation) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto table0_f0 = field("table0_f0", utf8());
+  auto table0_f1 = field("table0_f1", utf8());
+  auto table0_f2 = field("table0_f2", uint32());
+  auto table1_f0 = field("table1_f0", utf8());
+  auto table1_f1 = field("table1_f1", uint32());
+
+  ///////////////////////////////////////////
+  auto n_left = TreeExprBuilder::MakeFunction(
+      "codegen_left_schema",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2)},
+      uint32());
+  auto n_right = TreeExprBuilder::MakeFunction(
+      "codegen_right_schema",
+      {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto f_res = field("res", uint32());
+
+  auto n_left_key = TreeExprBuilder::MakeFunction(
+      "codegen_left_key_schema", {TreeExprBuilder::MakeField(table0_f0)}, uint32());
+  auto n_right_key_func = TreeExprBuilder::MakeFunction(
+      "upper", {TreeExprBuilder::MakeField(table1_f0)}, utf8());
+  auto n_right_key = TreeExprBuilder::MakeFunction("codegen_right_key_schema",
+                                                   {n_right_key_func}, uint32());
+  auto n_result = TreeExprBuilder::MakeFunction(
+      "result",
+      {TreeExprBuilder::MakeField(table0_f0), TreeExprBuilder::MakeField(table0_f1),
+       TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f0),
+       TreeExprBuilder::MakeField(table1_f1)},
+      uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
+  auto n_probeArrays = TreeExprBuilder::MakeFunction(
+      "conditionedProbeArraysInner",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
+  auto n_standalone =
+      TreeExprBuilder::MakeFunction("standalone", {n_probeArrays}, uint32());
+
+  auto probeArrays_expr = TreeExprBuilder::MakeExpression(n_standalone, f_res);
+
+  auto schema_table_0 = arrow::schema({table0_f0, table0_f1, table0_f2});
+  auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
+  auto schema_table =
+      arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
+
+  auto n_hash_kernel_pre = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config}, uint32());
+  auto n_hash_pre =
+      TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel_pre}, uint32());
+  auto hashRelation_expr_pre = TreeExprBuilder::MakeExpression(n_hash_pre, f_res);
+
+  auto n_hash_config_2 = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)2)}, uint32());
+  auto n_hash_kernel = TreeExprBuilder::MakeFunction(
+      "HashRelation", {n_left_key, n_hash_config_2}, uint32());
+  auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
+  auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
+
+  std::shared_ptr<CodeGenerator> expr_build_pre;
+  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_0, {hashRelation_expr_pre}, {},
+                                    &expr_build_pre, true));
+  std::shared_ptr<CodeGenerator> expr_build;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  std::shared_ptr<CodeGenerator> expr_probe;
+  ASSERT_NOT_OK(CreateCodeGenerator(
+      schema_table_1, {probeArrays_expr},
+      {table0_f0, table0_f1, table0_f2, table1_f0, table1_f1}, &expr_probe, true));
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_0;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> table_1;
+
+  std::vector<std::string> input_data_string = {R"(["BJ", "SH", "HZ", "BH", "NY", "SH"])",
+                                                R"(["A", "A", "C", "D", "C", "D"])",
+                                                "[10, 3, 1, 2, 13, 11]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  input_data_string = {R"(["TK", "SH", "PH", "NJ", "NB", "SZ"])",
+                       R"(["F", "F", "A", "B", "D", "C"])", "[6, 12, 5, 8, 16, 110]"};
+  MakeInputBatch(input_data_string, schema_table_0, &input_batch);
+  table_0.push_back(input_batch);
+
+  std::vector<std::string> input_data_2_string = {
+      R"(["sh", "sz", "bj", null, "ny", "hz"])", "[1, 2, 3, 4, 5, 6]"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  input_data_2_string = {R"(["ph", null, "jh", "kk", "nj", "sz"])",
+                         "[7, 8, 9, 10, null, 12]"};
+  MakeInputBatch(input_data_2_string, schema_table_1, &input_batch);
+  table_1.push_back(input_batch);
+
+  //////////////////////// data prepared /////////////////////////
+
+  std::vector<std::shared_ptr<RecordBatch>> expected_table;
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      R"(["SH", "SH", "SH", "SZ", "BJ", "NY", "HZ"])",
+      R"(["A", "D", "F", "C", "A", "C", "C"])", "[3, 11, 12, 110, 10, 13, 1]",
+      R"(["sh", "sh", "sh", "sz", "bj", "ny", "hz"])", "[1, 1, 1, 2, 3, 5, 6]"};
+  auto res_sch = arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  expected_result_string = {R"(["PH", "NJ", "SZ"])", R"(["A", "B", "C"])", "[5, 8, 110]",
+                            R"(["ph", "nj", "sz"])", "[7, null, 12]"};
+  MakeInputBatch(expected_result_string, res_sch, &expected_result);
+  expected_table.push_back(expected_result);
+
+  ////////////////////// evaluate //////////////////////
+  for (auto batch : table_0) {
+    ASSERT_NOT_OK(expr_build_pre->evaluate(batch, &dummy_result_batches));
+    ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIteratorBase> build_result_iterator_base_pre;
+  std::shared_ptr<ResultIteratorBase> build_result_iterator_base;
+  std::shared_ptr<ResultIteratorBase> probe_result_iterator_base;
+  ASSERT_NOT_OK(expr_build_pre->finish(&build_result_iterator_base_pre));
+  ASSERT_NOT_OK(expr_build->finish(&build_result_iterator_base));
+  ASSERT_NOT_OK(expr_probe->finish(&probe_result_iterator_base));
+  auto build_result_iterator_pre =
+      std::dynamic_pointer_cast<ResultIterator<HashRelation>>(
+          build_result_iterator_base_pre);
+  auto build_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<HashRelation>>(build_result_iterator_base);
+  auto probe_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          probe_result_iterator_base);
+  std::shared_ptr<HashRelation> hash_relation_pre;
+  ASSERT_NOT_OK(build_result_iterator_pre->Next(&hash_relation_pre));
+  std::shared_ptr<HashRelation> hash_relation;
+  ASSERT_NOT_OK(build_result_iterator->Next(&hash_relation));
+  hash_relation_pre->TESTGrowAndRehashKeyArray();
+  int64_t addrs[3];
+  int sizes[3];
+  ASSERT_NOT_OK(hash_relation_pre->UnsafeGetHashTableObject(addrs, sizes));
+  ASSERT_NOT_OK(hash_relation->UnsafeSetHashTableObject(3, addrs, sizes));
+  ASSERT_NOT_OK(probe_result_iterator->SetDependencies({build_result_iterator_base}));
+  // ASSERT_NOT_OK(probe_result_iterator->SetDependencies({build_result_iterator_base_pre}));
 
   for (int i = 0; i < 2; i++) {
     auto right_batch = table_1[i];

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_wscg.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_wscg.cc
@@ -71,9 +71,12 @@ TEST(TestArrowComputeWSCG, WSCGTestSingleInnerJoin) {
       uint64());
   auto n_condition = TreeExprBuilder::MakeFunction(
       "greater_than", {n_add, TreeExprBuilder::MakeField(table0_f2)}, boolean());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysInner",
-      {n_left, n_right, n_left_key, n_right_key, n_result, n_condition}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config, n_condition},
+      uint32());
   auto n_child_probe = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   ////////////////////////////////////////////////////////
   auto n_project_input = TreeExprBuilder::MakeFunction(
@@ -97,8 +100,6 @@ TEST(TestArrowComputeWSCG, WSCGTestSingleInnerJoin) {
   auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -215,9 +216,12 @@ TEST(TestArrowComputeWSCG, WSCGTestProjectKeyInnerJoin) {
       uint64());
   auto n_condition = TreeExprBuilder::MakeFunction(
       "greater_than", {n_add, TreeExprBuilder::MakeField(table0_f2)}, boolean());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysInner",
-      {n_left, n_right, n_left_key, n_right_key, n_result, n_condition}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config, n_condition},
+      uint32());
   auto n_child_probe = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   ////////////////////////////////////////////////////////
   auto n_project_input = TreeExprBuilder::MakeFunction(
@@ -242,8 +246,6 @@ TEST(TestArrowComputeWSCG, WSCGTestProjectKeyInnerJoin) {
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -360,9 +362,12 @@ TEST(TestArrowComputeWSCG, WSCGTestProjectFilterKeyInnerJoin) {
       uint64());
   auto n_condition = TreeExprBuilder::MakeFunction(
       "greater_than", {n_add, TreeExprBuilder::MakeField(table0_f2)}, boolean());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysInner",
-      {n_left, n_right, n_left_key, n_right_key, n_result, n_condition}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config, n_condition},
+      uint32());
   auto n_child_probe = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   ////////////////////////////////////////////////////////
   auto n_project_input = TreeExprBuilder::MakeFunction(
@@ -400,8 +405,6 @@ TEST(TestArrowComputeWSCG, WSCGTestProjectFilterKeyInnerJoin) {
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -512,9 +515,11 @@ TEST(TestArrowComputeWSCG, WSCGTestStringInnerJoin) {
        TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f0),
        TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysInner", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysInner",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -525,8 +530,6 @@ TEST(TestArrowComputeWSCG, WSCGTestStringInnerJoin) {
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -646,9 +649,11 @@ TEST(TestArrowComputeWSCG, WSCGTestTwoStringInnerJoin) {
        TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f0),
        TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysInner", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysInner",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -659,8 +664,6 @@ TEST(TestArrowComputeWSCG, WSCGTestTwoStringInnerJoin) {
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -773,9 +776,11 @@ TEST(TestArrowComputeWSCG, WSCGTestOuterJoin) {
        TreeExprBuilder::MakeField(table0_f2), TreeExprBuilder::MakeField(table1_f0),
        TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysOuter", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysOuter",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -786,8 +791,6 @@ TEST(TestArrowComputeWSCG, WSCGTestOuterJoin) {
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -901,9 +904,11 @@ TEST(TestArrowComputeWSCG, WSCGTestAntiJoin) {
       "result",
       {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysAnti", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysAnti",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -914,8 +919,6 @@ TEST(TestArrowComputeWSCG, WSCGTestAntiJoin) {
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -1026,9 +1029,12 @@ TEST(TestArrowComputeWSCG, WSCGTestAntiJoinWithCondition) {
       "greater_than",
       {TreeExprBuilder::MakeField(table0_f1), TreeExprBuilder::MakeField(table1_f1)},
       arrow::boolean());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysAnti",
-      {n_left, n_right, n_left_key, n_right_key, n_result, n_condition}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config, n_condition},
+      uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -1039,8 +1045,6 @@ TEST(TestArrowComputeWSCG, WSCGTestAntiJoinWithCondition) {
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -1147,9 +1151,11 @@ TEST(TestArrowComputeWSCG, WSCGTestSemiJoin) {
       "result",
       {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysSemi", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysSemi",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -1159,8 +1165,6 @@ TEST(TestArrowComputeWSCG, WSCGTestSemiJoin) {
   auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
   auto schema_table = arrow::schema({table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -1273,9 +1277,12 @@ TEST(TestArrowComputeWSCG, WSCGTestSemiJoinWithCondition) {
       "greater_than",
       {TreeExprBuilder::MakeField(table0_f1), TreeExprBuilder::MakeField(table0_f2)},
       arrow::boolean());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysSemi",
-      {n_left, n_right, n_left_key, n_right_key, n_result, n_condition}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config, n_condition},
+      uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -1285,8 +1292,6 @@ TEST(TestArrowComputeWSCG, WSCGTestSemiJoinWithCondition) {
   auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
   auto schema_table = arrow::schema({table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -1397,9 +1402,11 @@ TEST(TestArrowComputeWSCG, WSCGTestExistenceJoin) {
       {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(f_exist),
        TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
       "conditionedProbeArraysExistence",
-      {n_left, n_right, n_left_key, n_right_key, n_result}, uint32());
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -1410,8 +1417,6 @@ TEST(TestArrowComputeWSCG, WSCGTestExistenceJoin) {
   auto schema_table =
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
@@ -1537,9 +1542,11 @@ TEST(TestArrowComputeWSCG, WSCGTestSemiJoinWithCoalesce) {
       "result",
       {TreeExprBuilder::MakeField(table1_f0), TreeExprBuilder::MakeField(table1_f1)},
       uint32());
+  auto n_hash_config = TreeExprBuilder::MakeFunction(
+      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_probeArrays = TreeExprBuilder::MakeFunction(
-      "conditionedProbeArraysSemi", {n_left, n_right, n_left_key, n_right_key, n_result},
-      uint32());
+      "conditionedProbeArraysSemi",
+      {n_left, n_right, n_left_key, n_right_key, n_result, n_hash_config}, uint32());
   auto n_child = TreeExprBuilder::MakeFunction("child", {n_probeArrays}, uint32());
   //////////////////////////////////////////////////////////////////
   auto n_wscg = TreeExprBuilder::MakeFunction("wholestagecodegen", {n_child}, uint32());
@@ -1549,8 +1556,6 @@ TEST(TestArrowComputeWSCG, WSCGTestSemiJoinWithCoalesce) {
   auto schema_table_1 = arrow::schema({table1_f0, table1_f1});
   auto schema_table = arrow::schema({table1_f0, table1_f1});
 
-  auto n_hash_config = TreeExprBuilder::MakeFunction(
-      "build_keys_config_node", {TreeExprBuilder::MakeLiteral((int)1)}, uint32());
   auto n_hash_kernel = TreeExprBuilder::MakeFunction(
       "HashRelation", {n_left_key, n_hash_config}, uint32());
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());

--- a/oap-native-sql/cpp/src/third_party/row_wise_memory/hashMap.h
+++ b/oap-native-sql/cpp/src/third_party/row_wise_memory/hashMap.h
@@ -238,8 +238,7 @@ static inline bool growAndRehashKeyArray(unsafeHashMap* hashMap) {
  *   -1 if not exists
  */
 template <typename CType>
-static inline int safeLookup(unsafeHashMap* hashMap, CType keyRow, int hashVal,
-                             int* _step = nullptr) {
+static inline int safeLookup(unsafeHashMap* hashMap, CType keyRow, int hashVal) {
   assert(hashMap->keyArray != NULL);
   int mask = hashMap->arrayCapacity - 1;
   int pos = hashVal & mask;
@@ -253,7 +252,6 @@ static inline int safeLookup(unsafeHashMap* hashMap, CType keyRow, int hashVal,
 
     if (KeyAddressOffset < 0) {
       // This is a new key.
-      if (_step != nullptr) *_step = step;
       return HASH_NEW_KEY;
     } else {
       if ((int)keyHashCode == hashVal) {
@@ -262,7 +260,6 @@ static inline int safeLookup(unsafeHashMap* hashMap, CType keyRow, int hashVal,
         // Full hash code matches.  Let's compare the keys for equality.
         char* record = base + KeyAddressOffset;
         if (keyRow == *((CType*)getKeyFromBytesMap(record))) {
-          if (_step != nullptr) *_step = step;
           return 0;
         }
       }
@@ -282,7 +279,7 @@ static inline int safeLookup(unsafeHashMap* hashMap, CType keyRow, int hashVal,
  *   -1 if not exists
  */
 static inline int safeLookup(unsafeHashMap* hashMap, std::shared_ptr<UnsafeRow> keyRow,
-                             int hashVal, int* _step = nullptr) {
+                             int hashVal) {
   assert(hashMap->keyArray != NULL);
   int mask = hashMap->arrayCapacity - 1;
   int pos = hashVal & mask;
@@ -296,7 +293,6 @@ static inline int safeLookup(unsafeHashMap* hashMap, std::shared_ptr<UnsafeRow> 
 
     if (KeyAddressOffset < 0) {
       // This is a new key.
-      if (_step != nullptr) *_step = step;
       return HASH_NEW_KEY;
     } else {
       if ((int)keyHashCode == hashVal) {
@@ -304,7 +300,6 @@ static inline int safeLookup(unsafeHashMap* hashMap, std::shared_ptr<UnsafeRow> 
         char* record = base + KeyAddressOffset;
         if ((getKeyLength(record) == keyLength) &&
             (memcmp(keyRow->data, getKeyFromBytesMap(record), keyLength) == 0)) {
-          if (_step != nullptr) *_step = step;
           return 0;
         }
       }

--- a/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
+++ b/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
@@ -85,13 +85,13 @@ static inline void appendToUnsafeRow(UnsafeRow* row, const int& index, const T& 
 static inline void appendToUnsafeRow(UnsafeRow* row, const int& index,
                                      const std::string& str) {
   int numBytes = str.size();
-  int roundedSize = roundNumberOfBytesToNearestWord(numBytes);
+  // int roundedSize = roundNumberOfBytesToNearestWord(numBytes);
 
-  zeroOutPaddingBytes(row, numBytes);
+  // zeroOutPaddingBytes(row, numBytes);
   memcpy(row->data + row->cursor, str.c_str(), numBytes);
 
   // move the cursor forward.
-  row->cursor += roundedSize;
+  row->cursor += numBytes;
 }
 
 static inline void appendToUnsafeRow(UnsafeRow* row, const int& index,

--- a/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
+++ b/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
@@ -12,60 +12,40 @@
 
 #define TEMP_UNSAFEROW_BUFFER_SIZE 1024
 
-/* Unsafe Row Layout as below
+/* Unsafe Row Layout (This unsafe row only used to append all fields data as continuous
+ * memory, unable to be get data from)
  *
- * | validity | col 0 | col 1 | col 2 | ... | cursor |
+ * | validity | col 0 | col 1 | col 2 | ...
  * explain:
- * validity: 64 * n fields = 8 * n bytes
- * col: each col is 8 bytes, string or decimal col should be offsetAndLength
- * cursor: used by string data and decimal
+ * validity: n fields = (n/8 + 1) bytes
+ * col: each col has variable size
+ * cursor: used to pointer to cur unused pos
  *
  */
 struct UnsafeRow {
   int numFields;
-  int sizeInBytes;
   char* data = nullptr;
   int cursor;
   UnsafeRow() {}
   UnsafeRow(int numFields) : numFields(numFields) {
-    auto validity_size = ((numFields + 63) / 64) * 8;
-    cursor = validity_size + numFields * 8LL;
+    auto validity_size = (numFields / 8) + 1;
+    cursor = validity_size;
     data = (char*)nativeMalloc(TEMP_UNSAFEROW_BUFFER_SIZE, MEMTYPE_ROW);
     memset(data, 0, validity_size);
-    sizeInBytes = cursor;
   }
-  virtual ~UnsafeRow() {
+  ~UnsafeRow() {
     if (data) {
       nativeFree(data);
     }
   }
-};
-
-struct ReadOnlyUnsafeRow : public UnsafeRow {
-  ReadOnlyUnsafeRow(int _numFields) {
-    auto validity_size = ((numFields + 63) / 64) * 8;
-    cursor = validity_size + numFields * 8LL;
-    numFields = _numFields;
-  }
-  ~ReadOnlyUnsafeRow() override { data = nullptr; }
+  int sizeInBytes() { return cursor; }
 };
 
 static inline int calculateBitSetWidthInBytes(int numFields) {
-  return ((numFields + 63) / 64) * 8;
+  return ((numFields / 8) + 1);
 }
 
-static inline int64_t getFieldOffset(UnsafeRow* row, int ordinal) {
-  int bitSetWidthInBytes = calculateBitSetWidthInBytes(row->numFields);
-  return bitSetWidthInBytes + ordinal * 8LL;
-}
-
-static inline int getSizeInBytes(UnsafeRow* row) { return row->sizeInBytes; }
-
-static inline bool isEqualUnsafeRow(UnsafeRow* row0, UnsafeRow* row1) {
-  if (row0->sizeInBytes != row1->sizeInBytes) return false;
-
-  return (memcmp(row0->data, row1->data, row0->sizeInBytes) == 0);
-}
+static inline int getSizeInBytes(UnsafeRow* row) { return row->cursor; }
 
 static inline int roundNumberOfBytesToNearestWord(int numBytes) {
   int remainder = numBytes & 0x07;  // This is equivalent to `numBytes % 8`
@@ -84,207 +64,41 @@ static inline void zeroOutPaddingBytes(UnsafeRow* row, int numBytes) {
 
 static inline void setNullAt(UnsafeRow* row, int index) {
   assert((index >= 0) && (index < row->numFields));
-  int64_t mask = 1LL << (index & 0x3f);  // mod 64 and shift
-  int64_t wordOffset = (index >> 6) * WORD_SIZE;
-  int64_t word = *((int64_t*)(char*)(row->data + wordOffset));
+  auto bitSetIdx = index >> 3;     // mod 8
+  char mask = 1 << (index & 0x8);  // mod 8 and shift
+  auto word = *(row->data + bitSetIdx);
   // set validity
-  *((int64_t*)(row->data + wordOffset)) = word | mask;
-  // set data
-  *((int64_t*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL)) = 0;
+  *(row->data + bitSetIdx) = word | mask;
 }
 
-static inline void setNotNullAt(UnsafeRow* row, int index) {
-  assert((index >= 0) && (index < row->numFields));
-  int64_t mask = 1LL << (index & 0x3f);  // mod 64 and shift
-  int64_t wordOffset = (index >> 6) * WORD_SIZE;
-  int64_t word = *((int64_t*)(char*)(row->data + wordOffset));
-  // set validity
-  *((int64_t*)(row->data + wordOffset)) = word & ~mask;
+template <typename T>
+using is_number_alike =
+    std::integral_constant<bool, std::is_arithmetic<T>::value ||
+                                     std::is_floating_point<T>::value>;
+
+template <typename T, typename std::enable_if_t<is_number_alike<T>::value>* = nullptr>
+static inline void appendToUnsafeRow(UnsafeRow* row, const int& index, const T& val) {
+  *((T*)(row->data + row->cursor)) = val;
+  row->cursor += sizeof(T);
 }
 
-static inline void setOffsetAndSize(UnsafeRow* row, int ordinal, int64_t size) {
-  int64_t relativeOffset = row->cursor;
-  int64_t fieldOffset = ((row->numFields + 63) / 64) * 8 + ordinal * 8LL;
-  int64_t offsetAndSize = (relativeOffset << 32) | size;
-  // set data
-  *((int64_t*)(char*)(row->data + fieldOffset)) = offsetAndSize;
-}
-
-static inline bool isNull(UnsafeRow* row, int index) {
-  assert((index >= 0) && (index < row->numFields));
-  int64_t mask = 1LL << (index & 0x3f);  // mod 64 and shift
-  int64_t wordOffset = (index >> 6) * WORD_SIZE;
-  int64_t word = *((int64_t*)(char*)(row->data + wordOffset));
-  return (word & mask) != 0;
-}
-
-static inline void getValue(UnsafeRow* row, int index, bool* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val = *((bool*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, int8_t* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val = *((int8_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, uint8_t* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val = *((uint8_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, int16_t* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val = *((int16_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, uint16_t* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val =
-      *((uint16_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, int32_t* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val = *((int32_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, uint32_t* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val =
-      *((uint32_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, int64_t* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val = *((int64_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, uint64_t* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val =
-      *((uint64_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, float* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val = *((float*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, double* val) {
-  assert((index >= 0) && (index < row->numFields));
-  *val = *((double*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-}
-
-static inline void getValue(UnsafeRow* row, int index, std::string* val) {
-  assert((index >= 0) && (index < row->numFields));
-
-  int64_t offsetAndSize =
-      *((uint64_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-  int offset = (int)(offsetAndSize >> 32);
-  int size = (int)offsetAndSize;
-  *val = std::string((char*)(row->data + offset), size);
-}
-
-static inline void getValue(UnsafeRow* row, int index, arrow::Decimal128* val) {
-  assert((index >= 0) && (index < row->numFields));
-  int64_t offsetAndSize =
-      *((uint64_t*)(char*)(row->data + ((row->numFields + 63) / 64) * 8 + index * 8LL));
-  int offset = (int)(offsetAndSize >> 32);
-  int size = (int)offsetAndSize;
-  memcpy(val, row->data + offset, size);
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, bool val) {
-  setNotNullAt(row, index);
-  int64_t offset = ((row->numFields + 63) / 64) * 8 + index * 8LL;
-  *((int64_t*)(row->data + offset)) = val;
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, int8_t val) {
-  setNotNullAt(row, index);
-  int64_t offset = ((row->numFields + 63) / 64) * 8 + index * 8LL;
-  *((int64_t*)(row->data + offset)) = val;
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, uint8_t val) {
-  appendToUnsafeRow(row, index, static_cast<int8_t>(val));
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, int16_t val) {
-  setNotNullAt(row, index);
-  int64_t offset = ((row->numFields + 63) / 64) * 8 + index * 8LL;
-  uint64_t longValue = (uint64_t)(uint16_t)val;
-  *((int64_t*)(char*)(row->data + offset)) = longValue;
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, uint16_t val) {
-  appendToUnsafeRow(row, index, static_cast<int16_t>(val));
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, int32_t val) {
-  setNotNullAt(row, index);
-  int64_t offset = ((row->numFields + 63) / 64) * 8 + index * 8LL;
-  uint64_t longValue = (uint64_t)(unsigned int)val;
-  *((int64_t*)(char*)(row->data + offset)) = longValue;
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, uint32_t val) {
-  appendToUnsafeRow(row, index, static_cast<int32_t>(val));
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, int64_t val) {
-  setNotNullAt(row, index);
-  int64_t offset = ((row->numFields + 63) / 64) * 8 + index * 8LL;
-  *((int64_t*)(char*)(row->data + offset)) = val;
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, uint64_t val) {
-  appendToUnsafeRow(row, index, static_cast<int64_t>(val));
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, float val) {
-  setNotNullAt(row, index);
-  int64_t offset = ((row->numFields + 63) / 64) * 8 + index * 8LL;
-  double longValue = (double)val;
-  *((double*)(char*)(row->data + offset)) = val;
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, double val) {
-  setNotNullAt(row, index);
-  int64_t offset = ((row->numFields + 63) / 64) * 8 + index * 8LL;
-  *((double*)(char*)(row->data + offset)) = val;
-}
-
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, std::string str) {
+static inline void appendToUnsafeRow(UnsafeRow* row, const int& index,
+                                     const std::string& str) {
   int numBytes = str.size();
   int roundedSize = roundNumberOfBytesToNearestWord(numBytes);
 
-  setNotNullAt(row, index);
-
   zeroOutPaddingBytes(row, numBytes);
-
   memcpy(row->data + row->cursor, str.c_str(), numBytes);
-
-  setOffsetAndSize(row, index, numBytes);
 
   // move the cursor forward.
   row->cursor += roundedSize;
-  row->sizeInBytes = row->cursor;
 }
 
-static inline void appendToUnsafeRow(UnsafeRow* row, int index, arrow::Decimal128 dcm) {
+static inline void appendToUnsafeRow(UnsafeRow* row, const int& index,
+                                     const arrow::Decimal128& dcm) {
   int numBytes = 16;
-
-  setNotNullAt(row, index);
-
   zeroOutPaddingBytes(row, numBytes);
-
   memcpy(row->data + row->cursor, dcm.ToBytes().data(), numBytes);
-
-  setOffsetAndSize(row, index, numBytes);
-
   // move the cursor forward.
   row->cursor += numBytes;
-  row->sizeInBytes = row->cursor;
 }


### PR DESCRIPTION
Fixed: #1835

Update on 2020/10/30
1. added a timeout config to delete broadcast cached data automatically after several seconds
spark.sql.columnar.sort.broadcast.cache.timeout 300
300s means delete this obj after 300s first no refCnt condition reached. 

Update on 2020/11/03
1. added a new Cpp Kernel to merge multiple batches as One for BroadcastExchange
2. passed all TPCH and TPCDS 500G tests
3. Add an extra optimization when multiple key total length is small than 8 bytes, will merge them as one int64

Remains issues:
None