### PR TITLE
[OAP-1873][oap-native-sql] Columnar shuffle split variable length use UnsafeAppend

### DIFF
--- a/oap-native-sql/cpp/src/shuffle/splitter.h
+++ b/oap-native-sql/cpp/src/shuffle/splitter.h
@@ -106,7 +106,7 @@ class Splitter {
       const std::vector<std::shared_ptr<BuilderType>>& dst_builders, int64_t num_rows);
 
   arrow::Result<std::shared_ptr<arrow::RecordBatch>> MakeRecordBatchAndReset(
-      int32_t partition_id);
+      int32_t partition_id, bool reserve_buffer);
 
   std::string NextSpilledFileDir();
 
@@ -130,6 +130,10 @@ class Splitter {
   std::vector<int32_t> fixed_width_array_idx_;
   std::vector<int32_t> binary_array_idx_;
   std::vector<int32_t> large_binary_array_idx_;
+
+  bool empirical_size_calculated_ = false;
+  std::vector<int32_t> binary_array_empirical_size_;
+  std::vector<int32_t> large_binary_array_empirical_size_;
 
   // updated for each input record batch
   std::vector<int32_t> partition_id_;


### PR DESCRIPTION
1. Treat the sizes of the first input recordbatch's variable length arrays as empirical sizes for the destination buffers, and reserve data for each destination buffer when allocate.
2. Use ArrayBuilder->UnsafeAppend instead of ArrayBuilder->Append