### PR TITLE
[OAP-1967][oap-native-sql] add NaN support and optimization in columnar sort

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -22,6 +22,8 @@ import org.apache.spark.SparkConf
 class ColumnarPluginConfig(conf: SparkConf) {
   val enableColumnarSort: Boolean =
     conf.getBoolean("spark.sql.columnar.sort", defaultValue = false)
+  val enableColumnarSortNaNCheck: Boolean =
+    conf.getBoolean("spark.sql.columnar.sort.NaNCheck", defaultValue = false)
   val enableCodegenHashAggregate: Boolean =
     conf.getBoolean("spark.sql.columnar.codegen.hashAggregate", defaultValue = false)
   val enableColumnarBroadcastJoin: Boolean =

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -311,13 +311,15 @@ class SortArraysToIndicesKernel : public KernalBase {
                             std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                             std::vector<bool> sort_directions,
                             std::vector<bool> nulls_order,
+                            bool NaN_check,
                             std::shared_ptr<KernalBase>* out);
   SortArraysToIndicesKernel(arrow::compute::FunctionContext* ctx,
                             std::shared_ptr<arrow::Schema> result_schema,
                             gandiva::NodeVector sort_key_node,
                             std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                             std::vector<bool> sort_directions,
-                            std::vector<bool> nulls_order);
+                            std::vector<bool> nulls_order,
+                            bool NaN_check);
   arrow::Status Evaluate(const ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -43,27 +43,25 @@
 #include "utils/macros.h"
 
 /**
- *               The Overall Implementation of Sort Kernel
+                 The Overall Implementation of Sort Kernel
  * In general, there are three kenels to use when sorting for different data.
    They are SortInplaceKernel, SortOnekeyKernel and SortArraysToIndicesKernel.
- * If sorting for one non-string col without payload, SortInplaceKernel is used.
-   In this kernel, if sorted data has no null value, ska_sort is used for asc 
-   direciton, and std sort is used for desc direciton. If sorted data has null
-   value, arrow sort is used.
- * If sorting for one col with payload, or one string col without payload,
-   SortOnekeyKernel is used. There are two template classes for this kernel,
-   and the key dataype (numeric or string) determines which one will be compiled
-   in success. In this kernel, data is partitioned to null and valid value before
-   sort. ska_sort is used for asc direciton, and std sort is used for desc 
-   direciton.
- * If sorting for multiple cols, SortArraysToIndicesKernel is used.
-   This kernel will do codegen, and std sort is used.
+ * If sorting for one non-string and non-bool col without payload, SortInplaceKernel 
+   is used. In this kernel, if sorted data has no null value, ska_sort is used for 
+   asc direciton, and std sort is used for desc direciton. If sorted data has null
+   value, arrow sort is used. Data is partitioned to null, NaN (for double and 
+   float only) and valid value before sort.
+ * If sorting for one col with payload, and one string or bool col without payload,
+   SortOnekeyKernel is used. In this kernel, ska_sort is used for asc direciton, 
+   and std sort is used for desc direciton. Data is partitioned to null, NaN (for 
+   double and float only) and valid value before sort.
+ * If sorting for multiple cols, SortArraysToIndicesKernel is used. This kernel 
+   will do codegen, and std sort is used.
  * Projection is supported in all the three kernels. If projection is required, 
    projection is completed before sort, and the projected cols are used to do 
    comparison.
-   FIXME: 1. when data has null value, desc and nulls last are not supported in
-   Inplace. 2. datatype change after projection is not supported in Inplace.
-*/
+   FIXME: 1. datatype change after projection is not supported in Inplace.
+**/
 
 namespace sparkcolumnarplugin {
 namespace codegen {
@@ -71,12 +69,6 @@ namespace arrowcompute {
 namespace extra {
 using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
 using namespace sparkcolumnarplugin::precompile;
-
-template <typename CTYPE>
-using enable_if_number = std::enable_if_t<std::is_arithmetic<CTYPE>::value>;
-
-template <typename CTYPE>
-using enable_if_string = std::enable_if_t<std::is_same<CTYPE, std::string>::value>;
 
 ///////////////  SortArraysToIndices  ////////////////
 class SortArraysToIndicesKernel::Impl {
@@ -88,12 +80,18 @@ class SortArraysToIndicesKernel::Impl {
        std::vector<std::shared_ptr<arrow::DataType>> projected_types,
        std::vector<std::shared_ptr<arrow::Field>> key_field_list,
        std::vector<bool> sort_directions, 
-       std::vector<bool> nulls_order)
-      : ctx_(ctx), result_schema_(result_schema), 
-        key_projector_(key_projector), key_field_list_(key_field_list),
-        sort_directions_(sort_directions), nulls_order_(nulls_order), 
-        asc_(sort_directions[0]), nulls_first_(nulls_order[0]),
-        projected_types_(projected_types) {
+       std::vector<bool> nulls_order,
+       bool NaN_check)
+      : ctx_(ctx), 
+        result_schema_(result_schema), 
+        key_projector_(key_projector), 
+        key_field_list_(key_field_list),
+        sort_directions_(sort_directions), 
+        nulls_order_(nulls_order), 
+        asc_(sort_directions[0]), 
+        nulls_first_(nulls_order[0]),
+        projected_types_(projected_types),
+        NaN_check_(NaN_check) {
     for (auto field : key_field_list) {
       auto indices = result_schema->GetAllFieldIndices(field->name());
       if (indices.size() != 1) {
@@ -188,6 +186,7 @@ class SortArraysToIndicesKernel::Impl {
   // keep the direction and nulls order for the first key
   bool nulls_first_;
   bool asc_;
+  bool NaN_check_;
 
   class TypedSorterCodeGenImpl {
    public:
@@ -288,6 +287,7 @@ class SortArraysToIndicesKernel::Impl {
 #include <arrow/buffer.h>
 
 #include <algorithm>
+#include <cmath>
 
 #include "codegen/arrow_compute/ext/array_item_index.h"
 #include "precompile/builder.h"
@@ -483,6 +483,8 @@ extern "C" void MakeCodeGen(arrow::compute::FunctionContext* ctx,
     auto y_str_value = array + std::to_string(cur_key_id) + "_[y.array_id]->GetString(y.id)";
     auto is_x_null = array + std::to_string(cur_key_id) + "_[x.array_id]->IsNull(x.id)";
     auto is_y_null = array + std::to_string(cur_key_id) + "_[y.array_id]->IsNull(y.id)";
+    auto is_x_nan = "std::isnan(" + x_num_value + ")";
+    auto is_y_nan = "std::isnan(" + y_num_value + ")";
 
     // Multiple keys sorting w/ nulls first/last is supported.
     std::stringstream ss;
@@ -502,6 +504,26 @@ extern "C" void MakeCodeGen(arrow::compute::FunctionContext* ctx,
     } else {
       ss << "return true;\n}";
     }
+    // If datatype is floating
+    if (data_type->id() == arrow::Type::DOUBLE || 
+        data_type->id() == arrow::Type::FLOAT) {
+      if (NaN_check_) {
+        ss << " else if (" << is_x_nan << " && " << is_y_nan << ") {\n";
+        ss << "return false;} " << "else if (" << is_x_nan << ") {\n";
+        if (asc) {
+          ss << "return false;\n}";
+        } else {
+          ss << "return true;\n}";
+        }
+        ss << "else if (" << is_y_nan << ") {\n";
+        if (asc) {
+          ss << "return true;\n}";
+        } else {
+          ss << "return false;\n}";
+        }
+      }
+    }
+
     // If values accessed from x and y are both not null
     ss << " else {\n";
 
@@ -530,8 +552,14 @@ extern "C" void MakeCodeGen(arrow::compute::FunctionContext* ctx,
       ss << "if ((" <<  is_x_null << " && " << is_y_null << ") || (" 
          << x_str_value << " == " << y_str_value << ")) {";
     } else {
-      ss << "if ((" <<  is_x_null << " && " << is_y_null << ") || (" 
-         << x_num_value << " == " << y_num_value << ")) {";
+      if (NaN_check_) {
+        ss << "if ((" <<  is_x_null << " && " << is_y_null << ") || ("
+           << is_x_nan << " && " << is_y_nan << ") || ("
+           << x_num_value << " == " << y_num_value << ")) {";
+      } else {
+        ss << "if ((" <<  is_x_null << " && " << is_y_null << ") || ("
+           << x_num_value << " == " << y_num_value << ")) {";
+      }
     }
     ss << GetCompFunction_(
         cur_key_index + 1, projected, sort_key_index_list, key_field_list, 
@@ -710,9 +738,14 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
                     std::shared_ptr<arrow::Schema> result_schema,
                     std::shared_ptr<gandiva::Projector> key_projector,
                     std::vector<bool> sort_directions, 
-                    std::vector<bool> nulls_order)
-      : ctx_(ctx), nulls_first_(nulls_order[0]), asc_(sort_directions[0]),
-        result_schema_(result_schema), key_projector_(key_projector) {}
+                    std::vector<bool> nulls_order,
+                    bool NaN_check)
+      : ctx_(ctx), 
+        nulls_first_(nulls_order[0]), 
+        asc_(sort_directions[0]),
+        result_schema_(result_schema), 
+        key_projector_(key_projector),
+        NaN_check_(NaN_check) {}
 
   arrow::Status Evaluate(const ArrayList& in) override {
     num_batches_++;
@@ -735,39 +768,198 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
     return arrow::Status::OK();
   }
 
+  template <typename TYPE>
+  auto SortNoNull(TYPE* indices_begin, TYPE* indices_end)
+      -> typename std::enable_if_t<std::is_floating_point<TYPE>::value> {
+    if (asc_) {
+      auto sort_end = indices_end;
+      if (NaN_check_) {
+        sort_end = std::partition(indices_begin, indices_end,
+                                  [](TYPE i){return !std::isnan(i);});
+      }
+      ska_sort(indices_begin, sort_end);
+    } else {
+      auto sort_begin = indices_begin;
+      if (NaN_check_) {
+        sort_begin = std::partition(indices_begin, indices_end,
+                                    [](TYPE i){return std::isnan(i);});
+      }
+      auto desc_comp = [this](TYPE& x, TYPE& y) {
+        return x > y;
+      };
+      std::sort(sort_begin, indices_end, desc_comp);
+    }
+  }
+
+  template <typename TYPE>
+  auto SortNoNull(TYPE* indices_begin, TYPE* indices_end)
+      -> typename std::enable_if_t<!std::is_floating_point<TYPE>::value> {
+    if (asc_) {
+      ska_sort(indices_begin, indices_end);
+    } else {
+      auto desc_comp = [this](TYPE& x, TYPE& y) { 
+                       return x > y;
+                       };
+      std::sort(indices_begin, indices_end, desc_comp);
+    }
+  }
+
+  template <typename TYPE, typename ArrayType>
+  auto Sort(int64_t* indices_begin, int64_t* indices_end, const ArrayType& values)
+      -> typename std::enable_if_t<std::is_floating_point<TYPE>::value> {
+    std::iota(indices_begin, indices_end, 0);
+    auto sort_begin = indices_begin;
+    auto sort_end = indices_end;
+    
+    if (asc_) {
+      if (nulls_first_) {
+        if (NaN_check_) {
+          // values should be sorted to:
+          // null, null, ..., valid-1, valid-2, ..., valid-3, NaN, NaN, ...
+          sort_end = 
+              std::partition(indices_begin, indices_end, 
+                            [&values](uint64_t ind) { 
+                            return !std::isnan(values.GetView(ind)); 
+                            });
+          sort_begin = 
+              std::partition(indices_begin, sort_end, 
+                             [&values](uint64_t ind) { 
+                             return values.IsNull(ind); 
+                             });
+        }
+        ska_sort(sort_begin, sort_end, 
+                [&values](auto& x) -> decltype(auto){ return values.GetView(x); });
+      } else {
+        if (NaN_check_) {
+          // values should be sorted to:
+          // valid-1, valid-2, ..., valid-3, NaN, NaN, ..., null, null, ...
+          sort_end = std::partition(indices_begin, indices_end, 
+              [&values](uint64_t ind) { 
+              return !values.IsNull(ind) && !std::isnan(values.GetView(ind)); 
+              });
+          if (values.null_count() < static_cast<int64_t>(indices_end - sort_end)) {
+            // if NaNs exist, need to do partition for NaN and null value
+            auto null_begin = std::partition(sort_end, indices_end, 
+                [&values](uint64_t ind) { return !values.IsNull(ind); });
+          }
+        }
+        ska_sort(indices_begin, sort_end,
+                [&values](auto& x) -> decltype(auto){ return values.GetView(x); });
+      }
+    } else {
+      auto comp = [&values](uint64_t left, uint64_t right) {
+                  return values.GetView(left) > values.GetView(right);
+                  };
+      if (nulls_first_) {
+        if (NaN_check_) {
+          // values should be sorted to: 
+          // null, null, NaN, NaN, ..., valid-1, valid-2, ..., valid-3, ...
+          sort_begin = 
+              std::partition(indices_begin, indices_end, 
+                             [&values](uint64_t ind) { 
+                             return values.IsNull(ind) || 
+                                    std::isnan(values.GetView(ind)); 
+                             });
+          if (values.null_count() < static_cast<int64_t>(sort_begin - indices_begin)) {
+            // if NaNs exist, need to do partition for NaN and null value
+            auto null_end = 
+                std::partition(indices_begin, sort_begin, 
+                               [&values](uint64_t ind) { return values.IsNull(ind); 
+                               });
+          }
+        }
+        std::sort(sort_begin, indices_end, comp);
+      } else {
+        if (NaN_check_) {
+          // values should be sorted to: 
+          // NaN, NaN, ..., valid-1, valid-2, ..., valid-3, ..., null, null, ...
+          sort_begin = 
+              std::partition(indices_begin, indices_end, 
+                             [&values](uint64_t ind) { 
+                             return std::isnan(values.GetView(ind)); 
+                             });
+          sort_end = 
+              std::partition(sort_begin, indices_end, 
+                             [&values](uint64_t ind) { 
+                             return !values.IsNull(ind); 
+                             });
+        }
+        std::sort(sort_begin, sort_end, comp);
+      }
+    }
+  }
+
+  template <typename TYPE, typename ArrayType>
+  auto Sort(int64_t* indices_begin, int64_t* indices_end, const ArrayType& values)
+      -> typename std::enable_if_t<!std::is_floating_point<TYPE>::value> {
+    std::iota(indices_begin, indices_end, 0);
+    if (asc_) {
+      if (nulls_first_) {
+        auto nulls_end =
+            std::partition(indices_begin, indices_end,
+                           [&values](uint64_t ind) { return values.IsNull(ind); });
+        ska_sort(nulls_end, indices_end, 
+                [&values](auto& x) -> decltype(auto){ return values.GetView(x); });
+      } else {
+        auto nulls_begin =
+            std::partition(indices_begin, indices_end,
+                           [&values](uint64_t ind) { return !values.IsNull(ind); });
+        ska_sort(indices_begin, nulls_begin, 
+                [&values](auto& x) -> decltype(auto){ return values.GetView(x); });
+      }
+    } else {
+      auto comp = [&values](uint64_t left, uint64_t right) {
+                  return values.GetView(left) > values.GetView(right);
+                  };
+      if (nulls_first_) {
+        auto nulls_end =
+            std::partition(indices_begin, indices_end,
+                           [&values](uint64_t ind) { return values.IsNull(ind); });
+        std::sort(nulls_end, indices_end, comp);
+      } else {
+        auto nulls_begin =
+            std::partition(indices_begin, indices_end,
+                           [&values](uint64_t ind) { return !values.IsNull(ind); });
+        std::sort(indices_begin, nulls_begin, comp);
+      }
+    }
+  }
+  
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override {
     RETURN_NOT_OK(
         arrow::Concatenate(cached_0_, ctx_->memory_pool(), &concatenated_array_));
-    CTYPE* indices_begin = concatenated_array_->data()->GetMutableValues<CTYPE>(1);
-    CTYPE* indices_end = indices_begin + concatenated_array_->length();
-    auto valid_indices_begin = indices_begin;
-    auto valid_indices_end = indices_end;
     if (nulls_total_ > 0) {
-      // we use arrow sort for this scenario
-      // the indices_out of arrow sort is nulls_last
+      auto typed_array = std::dynamic_pointer_cast<ArrayType_0>(concatenated_array_);
       std::shared_ptr<arrow::Array> indices_out;
-      RETURN_NOT_OK(
-          arrow::compute::SortToIndices(ctx_, *concatenated_array_.get(), &indices_out));
+
+      int64_t buf_size = typed_array->length() * sizeof(uint64_t);
+      ARROW_ASSIGN_OR_RAISE(auto indices_buf, AllocateBuffer(buf_size, ctx_->memory_pool()));
+      int64_t* indices_begin = reinterpret_cast<int64_t*>(indices_buf->mutable_data());
+      int64_t* indices_end = indices_begin + typed_array->length();
+
+      Sort<CTYPE, ArrayType_0>(indices_begin, indices_end, *typed_array.get());
+      indices_out = std::make_shared<arrow::UInt64Array>(typed_array->length(), std::move(indices_buf));
       std::shared_ptr<arrow::Array> sort_out;
       arrow::compute::TakeOptions options;
       RETURN_NOT_OK(arrow::compute::Take(ctx_, *concatenated_array_.get(),
                                          *indices_out.get(), options, &sort_out));
-      *out = std::make_shared<SorterResultIterator>(ctx_, schema, sort_out);
+      *out = std::make_shared<SorterResultIterator>(ctx_, schema, sort_out, nulls_first_, asc_);
     } else {
-      if (asc_) {
-        ska_sort(valid_indices_begin, valid_indices_end);
-      } else {
-        auto desc_comp = [this](CTYPE& x, CTYPE& y) { return x > y; };
-        std::sort(valid_indices_begin, valid_indices_end, desc_comp);
-      }
-      *out = std::make_shared<SorterResultIterator>(ctx_, schema, concatenated_array_);
+      CTYPE* indices_begin = concatenated_array_->data()->GetMutableValues<CTYPE>(1);
+      CTYPE* indices_end = indices_begin + concatenated_array_->length();
+      auto valid_indices_begin = indices_begin;
+      auto valid_indices_end = indices_end;
+      
+      SortNoNull<CTYPE>(valid_indices_begin, valid_indices_end);
+      *out = std::make_shared<SorterResultIterator>(ctx_, schema, concatenated_array_, nulls_first_, asc_);
     }
     return arrow::Status::OK();
   }
 
  private:
+  using ArrayType_0 = typename arrow::TypeTraits<DATATYPE>::ArrayType;
   arrow::ArrayVector cached_0_;
   std::shared_ptr<arrow::Array> concatenated_array_;
   arrow::compute::FunctionContext* ctx_;
@@ -775,6 +967,7 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
   std::shared_ptr<gandiva::Projector> key_projector_;
   bool nulls_first_;
   bool asc_;
+  bool NaN_check_;
   uint64_t num_batches_ = 0;
   uint64_t items_total_ = 0;
   uint64_t nulls_total_ = 0;
@@ -783,16 +976,15 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
    public:
     SorterResultIterator(arrow::compute::FunctionContext* ctx,
                          std::shared_ptr<arrow::Schema> result_schema,
-                         std::shared_ptr<arrow::Array> result_arr)
+                         std::shared_ptr<arrow::Array> result_arr,
+                         bool nulls_first, bool asc)
         : ctx_(ctx),
           result_schema_(result_schema),
           total_length_(result_arr->length()),
-          nulls_total_(result_arr->null_count()) {
-      result_arr_ = std::dynamic_pointer_cast<ArrayType_0>(result_arr);
-      std::unique_ptr<arrow::ArrayBuilder> builder_0;
-      arrow::MakeBuilder(ctx_->memory_pool(), data_type_0, &builder_0);
-      builder_0_.reset(
-          arrow::internal::checked_cast<BuilderType_0*>(builder_0.release()));
+          nulls_total_(result_arr->null_count()),
+          nulls_first_(nulls_first),
+          asc_(asc),
+          result_arr_(result_arr) {
       batch_size_ = GetBatchSize();
     }
 
@@ -805,55 +997,126 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
       return true;
     }
 
+    class SliceImpl {
+     public:
+      SliceImpl(const arrow::ArrayData& in, arrow::MemoryPool* pool, 
+                int64_t length, int64_t offset, int64_t null_total, 
+                bool null_first, int64_t total_length)
+          : in_(in), 
+            pool_(pool), 
+            length_(length), 
+            offset_(offset), 
+            null_total_(null_total) {
+        out_data_.type = in.type;
+        out_data_.length = length;
+        out_data_.buffers.resize(in.buffers.size());
+        out_data_.child_data.resize(in.child_data.size());
+        for (auto& data : out_data_.child_data) {
+          data = std::make_shared<arrow::ArrayData>();
+        }
+        // decide null_count
+        if (null_first) {
+          out_data_.null_count = 
+              (offset + length) > null_total ? null_total : (offset + length);
+        } else {
+          auto valid_total = total_length - null_total;
+          out_data_.null_count = 
+              (offset + length) < valid_total ? 0 : (offset + length - valid_total);
+        }
+      }
+
+      /// offset, length pair for representing a Range of a buffer or array
+      struct Range {
+        int64_t offset, length;
+
+        Range() : offset(-1), length(0) {}
+        Range(int64_t o, int64_t l) : offset(o), length(l) {}
+      };
+
+      /// non-owning view into a range of bits
+      struct Bitmap {
+        Bitmap() = default;
+        Bitmap(const uint8_t* d, Range r) : data(d), range(r) {}
+        explicit Bitmap(const std::shared_ptr<arrow::Buffer>& buffer, Range r)
+            : Bitmap(buffer ? buffer->data() : nullptr, r) {}
+
+        const uint8_t* data;
+        Range range;
+
+        bool AllSet() const { return data == nullptr; }
+      };
+
+      arrow::Result<std::shared_ptr<arrow::Buffer>> SliceBufferImpl(
+        const std::shared_ptr<arrow::Buffer>& buffer) {
+        ARROW_ASSIGN_OR_RAISE(auto out, AllocateBuffer(8 * length_, pool_));
+        auto out_data = out->mutable_data();
+        auto data_begin = buffer->data();
+        std::memcpy(out_data, data_begin + 8 * offset_, 8 * length_);
+        return std::move(out);
+      }
+      
+      arrow::Status SliceBuffer(const std::shared_ptr<arrow::Buffer>& buffer) {
+        return SliceBufferImpl(buffer).Value(&out_data_.buffers[1]);
+      }
+
+      arrow::Result<std::shared_ptr<arrow::Buffer>> SliceBitmapImpl(const Bitmap& bitmap) {
+        auto length = bitmap.range.length;
+        auto offset = bitmap.range.offset;
+        ARROW_ASSIGN_OR_RAISE(auto out, AllocateBitmap(length, pool_));
+        uint8_t* dst = out->mutable_data();
+
+
+        int64_t bitmap_offset = 0;
+        if (bitmap.AllSet()) {
+          arrow::BitUtil::SetBitsTo(dst, offset, length, true);
+        } else {
+          arrow::internal::CopyBitmap(bitmap.data, offset, length, dst,
+                                      bitmap_offset, false);
+        }
+        
+        // finally (if applicable) zero out any trailing bits
+        if (auto preceding_bits = arrow::BitUtil::kPrecedingBitmask[length_ % 8]) {
+          dst[length_ / 8] &= preceding_bits;
+        }
+        return std::move(out);
+      }
+
+      arrow::Status SliceBitmap(const std::shared_ptr<arrow::Buffer>& buffer) {
+        Range range(8 * offset_, 8 * length_);
+        Bitmap bitmap = Bitmap(buffer, range);
+        return SliceBitmapImpl(bitmap).Value(&out_data_.buffers[0]);
+      } 
+      
+      arrow::Status Slice(arrow::ArrayData* out) {
+        const auto& buffer_0 = in_.buffers[0];
+        const auto& buffer_1 = in_.buffers[1];
+        if (out_data_.null_count) {
+          SliceBitmap(buffer_0);
+        }
+        SliceBuffer(buffer_1);
+        *out = std::move(out_data_);
+        return arrow::Status::OK();
+      }
+
+     private:
+      arrow::ArrayData in_;
+      arrow::ArrayData out_data_;
+      arrow::MemoryPool* pool_;
+      int64_t length_;
+      int64_t offset_;
+      int64_t null_total_;
+    };
+
     arrow::Status Next(std::shared_ptr<arrow::RecordBatch>* out) {
       auto length = (total_length_ - total_offset_) > batch_size_ ? batch_size_
                                                             : (total_length_ - total_offset_);
-      /**
-       * Here we take value from the sorted result_arr_ and append to builder.
-       * valid_count is used to count the valid value, for accessing the valid value 
-         in result_arr_.
-       * total_count is used to count both valid and null value, for determing if all values
-         are appended to builder in while loop.
-       * valid_offset_ is used to count the total added valid value, for accessing the valid value
-         in result_arr_.
-       * total_offset_ is used to count the total added null and valid value.
-      **/
-      uint64_t valid_count = 0;
-      uint64_t total_count = 0;
-      if (total_offset_ >= nulls_total_) {
-        // If no null value
-        while (total_count < length) {
-          RETURN_NOT_OK(builder_0_->Append(result_arr_->GetView(valid_offset_ + valid_count)));
-          valid_count++;
-          total_count++;
-        }
-        total_offset_ += length;
-        valid_offset_ += length;
-      } else {
-        // If has null value
-        while (total_count < length) {
-          if ((total_offset_ + total_count) < nulls_total_) {
-            // Append nulls first
-            // TODO: support nulls_last
-            RETURN_NOT_OK(builder_0_->AppendNull());
-          } else {
-            // After appending all null value, append valid value
-            // Because result_arr_ from arrow sort is nulls_last, valid_count is used to
-            // access data from the beginning of result_arr_.
-            RETURN_NOT_OK(builder_0_->Append(result_arr_->GetView(valid_offset_ + valid_count)));
-            // Add valid_count after appending one valid value
-            valid_count++;
-          }
-          // Add total_count for both valid and null value
-          total_count++;
-        }
-        valid_offset_ += valid_count;
-        total_offset_ += length;
-      }
-      std::shared_ptr<arrow::Array> out_0;
-      RETURN_NOT_OK(builder_0_->Finish(&out_0));
-      builder_0_->Reset();
-
+      arrow::ArrayData result_data = *result_arr_->data();
+      arrow::ArrayData out_data;
+      SliceImpl(result_data, ctx_->memory_pool(), length, total_offset_, 
+                nulls_total_, nulls_first_, total_length_).Slice(&out_data);
+      std::shared_ptr<arrow::Array> out_0 = 
+          MakeArray(std::make_shared<arrow::ArrayData>(std::move(out_data)));
+      total_offset_ += length;    
       *out = arrow::RecordBatch::Make(result_schema_, length, {out_0});
       return arrow::Status::OK();
     }
@@ -863,8 +1126,7 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
     using BuilderType_0 = typename arrow::TypeTraits<DATATYPE>::BuilderType;
     std::shared_ptr<arrow::DataType> data_type_0 =
         arrow::TypeTraits<DATATYPE>::type_singleton();
-    std::shared_ptr<ArrayType_0> result_arr_;
-    std::shared_ptr<BuilderType_0> builder_0_;
+    std::shared_ptr<arrow::Array> result_arr_;
 
     uint64_t total_offset_ = 0;
     uint64_t valid_offset_ = 0;
@@ -873,26 +1135,28 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
     std::shared_ptr<arrow::Schema> result_schema_;
     arrow::compute::FunctionContext* ctx_;
     uint64_t batch_size_;
+    bool nulls_first_;
+    bool asc_;
   };
 };
 
-template <typename DATATYPE, typename CTYPE, typename Enable = void>
-class SortOnekeyKernel {};
-
 ///////////////  SortArraysOneKey  ////////////////
-// This class is used when key type is arithmetic
 template <typename DATATYPE, typename CTYPE>
-class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>> 
-  : public SortArraysToIndicesKernel::Impl {
+class SortOnekeyKernel  : public SortArraysToIndicesKernel::Impl {
  public:
   SortOnekeyKernel(arrow::compute::FunctionContext* ctx,
                    std::shared_ptr<arrow::Schema> result_schema,
                    std::shared_ptr<gandiva::Projector> key_projector,
                    std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                    std::vector<bool> sort_directions, 
-                   std::vector<bool> nulls_order)
-      : ctx_(ctx), nulls_first_(nulls_order[0]), asc_(sort_directions[0]), 
-        result_schema_(result_schema), key_projector_(key_projector) {
+                   std::vector<bool> nulls_order,
+                   bool NaN_check)
+      : ctx_(ctx), 
+        nulls_first_(nulls_order[0]), 
+        asc_(sort_directions[0]), 
+        result_schema_(result_schema), 
+        key_projector_(key_projector),
+        NaN_check_(NaN_check) {
       #ifdef DEBUG
           std::cout << "UseSortOneKeyForArithmetic" << std::endl;
       #endif
@@ -935,62 +1199,199 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>>
     }
     return arrow::Status::OK();
   }
-
-  arrow::Status FinishInternal(std::shared_ptr<FixedSizeBinaryArray>* out) {    
-    // initiate buffer for all arrays
-    std::shared_ptr<arrow::Buffer> indices_buf;
-    int64_t buf_size = items_total_ * sizeof(ArrayItemIndex);
-    RETURN_NOT_OK(arrow::AllocateBuffer(ctx_->memory_pool(), buf_size, &indices_buf));
-    // start to partition not_null with null
-    ArrayItemIndex* indices_begin = 
-      reinterpret_cast<ArrayItemIndex*>(indices_buf->mutable_data());
-    ArrayItemIndex* indices_end = indices_begin + items_total_;
+    
+  void PartitionNulls(ArrayItemIndex* indices_begin, 
+                      ArrayItemIndex* indices_end) {
     int64_t indices_i = 0;
     int64_t indices_null = 0;
-    // we should support nulls first and nulls last here
-    // we should also support desc and asc here
-    for (int array_id = 0; array_id < num_batches_; array_id++) {
-      for (int64_t i = 0; i < length_list_[array_id]; i++) {
-        if (nulls_first_) {
-          if (!cached_key_[array_id]->IsNull(i)) {
-            (indices_begin + nulls_total_ + indices_i)->array_id = array_id;
-            (indices_begin + nulls_total_ + indices_i)->id = i;
-            indices_i++;
-          } else {
-            (indices_begin + indices_null)->array_id = array_id;
-            (indices_begin + indices_null)->id = i;
-            indices_null++;
+    
+    if (nulls_total_ == 0) {
+      // if all batches have no null value,
+      // we do not need to check whether the value is null
+      for (int array_id = 0; array_id < num_batches_; array_id++) {
+        for (int64_t i = 0; i < length_list_[array_id]; i++) {
+          (indices_begin + indices_i)->array_id = array_id;
+          (indices_begin + indices_i)->id = i;
+          indices_i++;
+        }
+      }
+    } else {
+      // we should support nulls first and nulls last here
+      for (int array_id = 0; array_id < num_batches_; array_id++) {
+        if (cached_key_[array_id]->null_count() == 0) {
+          // if this array has no null value, 
+          // we do need to check if the value is null
+          for (int64_t i = 0; i < length_list_[array_id]; i++) {
+            if (nulls_first_) {
+              (indices_begin + nulls_total_ + indices_i)->array_id = array_id;
+              (indices_begin + nulls_total_ + indices_i)->id = i;
+              indices_i++;
+            } else {
+              (indices_begin + indices_i)->array_id = array_id;
+              (indices_begin + indices_i)->id = i;
+              indices_i++;
+            }
           }
         } else {
-          if (!cached_key_[array_id]->IsNull(i)) {
-            (indices_begin + indices_i)->array_id = array_id;
-            (indices_begin + indices_i)->id = i;
-            indices_i++;
+          for (int64_t i = 0; i < length_list_[array_id]; i++) {
+            if (nulls_first_) {
+              if (!cached_key_[array_id]->IsNull(i)) {
+                (indices_begin + nulls_total_ + indices_i)->array_id = array_id;
+                (indices_begin + nulls_total_ + indices_i)->id = i;
+                indices_i++;
+              } else {
+                (indices_begin + indices_null)->array_id = array_id;
+                (indices_begin + indices_null)->id = i;
+                indices_null++;
+              }
+            } else {
+              if (!cached_key_[array_id]->IsNull(i)) {
+                (indices_begin + indices_i)->array_id = array_id;
+                (indices_begin + indices_i)->id = i;
+                indices_i++;
+              } else {
+                (indices_end - nulls_total_ + indices_null)->array_id = array_id;
+                (indices_end - nulls_total_ + indices_null)->id = i;
+                indices_null++;
+              }
+            }
+          }
+        }
+      }
+    }   
+  }
+
+  int64_t PartitionNaNs(ArrayItemIndex* indices_begin, 
+                        ArrayItemIndex* indices_end) {
+    int64_t indices_i = 0;
+    int64_t indices_nan = 0;
+    
+    for (int array_id = 0; array_id < num_batches_; array_id++) {
+      for (int64_t i = 0; i < length_list_[array_id]; i++) {
+        if (cached_key_[array_id]->IsNull(i)) {
+          continue;
+        }
+        if (nulls_first_) {
+          if (asc_) {
+            if (!std::isnan(cached_key_[array_id]->GetView(i))) {
+              (indices_begin + nulls_total_ + indices_i)->array_id = array_id;
+              (indices_begin + nulls_total_ + indices_i)->id = i;
+              indices_i++;
+            } else {
+              (indices_end - indices_nan - 1)->array_id = array_id;
+              (indices_end - indices_nan - 1)->id = i;
+              indices_nan++;
+            }
           } else {
-            (indices_end - nulls_total_ + indices_null)->array_id = array_id;
-            (indices_end - nulls_total_ + indices_null)->id = i;
-            indices_null++;
+            if (!std::isnan(cached_key_[array_id]->GetView(i))) {
+              (indices_end - indices_i - 1)->array_id = array_id;
+              (indices_end - indices_i - 1)->id = i;
+              indices_i++;
+            } else {
+              (indices_begin + nulls_total_ + indices_nan)->array_id = array_id;
+              (indices_begin + nulls_total_ + indices_nan)->id = i;
+              indices_nan++;
+            }
+          }
+        } else {
+          if (asc_) {
+            if (!std::isnan(cached_key_[array_id]->GetView(i))) {
+              (indices_begin + indices_i)->array_id = array_id;
+              (indices_begin + indices_i)->id = i;
+              indices_i++;
+            } else {
+              (indices_end - nulls_total_ - indices_nan - 1)->array_id = array_id;
+              (indices_end - nulls_total_ - indices_nan - 1)->id = i;
+              indices_nan++;
+            }
+          } else {
+            if (!std::isnan(cached_key_[array_id]->GetView(i))) {
+              (indices_end - nulls_total_ - indices_i - 1)->array_id = array_id;
+              (indices_end - nulls_total_ - indices_i - 1)->id = i;
+              indices_i++;
+            } else {
+              (indices_begin + indices_nan)->array_id = array_id;
+              (indices_begin + indices_nan)->id = i;
+              indices_nan++;
+            }
           }
         }
       }
     }
+    return indices_nan;
+  }
+
+  template <typename T>
+  auto Partition(ArrayItemIndex* indices_begin, ArrayItemIndex* indices_end, int64_t &num_nan)
+      -> typename std::enable_if_t<std::is_floating_point<T>::value> {
+    PartitionNulls(indices_begin, indices_end);
+    if (NaN_check_) {
+      num_nan = PartitionNaNs(indices_begin, indices_end);
+    }
+  }
+
+  template <typename T>
+  auto Partition(ArrayItemIndex* indices_begin, ArrayItemIndex* indices_end, int64_t &num_nan)
+      -> typename std::enable_if_t<!std::is_floating_point<T>::value> {
+    PartitionNulls(indices_begin, indices_end);
+  }
+
+  template <typename T>
+  auto Sort(ArrayItemIndex* indices_begin, ArrayItemIndex* indices_end, int64_t num_nan)
+      -> typename std::enable_if_t<!std::is_same<T, std::string>::value> {
     if (asc_) {
       if (nulls_first_) {
-        ska_sort(indices_begin + nulls_total_, indices_begin + items_total_, 
+        ska_sort(indices_begin + nulls_total_, indices_begin + items_total_ - num_nan, 
             [this](auto& x) -> decltype(auto){ return cached_key_[x.array_id]->GetView(x.id); });
       } else {
-        ska_sort(indices_begin, indices_begin + items_total_ - nulls_total_, 
+        ska_sort(indices_begin, indices_begin + items_total_ - nulls_total_ - num_nan, 
             [this](auto& x) -> decltype(auto){ return cached_key_[x.array_id]->GetView(x.id); });
       }
     } else {
       auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
         return cached_key_[x.array_id]->GetView(x.id) > cached_key_[y.array_id]->GetView(y.id);};
       if (nulls_first_) {
+        std::sort(indices_begin + nulls_total_ + num_nan, indices_begin + items_total_, comp);
+      } else {
+        std::sort(indices_begin + num_nan, indices_begin + items_total_ - nulls_total_, comp);
+      }
+    }
+  }
+
+  template <typename T>
+  auto Sort(ArrayItemIndex* indices_begin, ArrayItemIndex* indices_end, int64_t num_nan)
+      -> typename std::enable_if_t<std::is_same<T, std::string>::value> {
+    if (asc_) {
+      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
+        return cached_key_[x.array_id]->GetString(x.id) < cached_key_[y.array_id]->GetString(y.id);};
+      if (nulls_first_) {
+        std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
+      } else {
+        std::sort(indices_begin, indices_begin + items_total_ - nulls_total_, comp);
+      }
+    } else {
+      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
+        return cached_key_[x.array_id]->GetString(x.id) > cached_key_[y.array_id]->GetString(y.id);};
+      if (nulls_first_) {
         std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
       } else {
         std::sort(indices_begin, indices_begin + items_total_ - nulls_total_, comp);
       }
     }
+  }
+
+  arrow::Status FinishInternal(std::shared_ptr<FixedSizeBinaryArray>* out) {    
+    // initiate buffer for all arrays
+    std::shared_ptr<arrow::Buffer> indices_buf;
+    int64_t buf_size = items_total_ * sizeof(ArrayItemIndex);
+    RETURN_NOT_OK(arrow::AllocateBuffer(ctx_->memory_pool(), buf_size, &indices_buf));
+    ArrayItemIndex* indices_begin = 
+      reinterpret_cast<ArrayItemIndex*>(indices_buf->mutable_data());
+    ArrayItemIndex* indices_end = indices_begin + items_total_;
+    // do partition and sort here
+    int64_t num_nan = 0;
+    Partition<CTYPE>(indices_begin, indices_end, num_nan);
+    Sort<CTYPE>(indices_begin, indices_end, num_nan);
     std::shared_ptr<arrow::FixedSizeBinaryType> out_type;
     RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndex) / sizeof(int32_t), &out_type));
     RETURN_NOT_OK(MakeFixedSizeBinaryArray(out_type, items_total_, indices_buf, out));
@@ -1015,6 +1416,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>>
   std::shared_ptr<gandiva::Projector> key_projector_;
   bool nulls_first_;
   bool asc_;
+  bool NaN_check_;
   std::vector<int64_t> length_list_;
   uint64_t num_batches_ = 0;
   uint64_t items_total_ = 0;
@@ -1104,241 +1506,21 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>>
   };
 };
 
-///////////////  SortArraysOneKey  ////////////////
-// This class is used when key type is string
-template <typename DATATYPE, typename CTYPE>
-class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>> 
-  : public SortArraysToIndicesKernel::Impl {
- public:
-  SortOnekeyKernel(arrow::compute::FunctionContext* ctx, 
-      std::shared_ptr<arrow::Schema> result_schema,
-      std::shared_ptr<gandiva::Projector> key_projector,
-      std::vector<std::shared_ptr<arrow::Field>> key_field_list,
-      std::vector<bool> sort_directions, 
-      std::vector<bool> nulls_order)
-      : ctx_(ctx), nulls_first_(nulls_order[0]), asc_(sort_directions[0]), 
-        result_schema_(result_schema), key_projector_(key_projector) {
-      #ifdef DEBUG
-          std::cout << "UseSortOneKeyForString" << std::endl;
-      #endif
-      auto indices = result_schema->GetAllFieldIndices(key_field_list[0]->name());
-      if (indices.size() < 1) {
-        std::cout << "[ERROR] SortOnekeyKernel for string can't find key "
-                  << key_field_list[0]->ToString() << " from " 
-                  << result_schema->ToString() << std::endl;
-        throw;
-      }
-      key_id_ = indices[0];
-      col_num_ = result_schema->num_fields();
-  }
-
-  arrow::Status Evaluate(const ArrayList& in) override {
-    num_batches_++;
-    // do projection here
-    arrow::ArrayVector outputs;
-    if (key_projector_) {
-      auto length = in.size() > 0 ? in[key_id_]->length() : 0;
-      auto in_batch =
-          arrow::RecordBatch::Make(result_schema_, length, in);
-      RETURN_NOT_OK(
-          key_projector_->Evaluate(*in_batch, ctx_->memory_pool(), &outputs));
-      cached_key_.push_back(std::dynamic_pointer_cast<ArrayType_key>(outputs[0]));   
-      nulls_total_ += outputs[0]->null_count(); 
-    } else {
-      cached_key_.push_back(std::dynamic_pointer_cast<ArrayType_key>(in[key_id_]));
-      nulls_total_ += in[key_id_]->null_count();
-    }
-
-    items_total_ += in[key_id_]->length();
-    length_list_.push_back(in[key_id_]->length());
-    if (cached_.size() <= col_num_) {
-      cached_.resize(col_num_ + 1);
-    }
-    for (int i = 0; i < col_num_; i++) {
-      cached_[i].push_back(in[i]);
-    }
-    return arrow::Status::OK();
-  }
-
-  arrow::Status FinishInternal(std::shared_ptr<FixedSizeBinaryArray>* out) {    
-    // initiate buffer for all arrays
-    std::shared_ptr<arrow::Buffer> indices_buf;
-    int64_t buf_size = items_total_ * sizeof(ArrayItemIndex);
-    RETURN_NOT_OK(arrow::AllocateBuffer(ctx_->memory_pool(), buf_size, &indices_buf));
-    // start to partition not_null with null
-    ArrayItemIndex* indices_begin = 
-      reinterpret_cast<ArrayItemIndex*>(indices_buf->mutable_data());
-    ArrayItemIndex* indices_end = indices_begin + items_total_;
-    int64_t indices_i = 0;
-    int64_t indices_null = 0;
-    // we should support nulls first and nulls last here
-    // we should also support desc and asc here
-    for (int array_id = 0; array_id < num_batches_; array_id++) {
-      for (int64_t i = 0; i < length_list_[array_id]; i++) {
-        if (nulls_first_) {
-          if (!cached_key_[array_id]->IsNull(i)) {
-            (indices_begin + nulls_total_ + indices_i)->array_id = array_id;
-            (indices_begin + nulls_total_ + indices_i)->id = i;
-            indices_i++;
-          } else {
-            (indices_begin + indices_null)->array_id = array_id;
-            (indices_begin + indices_null)->id = i;
-            indices_null++;
-          }
-        } else {
-          if (!cached_key_[array_id]->IsNull(i)) {
-            (indices_begin + indices_i)->array_id = array_id;
-            (indices_begin + indices_i)->id = i;
-            indices_i++;
-          } else {
-            (indices_end - nulls_total_ + indices_null)->array_id = array_id;
-            (indices_end - nulls_total_ + indices_null)->id = i;
-            indices_null++;
-          }
-        }
-      }
-    }
-    if (asc_) {
-      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
-        return cached_key_[x.array_id]->GetString(x.id) < cached_key_[y.array_id]->GetString(y.id);};
-      if (nulls_first_) {
-        std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
-      } else {
-        std::sort(indices_begin, indices_begin + items_total_ - nulls_total_, comp);
-      }
-    } else {
-      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
-        return cached_key_[x.array_id]->GetString(x.id) > cached_key_[y.array_id]->GetString(y.id);};
-      if (nulls_first_) {
-        std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
-      } else {
-        std::sort(indices_begin, indices_begin + items_total_ - nulls_total_, comp);
-      }
-    }
-    std::shared_ptr<arrow::FixedSizeBinaryType> out_type;
-    RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndex) / sizeof(int32_t), &out_type));
-    RETURN_NOT_OK(MakeFixedSizeBinaryArray(out_type, items_total_, indices_buf, out));
-    return arrow::Status::OK();
-  }
-
-  arrow::Status MakeResultIterator(
-      std::shared_ptr<arrow::Schema> schema,
-      std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override {
-    std::shared_ptr<FixedSizeBinaryArray> indices_out;
-    RETURN_NOT_OK(FinishInternal(&indices_out));
-    *out = std::make_shared<SorterResultIterator>(ctx_, schema, indices_out, cached_);
-    return arrow::Status::OK();
-  }
-
- private:
-  using ArrayType_key = typename arrow::TypeTraits<DATATYPE>::ArrayType;
-  std::vector<std::shared_ptr<ArrayType_key>> cached_key_;
-  std::vector<arrow::ArrayVector> cached_;
-  arrow::compute::FunctionContext* ctx_;
-  std::shared_ptr<arrow::Schema> result_schema_;
-  std::shared_ptr<gandiva::Projector> key_projector_;
-  bool nulls_first_;
-  bool asc_;
-  std::vector<int64_t> length_list_;
-  uint64_t num_batches_ = 0;
-  uint64_t items_total_ = 0;
-  uint64_t nulls_total_ = 0;
-  int col_num_;
-  int key_id_;
-
-  class SorterResultIterator : public ResultIterator<arrow::RecordBatch> {
-   public:
-    SorterResultIterator(arrow::compute::FunctionContext* ctx,
-                         std::shared_ptr<arrow::Schema> schema,
-                         std::shared_ptr<FixedSizeBinaryArray> indices_in,
-                         std::vector<arrow::ArrayVector>& cached)
-        : ctx_(ctx),
-          schema_(schema),
-          indices_in_cache_(indices_in),
-          total_length_(indices_in->length()),
-          cached_in_(cached) {
-      col_num_ = schema->num_fields();
-      indices_begin_ = (ArrayItemIndex*)indices_in->value_data();
-      // appender_type won't be used
-      AppenderBase::AppenderType appender_type = AppenderBase::left;
-      for (int i = 0; i < col_num_; i++) {
-        auto field = schema->field(i);
-        std::shared_ptr<AppenderBase> appender;
-        MakeAppender(ctx_, field->type(), appender_type, &appender);
-        appender_list_.push_back(appender);
-      }
-      for (int i = 0; i < col_num_; i++) {
-        arrow::ArrayVector array_vector = cached_in_[i];
-        int array_num = array_vector.size();
-        for (int array_id = 0; array_id < array_num; array_id++) {
-          auto arr = array_vector[array_id];
-          appender_list_[i]->AddArray(arr);
-        }
-      }
-      batch_size_ = GetBatchSize();
-    }
-
-    std::string ToString() override { return "SortArraysToIndicesResultIterator"; }
-
-    bool HasNext() override {
-      if (offset_ >= total_length_) {
-        return false;
-      }
-      return true;
-    }
-
-    arrow::Status Next(std::shared_ptr<arrow::RecordBatch>* out) {
-      auto length = (total_length_ - offset_) > batch_size_ ? batch_size_
-                                                            : (total_length_ - offset_);
-      uint64_t count = 0;
-      for (int i = 0; i < col_num_; i++) {
-        while (count < length) {
-          auto item = indices_begin_ + offset_ + count++;
-          RETURN_NOT_OK(appender_list_[i]->Append(item->array_id, item->id));
-        }
-        count = 0;
-      }
-      offset_ += length;
-      ArrayList arrays;
-      for (int i = 0; i < col_num_; i++) {
-        std::shared_ptr<arrow::Array> out_array;
-        RETURN_NOT_OK(appender_list_[i]->Finish(&out_array));
-        arrays.push_back(out_array);
-        appender_list_[i]->Reset();
-      }
-
-      *out = arrow::RecordBatch::Make(schema_, length, arrays);
-      return arrow::Status::OK();
-    }
-
-   private:
-    uint64_t offset_ = 0;
-    const uint64_t total_length_;
-    std::shared_ptr<arrow::Schema> schema_;
-    arrow::compute::FunctionContext* ctx_;
-    uint64_t batch_size_;
-    int col_num_;
-    ArrayItemIndex* indices_begin_;
-    std::vector<arrow::ArrayVector> cached_in_;
-    std::vector<std::shared_ptr<arrow::DataType>> type_list_;
-    std::vector<std::shared_ptr<AppenderBase>> appender_list_;
-    std::vector<std::shared_ptr<arrow::Array>> array_list_;
-    std::shared_ptr<FixedSizeBinaryArray> indices_in_cache_;
-  };
-};
-
 arrow::Status SortArraysToIndicesKernel::Make(
     arrow::compute::FunctionContext* ctx,
     std::shared_ptr<arrow::Schema> result_schema,
     gandiva::NodeVector sort_key_node,
     std::vector<std::shared_ptr<arrow::Field>> key_field_list,
-    std::vector<bool> sort_directions, std::vector<bool> nulls_order,
+    std::vector<bool> sort_directions, 
+    std::vector<bool> nulls_order,
+    bool NaN_check,
     std::shared_ptr<KernalBase>* out) {
   *out = std::make_shared<SortArraysToIndicesKernel>(
-    ctx, result_schema, sort_key_node, key_field_list, sort_directions, nulls_order);
+    ctx, result_schema, sort_key_node, key_field_list, sort_directions, nulls_order, NaN_check);
   return arrow::Status::OK();
 }
 #define PROCESS_SUPPORTED_TYPES(PROCESS) \
+  PROCESS(arrow::BooleanType)            \
   PROCESS(arrow::UInt8Type)              \
   PROCESS(arrow::Int8Type)               \
   PROCESS(arrow::UInt16Type)             \
@@ -1357,7 +1539,8 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
     gandiva::NodeVector sort_key_node,
     std::vector<std::shared_ptr<arrow::Field>> key_field_list,
     std::vector<bool> sort_directions, 
-    std::vector<bool> nulls_order) {
+    std::vector<bool> nulls_order,
+    bool NaN_check) {
   // sort_key_node may need to do projection
   bool pre_processed_key_ = false;
   gandiva::NodePtr key_project;
@@ -1386,8 +1569,9 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
   }
 
   if (key_field_list.size() == 1 && result_schema->num_fields() == 1 
-      && key_field_list[0]->type()->id() != arrow::Type::STRING) {
-    // Will use SortInplace when sorting for one non-string col
+      && key_field_list[0]->type()->id() != arrow::Type::STRING
+      && key_field_list[0]->type()->id() != arrow::Type::BOOL) {
+    // Will use SortInplace when sorting for one non-string and non-boolean col 
 #ifdef DEBUG
     std::cout << "UseSortInplace" << std::endl;
 #endif
@@ -1395,7 +1579,7 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
 #define PROCESS(InType)                                                       \
   case InType::type_id: {                                                     \
     using CType = typename arrow::TypeTraits<InType>::CType;                  \
-    impl_.reset(new SortInplaceKernel<InType, CType>(ctx, result_schema, key_projector, sort_directions, nulls_order)); \
+    impl_.reset(new SortInplaceKernel<InType, CType>(ctx, result_schema, key_projector, sort_directions, nulls_order, NaN_check)); \
   } break;
       PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
@@ -1406,7 +1590,7 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
     }
   } else if (key_field_list.size() == 1 && result_schema->num_fields() >= 1) {
     // Will use SortOnekey when: 
-    // 1. sorting for one col inside several cols 2. sorting for one string col
+    // 1. sorting for one col with payload 2. sorting for one string col or one bool col
 #ifdef DEBUG
     std::cout << "UseSortOneKey" << std::endl;
 #endif
@@ -1414,13 +1598,13 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
       // if needs projection, will use projected type for key col
       if (projected_types[0]->id() == arrow::Type::STRING) {
         impl_.reset(new SortOnekeyKernel<arrow::StringType, std::string>(
-          ctx, result_schema, key_projector, key_field_list, sort_directions, nulls_order));
+          ctx, result_schema, key_projector, key_field_list, sort_directions, nulls_order, NaN_check));
       } else {
         switch (projected_types[0]->id()) {
 #define PROCESS(InType)                                                       \
     case InType::type_id: {                                                   \
       using CType = typename arrow::TypeTraits<InType>::CType;                \
-      impl_.reset(new SortOnekeyKernel<InType, CType>(ctx, result_schema, key_projector, key_field_list, sort_directions, nulls_order)); \
+      impl_.reset(new SortOnekeyKernel<InType, CType>(ctx, result_schema, key_projector, key_field_list, sort_directions, nulls_order, NaN_check)); \
     } break;
           PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
@@ -1434,13 +1618,13 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
       // if no projection, will use the original type for key col
       if (key_field_list[0]->type()->id() == arrow::Type::STRING) {
         impl_.reset(new SortOnekeyKernel<arrow::StringType, std::string>(
-          ctx, result_schema, key_projector, key_field_list, sort_directions, nulls_order));
+          ctx, result_schema, key_projector, key_field_list, sort_directions, nulls_order, NaN_check));
       } else {
         switch (key_field_list[0]->type()->id()) {
 #define PROCESS(InType)                                                       \
     case InType::type_id: {                                                   \
       using CType = typename arrow::TypeTraits<InType>::CType;                \
-      impl_.reset(new SortOnekeyKernel<InType, CType>(ctx, result_schema, key_projector, key_field_list, sort_directions, nulls_order)); \
+      impl_.reset(new SortOnekeyKernel<InType, CType>(ctx, result_schema, key_projector, key_field_list, sort_directions, nulls_order, NaN_check)); \
     } break;
           PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
@@ -1454,7 +1638,7 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
   } else {
     // Will use Sort Codegen when sorting for several cols
     impl_.reset(new Impl(ctx, result_schema, key_projector, projected_types, 
-                         key_field_list, sort_directions, nulls_order));
+                         key_field_list, sort_directions, nulls_order, NaN_check));
     auto status = impl_->LoadJITFunction(key_field_list, result_schema);
     if (!status.ok()) {
       std::cout << "LoadJITFunction failed, msg is " << status.message() << std::endl;

--- a/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/oap-native-sql/cpp/src/tests/arrow_compute_test_sort.cc
@@ -29,461 +29,9 @@
 namespace sparkcolumnarplugin {
 namespace codegen {
 
-TEST(TestArrowComputeSort, SortTestNullsFirstAsc) {
+TEST(TestArrowComputeSort, SortTestInPlaceNullsFirstAsc) {
   ////////////////////// prepare expr_vector ///////////////////////
-  auto f0 = field("f0", uint32());
-  auto f1 = field("f1", uint32());
-  auto arg_0 = TreeExprBuilder::MakeField(f0);
-  auto arg_1 = TreeExprBuilder::MakeField(f1);
-  auto f_res = field("res", uint32());
-  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
-  auto f_indices = field("indices", indices_type);
-
-  auto n_key_func = TreeExprBuilder::MakeFunction(
-      "key_function", {arg_0}, uint32());
-  auto n_key_field = TreeExprBuilder::MakeFunction(
-      "key_field", {arg_0}, uint32());
-  auto n_dir = TreeExprBuilder::MakeFunction(
-      "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
-  auto n_nulls_order = TreeExprBuilder::MakeFunction(
-      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
-  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
-  auto n_sort = TreeExprBuilder::MakeFunction(
-      "standalone", {n_sort_to_indices}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
-
-  auto sch = arrow::schema({f0, f1});
-  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
-  ///////////////////// Calculation //////////////////
-  std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
-
-  std::shared_ptr<arrow::RecordBatch> input_batch;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
-
-  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]",
-                                                "[11, 13, 5, 51, null, 33, 12]"};
-  MakeInputBatch(input_data_string, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]",
-                                                  "[2, null, 44, 43, 7, 34, 3]"};
-  MakeInputBatch(input_data_string_2, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
-                                                  "[4, 65, 16, 8, 10, 20, 34]"};
-  MakeInputBatch(input_data_string_3, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
-                                                  "[24, 18, 42, 19, 21, 36, 31]"};
-  MakeInputBatch(input_data_string_4, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
-                                                  "[38, 67, 23, 14, 9, 60, 22]"};
-  MakeInputBatch(input_data_string_5, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  ////////////////////////////////// calculation ///////////////////////////////////
-  std::shared_ptr<arrow::RecordBatch> expected_result;
-  std::vector<std::string> expected_result_string = {
-      "[null, null, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, "
-      "22, 23, 30, "
-      "32, 33, 35, 37, 41, 42, 43, 50, 52, 59, 64]",
-      "[34, 67, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, null, 16, 18, 19, 20, 21, 22, "
-      "23, 24, "
-      "31, 33, 34, 36, 38, 42, 43, 44, 51, null, 60, 65]"};
-  MakeInputBatch(expected_result_string, sch, &expected_result);
-
-  for (auto batch : input_batch_list) {
-    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
-  }
-  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
-  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
-  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
-  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
-      sort_result_iterator_base);
-
-  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
-  std::shared_ptr<arrow::RecordBatch> result_batch;
-
-  if (sort_result_iterator->HasNext()) {
-    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
-    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
-  }
-}
-
-TEST(TestArrowComputeSort, SortTestNullsLastAsc) {
-  ////////////////////// prepare expr_vector ///////////////////////
-  auto f0 = field("f0", uint32());
-  auto f1 = field("f1", uint32());
-  auto arg_0 = TreeExprBuilder::MakeField(f0);
-  auto arg_1 = TreeExprBuilder::MakeField(f1);
-  auto f_res = field("res", uint32());
-  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
-  auto f_indices = field("indices", indices_type);
-
-  auto n_key_func = TreeExprBuilder::MakeFunction(
-      "key_function", {arg_0}, uint32());
-  auto n_key_field = TreeExprBuilder::MakeFunction(
-      "key_field", {arg_0}, uint32());
-  auto n_dir = TreeExprBuilder::MakeFunction(
-      "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
-  auto n_nulls_order = TreeExprBuilder::MakeFunction(
-      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
-  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
-  auto n_sort = TreeExprBuilder::MakeFunction(
-      "standalone", {n_sort_to_indices}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
-
-  auto sch = arrow::schema({f0, f1});
-  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
-  ///////////////////// Calculation //////////////////
-  std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
-
-  std::shared_ptr<arrow::RecordBatch> input_batch;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
-
-  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]",
-                                                "[11, 13, 5, 51, null, 33, 12]"};
-  MakeInputBatch(input_data_string, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]",
-                                                  "[2, null, 44, 43, 7, 34, 3]"};
-  MakeInputBatch(input_data_string_2, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
-                                                  "[4, 65, 16, 8, 10, 20, 34]"};
-  MakeInputBatch(input_data_string_3, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
-                                                  "[24, 18, 42, 19, 21, 36, 31]"};
-  MakeInputBatch(input_data_string_4, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
-                                                  "[38, 67, 23, 14, 9, 60, 22]"};
-  MakeInputBatch(input_data_string_5, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  ////////////////////////////////// calculation ///////////////////////////////////
-  std::shared_ptr<arrow::RecordBatch> expected_result;
-  std::vector<std::string> expected_result_string = {
-      "[1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23, 30, "
-      "32, 33, 35, 37, 41, 42, 43, 50, 52, 59, 64, null, null]",
-      "[2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, null, 16, 18, 19, 20, 21, 22, 23, 24,"
-      "31, 33, 34, 36, 38, 42, 43, 44, 51, null, 60, 65, 34, 67]"};
-  MakeInputBatch(expected_result_string, sch, &expected_result);
-
-  for (auto batch : input_batch_list) {
-    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
-  }
-  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
-  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
-  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
-  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
-      sort_result_iterator_base);
-
-  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
-  std::shared_ptr<arrow::RecordBatch> result_batch;
-
-  if (sort_result_iterator->HasNext()) {
-    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
-    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
-  }
-}
-
-TEST(TestArrowComputeSort, SortTestNullsFirstDesc) {
-  ////////////////////// prepare expr_vector ///////////////////////
-  auto f0 = field("f0", uint32());
-  auto f1 = field("f1", uint32());
-  auto arg_0 = TreeExprBuilder::MakeField(f0);
-  auto arg_1 = TreeExprBuilder::MakeField(f1);
-  auto f_res = field("res", uint32());
-  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
-  auto f_indices = field("indices", indices_type);
-
-  auto n_key_func = TreeExprBuilder::MakeFunction(
-      "key_function", {arg_0}, uint32());
-  auto n_key_field = TreeExprBuilder::MakeFunction(
-      "key_field", {arg_0}, uint32());
-  auto n_dir = TreeExprBuilder::MakeFunction(
-      "sort_directions", {TreeExprBuilder::MakeLiteral(false)}, uint32());
-  auto n_nulls_order = TreeExprBuilder::MakeFunction(
-      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
-  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
-  auto n_sort = TreeExprBuilder::MakeFunction(
-      "standalone", {n_sort_to_indices}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
-
-  auto sch = arrow::schema({f0, f1});
-  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
-  ///////////////////// Calculation //////////////////
-  std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
-
-  std::shared_ptr<arrow::RecordBatch> input_batch;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
-
-  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]",
-                                                "[11, 13, 5, 51, null, 33, 12]"};
-  MakeInputBatch(input_data_string, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]",
-                                                  "[2, null, 44, 43, 7, 34, 3]"};
-  MakeInputBatch(input_data_string_2, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
-                                                  "[4, 65, 16, 8, 10, 20, 34]"};
-  MakeInputBatch(input_data_string_3, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
-                                                  "[24, 18, 42, 19, 21, 36, 31]"};
-  MakeInputBatch(input_data_string_4, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
-                                                  "[38, 67, 23, 14, 9, 60, 22]"};
-  MakeInputBatch(input_data_string_5, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  ////////////////////////////////// calculation ///////////////////////////////////
-  std::shared_ptr<arrow::RecordBatch> expected_result;
-  std::vector<std::string> expected_result_string = {
-      "[null ,null ,64 ,59 ,52 ,50 ,43 ,42 ,41 ,37 ,35 ,33 ,32 ,30 ,23 ,22 ,21 ,20 ,19 "
-      ",18 ,17 ,15 ,14 ,13 ,12 , 11 ,10 ,9 ,8 ,7 ,6 ,4 ,3 ,2 ,1]",
-      "[34 ,67 ,65 ,60 ,null ,51 ,44 ,43 ,42 ,38 ,36 ,34 ,33 ,31 ,24 ,23 ,22 ,21 , 20 "
-      ",19 ,18 ,16 ,null ,14 ,13 ,12 ,11 ,10 ,9 ,8 ,7 ,5 ,4 ,3 ,2]"};
-  MakeInputBatch(expected_result_string, sch, &expected_result);
-
-  for (auto batch : input_batch_list) {
-    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
-  }
-  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
-  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
-  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
-  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
-      sort_result_iterator_base);
-
-  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
-  std::shared_ptr<arrow::RecordBatch> result_batch;
-
-  if (sort_result_iterator->HasNext()) {
-    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
-    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
-  }
-}
-
-TEST(TestArrowComputeSort, SortTestNullsLastDesc) {
-  ////////////////////// prepare expr_vector ///////////////////////
-  auto f0 = field("f0", uint32());
-  auto f1 = field("f1", uint32());
-  auto arg_0 = TreeExprBuilder::MakeField(f0);
-  auto arg_1 = TreeExprBuilder::MakeField(f1);
-  auto f_res = field("res", uint32());
-  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
-  auto f_indices = field("indices", indices_type);
-
-  auto n_key_func = TreeExprBuilder::MakeFunction(
-      "key_function", {arg_0}, uint32());
-  auto n_key_field = TreeExprBuilder::MakeFunction(
-      "key_field", {arg_0}, uint32());
-  auto n_dir = TreeExprBuilder::MakeFunction(
-      "sort_directions", {TreeExprBuilder::MakeLiteral(false)}, uint32());
-  auto n_nulls_order = TreeExprBuilder::MakeFunction(
-      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
-  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
-  auto n_sort = TreeExprBuilder::MakeFunction(
-      "standalone", {n_sort_to_indices}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
-
-  auto sch = arrow::schema({f0, f1});
-  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
-  ///////////////////// Calculation //////////////////
-  std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
-
-  std::shared_ptr<arrow::RecordBatch> input_batch;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
-
-  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]",
-                                                "[11, 13, 5, 51, null, 33, 12]"};
-  MakeInputBatch(input_data_string, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]",
-                                                  "[2, null, 44, 43, 7, 34, 3]"};
-  MakeInputBatch(input_data_string_2, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
-                                                  "[4, 65, 16, 8, 10, 20, 34]"};
-  MakeInputBatch(input_data_string_3, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
-                                                  "[24, 18, 42, 19, 21, 36, 31]"};
-  MakeInputBatch(input_data_string_4, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
-                                                  "[38, 67, 23, 14, 9, 60, 22]"};
-  MakeInputBatch(input_data_string_5, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  ////////////////////////////////// calculation ///////////////////////////////////
-  std::shared_ptr<arrow::RecordBatch> expected_result;
-  std::vector<std::string> expected_result_string = {
-      "[64 ,59 ,52 ,50 ,43 ,42 ,41 ,37 ,35 ,33 ,32 ,30 ,23 ,22 ,21 ,20 ,19 "
-      ",18 ,17 ,15 ,14 ,13 ,12 , 11 ,10 ,9 ,8 ,7 ,6 ,4 ,3 ,2 ,1, null, null]",
-      "[65 ,60 ,null ,51 ,44 ,43 ,42 ,38 ,36 ,34 ,33 ,31 ,24 ,23 ,22 ,21 , 20 "
-      ",19 ,18 ,16 ,null ,14 ,13 ,12 ,11 ,10 ,9 ,8 ,7 ,5 ,4 ,3 ,2, 34, 67]"};
-  MakeInputBatch(expected_result_string, sch, &expected_result);
-
-  for (auto batch : input_batch_list) {
-    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
-  }
-  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
-  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
-  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
-  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
-      sort_result_iterator_base);
-
-  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
-  std::shared_ptr<arrow::RecordBatch> result_batch;
-
-  if (sort_result_iterator->HasNext()) {
-    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
-    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
-  }
-}
-
-TEST(TestArrowComputeSort, SortTestMultipleKeys) {
-  ////////////////////// prepare expr_vector ///////////////////////
-  auto f0 = field("f0", uint32());
-  auto f1 = field("f1", utf8());
-  auto f2 = field("f2", uint32());
-  auto f3 = field("f3", uint32());
-  auto arg_0 = TreeExprBuilder::MakeField(f0);
-  auto arg_1 = TreeExprBuilder::MakeField(f1);
-  auto arg_2 = TreeExprBuilder::MakeField(f2);
-  auto true_literal = TreeExprBuilder::MakeLiteral(true);
-  auto false_literal = TreeExprBuilder::MakeLiteral(false);
-  auto f_res = field("res", uint32());
-  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
-  auto f_indices = field("indices", indices_type);
-
-  auto n_key_func = TreeExprBuilder::MakeFunction(
-      "key_function", {arg_0, arg_1, arg_2}, uint32());
-  auto n_key_field = TreeExprBuilder::MakeFunction(
-      "key_field", {arg_0, arg_1, arg_2}, uint32());
-  auto n_dir = TreeExprBuilder::MakeFunction(
-      "sort_directions", {true_literal, false_literal, true_literal}, uint32());
-  auto n_nulls_order = TreeExprBuilder::MakeFunction(
-      "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
-  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
-  auto n_sort = TreeExprBuilder::MakeFunction(
-      "standalone", {n_sort_to_indices}, uint32());
-  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
-
-  auto sch = arrow::schema({f0, f1, f2, f3});
-  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2, f3};
-  ///////////////////// Calculation //////////////////
-  std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
-
-  std::shared_ptr<arrow::RecordBatch> input_batch;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
-
-  std::vector<std::string> input_data_string = {"[8, 8, 4, 50, 52, 32, 11]",
-                                                R"([null, "a", "a", "b", "b","b", "b"])",
-                                                "[11, 10, 5, 51, null, 33, 12]",
-                                                "[1, 3, 5, 10, null, 13, 2]"};
-  MakeInputBatch(input_data_string, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_2 = {"[1, 14, 8, 42, 6, null, 2]",
-                                                  R"(["a", "a", null, "b", "b", "a", "b"])",
-                                                  "[2, null, 44, 43, 7, 34, 3]",
-                                                  "[9, 7, 5, 1, 5, null, 17]"};
-  MakeInputBatch(input_data_string_2, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, 33]",
-                                                  R"(["a", "a", "b", "b", "b","b", "b"])",
-                                                  "[4, 65, 16, 8, 10, 20, 34]",
-                                                  "[8, 6, 2, 3, 10, 12, 15]"};
-  MakeInputBatch(input_data_string_3, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
-                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
-                                                  "[24, 18, 42, 19, 21, 36, 31]",
-                                                  "[15, 16, 2, 51, null, 33, 12]"};
-  MakeInputBatch(input_data_string_4, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
-                                                  R"(["a", "b", "a", "b", "b","b", "b"])",
-                                                  "[38, 67, 23, 14, null, 60, 22]",
-                                                  "[16, 17, 5, 15, 9, null, 19]"};
-  MakeInputBatch(input_data_string_5, sch, &input_batch);
-  input_batch_list.push_back(input_batch);
-
-  ////////////////////////////////// calculation ///////////////////////////////////
-  std::shared_ptr<arrow::RecordBatch> expected_result;
-  std::vector<std::string> expected_result_string = {
-      "[1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
-      "22, 23, 30, 32, 33, 35, 37, 41, 42, 50, 52, 59, 64, null, null]",
-      R"(["a","b","a","a","b","b", null, null,"b","b","b","a","b","b","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a","b","a"])",
-      "[2, 3, 4, 5, 7, 8, 11, 44, null, 16, 20, 10, 10, 12, 14, null, 18, 19, 21, 22, 23, "
-      "24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65, 67, 34]",
-      "[9, 17, 8, 5, 5, 3, 1, 5, 9, 2, 12, 3, 10, 2, 15, 7, 16, 51, null, 19, 5, "
-      "15, 12, 13, 15, 33, 16, 2, 1, 10, null, null, 6, 17, null]"};
-
-  MakeInputBatch(expected_result_string, sch, &expected_result);
-
-  for (auto batch : input_batch_list) {
-    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
-  }
-  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
-  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
-  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
-  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
-      sort_result_iterator_base);
-
-  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
-  std::shared_ptr<arrow::RecordBatch> result_batch;
-
-  if (sort_result_iterator->HasNext()) {
-    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
-    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
-  }
-}
-
-TEST(TestArrowComputeSort, SortTestInPlace) {
-  ////////////////////// prepare expr_vector ///////////////////////
-  auto f0 = field("f0", uint32());
+  auto f0 = field("f0", float64());
   auto arg_0 = TreeExprBuilder::MakeField(f0);
   auto true_literal = TreeExprBuilder::MakeLiteral(true);
   auto false_literal = TreeExprBuilder::MakeLiteral(false);
@@ -499,9 +47,11 @@ TEST(TestArrowComputeSort, SortTestInPlace) {
   auto n_dir = TreeExprBuilder::MakeFunction(
       "sort_directions", {true_literal}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
-      "sort_nulls_order", {false_literal}, uint32());
+      "sort_nulls_order", {true_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -521,7 +71,7 @@ TEST(TestArrowComputeSort, SortTestInPlace) {
   MakeInputBatch(input_data_string, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
-  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, null, 2]"};
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]"};
   MakeInputBatch(input_data_string_2, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
@@ -529,20 +79,881 @@ TEST(TestArrowComputeSort, SortTestInPlace) {
   MakeInputBatch(input_data_string_3, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
-  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]"};
+  std::vector<std::string> input_data_string_4 = {"[23, 17, NaN, 18, 20, 35, 30]"};
   MakeInputBatch(input_data_string_4, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
-  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]"};
+  std::vector<std::string> input_data_string_5 = {"[37, null, NaN, 13, 8, 59, 21]"};
   MakeInputBatch(input_data_string_5, sch, &input_batch);
   input_batch_list.push_back(input_batch);
 
   ////////////////////////////////// calculation ///////////////////////////////////
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string = {
-      "[null, null, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, "
+      "[null, null, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 15, 17, 18, 19, 20, 21, "
+      "23, 30, 32, 33, 35, 37, 42, 43, 50, 52, 59, 64, NaN, NaN, NaN]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+
+  auto sort_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestInplaceNullsLastAsc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+
+  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, NaN, 18, 20, 35, 30]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, NaN, 13, 8, 59, 21]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 15, 17, 18, 19, 20, 21, "
+      "23, 30, 32, 33, 35, 37, 42, 43, 50, 52, 59, 64, NaN, NaN, NaN, null, null]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+
+  auto sort_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestInplaceNullsFirstDesc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {false_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {true_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+
+  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, NaN, 18, 20, 35, 30]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, NaN, 13, 8, 59, 21]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null, null, NaN, NaN, NaN, 64, 59, 52, 50, 43, 42, 37, 35, 33, 32, 30, 23, "
+      "21, 20, 19, 18, 17, 15, 13, 12, 11, 10, 9, 8, 7, 6, 4, 3, 2, 1]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+
+  auto sort_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestInplaceNullsLastDesc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {false_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+
+  std::vector<std::string> input_data_string = {"[10, 12, 4, 50, 52, 32, 11]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, NaN, 18, 20, 35, 30]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, NaN, 13, 8, 59, 21]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[NaN, NaN, NaN, 64, 59, 52, 50, 43, 42, 37, 35, 33, 32, 30, 23, 21, 20, "
+      "19, 18, 17, 15, 13, 12, 11, 10, 9, 8, 7, 6, 4, 3, 2, 1, null, null]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+
+  auto sort_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestInplaceAsc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+
+  std::vector<std::string> input_data_string = {"[10, NaN, 4, 50, 52, 32, 11]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, 45, 2]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, NaN, 7, 9, 19, 33]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, 12, 22, 13, 8, 59, 21]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 18, 19, 20, 21, 22, 23, "
+      "30, 32, 33, 35, 37, 41, 42, 43, 45, 50, 52, 59, 64, NaN, NaN]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+
+  auto sort_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestInplaceDesc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {false_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+
+  std::vector<std::string> input_data_string = {"[10, NaN, 4, 50, 52, 32, 11]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 43, 42, 6, 45, 2]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, NaN, 7, 9, 19, 33]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, 12, 22, 13, 8, 59, 21]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[NaN, NaN, 64, 59, 52, 50, 45, 43, 42, 41, 37, 35, 33, 32, 30, 23, "
+      "22, 21, 20, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 4, 3, 2, 1]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+
+  auto sort_result_iterator =
+      std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+          sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAsc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[10, NaN, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, NaN, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null, null, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 13, 15, 17, 18, 19, 21, "
       "22, 23, 30, "
-      "32, 33, 35, 37, 41, 42, 43, 50, 52, 59, 64]"};
+      "32, 33, 35, 37, 41, 42, 43, 50, 52, 59, 64, NaN, NaN, NaN]",
+      "[34, 67, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 14, 16, 18, 19, 20, 22, "
+      "23, 24, "
+      "31, 33, 34, 36, 38, 42, 43, 44, 51, null, 60, 65, 21, null, 13]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestOnekeyNullsLastAsc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[10, NaN, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, NaN, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 13, 15, 17, 18, 19, 21, 22, 23, 30, "
+      "32, 33, 35, 37, 41, 42, 43, 50, 52, 59, 64, NaN, NaN, NaN, null, null]",
+      "[2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 14, 16, 18, 19, 20, 22, 23, 24,"
+      "31, 33, 34, 36, 38, 42, 43, 44, 51, null, 60, 65, 21, null, 13, 34, 67]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstDesc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(false)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[10, NaN, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, NaN, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null ,null , NaN, NaN, NaN, 64 ,59 ,52 ,50 ,43 ,42 ,41 ,37 ,35 ,33 ,32 ,30 "
+      ",23 ,22 ,21 ,19 ,18 ,17 ,15 ,13 , 11 ,10 ,9 ,8 ,7 ,6 ,4 ,3 ,2 ,1]",
+      "[34 ,67 ,13, null, 21, 65 ,60 ,null ,51 ,44 ,43 ,42 ,38 ,36 ,34 ,33 ,31 ,24 "
+      ",23 ,22 , 20 ,19 ,18 ,16 ,14 ,12 ,11 ,10 ,9 ,8 ,7 ,5 ,4 ,3 ,2]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestOnekeyNullsLastDesc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(false)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[10, NaN, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, NaN, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[NaN, NaN, NaN, 64 ,59 ,52 ,50 ,43 ,42 ,41 ,37 ,35 ,33 ,32 ,30 ,23 ,22 ,21 "
+      ",19 ,18 ,17 ,15 ,13 , 11 ,10 ,9 ,8 ,7 ,6 ,4 ,3 ,2 ,1, null, null]",
+      "[13, null, 21, 65 ,60 ,null ,51 ,44 ,43 ,42 ,38 ,36 ,34 ,33 ,31 ,24 ,23 ,22 "
+      ", 20 ,19 ,18 ,16 ,14 ,12 ,11 ,10 ,9 ,8 ,7 ,5 ,4 ,3 ,2, 34, 67]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestOnekeyBooleanDesc) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", boolean());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {false_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {true_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+
+  std::vector<std::string> input_data_string = {"[true, false, false, false, true, true, false]", 
+                                                "[1, 2, 3, 4, 5, 6, 7]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[true, true, false, false, false, true, false]",
+                                                  "[4, 2, 6, 0, 1, 4, 12]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[true, true, false, false, false, true, false]",
+                                                  "[6, 12, 16, 10, 11, 41, 2]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[true, true, false, false, false, true, false]",
+                                                  "[8, 22, 45, 12, 78, 12, 32]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[true, true, false, false, false, true, false]",
+                                                  "[18, 5, 6, 78, 11, 2, 12]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, "
+      "false, false, false, false, false, false, false, false, false, false, false, false, false, "
+      "false, false, false, false, false, false, false]",
+      "[18, 22, 8, 41, 1, 12, 12, 6, 4, 5, 2, 4, 6, 5, 2, 6, 10, 32, 78, 78, 11, 12, 12, 45, 2, "
+      "11, 16, 12, 1, 0, 6, 7, 4, 3, 2]"};
   MakeInputBatch(expected_result_string, sch, &expected_result);
 
   for (auto batch : input_batch_list) {
@@ -584,8 +995,10 @@ TEST(TestArrowComputeSort, SortTestOneKeyStr) {
       "sort_directions", {true_literal}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {false_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -668,8 +1081,10 @@ TEST(TestArrowComputeSort, SortTestOneKeyWithProjection) {
       "sort_directions", {true_literal}, uint32());
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {false_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -729,6 +1144,114 @@ TEST(TestArrowComputeSort, SortTestOneKeyWithProjection) {
   }
 }
 
+TEST(TestArrowComputeSort, SortTestMultipleKeysNaN) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", utf8());
+  auto f2 = field("f2", float64());
+  auto f3 = field("f3", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto arg_2 = TreeExprBuilder::MakeField(f2);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0, arg_1, arg_2}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0, arg_1, arg_2}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal, false_literal, true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1, f2, f3});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2, f3};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[8, NaN, 4, 50, 52, 32, 11]",
+                                                R"([null, "a", "a", "b", "b","b", "b"])",
+                                                "[11, NaN, 5, 51, null, 33, 12]",
+                                                "[1, 3, 5, 10, null, 13, 2]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, NaN, 42, 6, null, 2]",
+                                                  R"(["a", "a", null, "b", "b", "a", "b"])",
+                                                  "[2, null, 44, 43, 7, 34, 3]",
+                                                  "[9, 7, 5, 1, 5, null, 17]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, NaN]",
+                                                  R"(["a", "a", "b", "b", "b","b", "b"])",
+                                                  "[4, 65, 16, 8, 10, 20, 34]",
+                                                  "[8, 6, 2, 3, 10, 12, 15]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                  R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                  "[24, 18, 42, NaN, 21, 36, 31]",
+                                                  "[15, 16, 2, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  R"(["a", "b", "a", "b", "b","b", "b"])",
+                                                  "[38, 67, 23, 14, null, 60, 22]",
+                                                  "[16, 17, 5, 15, 9, null, 19]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
+      "22, 23, 30, 32, 35, 37, 41, 42, 50, 52, 59, 64, NaN, NaN, NaN, null, null]",
+      R"(["a","b","a","a","b","b", null,"b","b","b","b","b","b","a","a","b","b","b","a","a","b","b","b","a","a","b","b","b","b","a",null,"b","a","b","a"])",
+      "[2, 3, 4, 5, 7, 8, 11, null, 16, 20, 10, 12, 14, null, 18, NaN, 21, 22, 23, "
+      "24, 31, 33, 36, 38, 42, 43, 51, null, 60, 65, 44, 34, NaN, 67, 34]",
+      "[9, 17, 8, 5, 5, 3, 1, 9, 2, 12, 10, 2, 15, 7, 16, 51, null, 19, 5, "
+      "15, 12, 13, 33, 16, 2, 1, 10, null, null, 6, 5, 15, 3, 17, null]"};
+
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
 TEST(TestArrowComputeSort, SortTestMultipleKeysWithProjection) {
   ////////////////////// prepare expr_vector ///////////////////////
   auto f0 = field("f0", uint32());
@@ -779,8 +1302,10 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysWithProjection) {
   auto n_nulls_order = TreeExprBuilder::MakeFunction(
       "sort_nulls_order", {false_literal, false_literal, true_literal, true_literal, 
                            true_literal, true_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order}, uint32());
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -862,6 +1387,7 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysWithProjection) {
     ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
   }
 }
+
 
 }  // namespace codegen
 }  // namespace sparkcolumnarplugin


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this pr:
1. we added switchable NaN check for sort kernels;
2. to remove the dependency to arrow sort and improve the performance, we replaced arrow sort with the rewritten code;
3. to improve the performance, we changed multiple times of value copy into one-time memcopy in Inplace sort;
4. improved sort partition if array does not contain nulls.

fixes: https://github.com/Intel-bigdata/OAP/issues/1967
fixes: https://github.com/Intel-bigdata/OAP/pull/1778

