### PR TITLE
[OAP-1963] Fix for wrong conda channels selection to use Intel(R) distribution for Python*

### DIFF
--- a/dev/kubernetes/docker/oap-centos/oap.yml
+++ b/dev/kubernetes/docker/oap-centos/oap.yml
@@ -1,7 +1,7 @@
 name: oap-0.9.0
 channels:
-  - conda-forge
   - intel
+  - conda-forge
   - defaults
 dependencies:
   - python=3.7.7


### PR DESCRIPTION
Install Intel packages (numpy, MKL, oneDAL) instead of default. With up to 2x performance.

## How was this patch tested?
Docker image built successfully. 

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
N/A