### PR TITLE
[OAP-1977][oap-shuffle]Fix multiple descriptions and formats

### DIFF
--- a/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/BaseShuffleReader.scala
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/BaseShuffleReader.scala
@@ -128,7 +128,7 @@ private[spark] class BaseShuffleReader[K, C](handle: BaseShuffleHandle[K, _, C],
     // Sort the output if there is a sort ordering defined.
     val resultIter = dep.keyOrdering match {
       case Some(keyOrd: Ordering[K]) =>
-        assert(pmofConf.enablePmem == true)
+        assert(pmofConf.enablePmem)
         // Create an ExternalSorter to sort the data.
         val sorter =
           new PmemExternalSorter[K, C, C](context, handle, pmofConf, ordering = Some(keyOrd), serializer = dep.serializer)

--- a/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmemShuffleBlockResolver.scala
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmemShuffleBlockResolver.scala
@@ -11,7 +11,7 @@ private[spark] class PmemShuffleBlockResolver(
     conf: SparkConf,
     _blockManager: BlockManager = null)
   extends IndexShuffleBlockResolver(conf, _blockManager) with Logging {
-  // create ShuffleHandler here, so multiple executors can share
+  
   var partitionBufferArray: Array[PmemBlockOutputStream] = _
 
   override def getBlockData(blockId: BlockId, dirs: Option[Array[String]]): ManagedBuffer = {

--- a/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmofShuffleManager.scala
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/scala/org/apache/spark/shuffle/pmof/PmofShuffleManager.scala
@@ -10,7 +10,7 @@ import org.apache.spark.util.configuration.pmof.PmofConf
 import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv, TaskContext}
 
 private[spark] class PmofShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
-  logInfo("Initialize RdmaShuffleManager")
+  logInfo("Initialize PmofShuffleManager")
 
   if (!conf.getBoolean("spark.shuffle.spill", defaultValue = true)) {
     logWarning("spark.shuffle.spill was set to false")


### PR DESCRIPTION
The log info in PmofShuffleManager.scala:
fix logInfo("Initialize RdmaShuffleManager")
by logInfo("Initialize PmofShuffleManager")

simplify boolean expression in BaseShuffleReader
by assert(pmofConf.enablePmem)

Delete inappropriate comments in PmemShuffleBlockResolver:
// create ShuffleHandler here, so multiple executors can share


