### PR TITLE
[OAP-2006][oap-native-sql] Add memory usage test to CI

### DIFF
--- a/.github/workflows/report_ram_log.yml
+++ b/.github/workflows/report_ram_log.yml
@@ -1,0 +1,48 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Report RAM Log
+
+on:
+  workflow_run:
+    workflows: ["Native SQL Engine TPC-H Suite"]
+    types:
+      - completed
+
+jobs:
+  comment-on-pr:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Download log
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: tpch.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: comment_content
+          path: /tmp/
+      - name: Download previous event payload
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: tpch.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr_event
+          path: /tmp/
+      - name: Install OAP optimized Arrow
+        run: |
+          cd /tmp
+          git clone -b oap-master https://github.com/intel-bigdata/arrow.git
+          cd arrow/java
+          mvn clean install -P arrow-jni -am -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
+      - run: mvn test -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.CommentOnContextPR -pl oap-native-sql/core -am -Dexec.skip=true
+        env:
+          MAVEN_OPTS: "-Xmx2048m"
+          COMMENT_CONTENT_PATH: "/tmp/comment.md"
+          PREVIOUS_EVENT_PATH: "/tmp/event.json"
+          GITHUB_TOKEN: ${{ github.token }}
+

--- a/.github/workflows/report_ram_log.yml
+++ b/.github/workflows/report_ram_log.yml
@@ -38,8 +38,8 @@ jobs:
           cd /tmp
           git clone -b oap-master https://github.com/intel-bigdata/arrow.git
           cd arrow/java
-          mvn clean install -P arrow-jni -am -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
-      - run: mvn test -DmembersOnlySuites=com.intel.oap.tpch -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DtagsToInclude=com.intel.oap.tags.CommentOnContextPR -pl oap-native-sql/core -am -Dexec.skip=true
+          mvn clean install -B -P arrow-jni -am -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
+      - run: mvn test -B -DmembersOnlySuites=com.intel.oap.tpch -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DtagsToInclude=com.intel.oap.tags.CommentOnContextPR -pl oap-native-sql/core -am -Dexec.skip=true
         env:
           MAVEN_OPTS: "-Xmx2048m"
           COMMENT_CONTENT_PATH: "/tmp/comment.md"

--- a/.github/workflows/report_ram_log.yml
+++ b/.github/workflows/report_ram_log.yml
@@ -38,8 +38,8 @@ jobs:
           cd /tmp
           git clone -b oap-master https://github.com/intel-bigdata/arrow.git
           cd arrow/java
-          mvn clean install -P arrow-jni -am -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
-      - run: mvn test -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.CommentOnContextPR -pl oap-native-sql/core -am -Dexec.skip=true
+          mvn clean install -P arrow-jni -am -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
+      - run: mvn test -DmembersOnlySuites=com.intel.oap.tpch -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DtagsToInclude=com.intel.oap.tags.CommentOnContextPR -pl oap-native-sql/core -am -Dexec.skip=true
         env:
           MAVEN_OPTS: "-Xmx2048m"
           COMMENT_CONTENT_PATH: "/tmp/comment.md"

--- a/.github/workflows/report_ram_log.yml
+++ b/.github/workflows/report_ram_log.yml
@@ -1,5 +1,19 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 name: Report RAM Log
 

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           version: latest
       - run: sudo swapoff -a
+      - run: free
       - run: sudo apt-get install cmake
       - run: sudo apt-get install libboost-all-dev
       - name: Install OAP optimized Arrow

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -35,8 +35,8 @@ jobs:
           cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON && make -j2
           sudo make install
           cd ../../java
