### PR TITLE
[OAP-2027][rpmem-shuffle] Load native libraries from jar

### DIFF
--- a/oap-shuffle/RPMem-shuffle/core/src/main/java/org/apache/spark/storage/pmof/PmemBuffer.java
+++ b/oap-shuffle/RPMem-shuffle/core/src/main/java/org/apache/spark/storage/pmof/PmemBuffer.java
@@ -1,9 +1,10 @@
 package org.apache.spark.storage.pmof;
 
+import org.apache.spark.jni.pmof.JniUtils;
+import java.io.IOException;
+
+
 public class PmemBuffer {
-    static {
-        System.load("/usr/local/lib/libjnipmdk.so");
-    }
     private native long nativeNewPmemBuffer();
     private native long nativeNewPmemBufferBySize(long len);
     private native int nativeLoadPmemBuffer(long pmBuffer, long addr, int len);
@@ -21,7 +22,8 @@ public class PmemBuffer {
       pmBuffer = nativeNewPmemBuffer();
     }
 
-    PmemBuffer(long len) {
+    PmemBuffer(long len) throws IOException {
+      JniUtils.getInstance("jnipmdk");
       this.len = len;
       NettyByteBufferPool.unpooledInc(len);
       pmBuffer = nativeNewPmemBufferBySize(len);


### PR DESCRIPTION
Make rpmem shuffle plugin to load native library from built artifact instead of a fixd path.

It passed basic build process. 