### PR TITLE
[OAP-1947][oap-native-sql][C++] reduce sort kernel memory footprint

### DIFF
--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_item_index.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_item_index.h
@@ -35,7 +35,6 @@ struct ArrayItemIndexS {
   uint16_t id = 0;
   uint16_t array_id = 0;
   ArrayItemIndexS() : array_id(0), id(0) {}
-  ArrayItemIndexS(bool valid) : array_id(0), id(0) {}
   ArrayItemIndexS(uint16_t array_id, uint16_t id)
       : array_id(array_id), id(id) {}
 };

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_item_index.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_item_index.h
@@ -31,6 +31,15 @@ struct ArrayItemIndex {
   ArrayItemIndex(uint16_t array_id, uint16_t id)
       : array_id(array_id), id(id), valid(true) {}
 };
+struct ArrayItemIndexS {
+  uint16_t id = 0;
+  uint16_t array_id = 0;
+  ArrayItemIndexS() : array_id(0), id(0) {}
+  ArrayItemIndexS(bool valid) : array_id(0), id(0) {}
+  ArrayItemIndexS(uint16_t array_id, uint16_t id)
+      : array_id(array_id), id(id) {}
+};
+
 }  // namespace extra
 }  // namespace arrowcompute
 }  // namespace codegen


### PR DESCRIPTION

## What changes were proposed in this pull request?

reduce memory usage for sort kernel by using more compact data structure
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## How was this patch tested?

locally verified

