### PR TITLE
[OAP-1856][oap-native-sql]Remove ColumnarBHJ logic from AQE to ColumnarPlugin 

### DIFF
--- a/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarGuardRule.scala
+++ b/oap-native-sql/core/src/main/scala/com/intel/oap/ColumnarGuardRule.scala
@@ -91,6 +91,8 @@ case class ColumnarGuardRule(conf: SparkConf) extends Rule[SparkPlan] {
             plan.condition,
             plan.left,
             plan.right)
+        case plan: BroadcastExchangeExec =>
+          new ColumnarBroadcastExchangeExec(plan.mode, plan.child)
         case plan: BroadcastHashJoinExec =>
           ColumnarBroadcastHashJoinExec(
             plan.leftKeys,

--- a/oap-native-sql/tools/gitdiff_AdaptiveSparkPlanExec.patch
+++ b/oap-native-sql/tools/gitdiff_AdaptiveSparkPlanExec.patch
@@ -1,0 +1,46 @@
+diff --git a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+index 87eb01438d..f6a3333b90 100644
+--- a/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
++++ b/oap-native-sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+@@ -100,11 +100,10 @@ case class AdaptiveSparkPlanExec(
+     // The following two rules need to make use of 'CustomShuffleReaderExec.partitionSpecs'
+     // added by `CoalesceShufflePartitions`. So they must be executed after it.
+     OptimizeSkewedJoin(conf),
+-    OptimizeLocalShuffleReader(conf))
+-
+-  @transient private val additionalRules: Seq[Rule[SparkPlan]] = Seq(
++    OptimizeLocalShuffleReader(conf),
+     ApplyColumnarRulesAndInsertTransitions(conf, context.session.sessionState.columnarRules),
+-    CollapseCodegenStages(conf))
++    CollapseCodegenStages(conf)
++  )
+ 
+   @transient private val costEvaluator = SimpleCostEvaluator
+ 
+@@ -228,8 +227,7 @@ case class AdaptiveSparkPlanExec(
+       }
+ 
+       // Run the final plan when there's no more unfinished stages.
+-      currentPhysicalPlan =
+-        applyPhysicalRules(result.newPlan, queryStageOptimizerRules ++ additionalRules)
++      currentPhysicalPlan = applyPhysicalRules(result.newPlan, queryStageOptimizerRules)
+       isFinalPlan = true
+       executionId.foreach(onUpdatePlan(_, Seq(currentPhysicalPlan)))
+       currentPhysicalPlan
+@@ -376,13 +374,11 @@ case class AdaptiveSparkPlanExec(
+ 
+   private def newQueryStage(e: Exchange): QueryStageExec = {
+     val optimizedPlan = applyPhysicalRules(e.child, queryStageOptimizerRules)
+-    val optimizedPlanWithExchange =
+-      applyPhysicalRules(e.withNewChildren(Seq(optimizedPlan)), additionalRules)
+-    val queryStage = optimizedPlanWithExchange match {
++    val queryStage = e match {
+       case s: ShuffleExchangeExec =>
+-        ShuffleQueryStageExec(currentStageId, optimizedPlanWithExchange)
++        ShuffleQueryStageExec(currentStageId, s.copy(child = optimizedPlan))
+       case b: BroadcastExchangeExec =>
+-        BroadcastQueryStageExec(currentStageId, optimizedPlanWithExchange)
++        BroadcastQueryStageExec(currentStageId, b.copy(child = optimizedPlan))
+     }
+     currentStageId += 1
+     setLogicalLinkForNewQueryStage(queryStage, e)


### PR DESCRIPTION
In this PR, we moved out most modifications inside AQE, and put them to ColumnarPlugin.scala
Passed TPCDS tests with AQE enabled + V2
Passed TPCDS tests with DPP enabled + V1
Also tested with TPCH Q2 and Q16 with AQE is off.

put remaining modification diff as a patch in tools folder, so we can keep a track.

Fixed: https://github.com/Intel-bigdata/OAP/issues/1856