### PR TITLE
[OAP-2028][OAP-cache][POAE7-635] Fix set concurrent access bug

### DIFF
--- a/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/oap-cache/oap/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -1141,7 +1141,10 @@ class ExternalCache(fiberType: FiberType) extends OapCache with Logging {
     // Remove plasmaClient.list() since this call have a lot overhead,
     // especially in multi executor case
     cacheTotalCount = new AtomicLong(fiberSet.size)
-    fiberSet.asScala.toSet
+    val tmp = scala.collection.mutable.Set[FiberId]()
+    fiberSet.forEach(id => tmp.add(id))
+    // val tmp: Collections.synchronizedSet = fiberSet.clone()
+    tmp.toSet
   }
 
   override def invalidate(fiber: FiberId): Unit = { }


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix set concurrent access bug, which will cause metrics not right

## How was this patch tested?

E2E test, cache statistics on web UI shows right