-          mvn clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -P arrow-jni -am -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
-      - run: mvn test -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs -pl oap-native-sql/core -am
+          mvn clean install -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -P arrow-jni -am -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
+      - run: mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs -pl oap-native-sql/core -am
         env:
           MAVEN_OPTS: "-Xmx2048m"
           COMMENT_TEXT_OUTPUT_PATH: "/tmp/comment_text.txt"

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -1,0 +1,51 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Native SQL Engine TPC-H Suite
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  ram-usage-test:
+    if: ${{ contains(github.event.pull_request.title, '[oap-native-sql]') || contains(github.event.pull_request.title, '[oap-data-source]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - uses: iterative/setup-cml@v1
+        with:
+          version: latest
+      - run: sudo swapoff -a
+      - run: sudo apt-get install cmake
+      - run: sudo apt-get install libboost-all-dev
+      - name: Install OAP optimized Arrow
+        run: |
+          cd /tmp
+          git clone https://github.com/intel-bigdata/arrow.git
+          cd arrow && git checkout oap-master && cd cpp
+          mkdir build && cd build
+          cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON && make -j2
+          sudo make install
+          cd ../../java
+          mvn clean install -P arrow-jni -am -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
+      - run: mvn test -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs -pl oap-native-sql/core -am
+        env:
+          MAVEN_OPTS: "-Xmx2048m"
+          COMMENT_TEXT_OUTPUT_PATH: "/tmp/comment_text.txt"
+          COMMENT_IMAGE_OUTPUT_PATH: "/tmp/comment_image.png"
+      - run: cml-publish /tmp/comment_image.png --md > /tmp/comment.md
+      - run: echo "::set-output name=event_path::${GITHUB_EVENT_PATH}"
+        id: output-envs
+      - uses: actions/upload-artifact@v2
+        with:
+          name: comment_content
+          path: /tmp/comment.md
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr_event
+          path: ${{steps.output-envs.outputs.event_path}}

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -5,11 +5,13 @@ name: Native SQL Engine TPC-H Suite
 
 on:
   pull_request:
-    branches: [ master ]
+    paths:
+      - '.github/workflows/tpch.yml'
+      - 'oap-native-sql/**'
+      - 'oap-data-source/arrow/**'
 
 jobs:
   ram-usage-test:
-    if: ${{ contains(github.event.pull_request.title, '[oap-native-sql]') || contains(github.event.pull_request.title, '[oap-data-source]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -35,8 +35,8 @@ jobs:
           cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON && make -j2
           sudo make install
           cd ../../java
-          mvn clean install -P arrow-jni -am -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
-      - run: mvn test -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs -pl oap-native-sql/core -am
+          mvn clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -P arrow-jni -am -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
+      - run: mvn test -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs -pl oap-native-sql/core -am
         env:
           MAVEN_OPTS: "-Xmx2048m"
           COMMENT_TEXT_OUTPUT_PATH: "/tmp/comment_text.txt"

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -1,5 +1,19 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 name: Native SQL Engine TPC-H Suite
 

--- a/oap-native-sql/core/pom.xml
+++ b/oap-native-sql/core/pom.xml
@@ -229,6 +229,42 @@
       <version>2.52.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.prestosql.tpch</groupId>
+      <artifactId>tpch</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>github-api</artifactId>
+      <version>1.117</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.10.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.10.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.10.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.knowm.xchart</groupId>
+      <artifactId>xchart</artifactId>
+      <version>3.6.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q1.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q1.sql
@@ -1,0 +1,23 @@
+-- using default substitutions
+
+select
+	l_returnflag,
+	l_linestatus,
+	sum(l_quantity) as sum_qty,
+	sum(l_extendedprice) as sum_base_price,
+	sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+	avg(l_quantity) as avg_qty,
+	avg(l_extendedprice) as avg_price,
+	avg(l_discount) as avg_disc,
+	count(*) as count_order
+from
+	lineitem
+where
+	l_shipdate <= date '1998-12-01' - interval '90' day
+group by
+	l_returnflag,
+	l_linestatus
+order by
+	l_returnflag,
+	l_linestatus

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q10.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q10.sql
@@ -1,0 +1,34 @@
+-- using default substitutions
+
+select
+	c_custkey,
+	c_name,
+	sum(l_extendedprice * (1 - l_discount)) as revenue,
+	c_acctbal,
+	n_name,
+	c_address,
+	c_phone,
+	c_comment
+from
+	customer,
+	orders,
+	lineitem,
+	nation
+where
+	c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and o_orderdate >= date '1993-10-01'
+	and o_orderdate < date '1993-10-01' + interval '3' month
+	and l_returnflag = 'R'
+	and c_nationkey = n_nationkey
+group by
+	c_custkey,
+	c_name,
+	c_acctbal,
+	c_phone,
+	n_name,
+	c_address,
+	c_comment
+order by
+	revenue desc
+limit 20

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q11.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q11.sql
@@ -1,0 +1,29 @@
+-- using default substitutions
+
+select
+	ps_partkey,
+	sum(ps_supplycost * ps_availqty) as value
+from
+	partsupp,
+	supplier,
+	nation
+where
+	ps_suppkey = s_suppkey
+	and s_nationkey = n_nationkey
+	and n_name = 'GERMANY'
+group by
+	ps_partkey having
+		sum(ps_supplycost * ps_availqty) > (
+			select
+				sum(ps_supplycost * ps_availqty) * 0.0001000000
+			from
+				partsupp,
+				supplier,
+				nation
+			where
+				ps_suppkey = s_suppkey
+				and s_nationkey = n_nationkey
+				and n_name = 'GERMANY'
+		)
+order by
+	value desc

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q12.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q12.sql
@@ -1,0 +1,30 @@
+-- using default substitutions
+
+select
+	l_shipmode,
+	sum(case
+		when o_orderpriority = '1-URGENT'
+			or o_orderpriority = '2-HIGH'
+			then 1
+		else 0
+	end) as high_line_count,
+	sum(case
+		when o_orderpriority <> '1-URGENT'
+			and o_orderpriority <> '2-HIGH'
+			then 1
+		else 0
+	end) as low_line_count
+from
+	orders,
+	lineitem
+where
+	o_orderkey = l_orderkey
+	and l_shipmode in ('MAIL', 'SHIP')
+	and l_commitdate < l_receiptdate
+	and l_shipdate < l_commitdate
+	and l_receiptdate >= date '1994-01-01'
+	and l_receiptdate < date '1994-01-01' + interval '1' year
+group by
+	l_shipmode
+order by
+	l_shipmode

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q13.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q13.sql
@@ -1,0 +1,22 @@
+-- using default substitutions
+
+select
+	c_count,
+	count(*) as custdist
+from
+	(
+		select
+			c_custkey,
+			count(o_orderkey) as c_count
+		from
+			customer left outer join orders on
+				c_custkey = o_custkey
+				and o_comment not like '%special%requests%'
+		group by
+			c_custkey
+	) as c_orders
+group by
+	c_count
+order by
+	custdist desc,
+	c_count desc

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q14.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q14.sql
@@ -1,0 +1,15 @@
+-- using default substitutions
+
+select
+	100.00 * sum(case
+		when p_type like 'PROMO%'
+			then l_extendedprice * (1 - l_discount)
+		else 0
+	end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+from
+	lineitem,
+	part
+where
+	l_partkey = p_partkey
+	and l_shipdate >= date '1995-09-01'
+	and l_shipdate < date '1995-09-01' + interval '1' month

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q15.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q15.sql
@@ -1,0 +1,35 @@
+-- using default substitutions
+
+with revenue0 as
+	(select
+		l_suppkey as supplier_no,
+		sum(l_extendedprice * (1 - l_discount)) as total_revenue
+	from
+		lineitem
+	where
+		l_shipdate >= date '1996-01-01'
+		and l_shipdate < date '1996-01-01' + interval '3' month
+	group by
+		l_suppkey)
+
+
+select
+	s_suppkey,
+	s_name,
+	s_address,
+	s_phone,
+	total_revenue
+from
+	supplier,
+	revenue0
+where
+	s_suppkey = supplier_no
+	and total_revenue = (
+		select
+			max(total_revenue)
+		from
+			revenue0
+	)
+order by
+	s_suppkey
+

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q16.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q16.sql
@@ -1,0 +1,32 @@
+-- using default substitutions
+
+select
+	p_brand,
+	p_type,
+	p_size,
+	count(distinct ps_suppkey) as supplier_cnt
+from
+	partsupp,
+	part
+where
+	p_partkey = ps_partkey
+	and p_brand <> 'Brand#45'
+	and p_type not like 'MEDIUM POLISHED%'
+	and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
+	and ps_suppkey not in (
+		select
+			s_suppkey
+		from
+			supplier
+		where
+			s_comment like '%Customer%Complaints%'
+	)
+group by
+	p_brand,
+	p_type,
+	p_size
+order by
+	supplier_cnt desc,
+	p_brand,
+	p_type,
+	p_size

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q17.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q17.sql
@@ -1,0 +1,19 @@
+-- using default substitutions
+
+select
+	sum(l_extendedprice) / 7.0 as avg_yearly
+from
+	lineitem,
+	part
+where
+	p_partkey = l_partkey
+	and p_brand = 'Brand#23'
+	and p_container = 'MED BOX'
+	and l_quantity < (
+		select
+			0.2 * avg(l_quantity)
+		from
+			lineitem
+		where
+			l_partkey = p_partkey
+	)

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q18.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q18.sql
@@ -1,0 +1,35 @@
+-- using default substitutions
+
+select
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice,
+	sum(l_quantity)
+from
+	customer,
+	orders,
+	lineitem
+where
+	o_orderkey in (
+		select
+			l_orderkey
+		from
+			lineitem
+		group by
+			l_orderkey having
+				sum(l_quantity) > 300
+	)
+	and c_custkey = o_custkey
+	and o_orderkey = l_orderkey
+group by
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice
+order by
+	o_totalprice desc,
+	o_orderdate
+limit 100

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q19.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q19.sql
@@ -1,0 +1,37 @@
+-- using default substitutions
+
+select
+	sum(l_extendedprice* (1 - l_discount)) as revenue
+from
+	lineitem,
+	part
+where
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#12'
+		and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+		and l_quantity >= 1 and l_quantity <= 1 + 10
+		and p_size between 1 and 5
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	or
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#23'
+		and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+		and l_quantity >= 10 and l_quantity <= 10 + 10
+		and p_size between 1 and 10
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	or
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#34'
+		and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+		and l_quantity >= 20 and l_quantity <= 20 + 10
+		and p_size between 1 and 15
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q2.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q2.sql
@@ -1,0 +1,46 @@
+-- using default substitutions
+
+select
+	s_acctbal,
+	s_name,
+	n_name,
+	p_partkey,
+	p_mfgr,
+	s_address,
+	s_phone,
+	s_comment
+from
+	part,
+	supplier,
+	partsupp,
+	nation,
+	region
+where
+	p_partkey = ps_partkey
+	and s_suppkey = ps_suppkey
+	and p_size = 15
+	and p_type like '%BRASS'
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'EUROPE'
+	and ps_supplycost = (
+		select
+			min(ps_supplycost)
+		from
+			partsupp,
+			supplier,
+			nation,
+			region
+		where
+			p_partkey = ps_partkey
+			and s_suppkey = ps_suppkey
+			and s_nationkey = n_nationkey
+			and n_regionkey = r_regionkey
+			and r_name = 'EUROPE'
+	)
+order by
+	s_acctbal desc,
+	n_name,
+	s_name,
+	p_partkey
+limit 100

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q20.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q20.sql
@@ -1,0 +1,39 @@
+-- using default substitutions
+
+select
+	s_name,
+	s_address
+from
+	supplier,
+	nation
+where
+	s_suppkey in (
+		select
+			ps_suppkey
+		from
+			partsupp
+		where
+			ps_partkey in (
+				select
+					p_partkey
+				from
+					part
+				where
+					p_name like 'forest%'
+			)
+			and ps_availqty > (
+				select
+					0.5 * sum(CAST(l_quantity AS DOUBLE))
+				from
+					lineitem
+				where
+					l_partkey = ps_partkey
+					and l_suppkey = ps_suppkey
+					and l_shipdate >= date '1994-01-01'
+					and l_shipdate < date '1994-01-01' + interval '1' year
+			)
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'CANADA'
+order by
+	s_name

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q21.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q21.sql
@@ -1,0 +1,42 @@
+-- using default substitutions
+
+select
+	s_name,
+	count(*) as numwait
+from
+	supplier,
+	lineitem l1,
+	orders,
+	nation
+where
+	s_suppkey = l1.l_suppkey
+	and o_orderkey = l1.l_orderkey
+	and o_orderstatus = 'F'
+	and l1.l_receiptdate > l1.l_commitdate
+	and exists (
+		select
+			*
+		from
+			lineitem l2
+		where
+			l2.l_orderkey = l1.l_orderkey
+			and l2.l_suppkey <> l1.l_suppkey
+	)
+	and not exists (
+		select
+			*
+		from
+			lineitem l3
+		where
+			l3.l_orderkey = l1.l_orderkey
+			and l3.l_suppkey <> l1.l_suppkey
+			and l3.l_receiptdate > l3.l_commitdate
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'SAUDI ARABIA'
+group by
+	s_name
+order by
+	numwait desc,
+	s_name
+limit 100

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q22.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q22.sql
@@ -1,0 +1,39 @@
+-- using default substitutions
+
+select
+	cntrycode,
+	count(*) as numcust,
+	sum(c_acctbal) as totacctbal
+from
+	(
+		select
+			substring(c_phone, 1, 2) as cntrycode,
+			c_acctbal
+		from
+			customer
+		where
+			substring(c_phone, 1, 2) in
+				('13', '31', '23', '29', '30', '18', '17')
+			and c_acctbal > (
+				select
+					avg(c_acctbal)
+				from
+					customer
+				where
+					c_acctbal > 0.00
+					and substring(c_phone, 1, 2) in
+						('13', '31', '23', '29', '30', '18', '17')
+			)
+			and not exists (
+				select
+					*
+				from
+					orders
+				where
+					o_custkey = c_custkey
+			)
+	) as custsale
+group by
+	cntrycode
+order by
+	cntrycode

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q3.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q3.sql
@@ -1,0 +1,25 @@
+-- using default substitutions
+
+select
+	l_orderkey,
+	sum(l_extendedprice * (1 - l_discount)) as revenue,
+	o_orderdate,
+	o_shippriority
+from
+	customer,
+	orders,
+	lineitem
+where
+	c_mktsegment = 'BUILDING'
+	and c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and o_orderdate < date '1995-03-15'
+	and l_shipdate > date '1995-03-15'
+group by
+	l_orderkey,
+	o_orderdate,
+	o_shippriority
+order by
+	revenue desc,
+	o_orderdate
+limit 10

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q4.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q4.sql
@@ -1,0 +1,23 @@
+-- using default substitutions
+
+select
+	o_orderpriority,
+	count(*) as order_count
+from
+	orders
+where
+	o_orderdate >= date '1993-07-01'
+	and o_orderdate < date '1993-07-01' + interval '3' month
+	and exists (
+		select
+			*
+		from
+			lineitem
+		where
+			l_orderkey = o_orderkey
+			and l_commitdate < l_receiptdate
+	)
+group by
+	o_orderpriority
+order by
+	o_orderpriority

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q5.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q5.sql
@@ -1,0 +1,26 @@
+-- using default substitutions
+
+select
+	n_name,
+	sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+	customer,
+	orders,
+	lineitem,
+	supplier,
+	nation,
+	region
+where
+	c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and l_suppkey = s_suppkey
+	and c_nationkey = s_nationkey
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'ASIA'
+	and o_orderdate >= date '1994-01-01'
+	and o_orderdate < date '1994-01-01' + interval '1' year
+group by
+	n_name
+order by
+	revenue desc

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q6.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q6.sql
@@ -1,0 +1,11 @@
+-- using default substitutions
+
+select
+	sum(l_extendedprice * l_discount) as revenue
+from
+	lineitem
+where
+	l_shipdate >= date '1994-01-01'
+	and l_shipdate < date '1994-01-01' + interval '1' year
+	and l_discount between .06 - 0.01 and .06 + 0.01
+	and l_quantity < 24

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q7.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q7.sql
@@ -1,0 +1,41 @@
+-- using default substitutions
+
+select
+	supp_nation,
+	cust_nation,
+	l_year,
+	sum(volume) as revenue
+from
+	(
+		select
+			n1.n_name as supp_nation,
+			n2.n_name as cust_nation,
+			year(l_shipdate) as l_year,
+			l_extendedprice * (1 - l_discount) as volume
+		from
+			supplier,
+			lineitem,
+			orders,
+			customer,
+			nation n1,
+			nation n2
+		where
+			s_suppkey = l_suppkey
+			and o_orderkey = l_orderkey
+			and c_custkey = o_custkey
+			and s_nationkey = n1.n_nationkey
+			and c_nationkey = n2.n_nationkey
+			and (
+				(n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
+				or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
+			)
+			and l_shipdate between date '1995-01-01' and date '1996-12-31'
+	) as shipping
+group by
+	supp_nation,
+	cust_nation,
+	l_year
+order by
+	supp_nation,
+	cust_nation,
+	l_year

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q8.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q8.sql
@@ -1,0 +1,39 @@
+-- using default substitutions
+
+select
+	o_year,
+	sum(case
+		when nation = 'BRAZIL' then volume
+		else 0
+	end) / sum(volume) as mkt_share
+from
+	(
+		select
+			year(o_orderdate) as o_year,
+			l_extendedprice * (1 - l_discount) as volume,
+			n2.n_name as nation
+		from
+			part,
+			supplier,
+			lineitem,
+			orders,
+			customer,
+			nation n1,
+			nation n2,
+			region
+		where
+			p_partkey = l_partkey
+			and s_suppkey = l_suppkey
+			and l_orderkey = o_orderkey
+			and o_custkey = c_custkey
+			and c_nationkey = n1.n_nationkey
+			and n1.n_regionkey = r_regionkey
+			and r_name = 'AMERICA'
+			and s_nationkey = n2.n_nationkey
+			and o_orderdate between date '1995-01-01' and date '1996-12-31'
+			and p_type = 'ECONOMY ANODIZED STEEL'
+	) as all_nations
+group by
+	o_year
+order by
+	o_year

--- a/oap-native-sql/core/src/test/resources/tpch-queries/q9.sql
+++ b/oap-native-sql/core/src/test/resources/tpch-queries/q9.sql
@@ -1,0 +1,34 @@
+-- using default substitutions
+
+select
+	nation,
+	o_year,
+	sum(amount) as sum_profit
+from
+	(
+		select
+			n_name as nation,
+			year(o_orderdate) as o_year,
+			l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+		from
+			part,
+			supplier,
+			lineitem,
+			partsupp,
+			orders,
+			nation
+		where
+			s_suppkey = l_suppkey
+			and ps_suppkey = l_suppkey
+			and ps_partkey = l_partkey
+			and p_partkey = l_partkey
+			and o_orderkey = l_orderkey
+			and s_nationkey = n_nationkey
+			and p_name like '%green%'
+	) as profit
+group by
+	nation,
+	o_year
+order by
+	nation,
+	o_year desc

--- a/oap-native-sql/core/src/test/scala/com/intel/oap/tags/CommentOnContextPR.scala
+++ b/oap-native-sql/core/src/test/scala/com/intel/oap/tags/CommentOnContextPR.scala
@@ -1,0 +1,5 @@
+package com.intel.oap.tags
+
+import org.scalatest.Tag
+
+object CommentOnContextPR extends Tag("com.intel.oap.tags.CommentOnContextPR")

--- a/oap-native-sql/core/src/test/scala/com/intel/oap/tags/CommentOnContextPR.scala
+++ b/oap-native-sql/core/src/test/scala/com/intel/oap/tags/CommentOnContextPR.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.intel.oap.tags
 
 import org.scalatest.Tag

--- a/oap-native-sql/core/src/test/scala/com/intel/oap/tags/TestAndWriteLogs.scala
+++ b/oap-native-sql/core/src/test/scala/com/intel/oap/tags/TestAndWriteLogs.scala
@@ -1,0 +1,5 @@
+package com.intel.oap.tags
+
+import org.scalatest.Tag
+
+object TestAndWriteLogs extends Tag("com.intel.oap.tags.TestAndWriteLogs")

--- a/oap-native-sql/core/src/test/scala/com/intel/oap/tags/TestAndWriteLogs.scala
+++ b/oap-native-sql/core/src/test/scala/com/intel/oap/tags/TestAndWriteLogs.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.intel.oap.tags
 
 import org.scalatest.Tag

--- a/oap-native-sql/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
+++ b/oap-native-sql/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
@@ -647,15 +647,6 @@ object MemoryUsageTest {
 
     val repository = inst.getRepository(repoSlug)
     val pr = repository.getPullRequest(prId)
-    val title = pr.getTitle
-    if (StringUtils.isEmpty(title)) {
-      stdoutLog("PR title is empty, ignoring")
-      return None
-    }
-    if (!title.contains("[oap-native-sql]") && !title.contains("[oap-data-source]")) {
-      stdoutLog("PR title <%s> not matching, ignoring".format(title))
-      return None
-    }
     val c = pr.comment(comment)
     stdoutLog("Comment successfully submitted. ")
     Some(c)

--- a/oap-native-sql/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
+++ b/oap-native-sql/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
@@ -1,0 +1,662 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.tpch
+
+import java.io.{File, FileOutputStream, InputStreamReader, OutputStreamWriter}
+import java.lang.management.ManagementFactory
+import java.nio.charset.StandardCharsets
+import java.sql.Date
+import java.text.SimpleDateFormat
+import java.util.{Scanner, StringTokenizer}
+import java.util.concurrent.{Executors, ScheduledFuture, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.intel.oap.tags.{CommentOnContextPR, TestAndWriteLogs}
+import com.intel.oap.tpch.MemoryUsageTest.{commentOnContextPR, stdoutLog, RAMMonitor}
+import io.prestosql.tpch._
+import javax.imageio.ImageIO
+import org.apache.commons.io.FileUtils
+import org.apache.commons.lang.StringUtils
+import org.apache.log4j.{Level, LogManager}
+import org.apache.spark.sql.{QueryTest, Row, SaveMode}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.types._
+import org.codehaus.jackson.map.ObjectMapper
+import org.knowm.xchart.{BitmapEncoder, XYChartBuilder}
+import org.knowm.xchart.BitmapEncoder.BitmapFormat
+import org.knowm.xchart.XYSeries.XYSeriesRenderStyle
+import org.knowm.xchart.style.Styler.ChartTheme
+import org.kohsuke.github.{GHIssueComment, GitHubBuilder}
+
+import scala.collection.mutable.ArrayBuffer
+
+class MemoryUsageTest extends QueryTest with SharedSparkSession {
+
+  private val MAX_DIRECT_MEMORY = "6g"
+  private val TPCH_WRITE_PATH = "/tmp/tpch-generated"
+
+  override protected def sparkConf: SparkConf = {
+    val conf = super.sparkConf
+    conf.set("spark.memory.offHeap.size", String.valueOf(MAX_DIRECT_MEMORY))
+        .set("spark.sql.extensions", "com.intel.oap.ColumnarPlugin")
+        .set("spark.sql.codegen.wholeStage", "false")
+        .set("spark.sql.sources.useV1SourceList", "")
+        .set("spark.sql.columnar.tmp_dir", "/tmp/")
+        .set("spark.sql.adaptive.enabled", "false")
+        .set("spark.sql.columnar.sort.broadcastJoin", "true")
+        .set("spark.storage.blockManagerSlaveTimeoutMs", "3600000")
+        .set("spark.executor.heartbeatInterval", "3600000")
+        .set("spark.network.timeout", "3601s")
+        .set("spark.oap.sql.columnar.preferColumnar", "true")
+        .set("spark.sql.columnar.codegen.hashAggregate", "false")
+        .set("spark.sql.columnar.sort", "true")
+        .set("spark.sql.columnar.window", "true")
+        .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+        //          .set("spark.sql.autoBroadcastJoinThreshold", "1")
+        .set("spark.unsafe.exceptionOnMemoryLeak", "false")
+        .set("spark.sql.columnar.sort.broadcast.cache.timeout", "600")
+    return conf
+  }
+
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+  }
+
+  def createTPCHTables(): Unit = {
+    // gen tpc-h data
+    val scale = 0.1D
+    val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
+
+    // lineitem
+    def lineItemGenerator = { () =>
+      new LineItemGenerator(scale, 1, 1)
+    }
+
+    def lineItemSchema = {
+      StructType(Seq(
+        StructField("l_orderkey", LongType),
+        StructField("l_partkey", LongType),
+        StructField("l_suppkey", LongType),
+        StructField("l_linenumber", IntegerType),
+        StructField("l_quantity", LongType),
+        StructField("l_extendedprice", DoubleType),
+        StructField("l_discount", DoubleType),
+        StructField("l_tax", DoubleType),
+        StructField("l_returnflag", StringType),
+        StructField("l_linestatus", StringType),
+        StructField("l_commitdate", DateType),
+        StructField("l_receiptdate", DateType),
+        StructField("l_shipinstruct", StringType),
+        StructField("l_shipmode", StringType),
+        StructField("l_comment", StringType),
+        StructField("l_shipdate", DateType)
+      ))
+    }
+
+    def lineItemParser: LineItem => Row =
+      lineItem =>
+        Row(
+          lineItem.getOrderKey,
+          lineItem.getPartKey,
+          lineItem.getSupplierKey,
+          lineItem.getLineNumber,
+          lineItem.getQuantity,
+          lineItem.getExtendedPrice,
+          lineItem.getDiscount,
+          lineItem.getTax,
+          lineItem.getReturnFlag,
+          lineItem.getStatus,
+          Date.valueOf(GenerateUtils.formatDate(lineItem.getCommitDate)),
+          Date.valueOf(GenerateUtils.formatDate(lineItem.getReceiptDate)),
+          lineItem.getShipInstructions,
+          lineItem.getShipMode,
+          lineItem.getComment,
+          Date.valueOf(GenerateUtils.formatDate(lineItem.getShipDate))
+        )
+
+    // customer
+    def customerGenerator = { () =>
+      new CustomerGenerator(scale, 1, 1)
+    }
+
+    def customerSchema = {
+      StructType(Seq(
+        StructField("c_custkey", LongType),
+        StructField("c_name", StringType),
+        StructField("c_address", StringType),
+        StructField("c_nationkey", LongType),
+        StructField("c_phone", StringType),
+        StructField("c_acctbal", DoubleType),
+        StructField("c_comment", StringType),
+        StructField("c_mktsegment", StringType)
+      ))
+    }
+
+    def customerParser: Customer => Row =
+      customer =>
+        Row(
+          customer.getCustomerKey,
+          customer.getName,
+          customer.getAddress,
+          customer.getNationKey,
+          customer.getPhone,
+          customer.getAccountBalance,
+          customer.getComment,
+          customer.getMarketSegment,
+        )
+
+    def rowCountOf[U](itr: java.lang.Iterable[U]): Long = {
+      var cnt = 0L
+      val iterator = itr.iterator
+      while (iterator.hasNext) {
+        iterator.next()
+        cnt = cnt + 1
+      }
+      cnt
+    }
+
+    // orders
+    def orderGenerator = { () =>
+      new OrderGenerator(scale, 1, 1)
+    }
+
+    def orderSchema = {
+      StructType(Seq(
+        StructField("o_orderkey", LongType),
+        StructField("o_custkey", LongType),
+        StructField("o_orderstatus", StringType),
+        StructField("o_totalprice", DoubleType),
+        StructField("o_orderpriority", StringType),
+        StructField("o_clerk", StringType),
+        StructField("o_shippriority", IntegerType),
+        StructField("o_comment", StringType),
+        StructField("o_orderdate", DateType)
+      ))
+    }
+
+    def orderParser: Order => Row =
+      order =>
+        Row(
+          order.getOrderKey,
+          order.getCustomerKey,
+          String.valueOf(order.getOrderStatus),
+          order.getTotalPrice,
+          order.getOrderPriority,
+          order.getClerk,
+          order.getShipPriority,
+          order.getComment,
+          Date.valueOf(GenerateUtils.formatDate(order.getOrderDate))
+        )
+
+    // partsupp
+    def partSupplierGenerator = { () =>
+      new PartSupplierGenerator(scale, 1, 1)
+    }
+
+    def partSupplierSchema = {
+      StructType(Seq(
+        StructField("ps_partkey", LongType),
+        StructField("ps_suppkey", LongType),
+        StructField("ps_availqty", IntegerType),
+        StructField("ps_supplycost", DoubleType),
+        StructField("ps_comment", StringType)
+      ))
+    }
+
+    def partSupplierParser: PartSupplier => Row =
+      ps =>
+        Row(
+          ps.getPartKey,
+          ps.getSupplierKey,
+          ps.getAvailableQuantity,
+          ps.getSupplyCost,
+          ps.getComment
+        )
+
+    // supplier
+    def supplierGenerator = { () =>
+      new SupplierGenerator(scale, 1, 1)
+    }
+
+    def supplierSchema = {
+      StructType(Seq(
+        StructField("s_suppkey", LongType),
+        StructField("s_name", StringType),
+        StructField("s_address", StringType),
+        StructField("s_nationkey", LongType),
+        StructField("s_phone", StringType),
+        StructField("s_acctbal", DoubleType),
+        StructField("s_comment", StringType)
+      ))
+    }
+
+    def supplierParser: Supplier => Row =
+      s =>
+        Row(
+          s.getSupplierKey,
+          s.getName,
+          s.getAddress,
+          s.getNationKey,
+          s.getPhone,
+          s.getAccountBalance,
+          s.getComment
+        )
+
+    // nation
+    def nationGenerator = { () =>
+      new NationGenerator()
+    }
+
+    def nationSchema = {
+      StructType(Seq(
+        StructField("n_nationkey", LongType),
+        StructField("n_name", StringType),
+        StructField("n_regionkey", LongType),
+        StructField("n_comment", StringType)
+      ))
+    }
+
+    def nationParser: Nation => Row =
+      nation =>
+        Row(
+          nation.getNationKey,
+          nation.getName,
+          nation.getRegionKey,
+          nation.getComment
+        )
+
+    // part
+    def partGenerator = { () =>
+      new PartGenerator(scale, 1, 1)
+    }
+
+    def partSchema = {
+      StructType(Seq(
+        StructField("p_partkey", LongType),
+        StructField("p_name", StringType),
+        StructField("p_mfgr", StringType),
+        StructField("p_type", StringType),
+        StructField("p_size", IntegerType),
+        StructField("p_container", StringType),
+        StructField("p_retailprice", DoubleType),
+        StructField("p_comment", StringType),
+        StructField("p_brand", StringType)
+      ))
+    }
+
+    def partParser: Part => Row =
+      part =>
+        Row(
+          part.getPartKey,
+          part.getName,
+          part.getManufacturer,
+          part.getType,
+          part.getSize,
+          part.getContainer,
+          part.getRetailPrice,
+          part.getComment,
+          part.getBrand
+        )
+
+    // region
+    def regionGenerator = { () =>
+      new RegionGenerator()
+    }
+
+    def regionSchema = {
+      StructType(Seq(
+        StructField("r_regionkey", LongType),
+        StructField("r_name", StringType),
+        StructField("r_comment", StringType)
+      ))
+    }
+
+    def regionParser: Region => Row =
+      region =>
+        Row(
+          region.getRegionKey,
+          region.getName,
+          region.getComment
+        )
+
+    def generate[U](tableName: String, schema: StructType, gen: () => java.lang.Iterable[U],
+        parser: U => Row): Unit = {
+      spark.range(0, rowCountOf(gen.apply()), 1L, 1)
+          .mapPartitions { itr =>
+            val lineItem = gen.apply()
+            val lineItemItr = lineItem.iterator()
+            val rows = itr.map { _ =>
+              val item = lineItemItr.next()
+              parser(item)
+            }
+            rows
+          }(RowEncoder(schema))
+          .write
+          .mode(SaveMode.Overwrite)
+          .parquet(TPCH_WRITE_PATH + File.separator + tableName)
+    }
+
+    generate("lineitem", lineItemSchema, lineItemGenerator, lineItemParser)
+    generate("customer", customerSchema, customerGenerator, customerParser)
+    generate("orders", orderSchema, orderGenerator, orderParser)
+    generate("partsupp", partSupplierSchema, partSupplierGenerator, partSupplierParser)
+    generate("supplier", supplierSchema, supplierGenerator, supplierParser)
+    generate("nation", nationSchema, nationGenerator, nationParser)
+    generate("part", partSchema, partGenerator, partParser)
+    generate("region", regionSchema, regionGenerator, regionParser)
+
+
+    val files = new File(TPCH_WRITE_PATH).listFiles()
+    files.foreach(file => {
+      MemoryUsageTest.stdoutLog("Creating catalog table: " + file.getName)
+      spark.catalog.createTable(file.getName, file.getAbsolutePath, "arrow")
+      try {
+        spark.catalog.recoverPartitions(file.getName)
+      } catch {
+        case _: Throwable =>
+      }
+    })
+  }
+
+  test("comment on context pr", CommentOnContextPR) {
+    val commentContentPath = System.getenv("COMMENT_CONTENT_PATH")
+    if (StringUtils.isEmpty(commentContentPath)) {
+      MemoryUsageTest.stdoutLog("No COMMENT_CONTENT_PATH set. Aborting... ")
+      throw new IllegalArgumentException("No COMMENT_CONTENT_PATH set")
+    }
+
+    val repoSlug = System.getenv("GITHUB_REPOSITORY")
+    stdoutLog("Reading essential env variables... " +
+        "Envs: GITHUB_REPOSITORY: %s" .format(repoSlug))
+
+    if (StringUtils.isEmpty(repoSlug)) {
+      throw new IllegalArgumentException("No GITHUB_REPOSITORY set")
+    }
+
+    val eventPath = System.getenv("PREVIOUS_EVENT_PATH")
+    stdoutLog("Reading essential env variables... " +
+        "Envs: PREVIOUS_EVENT_PATH: %s" .format(eventPath))
+
+    if (StringUtils.isEmpty(eventPath)) {
+      throw new IllegalArgumentException("No PREVIOUS_EVENT_PATH set")
+    }
+
+    val token = System.getenv("GITHUB_TOKEN")
+
+    if (StringUtils.isEmpty(token)) {
+      throw new IllegalArgumentException("No GITHUB_TOKEN set")
+    }
+
+    val ghEventPayloadJson = new ObjectMapper().readTree(FileUtils.readFileToString(new File(eventPath)))
+    val prId = ghEventPayloadJson.get("number").asInt()
+
+    commentOnContextPR(repoSlug, prId, token, FileUtils.readFileToString(new File(commentContentPath)))
+  }
+
+  test("memory usage test long-run", TestAndWriteLogs) {
+    LogManager.getRootLogger.setLevel(Level.WARN)
+    val commentTextOutputPath = System.getenv("COMMENT_TEXT_OUTPUT_PATH")
+    if (StringUtils.isEmpty(commentTextOutputPath)) {
+      MemoryUsageTest.stdoutLog("No COMMENT_TEXT_OUTPUT_PATH set. Aborting... ")
+      throw new IllegalArgumentException("No COMMENT_TEXT_OUTPUT_PATH set")
+    }
+
+    val commentImageOutputPath = System.getenv("COMMENT_IMAGE_OUTPUT_PATH")
+    if (StringUtils.isEmpty(commentImageOutputPath)) {
+      MemoryUsageTest.stdoutLog("No COMMENT_IMAGE_OUTPUT_PATH set. Aborting... ")
+      throw new IllegalArgumentException("No COMMENT_IMAGE_OUTPUT_PATH set")
+    }
+
+    val ramMonitor = new RAMMonitor()
+    ramMonitor.startMonitorDaemon(commentImageOutputPath)
+    val writer = new OutputStreamWriter(new FileOutputStream(commentTextOutputPath))
+
+    def writeCommentLine(line: String): Unit = {
+      writer.write(line)
+      writer.write('\n')
+      writer.flush()
+      MemoryUsageTest.stdoutLog("Wrote log line: " + line)
+    }
+
+    writeCommentLine("GitHub Action TPC-H RAM usage test starts to run. " +
+        "Report will be continuously updated in following block.")
+
+    def genReportLine(): String = {
+      val jvmHeapUsed = ramMonitor.getJVMHeapUsed()
+      val jvmHeapTotal = ramMonitor.getJVMHeapTotal()
+      val processRes = ramMonitor.getCurrentPIDRAMUsed()
+      val os = ramMonitor.getOSRAMUsed()
+      val lineBuilder = new StringBuilder
+      lineBuilder
+          .append("Off-Heap Allocated: %d MB,".format((processRes - jvmHeapTotal) / 1000L))
+          .append(' ')
+          .append("Off-Heap Allocation Ratio: %.2f%%,".format((processRes - jvmHeapTotal) * 100.0D / processRes))
+          .append(' ')
+          .append("JVM Heap Used: %d MB,".format(jvmHeapUsed / 1000L))
+          .append(' ')
+          .append("JVM Heap Total: %d MB,".format(jvmHeapTotal / 1000L))
+          .append(' ')
+          .append("Process Resident: %d MB,".format(processRes / 1000L))
+          .append(' ')
+          .append("OS Used: %d MB".format((os / 1000L)))
+      val line = lineBuilder.toString()
+      "Appending RAM report line: " + line
+    }
+
+    try {
+      createTPCHTables()
+      writeCommentLine("```")
+      writeCommentLine("Before suite starts: %s".format(genReportLine()))
+      (1 to 5).foreach { executionId =>
+        writeCommentLine("Iteration %d:".format(executionId))
+        (1 to 22).foreach(i => {
+          runTPCHQuery(i, executionId)
+          writeCommentLine("  Query %d: %s".format(i, genReportLine()))
+        })
+      }
+    } catch {
+      case e: Throwable =>
+        writeCommentLine("Error executing TPC-H queries: %s".format(e.getMessage))
+    }
+    writeCommentLine("```")
+    writer.close()
+    ramMonitor.close()
+  }
+
+  private def runTPCHQuery(caseId: Int, roundId: Int): Unit = {
+    val path = "tpch-queries/q" + caseId + ".sql";
+    val absolute = MemoryUsageTest.locateResourcePath(path)
+    val sql = FileUtils.readFileToString(new File(absolute), StandardCharsets.UTF_8)
+    MemoryUsageTest.stdoutLog("Running TPC-H query %d (round %d)... ".format(caseId, roundId))
+    val df = spark.sql(sql)
+    df.show(100)
+  }
+}
+
+object MemoryUsageTest {
+
+  private def locateResourcePath(resource: String): String = {
+    classOf[MemoryUsageTest].getClassLoader.getResource("")
+        .getPath.concat(File.separator).concat(resource)
+  }
+
+  private def delete(path: String): Unit = {
+    FileUtils.forceDelete(new File(path))
+  }
+
+  // not thread-safe
+  class RAMMonitor extends AutoCloseable {
+    val executor = Executors.newSingleThreadScheduledExecutor()
+    var closed = false
+
+    def getJVMHeapUsed(): Long = {
+      val heapTotalBytes = Runtime.getRuntime.totalMemory()
+      val heapUsed = (heapTotalBytes - Runtime.getRuntime.freeMemory()) / 1024L
+      heapUsed
+    }
+
+    def getJVMHeapTotal(): Long = {
+      val heapTotalBytes = Runtime.getRuntime.totalMemory()
+      val heapTotal = heapTotalBytes / 1024L
+      heapTotal
+    }
+
+    def getCurrentPIDRAMUsed(): Long = {
+      val proc = Runtime.getRuntime.exec("ps -p " + getPID() + " -o rss")
+      val in = new InputStreamReader(proc.getInputStream)
+      val buff = new StringBuilder
+
+      def scan: Unit = {
+        while (true) {
+          val ch = in.read()
+          if (ch == -1) {
+            return;
+          }
+          buff.append(ch.asInstanceOf[Char])
+        }
+      }
+      scan
+      in.close()
+      val output = buff.toString()
+      val scanner = new Scanner(output)
+      scanner.nextLine()
+      scanner.nextLine().toLong
+    }
+
+    private def getPID(): String = {
+      val beanName = ManagementFactory.getRuntimeMXBean.getName
+      return beanName.substring(0, beanName.indexOf('@'))
+    }
+
+    def getOSRAMUsed(): Long = {
+      val proc = Runtime.getRuntime.exec("free")
+      val in = new InputStreamReader(proc.getInputStream)
+      val buff = new StringBuilder
+
+      def scan: Unit = {
+        while (true) {
+          val ch = in.read()
+          if (ch == -1) {
+            return;
+          }
+          buff.append(ch.asInstanceOf[Char])
+        }
+      }
+      scan
+      in.close()
+      val output = buff.toString()
+      val scanner = new Scanner(output)
+      scanner.nextLine()
+      val memLine = scanner.nextLine()
+      val tok = new StringTokenizer(memLine)
+      tok.nextToken()
+      tok.nextToken()
+      return tok.nextToken().toLong
+    }
+
+    def startMonitorDaemon(chartOutputPath: String): ScheduledFuture[_] = {
+      if (closed) {
+        throw new IllegalStateException()
+      }
+      val counter = new AtomicInteger(0)
+      val heapUsedBuffer = ArrayBuffer[Int]()
+      val heapTotalBuffer = ArrayBuffer[Int]()
+      val pidRamUsedBuffer = ArrayBuffer[Int]()
+      val osRamUsedBuffer = ArrayBuffer[Int]()
+
+      executor.scheduleAtFixedRate(new Runnable {
+        override def run(): Unit = {
+          val i = counter.getAndIncrement()
+          val pidRamUsed = getCurrentPIDRAMUsed()
+          val osRamUsed = getOSRAMUsed()
+          val heapUsed = getJVMHeapUsed()
+          val heapTotal = getJVMHeapTotal()
+
+          heapUsedBuffer.append((heapUsed / 1024).toInt)
+          heapTotalBuffer.append((heapTotal / 1024).toInt)
+          pidRamUsedBuffer.append((pidRamUsed / 1024).toInt)
+          osRamUsedBuffer.append((osRamUsed / 1024).toInt)
+
+
+          if (i % 10 == 0) {
+            val chart = new XYChartBuilder()
+                .width(768)
+                .height(512)
+                .title("RAM Usage History (TPC-H)")
+                .xAxisTitle("Up Time (Second)")
+                .yAxisTitle("RAM Used (MB)")
+                .theme(ChartTheme.XChart)
+                .build
+            chart.getStyler.setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Scatter)
+
+            chart.addSeries("JVM Heap Used", heapUsedBuffer.toArray)
+            chart.addSeries("JVM Heap Total", heapTotalBuffer.toArray)
+            chart.addSeries("Process Res Total", pidRamUsedBuffer.toArray)
+            chart.addSeries("OS Used Total", osRamUsedBuffer.toArray)
+
+            val out = new FileOutputStream(chartOutputPath)
+            try {
+              BitmapEncoder.saveBitmap(chart, out, BitmapFormat.PNG)
+            } finally {
+              out.close()
+            }
+          }
+        }
+      }, 0L, 1000L, TimeUnit.MILLISECONDS)
+    }
+
+
+    override def close(): Unit = {
+      executor.shutdown()
+      executor.awaitTermination(Long.MaxValue, TimeUnit.MILLISECONDS)
+      closed = true
+    }
+  }
+
+  def commentOnContextPR(repoSlug: String, prId: Int, token: String, comment: String): Option[GHIssueComment] = {
+    val inst = new GitHubBuilder()
+        .withAppInstallationToken(token)
+      .build()
+
+    val repository = inst.getRepository(repoSlug)
+    val pr = repository.getPullRequest(prId)
+    val title = pr.getTitle
+    if (StringUtils.isEmpty(title)) {
+      stdoutLog("PR title is empty, ignoring")
+      return None
+    }
+    if (!title.contains("[oap-native-sql]") && !title.contains("[oap-data-source]")) {
+      stdoutLog("PR title <%s> not matching, ignoring".format(title))
+      return None
+    }
+    val c = pr.comment(comment)
+    stdoutLog("Comment successfully submitted. ")
+    Some(c)
+  }
+  
+  def stdoutLog(line: Any): Unit = {
+    println("[RAM Reporter] %s".format(line))
+  }
+}


### PR DESCRIPTION
Enables some GitHub actions to achieve continuous memory leak test on native SQL engine PRs.

For each build a 5*22 TPC-H test on small dataset (<100 MB) will be ran. Once the test is completed, target PR will receive a report. 

See [example](https://github.com/zhztheplayer/OAP/pull/8)