### PR TITLE
[OAP-1947][oap-native-sql][C++] reduce sort kernel memory footprint

### DIFF
--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_item_index.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/array_item_index.h
@@ -31,6 +31,14 @@ struct ArrayItemIndex {
   ArrayItemIndex(uint16_t array_id, uint16_t id)
       : array_id(array_id), id(id), valid(true) {}
 };
+struct ArrayItemIndexS {
+  uint16_t id = 0;
+  uint16_t array_id = 0;
+  ArrayItemIndexS() : array_id(0), id(0) {}
+  ArrayItemIndexS(bool valid) : array_id(0), id(0) {}
+  ArrayItemIndexS(uint16_t array_id, uint16_t id)
+      : array_id(array_id), id(id) {}
+};
 }  // namespace extra
 }  // namespace arrowcompute
 }  // namespace codegen

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -317,12 +317,12 @@ class TypedSorterImpl : public CodeGenBase {
            R"(
     // initiate buffer for all arrays
     std::shared_ptr<arrow::Buffer> indices_buf;
-    int64_t buf_size = items_total_ * sizeof(ArrayItemIndex);
+    int64_t buf_size = items_total_ * sizeof(ArrayItemIndexS);
     RETURN_NOT_OK(arrow::AllocateBuffer(ctx_->memory_pool(), buf_size, &indices_buf));
 
-    ArrayItemIndex* indices_begin =
-        reinterpret_cast<ArrayItemIndex*>(indices_buf->mutable_data());
-    ArrayItemIndex* indices_end = indices_begin + items_total_;
+    ArrayItemIndexS* indices_begin =
+        reinterpret_cast<ArrayItemIndexS*>(indices_buf->mutable_data());
+    ArrayItemIndexS* indices_end = indices_begin + items_total_;
 
     int64_t indices_i = 0;
     for (int array_id = 0; array_id < num_batches_; array_id++) {
@@ -336,7 +336,7 @@ class TypedSorterImpl : public CodeGenBase {
     )" + sort_func_str +
            R"(
     std::shared_ptr<arrow::FixedSizeBinaryType> out_type;
-    RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndex) / sizeof(int32_t), &out_type));
+    RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndexS) / sizeof(int32_t), &out_type));
     RETURN_NOT_OK(MakeFixedSizeBinaryArray(out_type, items_total_, indices_buf, out));
     return arrow::Status::OK();
   }
@@ -369,7 +369,7 @@ class TypedSorterImpl : public CodeGenBase {
            R"(): ctx_(ctx), total_length_(indices_in->length()), indices_in_cache_(indices_in) {
      )" + result_iter_define_str +
            R"(
-      indices_begin_ = (ArrayItemIndex*)indices_in->value_data();
+      indices_begin_ = (ArrayItemIndexS*)indices_in->value_data();
     }
 
     std::string ToString() override { return "SortArraysToIndicesResultIterator"; }
@@ -404,7 +404,7 @@ class TypedSorterImpl : public CodeGenBase {
            R"(
     std::shared_ptr<FixedSizeBinaryArray> indices_in_cache_;
     uint64_t offset_ = 0;
-    ArrayItemIndex* indices_begin_;
+    ArrayItemIndexS* indices_begin_;
     const uint64_t total_length_;
     std::shared_ptr<arrow::Schema> result_schema_;
     arrow::compute::FunctionContext* ctx_;
@@ -446,7 +446,7 @@ extern "C" void MakeCodeGen(arrow::compute::FunctionContext* ctx,
     } else {
       projected = false;
     }
-    ss << "auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {"
+    ss << "auto comp = [this](ArrayItemIndexS x, ArrayItemIndexS y) {"
        << GetCompFunction_(0, projected, sort_key_index_list, key_field_list, 
                            projected_types, sort_directions, nulls_order) << "};";
     return ss.str();
@@ -939,12 +939,12 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>>
   arrow::Status FinishInternal(std::shared_ptr<FixedSizeBinaryArray>* out) {    
     // initiate buffer for all arrays
     std::shared_ptr<arrow::Buffer> indices_buf;
-    int64_t buf_size = items_total_ * sizeof(ArrayItemIndex);
+    int64_t buf_size = items_total_ * sizeof(ArrayItemIndexS);
     RETURN_NOT_OK(arrow::AllocateBuffer(ctx_->memory_pool(), buf_size, &indices_buf));
     // start to partition not_null with null
-    ArrayItemIndex* indices_begin = 
-      reinterpret_cast<ArrayItemIndex*>(indices_buf->mutable_data());
-    ArrayItemIndex* indices_end = indices_begin + items_total_;
+    ArrayItemIndexS* indices_begin = 
+      reinterpret_cast<ArrayItemIndexS*>(indices_buf->mutable_data());
+    ArrayItemIndexS* indices_end = indices_begin + items_total_;
     int64_t indices_i = 0;
     int64_t indices_null = 0;
     // we should support nulls first and nulls last here
@@ -983,7 +983,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>>
             [this](auto& x) -> decltype(auto){ return cached_key_[x.array_id]->GetView(x.id); });
       }
     } else {
-      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
+      auto comp = [this](ArrayItemIndexS x, ArrayItemIndexS y) {
         return cached_key_[x.array_id]->GetView(x.id) > cached_key_[y.array_id]->GetView(y.id);};
       if (nulls_first_) {
         std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
@@ -992,7 +992,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>>
       }
     }
     std::shared_ptr<arrow::FixedSizeBinaryType> out_type;
