### PR TITLE
[OAP-2050][oap-data-source][arrow] Add S3 support

### DIFF
--- a/oap-data-source/arrow/pom.xml
+++ b/oap-data-source/arrow/pom.xml
@@ -69,6 +69,25 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>2.7.3</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala.version}</version>

--- a/oap-data-source/arrow/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowUtils.scala
+++ b/oap-data-source/arrow/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowUtils.scala
@@ -185,6 +185,7 @@ object ArrowUtils {
     Option(options.filesystem match {
       case "local" => FileSystem.LOCAL
       case "hdfs" => FileSystem.HDFS
+      case "s3fs" => FileSystem.S3FS
       case _ => throw new IllegalArgumentException("Unrecognizable filesystem")
     })
   }

--- a/oap-data-source/arrow/standard/src/test/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowDataSourceTest.scala
+++ b/oap-data-source/arrow/standard/src/test/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowDataSourceTest.scala
@@ -102,11 +102,11 @@ class ArrowDataSourceTest extends QueryTest with SharedSparkSession {
   }
 
   test("reading parquet file") {
-    val path = ArrowDataSourceTest.locateResourcePath(parquetFile1)
+    val path = "s3://access:secret@intel-bigdata/2020/06"
     verifyParquet(
       spark.read
         .option(ArrowOptions.KEY_ORIGINAL_FORMAT, "parquet")
-        .option(ArrowOptions.KEY_FILESYSTEM, "hdfs")
+        .option(ArrowOptions.KEY_FILESYSTEM, "s3fs")
         .arrow(path))
   }
 


### PR DESCRIPTION
Note: This will require for `ARROW_S3=ON` during Arrow build

How to build AWS in this case:
```
cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_ONLY="s3;core;config;transfer"
```

How to use S3 in Arrow datasource:
```
Spark.read.option(ArrowOptions.KEY_ORIGINAL_FORMAT, "parquet")
        .option(ArrowOptions.KEY_FILESYSTEM, "s3fs")
        .arrow("s3://access:secret@intel-bigdata/2020/06))
```

Other references:
https://issues.apache.org/jira/browse/ARROW-8565?src=confmacro
https://spark.apache.org/docs/2.3.0/cloud-integration.html
https://arrow.apache.org/docs/r/articles/install.html
https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup.html
https://medium.com/knoldus/apache-spark-read-data-from-s3-bucket-a53a395c3282