### PR TITLE
[OAP-1983][oap-native-sql] Fix Q38 and Q87 when unsafeRow contains null

### DIFF
--- a/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
+++ b/oap-native-sql/cpp/src/third_party/row_wise_memory/unsafe_row.h
@@ -11,6 +11,7 @@
 #include "third_party/row_wise_memory/native_memory.h"
 
 #define TEMP_UNSAFEROW_BUFFER_SIZE 1024
+static constexpr uint8_t kBitmask[] = {1, 2, 4, 8, 16, 32, 64, 128};
 
 /* Unsafe Row Layout (This unsafe row only used to append all fields data as continuous
  * memory, unable to be get data from)
@@ -69,11 +70,8 @@ static inline void zeroOutPaddingBytes(UnsafeRow* row, int numBytes) {
 
 static inline void setNullAt(UnsafeRow* row, int index) {
   assert((index >= 0) && (index < row->numFields));
-  auto bitSetIdx = index >> 3;     // mod 8
-  char mask = 1 << (index & 0x8);  // mod 8 and shift
-  auto word = *(row->data + bitSetIdx);
-  // set validity
-  *(row->data + bitSetIdx) = word | mask;
+  auto bitSetIdx = index >> 3;  // mod 8
+  *(row->data + bitSetIdx) |= kBitmask[index % 8];
 }
 
 template <typename T>


### PR DESCRIPTION
When hashcheck is enabled, observed that Q38 and Q87 will generate incorrect result.
Root cause is setNull function in unsafeRow has some bug, which leads to incorrect validity. So fix in this PR

Signed-off-by: Chendi Xue <chendi.xue@intel.com>

Fixed: https://github.com/Intel-bigdata/OAP/issues/1989