### PR TITLE
[OAP-1929][oap-native-sql] fix builder memleak in non-codegen aggregate

### DIFF
--- a/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -39,6 +39,7 @@ namespace arrowcompute {
 class ExprVisitorImpl {
  public:
   ExprVisitorImpl(ExprVisitor* p) : p_(p) {}
+  virtual ~ExprVisitorImpl() {}
   virtual arrow::Status Eval() {
     return arrow::Status::NotImplemented("ExprVisitorImpl Eval is abstract.");
   }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -1314,6 +1314,8 @@ class HashArrayKernel::Impl {
     pool_ = ctx_->memory_pool();
   }
 
+  virtual ~Impl() {}
+
   arrow::Status Evaluate(const ArrayList& in, std::shared_ptr<arrow::Array>* out) {
     auto length = in[0]->length();
     auto num_columns = in.size();

--- a/oap-native-sql/cpp/src/third_party/row_wise_memory/hashMap.h
+++ b/oap-native-sql/cpp/src/third_party/row_wise_memory/hashMap.h
@@ -41,7 +41,7 @@ typedef struct {
 static inline void dump(unsafeHashMap* hm) {
   printf("=================== HashMap DUMP =======================\n");
   printf("keyarray capacity is %d\n", hm->arrayCapacity);
-  printf("bytemap capacity is %d\n", hm->mapSize);
+  printf("bytemap capacity is %lu\n", hm->mapSize);
   printf("bytesInKey is %d\n", hm->bytesInKeyArray);
   printf("cursor is %d\n", hm->cursor);
   printf("numKeys is %d\n", hm->numKeys);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr fixes memleak in non-codegen aggregate relating to allocated builder not being deleted.
fixes: https://github.com/Intel-bigdata/OAP/issues/1929

## How was this patch tested?

locally tested

