### PR TITLE
[OAP-1998][oap-native-sql] Add support to do numa binding for Columnar Operations

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkConf
 
 case class ColumnarNumaBindingInfo(
     enableNumaBinding: Boolean,
-    totalCoreRange: Array[(Int, Int)] = null,
+    totalCoreRange: Array[String] = null,
     numCoresPerExecutor: Int = -1) {}
 
 class ColumnarPluginConfig(conf: SparkConf) {
@@ -67,13 +67,13 @@ class ColumnarPluginConfig(conf: SparkConf) {
         ColumnarNumaBindingInfo(false)
       } else {
         val numCores = conf.getInt("spark.executor.cores", defaultValue = 1)
-        val coreRangeList: Array[(Int, Int)] = tmp.split(",").map(range => {
-            val res = range.trim.split("-")
+        val coreRangeList: Array[String] = tmp.split('|').map(_.trim)
+            /*val res = range.trim.split("-")
             res match {
               case Array(start, end, _*) => (start.toInt, end.toInt)
               case _ => (-1, -1)
             }
-          }).filter(_ != (-1, -1))
+          }).filter(_ != (-1, -1))*/
         ColumnarNumaBindingInfo(true, coreRangeList, numCores)
       }
 

--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -19,6 +19,11 @@ package com.intel.oap
 
 import org.apache.spark.SparkConf
 
+case class ColumnarNumaBindingInfo(
+    enableNumaBinding: Boolean,
+    totalCoreRange: Array[(Int, Int)] = null,
+    numCoresPerExecutor: Int = -1) {}
+
 class ColumnarPluginConfig(conf: SparkConf) {
   val enableColumnarSort: Boolean =
     conf.getBoolean("spark.sql.columnar.sort", defaultValue = false)
@@ -51,6 +56,29 @@ class ColumnarPluginConfig(conf: SparkConf) {
     conf.getInt("spark.sql.columnar.sort.broadcast.cache.timeout", defaultValue = -1)
   val hashCompare: Boolean =
     conf.getBoolean("spark.oap.sql.columnar.hashCompare", defaultValue = false)
+  val numaBindingInfo: ColumnarNumaBindingInfo = {
+    val enableNumaBinding: Boolean =
+      conf.getBoolean("spark.oap.sql.columnar.numaBinding", defaultValue = false)
+    if (enableNumaBinding == false) {
+      ColumnarNumaBindingInfo(false)
+    } else {
+      val tmp = conf.getOption("spark.oap.sql.columnar.coreRange").getOrElse(null)
+      if (tmp == null) {
+        ColumnarNumaBindingInfo(false)
+      } else {
+        val numCores = conf.getInt("spark.executor.cores", defaultValue = 1)
+        val coreRangeList: Array[(Int, Int)] = tmp.split(",").map(range => {
+            val res = range.trim.split("-")
+            res match {
+              case Array(start, end, _*) => (start.toInt, end.toInt)
+              case _ => (-1, -1)
+            }
+          }).filter(_ != (-1, -1))
+        ColumnarNumaBindingInfo(true, coreRangeList, numCores)
+      }
+
+    }
+  }
 }
 
 object ColumnarPluginConfig {

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/util/ExecutorManager.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/util/ExecutorManager.scala
@@ -28,11 +28,11 @@ object ExecutorManager {
       val numCorePerExecutor = numaInfo.numCoresPerExecutor
       val coreRange = numaInfo.totalCoreRange
       val shouldBindNumaIdx = executorIdOnLocalNode.indexOf(executorId) % coreRange.size
-      val coreStartIdx = coreRange(shouldBindNumaIdx)._1
-      val coreEndIdx = coreRange(shouldBindNumaIdx)._2
+      //val coreStartIdx = coreRange(shouldBindNumaIdx)._1
+      //val coreEndIdx = coreRange(shouldBindNumaIdx)._2
       System.out.println(
         s"executorId is ${executorId}, executorIdOnLocalNode is ${executorIdOnLocalNode}")
-      val taskSetCmd = s"taskset -cpa ${coreStartIdx}-${coreEndIdx} ${getProcessId()}"
+      val taskSetCmd = s"taskset -cpa ${coreRange(shouldBindNumaIdx)} ${getProcessId()}"
       System.out.println(taskSetCmd)
       isTaskSet = true
       Utils.executeCommand(Seq("bash", "-c", taskSetCmd))

--- a/oap-native-sql/core/src/main/scala/org/apache/spark/util/ExecutorManager.scala
+++ b/oap-native-sql/core/src/main/scala/org/apache/spark/util/ExecutorManager.scala
@@ -1,0 +1,46 @@
+package org.apache.spark.util
+
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv}
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.io.{InputStreamReader, BufferedReader}
+import scala.collection.mutable.ListBuffer
+import java.lang.management.ManagementFactory
+import com.intel.oap._
+
+object ExecutorManager {
+  def getExecutorIds(sc: SparkContext): Seq[String] = sc.getExecutorIds
+  var isTaskSet: Boolean = false
+  def tryTaskSet(numaInfo: ColumnarNumaBindingInfo) = synchronized {
+    if (numaInfo.enableNumaBinding && !isTaskSet) {
+      val cmd_output =
+        Utils.executeAndGetOutput(
+          Seq("bash", "-c", "ps -ef | grep YarnCoarseGrainedExecutorBackend"))
+      val getExecutorId = """--executor-id (\d+)""".r
+      val executorIdOnLocalNode = {
+        val tmp = for (m <- getExecutorId.findAllMatchIn(cmd_output)) yield m.group(1)
+        tmp.toList.distinct
+      }
+      val executorId = SparkEnv.get.executorId
+      val numCorePerExecutor = numaInfo.numCoresPerExecutor
+      val coreRange = numaInfo.totalCoreRange
+      val shouldBindNumaIdx = executorIdOnLocalNode.indexOf(executorId) % coreRange.size
+      val coreStartIdx = coreRange(shouldBindNumaIdx)._1
+      val coreEndIdx = coreRange(shouldBindNumaIdx)._2
+      System.out.println(
+        s"executorId is ${executorId}, executorIdOnLocalNode is ${executorIdOnLocalNode}")
+      val taskSetCmd = s"taskset -cpa ${coreStartIdx}-${coreEndIdx} ${getProcessId()}"
+      System.out.println(taskSetCmd)
+      isTaskSet = true
+      Utils.executeCommand(Seq("bash", "-c", taskSetCmd))
+    }
+  }
+  def getProcessId(): Int = {
+    val runtimeMXBean = ManagementFactory.getRuntimeMXBean()
+    runtimeMXBean.getName().split("@")(0).toInt
+  }
+
+}


### PR DESCRIPTION
This PR is used to bind each executor to dedicate cores, example as below

fixes: #1998

====== 2020/12/04 Updated ======
Need to use two configuration to control this feature

```
 spark.oap.sql.columnar.numaBinding true
 spark.oap.sql.columnar.coreRange 0-25,52-77|26-51,78-104
```

![image](https://user-images.githubusercontent.com/4355494/101157501-2ed15680-3665-11eb-96cb-3d6990b19bc7.png)

Signed-off-by: Chendi Xue <chendi.xue@intel.com>