### PR TITLE
[OAP-1924][OAP-CACHE]Decouple hearbeat message and use conf to determine whether to report locailty information for branch branch-1.0-spark-3.x

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
@@ -51,17 +51,17 @@ private[spark] class OapRpcManagerSlave(
   startOapHeartbeater()
 
   protected def heartbeatMessages: Array[() => Heartbeat] = {
-    if (SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ENABLED)) {
-      return Array(
-        () => FiberCacheMetricsHeartbeat(executorId, blockManager.blockManagerId,
-          CacheStats.status(fiberCacheManager.cacheStats, conf)))
-    } else {
-      return Array(
-        () => FiberCacheHeartbeat(
-          executorId, blockManager.blockManagerId, fiberCacheManager.status()),
-        () => FiberCacheMetricsHeartbeat(executorId, blockManager.blockManagerId,
-          CacheStats.status(fiberCacheManager.cacheStats, conf)))
-    }
+    return Array(
+      () => FiberCacheHeartbeat(
+        executorId, blockManager.blockManagerId, fiberCacheManager.status()),
+      () => FiberCacheMetricsHeartbeat(executorId, blockManager.blockManagerId,
+        CacheStats.status(fiberCacheManager.cacheStats, conf)))
+  }
+
+  protected def metricsHeartbeatMessages: Array[() => Heartbeat] = {
+    return Array(
+      () => FiberCacheMetricsHeartbeat(executorId, blockManager.blockManagerId,
+        CacheStats.status(fiberCacheManager.cacheStats, conf)))
   }
 
   private def initialize() = {
@@ -84,6 +84,12 @@ private[spark] class OapRpcManagerSlave(
       }
     }
 
+    def reportMetricsHeartbeat(): Unit = {
+      if (blockManager.blockManagerId != null) {
+        metricsHeartbeatMessages.map(_.apply()).foreach(send)
+      }
+    }
+
     val intervalMs = conf.getTimeAsMs(
       OapConf.OAP_HEARTBEAT_INTERVAL.key, OapConf.OAP_HEARTBEAT_INTERVAL.defaultValue.get)
 
@@ -93,8 +99,18 @@ private[spark] class OapRpcManagerSlave(
     val heartbeatTask = new Runnable() {
       override def run(): Unit = Utils.logUncaughtExceptions(reportHeartbeat())
     }
-    oapHeartbeater.scheduleAtFixedRate(
-      heartbeatTask, initialDelay, intervalMs, TimeUnit.MILLISECONDS)
+
+    val metricsHeartbeatTask = new Runnable() {
+      override def run(): Unit = Utils.logUncaughtExceptions(reportMetricsHeartbeat())
+    }
+
+    if (!SparkEnv.get.conf.get(OapConf.OAP_EXTERNAL_CACHE_METADB_ENABLED)) {
+      oapHeartbeater.scheduleAtFixedRate(
+        heartbeatTask, initialDelay, intervalMs, TimeUnit.MILLISECONDS)
+    } else {
+      oapHeartbeater.scheduleAtFixedRate(
+        metricsHeartbeatTask, initialDelay, intervalMs, TimeUnit.MILLISECONDS)
+    }
   }
 
   override private[spark] def stop(): Unit = {

--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/oap/rpc/OapRpcManagerSlave.scala
@@ -51,7 +51,7 @@ private[spark] class OapRpcManagerSlave(
   startOapHeartbeater()
 
   protected def heartbeatMessages: Array[() => Heartbeat] = {
-    return Array(
+    Array(
       () => FiberCacheHeartbeat(
         executorId, blockManager.blockManagerId, fiberCacheManager.status()),
       () => FiberCacheMetricsHeartbeat(executorId, blockManager.blockManagerId,


### PR DESCRIPTION
We are using external DB to store cache locality info, but the old OAP report mechanism still reports cache locality to the driver through RPC. Need to decouple this.

1:Using external DB => not report cache locality to the driver through RPC. But still, need to report cache metrics to the driver through RPC.
2:Using report mechanism =>follow current behavior.

In the code, it will check the configuration of whether to use Redis.
If used, just report metrics information.
If not, report both metrics and locality information.