### PR TITLE
[OAP-1926]Bump jetty version to 9.4.33.v20201020 to fix SDL high vuln…

### DIFF
--- a/oap-cache/oap/pom.xml
+++ b/oap-cache/oap/pom.xml
@@ -43,7 +43,7 @@
     <scalatest.version>3.0.3</scalatest.version>
     <scalacheck.version>1.14.2</scalacheck.version>
     <parquet.version>1.10.1</parquet.version>
-    <jetty.version>9.4.18.v20190429</jetty.version>
+    <jetty.version>9.4.33.v20201020</jetty.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <!--diff: Spark-2.4.4 use orc 1.5.5 -->
     <orc.version>1.5.10</orc.version>

--- a/oap-spark/pom.xml
+++ b/oap-spark/pom.xml
@@ -21,7 +21,7 @@
     <spark.internal.version>3.0.0</spark.internal.version>
     <maven-patch-plugin.version>1.2</maven-patch-plugin.version>
     <maven-resource-plugin.version>2.6</maven-resource-plugin.version>
-    <jetty.version>9.4.18.v20190429</jetty.version>
+    <jetty.version>9.4.33.v20201020</jetty.version>
   </properties>
 
     <dependencies>


### PR DESCRIPTION
…erabilities

## What changes were proposed in this pull request?

Bump jetty version to to 9.4.33.v20201020 to fix SDL high vulnerabilities


## How was this patch tested?

Pass UT 
