### PR TITLE
[OAP-1610][SQL-Data-Source-Cache][SDLe]Modify pom.xml to pass SDLe BD…

### DIFF
--- a/oap-cache/oap/pom.xml
+++ b/oap-cache/oap/pom.xml
@@ -440,6 +440,14 @@
               <include>org.reflections:reflections</include>
             </includes>
           </artifactSet>
+          <filters>
+            <filter>
+              <artifact>org.apache.parquet:*</artifact>
+              <excludes>
+                <exclude>shaded/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
           <relocations>
             <relocation>
               <pattern>org.eclipse.jetty</pattern>


### PR DESCRIPTION
…BA binaries vulnerabilities scanning

Exclude shaded dependencies of Parquet, for parquet10.0.1 jar has vulnerabilites on jackson and thrift0.9.3, same as #1500 


## How was this patch tested?