-    RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndex) / sizeof(int32_t), &out_type));
+    RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndexS) / sizeof(int32_t), &out_type));
     RETURN_NOT_OK(MakeFixedSizeBinaryArray(out_type, items_total_, indices_buf, out));
     return arrow::Status::OK();
   }
@@ -1034,7 +1034,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>>
           total_length_(indices_in->length()),
           cached_in_(cached) {
       col_num_ = schema->num_fields();
-      indices_begin_ = (ArrayItemIndex*)indices_in->value_data();
+      indices_begin_ = (ArrayItemIndexS*)indices_in->value_data();
       // appender_type won't be used
       AppenderBase::AppenderType appender_type = AppenderBase::left;
       for (int i = 0; i < col_num_; i++) {
@@ -1095,7 +1095,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_number<CTYPE>>
     arrow::compute::FunctionContext* ctx_;
     uint64_t batch_size_;
     int col_num_;
-    ArrayItemIndex* indices_begin_;
+    ArrayItemIndexS* indices_begin_;
     std::vector<arrow::ArrayVector> cached_in_;
     std::vector<std::shared_ptr<arrow::DataType>> type_list_;
     std::vector<std::shared_ptr<AppenderBase>> appender_list_;
@@ -1163,12 +1163,12 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>>
   arrow::Status FinishInternal(std::shared_ptr<FixedSizeBinaryArray>* out) {    
     // initiate buffer for all arrays
     std::shared_ptr<arrow::Buffer> indices_buf;
-    int64_t buf_size = items_total_ * sizeof(ArrayItemIndex);
+    int64_t buf_size = items_total_ * sizeof(ArrayItemIndexS);
     RETURN_NOT_OK(arrow::AllocateBuffer(ctx_->memory_pool(), buf_size, &indices_buf));
     // start to partition not_null with null
-    ArrayItemIndex* indices_begin = 
-      reinterpret_cast<ArrayItemIndex*>(indices_buf->mutable_data());
-    ArrayItemIndex* indices_end = indices_begin + items_total_;
+    ArrayItemIndexS* indices_begin = 
+      reinterpret_cast<ArrayItemIndexS*>(indices_buf->mutable_data());
+    ArrayItemIndexS* indices_end = indices_begin + items_total_;
     int64_t indices_i = 0;
     int64_t indices_null = 0;
     // we should support nulls first and nulls last here
@@ -1199,7 +1199,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>>
       }
     }
     if (asc_) {
-      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
+      auto comp = [this](ArrayItemIndexS x, ArrayItemIndexS y) {
         return cached_key_[x.array_id]->GetString(x.id) < cached_key_[y.array_id]->GetString(y.id);};
       if (nulls_first_) {
         std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
@@ -1207,7 +1207,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>>
         std::sort(indices_begin, indices_begin + items_total_ - nulls_total_, comp);
       }
     } else {
-      auto comp = [this](ArrayItemIndex x, ArrayItemIndex y) {
+      auto comp = [this](ArrayItemIndexS x, ArrayItemIndexS y) {
         return cached_key_[x.array_id]->GetString(x.id) > cached_key_[y.array_id]->GetString(y.id);};
       if (nulls_first_) {
         std::sort(indices_begin + nulls_total_, indices_begin + items_total_, comp);
@@ -1216,7 +1216,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>>
       }
     }
     std::shared_ptr<arrow::FixedSizeBinaryType> out_type;
-    RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndex) / sizeof(int32_t), &out_type));
+    RETURN_NOT_OK(MakeFixedSizeBinaryType(sizeof(ArrayItemIndexS) / sizeof(int32_t), &out_type));
     RETURN_NOT_OK(MakeFixedSizeBinaryArray(out_type, items_total_, indices_buf, out));
     return arrow::Status::OK();
   }
@@ -1258,7 +1258,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>>
           total_length_(indices_in->length()),
           cached_in_(cached) {
       col_num_ = schema->num_fields();
-      indices_begin_ = (ArrayItemIndex*)indices_in->value_data();
+      indices_begin_ = (ArrayItemIndexS*)indices_in->value_data();
       // appender_type won't be used
       AppenderBase::AppenderType appender_type = AppenderBase::left;
       for (int i = 0; i < col_num_; i++) {
@@ -1318,7 +1318,7 @@ class SortOnekeyKernel<DATATYPE, CTYPE, enable_if_string<CTYPE>>
     arrow::compute::FunctionContext* ctx_;
     uint64_t batch_size_;
     int col_num_;
-    ArrayItemIndex* indices_begin_;
+    ArrayItemIndexS* indices_begin_;
     std::vector<arrow::ArrayVector> cached_in_;
     std::vector<std::shared_ptr<arrow::DataType>> type_list_;
     std::vector<std::shared_ptr<AppenderBase>> appender_list_;


### PR DESCRIPTION
reduce sort memory footprint by using smaller data structure

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## What changes were proposed in this pull request?
reduce sort memory footprint by using smaller data structure

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## How was this patch tested?

locally verified

