### PR TITLE
[OAP-2041][oap-native-sql] skip null checking if allowed

### DIFF
--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/merge_join_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/merge_join_kernel.cc
@@ -429,20 +429,31 @@ class ConditionedJoinArraysKernel::Impl {
                            const std::vector<int>& right_key_index_list) {
     std::stringstream ss;
     for (auto i : left_shuffle_index_list) {
+      ss << "if (cached_0_" << i << "_[tmp.array_id]->null_count()) {" << std::endl;
       ss << "if (cached_0_" << i << "_[tmp.array_id]->IsNull(tmp.id)) {" << std::endl;
       ss << "  RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
       ss << "} else {" << std::endl;
       ss << "  RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
          << "_[tmp.array_id]->GetView(tmp.id)));" << std::endl;
       ss << "}" << std::endl;
+      ss << "} else {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
+         << "_[tmp.array_id]->GetView(tmp.id)));" << std::endl;
+      ss << "}" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
+      ss << "if (cached_1_" << i << "_->null_count()) {" << std::endl;
       ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
       ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());" << std::endl;
       ss << "} else {" << std::endl;
       ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
          << "_->GetView(i)));" << std::endl;
       ss << "}" << std::endl;
+      ss << "} else {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+         << "_->GetView(i)));" << std::endl;
+      ss << "}" << std::endl;
+
     }
     std::string shuffle_str;
     if (cond_check) {
@@ -503,6 +514,7 @@ class ConditionedJoinArraysKernel::Impl {
     std::stringstream left_valid_ss;
     std::stringstream right_valid_ss;
     for (auto i : left_shuffle_index_list) {
+      left_valid_ss << "if (cached_0_" << i << "_[tmp.array_id]->null_count()) {" << std::endl;
       left_valid_ss << "if (cached_0_" << i << "_[tmp.array_id]->IsNull(tmp.id)) {"
                     << std::endl;
       left_valid_ss << "  RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());"
@@ -511,9 +523,14 @@ class ConditionedJoinArraysKernel::Impl {
       left_valid_ss << "  RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
                     << "_[tmp.array_id]->GetView(tmp.id)));" << std::endl;
       left_valid_ss << "}" << std::endl;
+      left_valid_ss << "} else {" << std::endl;
+      left_valid_ss << "  RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
+                    << "_[tmp.array_id]->GetView(tmp.id)));" << std::endl;
+      left_valid_ss << "}" << std::endl;
       left_null_ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
+      right_valid_ss << "if (cached_1_" << i << "_->null_count()) {" << std::endl;
       right_valid_ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
       right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());"
                      << std::endl;
@@ -521,6 +538,11 @@ class ConditionedJoinArraysKernel::Impl {
       right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
                      << "_->GetView(i)));" << std::endl;
       right_valid_ss << "}" << std::endl;
+      right_valid_ss << "} else {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+         << "_->GetView(i)));" << std::endl;
+      right_valid_ss << "}" << std::endl;
+
     }
     std::string shuffle_str;
     if (cond_check) {
@@ -607,6 +629,7 @@ class ConditionedJoinArraysKernel::Impl {
       left_null_ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
+      right_valid_ss << "if (cached_1_" << i << "_->null_count()) {" << std::endl;
       right_valid_ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
       right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());"
                      << std::endl;
@@ -614,6 +637,11 @@ class ConditionedJoinArraysKernel::Impl {
       right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
                      << "_->GetView(i)));" << std::endl;
       right_valid_ss << "}" << std::endl;
+      right_valid_ss << "} else {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+         << "_->GetView(i)));" << std::endl;
+      right_valid_ss << "}" << std::endl;
+
     }
     std::string shuffle_str;
     if (cond_check) {
@@ -675,8 +703,13 @@ class ConditionedJoinArraysKernel::Impl {
       ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
+      ss << "if (cached_1_" << i << "_->null_count()) {" << std::endl;
       ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
       ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());" << std::endl;
+      ss << "} else {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+         << "_->GetView(i)));" << std::endl;
+      ss << "}" << std::endl;
       ss << "} else {" << std::endl;
       ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
          << "_->GetView(i)));" << std::endl;

--- a/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
+++ b/oap-native-sql/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
@@ -604,6 +604,7 @@ class ConditionedProbeArraysKernel::Impl {
     std::stringstream left_valid_ss;
     std::stringstream right_valid_ss;
     for (auto i : left_shuffle_index_list) {
+      left_valid_ss << "if (cached_0_" << i << "_[tmp.array_id]->null_count()) {" << std::endl;
       left_valid_ss << "if (cached_0_" << i << "_[tmp.array_id]->IsNull(tmp.id)) {"
                     << std::endl;
       left_valid_ss << "  RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());"
@@ -612,15 +613,24 @@ class ConditionedProbeArraysKernel::Impl {
       left_valid_ss << "  RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
                     << "_[tmp.array_id]->GetView(tmp.id)));" << std::endl;
       left_valid_ss << "}" << std::endl;
+      left_valid_ss << "} else {" << std::endl;
+      left_valid_ss << "  RETURN_NOT_OK(builder_0_" << i << "_->Append(cached_0_" << i
+                    << "_[tmp.array_id]->GetView(tmp.id)));" << std::endl;
+      left_valid_ss << "}" << std::endl;
       left_null_ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
+      right_valid_ss << "if (cached_1_" << i << "_->null_count()) {" << std::endl;
       right_valid_ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
       right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());"
                      << std::endl;
       right_valid_ss << "} else {" << std::endl;
       right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
                      << "_->GetView(i)));" << std::endl;
+      right_valid_ss << "}" << std::endl;
+      right_valid_ss << "} else {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+         << "_->GetView(i)));" << std::endl;
       right_valid_ss << "}" << std::endl;
     }
     std::string shuffle_str;
@@ -667,12 +677,17 @@ class ConditionedProbeArraysKernel::Impl {
       left_null_ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
+      right_valid_ss << "if (cached_1_" << i << "_->null_count()) {" << std::endl;
       right_valid_ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
       right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());"
                      << std::endl;
       right_valid_ss << "} else {" << std::endl;
       right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
                      << "_->GetView(i)));" << std::endl;
+      right_valid_ss << "}" << std::endl;
+      right_valid_ss << "} else {" << std::endl;
+      right_valid_ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+         << "_->GetView(i)));" << std::endl;
       right_valid_ss << "}" << std::endl;
     }
     std::string shuffle_str;
@@ -717,8 +732,13 @@ class ConditionedProbeArraysKernel::Impl {
       ss << "RETURN_NOT_OK(builder_0_" << i << "_->AppendNull());" << std::endl;
     }
     for (auto i : right_shuffle_index_list) {
+      ss << "if (cached_1_" << i << "_->null_count()) {" << std::endl;
       ss << "if (cached_1_" << i << "_->IsNull(i)) {" << std::endl;
       ss << "  RETURN_NOT_OK(builder_1_" << i << "_->AppendNull());" << std::endl;
+      ss << "} else {" << std::endl;
+      ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
+         << "_->GetView(i)));" << std::endl;
+      ss << "}" << std::endl;
       ss << "} else {" << std::endl;
       ss << "  RETURN_NOT_OK(builder_1_" << i << "_->Append(cached_1_" << i
          << "_->GetView(i)));" << std::endl;


### PR DESCRIPTION
## What changes were proposed in this pull request?

when joining, we could skip the if_is_null checking if the whole batch didn't contain `null`


## How was this patch tested?

locally verified on TPC-H/TPC-DS


