### PR TITLE
[OAP-1983][oap-native-sql] Fix hashCheck performance issue

### DIFF
--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
@@ -58,7 +58,6 @@ class ColumnarHashedRelation(
       if (!closed.getAndSet(true)) {
         hashRelationObj.close
         arrowColumnarBatch.foreach(_.close)
-        System.err.println(s"ColumnarHashedRelation close called")
       }
     }
     refCnt.get

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_context.h
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/codegen_context.h
@@ -24,6 +24,7 @@ struct CodeGenContext {
   std::vector<std::string> header_codes;
   std::string hash_relation_prepare_codes;
   std::string prepare_codes;
+  std::string unsafe_row_prepare_codes;
   std::string process_codes;
   std::string finish_codes;
   std::string definition_codes;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
@@ -140,7 +140,6 @@ class HashRelationKernel::Impl {
     }
     if (builder_type_ == 2) return arrow::Status::OK();
     std::shared_ptr<arrow::Array> key_array;
-    auto status = arrow::Status::OK();
     if (builder_type_ == 0) {
       if (key_projector_) {
         arrow::ArrayVector outputs;
@@ -193,7 +192,7 @@ class HashRelationKernel::Impl {
   case TypeTraits<InType>::type_id: {                                     \
     using ArrayType = precompile::TypeTraits<InType>::ArrayType;          \
     auto typed_key_arr = std::make_shared<ArrayType>(project_outputs[0]); \
-    status = hash_relation_->AppendKeyColumn(key_array, typed_key_arr);   \
+    return hash_relation_->AppendKeyColumn(key_array, typed_key_arr);     \
   } break;
           PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
@@ -214,10 +213,10 @@ class HashRelationKernel::Impl {
           RETURN_NOT_OK(MakeUnsafeArray(arr->type(), i++, arr, &payload));
           payloads.push_back(payload);
         }
-        status = hash_relation_->AppendKeyColumn(key_array, payloads);
+        return hash_relation_->AppendKeyColumn(key_array, payloads);
       }
     }
-    return status;
+    return arrow::Status::OK();
   }
 
   std::string GetSignature() { return ""; }

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/whole_stage_codegen_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/whole_stage_codegen_kernel.cc
@@ -287,7 +287,9 @@ class TypedWholeStageCodeGenImpl : public CodeGenBase {
                << GetTypeString(input_field_list[i]->type(), "Array") << ">(in[" << i
                << "]);";
     }
-
+    if (codegen_ctx_list.size() > 0) {
+      codes_ss << codegen_ctx_list[0]->unsafe_row_prepare_codes << std::endl;
+    }
     codes_ss << R"(
           uint64_t out_length = 0;
           auto length = typed_in_0->length();
@@ -321,8 +323,14 @@ class TypedWholeStageCodeGenImpl : public CodeGenBase {
       }
     }
     // paste children's codegen
+    int codegen_ctx_idx = 0;
     for (auto codegen_ctx : codegen_ctx_list) {
+      codegen_ctx_idx++;
       codes_ss << codegen_ctx->prepare_codes << std::endl;
+      if (codegen_ctx_idx < codegen_ctx_list.size()) {
+        codes_ss << codegen_ctx_list[codegen_ctx_idx]->unsafe_row_prepare_codes
+                 << std::endl;
+      }
       codes_ss << codegen_ctx->process_codes << std::endl;
     }
 

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation.h
@@ -265,7 +265,12 @@ class HashRelation {
     return safeLookup(hash_table_, payload, v);
   }
 
-  int GetNull() { return null_index_set_ ? 0 : HASH_NEW_KEY; }
+  int GetNull() {
+    // since vanilla spark doesn't support to join with two nulls
+    // we should always return -1 here;
+    // return null_index_set_ ? 0 : HASH_NEW_KEY;
+    return HASH_NEW_KEY;
+  }
 
   arrow::Status AppendPayloadColumn(int idx, std::shared_ptr<arrow::Array> in) {
     return hash_relation_column_list_[idx]->AppendColumn(in);
@@ -364,12 +369,14 @@ class HashRelation {
   }
 
   arrow::Status InsertNull(uint32_t array_id, uint32_t id) {
-    if (!null_index_set_) {
-      null_index_set_ = true;
-      null_index_list_ = {ArrayItemIndex(array_id, id)};
-    } else {
-      null_index_list_.emplace_back(array_id, id);
-    }
+    // since vanilla spark doesn't support match null in join
+    // we can directly retun to optimize
+    // if (!null_index_set_) {
+    //  null_index_set_ = true;
+    //  null_index_list_ = {ArrayItemIndex(array_id, id)};
+    //} else {
+    //  null_index_list_.emplace_back(array_id, id);
+    //}
     return arrow::Status::OK();
   }
 };

--- a/oap-native-sql/cpp/src/codegen/common/hash_relation.h
+++ b/oap-native-sql/cpp/src/codegen/common/hash_relation.h
@@ -149,6 +149,8 @@ class HashRelation {
       for (auto payload_arr : payloads) {
         payload_arr->Append(i, &payload);
       }
+      // chendi: Since spark won't join rows contain null, we will skip null row.
+      if (payload->isNullExists()) continue;
       RETURN_NOT_OK(Insert(typed_array->GetView(i), payload, num_arrays_, i));
     }
 

--- a/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
+++ b/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
@@ -40,9 +40,9 @@ struct UnsafeRow {
   }
   int sizeInBytes() { return cursor; }
   void reset() {
+    memset(data, 0, cursor);
     auto validity_size = (numFields / 8) + 1;
     cursor = validity_size;
-    memset(data, 0, validity_size);
   }
 };
 

--- a/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
+++ b/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
@@ -44,6 +44,12 @@ struct UnsafeRow {
     auto validity_size = (numFields / 8) + 1;
     cursor = validity_size;
   }
+  bool isNullExists() {
+    for (int i = 0; i < ((numFields / 8) + 1); i++) {
+      if (data[i] != 0) return true;
+    }
+    return false;
+  }
 };
 
 static inline int calculateBitSetWidthInBytes(int numFields) {


### PR DESCRIPTION
This PR is aim to fix a detected issue when running TPCDS Q35 with hash check enabled, one task was observed to be extremely slow.

Fixed: https://github.com/Intel-bigdata/OAP/issues/1983
Fixed: https://github.com/Intel-bigdata/OAP/issues/1986

2020/12/02 updated:
1. Fix of Q38 and Q87 is in a separate PR.
2. Also add skip null rows fix in this PR, issue 1986, @rui-mo 
