### PR TITLE
[OAP-1888][oap-native-sql]Add hash collision check for all HashJoins and hashAggr

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -47,6 +47,8 @@ class ColumnarPluginConfig(conf: SparkConf) {
     conf.getOption("spark.sql.columnar.tmp_dir").getOrElse(null)
   val broadcastCacheTimeout: Int =
     conf.getInt("spark.sql.columnar.sort.broadcast.cache.timeout", defaultValue = -1)
+  val hashCompare: Boolean =
+    conf.getBoolean("spark.oap.sql.columnar.hashCompare", defaultValue = false)
 }
 
 object ColumnarPluginConfig {

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/CoalesceBatchesExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/CoalesceBatchesExec.scala
@@ -17,8 +17,11 @@
 
 package com.intel.oap.execution
 
+import com.intel.oap.expression.ConverterUtils
 import com.intel.oap.vectorized.ArrowWritableColumnVector
+import com.intel.oap.vectorized.CloseableColumnBatchIterator
 import org.apache.arrow.vector.util.VectorBatchAppender
+import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -27,7 +30,8 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.datasources.v2.arrow.SparkMemoryUtils
-import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.types.{StructType, StructField}
 
 import scala.collection.mutable.ListBuffer
 
@@ -63,28 +67,26 @@ case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
     val concatTime = longMetric("concatTime")
     val avgCoalescedNumRows = longMetric("avgCoalescedNumRows")
 
+    var allocator: BufferAllocator = null
+
     child.executeColumnar().mapPartitions { iter =>
       val beforeInput = System.nanoTime
       val hasInput = iter.hasNext
       collectTime += System.nanoTime - beforeInput
-      if (hasInput) {
+      val res = if (hasInput) {
         new Iterator[ColumnarBatch] {
-          var target: ColumnarBatch = _
           var numBatchesTotal: Long = _
           var numRowsTotal: Long = _
+          val resultStructType =
+            StructType(output.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
+          System.out.println(s"Coalecse schema is ${resultStructType}")
 
           SparkMemoryUtils.addLeakSafeTaskCompletionListener[Unit] { _ =>
-            closePrevious()
             if (numBatchesTotal > 0) {
               avgCoalescedNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
             }
-          }
-
-          private def closePrevious(): Unit = {
-            if (target != null) {
-              target.close()
-              target = null
-            }
+            System.out.println(
+              s"coalecse input should be cleaned, schema is ${resultStructType}, allocator stat is ${allocator.toVerboseString}")
           }
 
           override def hasNext: Boolean = {
@@ -95,7 +97,6 @@ case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
           }
 
           override def next(): ColumnarBatch = {
-            closePrevious()
 
             if (!hasNext) {
               throw new NoSuchElementException("End of ColumnarBatch iterator")
@@ -104,24 +105,31 @@ case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
             var rowCount = 0
             val batchesToAppend = ListBuffer[ColumnarBatch]()
 
-            target = iter.next()
-            target.retain()
-            rowCount += target.numRows
-
             while (hasNext && rowCount < recordsPerBatch) {
               val delta = iter.next()
               delta.retain()
               rowCount += delta.numRows
               batchesToAppend += delta
+              if (allocator == null) {
+                allocator = delta
+                  .column(0)
+                  .asInstanceOf[ArrowWritableColumnVector]
+                  .getValueVector
+                  .getAllocator
+              }
             }
 
             val beforeConcat = System.nanoTime
+            val resultColumnVectors =
+              ArrowWritableColumnVector.allocateColumnsUnsafe(rowCount, resultStructType).toArray
+            val target =
+              new ColumnarBatch(resultColumnVectors.map(_.asInstanceOf[ColumnVector]), rowCount)
             coalesce(target, batchesToAppend.toList)
             target.setNumRows(rowCount)
 
             concatTime += System.nanoTime - beforeConcat
             numOutputRows += rowCount
-            numInputBatches += (1 + batchesToAppend.length)
+            numInputBatches += batchesToAppend.length
             numOutputBatches += 1
 
             // used for calculating avgCoalescedNumRows
@@ -136,6 +144,7 @@ case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
       } else {
         Iterator.empty
       }
+      new CloseableColumnBatchIterator(res)
     }
   }
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -197,7 +197,7 @@ case class ColumnarShuffledHashJoinExec(
       val hashRelationKernel = new ExpressionEvaluator()
       val hashRelationBatchHolder: ListBuffer[ColumnarBatch] = ListBuffer()
       val hash_relation_function =
-        ColumnarConditionedProbeJoin.prepareHashBuildFunction(buildKeyExprs, buildPlan.output)
+        ColumnarConditionedProbeJoin.prepareHashBuildFunction(buildKeyExprs, buildPlan.output, 1)
       val hash_relation_schema = ConverterUtils.toArrowSchema(buildPlan.output)
       val hash_relation_expr =
         TreeBuilder.makeExpression(
@@ -220,7 +220,7 @@ case class ColumnarShuffledHashJoinExec(
 
       val native_function = TreeBuilder.makeFunction(
         s"standalone",
-        Lists.newArrayList(getKernelFunction(0)),
+        Lists.newArrayList(getKernelFunction(1)),
         new ArrowType.Int(32, true))
       val probe_expr =
         TreeBuilder
@@ -295,7 +295,19 @@ case class ColumnarShuffledHashJoinExec(
     ArrowUtils.fromAttributes(attributes)
   }
 
-  def getCodeGenSignature =
+  def doCodeGenForStandalone: ColumnarCodegenContext = {
+    val outputSchema = ConverterUtils.toArrowSchema(output)
+    val (codeGenNode, inputSchema) = (
+      TreeBuilder
+        .makeFunction(
+          s"child",
+          Lists.newArrayList(getKernelFunction),
+          new ArrowType.Int(32, true)),
+      ConverterUtils.toArrowSchema(streamedPlan.output))
+    ColumnarCodegenContext(inputSchema, outputSchema, codeGenNode)
+  }
+
+  /*def getCodeGenSignature =
     try {
       ColumnarShuffledHashJoin.prebuild(
         leftKeys,
@@ -314,7 +326,7 @@ case class ColumnarShuffledHashJoinExec(
         ""
       case e: Throwable =>
         throw e
-    }
+    }*/
 
   def uploadAndListJars(signature: String): Seq[String] =
     if (signature != "") {
@@ -331,7 +343,7 @@ case class ColumnarShuffledHashJoinExec(
       Seq()
     }
 
-  def getCodeGenIterator: RDD[ColumnarBatch] = {
+  /*def getCodeGenIterator: RDD[ColumnarBatch] = {
     val numOutputRows = longMetric("numOutputRows")
     val numOutputBatches = longMetric("numOutputBatches")
     val totalTime = longMetric("processTime")
@@ -376,5 +388,163 @@ case class ColumnarShuffledHashJoinExec(
         new CloseableColumnBatchIterator(vjoinResult)
     }
 
+  }*/
+
+  def getCodeGenCtx: ColumnarCodegenContext = {
+    var resCtx: ColumnarCodegenContext = null
+    try {
+      // If this BHJ contains condition, currently we only support doing codegen through WSCG
+      val childCtx = doCodeGenForStandalone
+      val wholeStageCodeGenNode = TreeBuilder.makeFunction(
+        s"wholestagecodegen",
+        Lists.newArrayList(childCtx.root),
+        new ArrowType.Int(32, true))
+      resCtx =
+        ColumnarCodegenContext(childCtx.inputSchema, childCtx.outputSchema, wholeStageCodeGenNode)
+    } catch {
+      case e: UnsupportedOperationException
+          if e.getMessage == "Unsupport to generate native expression from replaceable expression." =>
+        logWarning(e.getMessage())
+        ""
+      case e: Throwable =>
+        throw e
+    }
+    resCtx
   }
+
+  def getCodeGenSignature = {
+    val resCtx = getCodeGenCtx
+    //resCtx = doCodeGen
+    if (resCtx != null) {
+      val expression =
+        TreeBuilder.makeExpression(
+          resCtx.root,
+          Field.nullable("result", new ArrowType.Int(32, true)))
+      val nativeKernel = new ExpressionEvaluator()
+      nativeKernel.build(
+        resCtx.inputSchema,
+        Lists.newArrayList(expression),
+        resCtx.outputSchema,
+        true)
+    } else {
+      ""
+    }
+  }
+
+  def getCodeGenIterator: RDD[ColumnarBatch] = {
+    val numOutputRows = longMetric("numOutputRows")
+    val totalTime = longMetric("processTime")
+    val buildTime = longMetric("buildTime")
+    val joinTime = longMetric("joinTime")
+
+    var build_elapse: Long = 0
+    var eval_elapse: Long = 0
+
+    val signature = getCodeGenSignature
+    val listJars = uploadAndListJars(signature)
+    val timeout = ColumnarPluginConfig.getConf(sparkConf).broadcastCacheTimeout
+    val hashRelationBatchHolder: ListBuffer[ColumnarBatch] = ListBuffer()
+
+    streamedPlan.executeColumnar().zipPartitions(buildPlan.executeColumnar()) {
+      (streamIter, buildIter) =>
+        ColumnarPluginConfig.getConf(sparkConf)
+        val execTempDir = ColumnarPluginConfig.getTempFile
+        val jarList = listJars
+          .map(jarUrl => {
+            logWarning(s"Get Codegened library Jar ${jarUrl}")
+            UserAddedJarUtils.fetchJarFromSpark(
+              jarUrl,
+              execTempDir,
+              s"spark-columnar-plugin-codegen-precompile-${signature}.jar",
+              sparkConf)
+            s"${execTempDir}/spark-columnar-plugin-codegen-precompile-${signature}.jar"
+          })
+        val resCtx = getCodeGenCtx
+        val expression =
+          TreeBuilder
+            .makeExpression(resCtx.root, Field.nullable("result", new ArrowType.Int(32, true)))
+        val nativeKernel = new ExpressionEvaluator(jarList.toList.asJava)
+        nativeKernel
+          .build(resCtx.inputSchema, Lists.newArrayList(expression), resCtx.outputSchema, true)
+
+        // received broadcast value contain a hashmap and raw recordBatch
+        val beforeEval = System.nanoTime()
+        val ctx = dependentPlanCtx
+        val hashRelationKernel = new ExpressionEvaluator()
+        val hash_relation_expression = TreeBuilder
+          .makeExpression(ctx.root, Field.nullable("result", new ArrowType.Int(32, true)))
+        hashRelationKernel
+          .build(ctx.inputSchema, Lists.newArrayList(hash_relation_expression), true)
+        // we need to set original recordBatch to hashRelationKernel
+        while (buildIter.hasNext) {
+          val dep_cb = buildIter.next()
+          if (dep_cb.numRows > 0) {
+            (0 until dep_cb.numCols).toList.foreach(i =>
+              dep_cb.column(i).asInstanceOf[ArrowWritableColumnVector].retain())
+            hashRelationBatchHolder += dep_cb
+            val dep_rb = ConverterUtils.createArrowRecordBatch(dep_cb)
+            hashRelationKernel.evaluate(dep_rb)
+            ConverterUtils.releaseArrowRecordBatch(dep_rb)
+          }
+        }
+        val hashRelationResultIterator = hashRelationKernel.finishByIterator()
+        val nativeIterator = nativeKernel.finishByIterator()
+        nativeIterator.setDependencies(Array(hashRelationResultIterator))
+        build_elapse += (System.nanoTime() - beforeEval)
+        // now we can return this wholestagecodegen itervar closed = false
+        var closed = false
+        def close = {
+          closed = true
+          joinTime += (eval_elapse / 1000000)
+          buildTime += (build_elapse / 1000000)
+          totalTime += ((eval_elapse + build_elapse) / 1000000)
+          hashRelationBatchHolder.foreach(_.close)
+          hashRelationKernel.close
+          hashRelationResultIterator.close
+          nativeKernel.close
+          nativeIterator.close
+        }
+        val resultStructType = ArrowUtils.fromArrowSchema(resCtx.outputSchema)
+        val res = new Iterator[ColumnarBatch] {
+          override def hasNext: Boolean = {
+            streamIter.hasNext
+          }
+
+          override def next(): ColumnarBatch = {
+            val cb = streamIter.next()
+            if (cb.numRows == 0) {
+              val resultColumnVectors = ArrowWritableColumnVector
+                .allocateColumns(0, resultStructType)
+                .toArray
+              return new ColumnarBatch(resultColumnVectors.map(_.asInstanceOf[ColumnVector]), 0)
+            }
+            val beforeEval = System.nanoTime()
+            val input_rb =
+              ConverterUtils.createArrowRecordBatch(cb)
+            val output_rb = nativeIterator.process(resCtx.inputSchema, input_rb)
+            if (output_rb == null) {
+              ConverterUtils.releaseArrowRecordBatch(input_rb)
+              eval_elapse += System.nanoTime() - beforeEval
+              val resultColumnVectors =
+                ArrowWritableColumnVector.allocateColumns(0, resultStructType).toArray
+              return new ColumnarBatch(resultColumnVectors.map(_.asInstanceOf[ColumnVector]), 0)
+            }
+            val outputNumRows = output_rb.getLength
+            ConverterUtils.releaseArrowRecordBatch(input_rb)
+            val output = ConverterUtils.fromArrowRecordBatch(resCtx.outputSchema, output_rb)
+            ConverterUtils.releaseArrowRecordBatch(output_rb)
+            eval_elapse += System.nanoTime() - beforeEval
+            numOutputRows += outputNumRows
+            new ColumnarBatch(
+              output.map(v => v.asInstanceOf[ColumnVector]).toArray,
+              outputNumRows)
+          }
+        }
+        SparkMemoryUtils.addLeakSafeTaskCompletionListener[Unit](_ => {
+          close
+        })
+        new CloseableColumnBatchIterator(res)
+    }
+  }
+
 }

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregateExpression.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/expression/ColumnarAggregateExpression.scala
@@ -37,7 +37,7 @@ trait ColumnarAggregateExpressionBase extends ColumnarExpression with Logging {
   }
 }
 
-class ColumnarUniqueAggregateExpression(aggrFieldList: List[Field]) extends ColumnarAggregateExpressionBase with Logging {
+class ColumnarUniqueAggregateExpression(aggrFieldList: List[Field], hashCollisionCheck: Int = 0) extends ColumnarAggregateExpressionBase with Logging {
 
   override def requiredColNum: Int = 1
   override def expectedResColNum: Int = 1
@@ -49,8 +49,9 @@ class ColumnarUniqueAggregateExpression(aggrFieldList: List[Field]) extends Colu
       // if keyList has keys, we need to do groupby by these keys.
       var inputFieldNode = 
         keyFieldList.map({field => TreeBuilder.makeField(field)}).asJava
+        val encodeArrayFuncName = if (hashCollisionCheck == 1) "encodeArraySafe" else "encodeArray"
       val encodeNode = TreeBuilder.makeFunction(
-        "encodeArray",
+        encodeArrayFuncName,
         inputFieldNode,
         resultType/*this arg won't be used*/)
       inputFieldNode = 
@@ -73,7 +74,7 @@ class ColumnarAggregateExpression(
     aggregateFunction: AggregateFunction,
     mode: AggregateMode,
     isDistinct: Boolean,
-    resultId: ExprId)
+    resultId: ExprId, hashCollisionCheck: Int = 0)
     extends AggregateExpression(aggregateFunction, mode, isDistinct, None, resultId)
     with ColumnarAggregateExpressionBase
     with Logging {
@@ -129,8 +130,9 @@ class ColumnarAggregateExpression(
       // if keyList has keys, we need to do groupby by these keys.
       var inputFieldNode = 
         keyFieldList.map({field => TreeBuilder.makeField(field)}).asJava
+        val encodeArrayFuncName = if (hashCollisionCheck == 1) "encodeArraySafe" else "encodeArray"
       val encodeNode = TreeBuilder.makeFunction(
-        "encodeArray",
+        encodeArrayFuncName,
         inputFieldNode,
         resultType/*this arg won't be used*/)
       inputFieldNode = 

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -456,7 +456,11 @@ arrow::Status ExprVisitor::MakeExprVisitorImpl(const std::string& func_name,
     goto finish;
   }
   if (func_name.compare("encodeArray") == 0) {
-    RETURN_NOT_OK(EncodeVisitorImpl::Make(p, &impl_));
+    RETURN_NOT_OK(EncodeVisitorImpl::Make(p, 0, &impl_));
+    goto finish;
+  }
+  if (func_name.compare("encodeArraySafe") == 0) {
+    RETURN_NOT_OK(EncodeVisitorImpl::Make(p, 1, &impl_));
     goto finish;
   }
   goto unrecognizedFail;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -511,9 +511,11 @@ class WindowVisitorImpl : public ExprVisitorImpl {
 ////////////////////////// EncodeVisitorImpl ///////////////////////
 class EncodeVisitorImpl : public ExprVisitorImpl {
  public:
-  EncodeVisitorImpl(ExprVisitor* p) : ExprVisitorImpl(p) {}
-  static arrow::Status Make(ExprVisitor* p, std::shared_ptr<ExprVisitorImpl>* out) {
-    auto impl = std::make_shared<EncodeVisitorImpl>(p);
+  EncodeVisitorImpl(ExprVisitor* p, int hash_table_type)
+      : ExprVisitorImpl(p), hash_table_type_(hash_table_type) {}
+  static arrow::Status Make(ExprVisitor* p, int hash_table_type,
+                            std::shared_ptr<ExprVisitorImpl>* out) {
+    auto impl = std::make_shared<EncodeVisitorImpl>(p, hash_table_type);
     *out = impl;
     return arrow::Status::OK();
   }
@@ -534,8 +536,13 @@ class EncodeVisitorImpl : public ExprVisitorImpl {
 
     // create a new kernel to memcpy all keys as one binary array
     if (type_list.size() > 1) {
-      RETURN_NOT_OK(
-          extra::ConcatArrayKernel::Make(&p_->ctx_, type_list, &concat_kernel_));
+      if (hash_table_type_ == 0) {
+        RETURN_NOT_OK(
+            extra::HashArrayKernel::Make(&p_->ctx_, type_list, &concat_kernel_));
+      } else {
+        RETURN_NOT_OK(
+            extra::ConcatArrayKernel::Make(&p_->ctx_, type_list, &concat_kernel_));
+      }
     }
 
     auto result_field = field("res", arrow::uint64());
@@ -576,6 +583,7 @@ class EncodeVisitorImpl : public ExprVisitorImpl {
   std::vector<int> col_id_list_;
   std::shared_ptr<extra::KernalBase> concat_kernel_;
   uint64_t concat_elapse_time = 0;
+  int hash_table_type_;
 };
 
 ////////////////////////// SortArraysToIndicesVisitorImpl ///////////////////////

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -534,7 +534,8 @@ class EncodeVisitorImpl : public ExprVisitorImpl {
 
     // create a new kernel to memcpy all keys as one binary array
     if (type_list.size() > 1) {
-      RETURN_NOT_OK(extra::HashArrayKernel::Make(&p_->ctx_, type_list, &concat_kernel_));
+      RETURN_NOT_OK(
+          extra::ConcatArrayKernel::Make(&p_->ctx_, type_list, &concat_kernel_));
     }
 
     auto result_field = field("res", arrow::uint64());

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
@@ -660,12 +660,13 @@ class ConditionedProbeKernel::Impl {
           }
         }
         uint64_t out_length = 0;
+        auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
         for (int i = 0; i < key_array->length(); i++) {
           int index;
           if (!do_unsafe_row) {
             index = fast_probe(i);
           } else {
-            auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+            unsafe_key_row->reset();
             for (auto payload_arr : payloads) {
               payload_arr->Append(i, &unsafe_key_row);
             }
@@ -755,12 +756,13 @@ class ConditionedProbeKernel::Impl {
           }
         }
         uint64_t out_length = 0;
+        auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
         for (int i = 0; i < key_array->length(); i++) {
           int index;
           if (!do_unsafe_row) {
             index = fast_probe(i);
           } else {
-            auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+            unsafe_key_row->reset();
             for (auto payload_arr : payloads) {
               payload_arr->Append(i, &unsafe_key_row);
             }
@@ -858,12 +860,13 @@ class ConditionedProbeKernel::Impl {
           }
         }
         uint64_t out_length = 0;
+        auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
         for (int i = 0; i < key_array->length(); i++) {
           int index;
           if (!do_unsafe_row) {
             index = fast_probe(i);
           } else {
-            auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+            unsafe_key_row->reset();
             for (auto payload_arr : payloads) {
               payload_arr->Append(i, &unsafe_key_row);
             }
@@ -952,12 +955,13 @@ class ConditionedProbeKernel::Impl {
         }
 
         uint64_t out_length = 0;
+        auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
         for (int i = 0; i < key_array->length(); i++) {
           int index;
           if (!do_unsafe_row) {
             index = fast_probe(i);
           } else {
-            auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+            unsafe_key_row->reset();
             for (auto payload_arr : payloads) {
               payload_arr->Append(i, &unsafe_key_row);
             }
@@ -1047,12 +1051,13 @@ class ConditionedProbeKernel::Impl {
           }
         }
         uint64_t out_length = 0;
+        auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
         for (int i = 0; i < key_array->length(); i++) {
           int index;
           if (!do_unsafe_row) {
             index = fast_probe(i);
           } else {
-            auto unsafe_key_row = std::make_shared<UnsafeRow>(payloads.size());
+            unsafe_key_row->reset();
             for (auto payload_arr : payloads) {
               payload_arr->Append(i, &unsafe_key_row);
             }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -1380,8 +1380,9 @@ class ConcatArrayKernel::Impl {
     }
 
     builder_->Reset();
+    std::shared_ptr<UnsafeRow> payload = std::make_shared<UnsafeRow>(payloads.size());
     for (int i = 0; i < length; i++) {
-      std::shared_ptr<UnsafeRow> payload = std::make_shared<UnsafeRow>(payloads.size());
+      payload->reset();
       for (auto payload_arr : payloads) {
         RETURN_NOT_OK(payload_arr->Append(i, &payload));
       }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -1356,6 +1356,69 @@ arrow::Status HashArrayKernel::Evaluate(const ArrayList& in,
   return impl_->Evaluate(in, out);
 }
 
+///////////////  ConcatArray  ////////////////
+class ConcatArrayKernel::Impl {
+ public:
+  Impl(arrow::compute::FunctionContext* ctx,
+       std::vector<std::shared_ptr<arrow::DataType>> type_list)
+      : ctx_(ctx) {
+    pool_ = ctx_->memory_pool();
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    arrow::MakeBuilder(ctx_->memory_pool(), arrow::utf8(), &array_builder);
+    builder_.reset(
+        arrow::internal::checked_cast<arrow::StringBuilder*>(array_builder.release()));
+  }
+
+  arrow::Status Evaluate(const ArrayList& in, std::shared_ptr<arrow::Array>* out) {
+    auto length = in[0]->length();
+    std::vector<std::shared_ptr<UnsafeArray>> payloads;
+    int i = 0;
+    for (auto arr : in) {
+      std::shared_ptr<UnsafeArray> payload;
+      RETURN_NOT_OK(MakeUnsafeArray(arr->type(), i++, arr, &payload));
+      payloads.push_back(payload);
+    }
+
+    builder_->Reset();
+    for (int i = 0; i < length; i++) {
+      std::shared_ptr<UnsafeRow> payload = std::make_shared<UnsafeRow>(payloads.size());
+      for (auto payload_arr : payloads) {
+        RETURN_NOT_OK(payload_arr->Append(i, &payload));
+      }
+      RETURN_NOT_OK(builder_->Append(payload->data, (int64_t)payload->sizeInBytes()));
+    }
+
+    RETURN_NOT_OK(builder_->Finish(out));
+
+    return arrow::Status::OK();
+  }
+
+ private:
+  arrow::compute::FunctionContext* ctx_;
+  std::unique_ptr<arrow::StringBuilder> builder_;
+  arrow::MemoryPool* pool_;
+};
+
+arrow::Status ConcatArrayKernel::Make(
+    arrow::compute::FunctionContext* ctx,
+    std::vector<std::shared_ptr<arrow::DataType>> type_list,
+    std::shared_ptr<KernalBase>* out) {
+  *out = std::make_shared<ConcatArrayKernel>(ctx, type_list);
+  return arrow::Status::OK();
+}
+
+ConcatArrayKernel::ConcatArrayKernel(
+    arrow::compute::FunctionContext* ctx,
+    std::vector<std::shared_ptr<arrow::DataType>> type_list) {
+  impl_.reset(new Impl(ctx, type_list));
+  kernel_name_ = "ConcatArrayKernel";
+}
+
+arrow::Status ConcatArrayKernel::Evaluate(const ArrayList& in,
+                                          std::shared_ptr<arrow::Array>* out) {
+  return impl_->Evaluate(in, out);
+}
+
 ///////////////  ConcatArrayList  ////////////////
 class ConcatArrayListKernel::Impl {
  public:

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -628,6 +628,21 @@ class FilterKernel : public KernalBase {
   std::unique_ptr<Impl> impl_;
   arrow::compute::FunctionContext* ctx_;
 };
+class ConcatArrayKernel : public KernalBase {
+ public:
+  static arrow::Status Make(arrow::compute::FunctionContext* ctx,
+                            std::vector<std::shared_ptr<arrow::DataType>> type_list,
+                            std::shared_ptr<KernalBase>* out);
+  ConcatArrayKernel(arrow::compute::FunctionContext* ctx,
+                    std::vector<std::shared_ptr<arrow::DataType>> type_list);
+  arrow::Status Evaluate(const ArrayList& in,
+                         std::shared_ptr<arrow::Array>* out) override;
+  class Impl;
+
+ private:
+  std::unique_ptr<Impl> impl_;
+  arrow::compute::FunctionContext* ctx_;
+};
 }  // namespace extra
 }  // namespace arrowcompute
 }  // namespace codegen

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation.h
@@ -142,8 +142,9 @@ class HashRelation {
       const std::vector<std::shared_ptr<UnsafeArray>>& payloads) {
     // This Key should be Hash Key
     auto typed_array = std::make_shared<ArrayType>(in);
+    std::shared_ptr<UnsafeRow> payload = std::make_shared<UnsafeRow>(payloads.size());
     for (int i = 0; i < typed_array->length(); i++) {
-      std::shared_ptr<UnsafeRow> payload = std::make_shared<UnsafeRow>(payloads.size());
+      payload->reset();
       for (auto payload_arr : payloads) {
         payload_arr->Append(i, &payload);
       }

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation.h
@@ -124,6 +124,7 @@ class HashRelation {
       int key_size = -1)
       : HashRelation(hash_relation_column) {
     hash_table_ = createUnsafeHashMap(1024 * 1024, 256 * 1024 * 1024, key_size);
+    arrayid_list_.reserve(64);
   }
 
   ~HashRelation() {
@@ -191,13 +192,9 @@ class HashRelation {
     if (hash_table_ == nullptr) {
       throw std::runtime_error("HashRelation Get failed, hash_table is null.");
     }
-    std::vector<char*> res_out;
-    auto res = safeLookup(hash_table_, payload, v, &res_out);
+    auto res = safeLookup(hash_table_, payload, v, &arrayid_list_);
     if (res == -1) return -1;
-    arrayid_list_.clear();
-    for (auto index : res_out) {
-      arrayid_list_.push_back(*((ArrayItemIndex*)index));
-    }
+
     return 0;
   }
 
@@ -205,13 +202,8 @@ class HashRelation {
     if (hash_table_ == nullptr) {
       throw std::runtime_error("HashRelation Get failed, hash_table is null.");
     }
-    std::vector<char*> res_out;
-    auto res = safeLookup(hash_table_, payload.data(), payload.size(), v, &res_out);
+    auto res = safeLookup(hash_table_, payload.data(), payload.size(), v, &arrayid_list_);
     if (res == -1) return -1;
-    arrayid_list_.clear();
-    for (auto index : res_out) {
-      arrayid_list_.push_back(*((ArrayItemIndex*)index));
-    }
     return 0;
   }
 
@@ -219,13 +211,8 @@ class HashRelation {
     if (hash_table_ == nullptr) {
       throw std::runtime_error("HashRelation Get failed, hash_table is null.");
     }
-    std::vector<char*> res_out;
-    auto res = safeLookup(hash_table_, payload, v, &res_out);
+    auto res = safeLookup(hash_table_, payload, v, &arrayid_list_);
     if (res == -1) return -1;
-    arrayid_list_.clear();
-    for (auto index : res_out) {
-      arrayid_list_.push_back(*((ArrayItemIndex*)index));
-    }
     return 0;
   }
 

--- a/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
+++ b/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
@@ -39,6 +39,11 @@ struct UnsafeRow {
     }
   }
   int sizeInBytes() { return cursor; }
+  void reset() {
+    auto validity_size = (numFields / 8) + 1;
+    cursor = validity_size;
+    memset(data, 0, validity_size);
+  }
 };
 
 static inline int calculateBitSetWidthInBytes(int numFields) {


### PR DESCRIPTION
Fixed: https://github.com/Intel-bigdata/OAP/issues/1888

updated 2020/11/12
a. Add a config spark.oap.sql.columnar.hashCompare default false
b. Saw performance drop in TPCH Q1 after merge multiple key as unsafeRow and compare