### PR TITLE
[OAP-1914]Update setup-miniconda version to v2

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           auto-activate-base: true


### PR DESCRIPTION
## What changes were proposed in this pull request?

Closes #1914 
Change setup-miniconda v1 to v2 to fix a warning issue from Github Action.
Based on the latest release from setup-miniconda, v2 has resolve this issue and released several days ago.
https://github.com/conda-incubator/setup-miniconda/releases

## How was this patch tested?

This patch has been tested in my forked repo and not receive any warning in Arrow-cpp build from Github Action.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

