### PR TITLE
[OAP-1921][rpmem-shuffle] For BDBA analysis to exclude unused library

### DIFF
--- a/oap-shuffle/RPMem-shuffle/core/pom.xml
+++ b/oap-shuffle/RPMem-shuffle/core/pom.xml
@@ -127,6 +127,7 @@
                                         <exclude>META-INF/native/windows64/leveldbjni.dll</exclude>
                                         <exclude>META-INF/native/osx/libleveldbjni.jnilib</exclude>
                                         <exclude>org/sqlite/native/DragonFlyBSD/x86_64/libsqlitejdbc.so</exclude>
+					<exclude>org/sqlite/native/Mac/x86_64/libsqlitejdbc.jnilib</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
Exclude unused library libsqlitejdbc.jnilib which is for MAC OS, the modification passed build process. 

